### PR TITLE
fix java.lang.IllegalAccessException: Field is final

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/FastResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/FastResultSetHandler.java
@@ -346,7 +346,7 @@ public class FastResultSetHandler implements ResultSetHandler {
         }
       }
       final String property = metaObject.findProperty(propertyName, configuration.isMapUnderscoreToCamelCase());
-      if (property != null) {
+      if (property != null &&metaObject.hasSetter(property) ) {
         final Class<?> propertyType = metaObject.getSetterType(property);
         if (typeHandlerRegistry.hasTypeHandler(propertyType)) {
           final TypeHandler<?> typeHandler = resultColumnCache.getTypeHandler(propertyType, columnName);

--- a/src/main/java/org/apache/ibatis/reflection/Reflector.java
+++ b/src/main/java/org/apache/ibatis/reflection/Reflector.java
@@ -18,6 +18,7 @@ package org.apache.ibatis.reflection;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.lang.reflect.ReflectPermission;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -224,10 +225,12 @@ public class Reflector {
           // Ignored. This is only a final precaution, nothing we can do.
         }
       }
-      if (field.isAccessible()) {
-        if (!setMethods.containsKey(field.getName())) {
-          // issue 379 - removed the check for final because JDK 1.5 allows
-          // modification of final fields through reflection (JSR-133).  (JGB)
+      int modifier=field.getModifiers();
+      // issue 379 - removed the check for final because JDK 1.5 allows
+      // modification of final fields through reflection (JSR-133).  (JGB)
+      // allow final but not final static
+      if (field.isAccessible() && !(Modifier.isFinal(modifier) && Modifier.isStatic(modifier))) {
+      if (!setMethods.containsKey(field.getName())) {
           addSetField(field);
         }
         if (!getMethods.containsKey(field.getName())) {

--- a/src/test/java/org/apache/ibatis/submitted/automapping/Article.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/Article.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2013 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.submitted.automapping;
+
+public class Article {
+	public final Integer version=0; 
+}

--- a/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
@@ -17,9 +17,11 @@ package org.apache.ibatis.submitted.automapping;
 
 import java.io.Reader;
 import java.sql.Connection;
+import java.util.List;
 
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.AutoMappingBehavior;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -29,36 +31,67 @@ import org.junit.Test;
 
 public class AutomappingTest {
 
-  private static SqlSessionFactory sqlSessionFactory;
+	private static SqlSessionFactory sqlSessionFactory;
 
-  @BeforeClass
-  public static void setUp() throws Exception {
-    // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/automapping/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+	@BeforeClass
+	public static void setUp() throws Exception {
+		// create a SqlSessionFactory
+		Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/automapping/mybatis-config.xml");
+		sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+		reader.close();
 
-    // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/automapping/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    reader.close();
-    session.close();
-  }
+		// populate in-memory database
+		SqlSession session = sqlSessionFactory.openSession();
+		Connection conn = session.getConnection();
+		reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/automapping/CreateDB.sql");
+		ScriptRunner runner = new ScriptRunner(conn);
+		runner.setLogWriter(null);
+		runner.runScript(reader);
+		reader.close();
+		session.close();
+	}
 
-  @Test
-  public void shouldGetAUser() {
-    SqlSession sqlSession = sqlSessionFactory.openSession();
-    try {
-      Mapper mapper = sqlSession.getMapper(Mapper.class);
-      User user = mapper.getUser(1);
-      Assert.assertEquals("User1", user.getName());
-    } finally {
-      sqlSession.close();
-    }
-  }
+	@Test
+	public void shouldGetAUser() {
+		SqlSession sqlSession = sqlSessionFactory.openSession();
+		try {
+			Mapper mapper = sqlSession.getMapper(Mapper.class);
+			User user = mapper.getUser(1);
+			Assert.assertEquals("User1", user.getName());
+		} finally {
+			sqlSession.close();
+		}
+	}
 
+	@Test
+	public void shouldGetBooks() {
+		//set automapping to default partial
+		sqlSessionFactory.getConfiguration().setAutoMappingBehavior(AutoMappingBehavior.PARTIAL);
+		SqlSession sqlSession = sqlSessionFactory.openSession();
+		try {
+			Mapper mapper = sqlSession.getMapper(Mapper.class);
+			//no errors throw
+			List<Book> books = mapper.getBooks();
+			Assert.assertTrue("should return results,no errors throw", !books.isEmpty());
+		} finally {
+			sqlSession.close();
+		}
+	}
+
+	@Test
+	public void shouldUpdateFinalField() {
+		//set automapping to default partial
+		sqlSessionFactory.getConfiguration().setAutoMappingBehavior(AutoMappingBehavior.PARTIAL);
+		SqlSession sqlSession = sqlSessionFactory.openSession();
+		try {
+			Mapper mapper = sqlSession.getMapper(Mapper.class);
+			Article article = mapper.getArticle();
+			//Java Language Specification 17.5.3 Subsequent Modification of Final Fields
+			//http://docs.oracle.com/javase/specs/jls/se5.0/html/memory.html#17.5.3
+			//The final field should be updated in mapping
+			Assert.assertTrue("should update version in mapping", article.version > 0);
+		} finally {
+			sqlSession.close();
+		}
+	}
 }

--- a/src/test/java/org/apache/ibatis/submitted/automapping/Book.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/Book.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.submitted.automapping;
+
+public class Book {
+	public static final Integer version=0;
+	private String name;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/automapping/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/CreateDB.sql
@@ -16,9 +16,18 @@
 
 drop table users if exists;
 
+drop table books if exists;
+
 create table users (
   id int,
   name varchar(20)
 );
 
+create table books (
+  version int,
+  name varchar(20)
+);
+
 insert into users (id, name) values(1, 'User1');
+
+insert into books (version, name) values(99, 'Learn Java');

--- a/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.java
@@ -15,8 +15,13 @@
  */
 package org.apache.ibatis.submitted.automapping;
 
+import java.util.List;
+
 public interface Mapper {
 
   User getUser(Integer id);
 
+  List<Book> getBooks();
+  
+  Article getArticle();
 }

--- a/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.xml
@@ -26,5 +26,16 @@
 
 	<resultMap type="org.apache.ibatis.submitted.automapping.User" id="result" autoMapping="true">
 	</resultMap>
-
+	
+	<resultMap type="org.apache.ibatis.submitted.automapping.Book" id="bookResult">
+		 <result property="name" column="name"/>
+	</resultMap>
+	
+	<select id="getBooks" resultMap="bookResult">
+		select version,name from books
+	</select>
+	
+	<select id="getArticle" resultType="org.apache.ibatis.submitted.automapping.Article">
+		select 9 as version from INFORMATION_SCHEMA.SYSTEM_USERS
+	</select>	
 </mapper>


### PR DESCRIPTION
Signed-off-by: Ted Shaw xiao.xj@gmail.com
AutoMapping is default to PARTIAL which may map column to static final field by name, and a <java.lang.IllegalAccessException: Field is final> error will throw out. The pull request fixes the issue and attaches test cases to verify "final static" and "final" setter
