### PR TITLE
Fix NullPoint exception caused by missing TypeHandler

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/NestedResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/NestedResultSetHandler.java
@@ -294,10 +294,16 @@ public class NestedResultSetHandler extends FastResultSetHandler {
         createRowKeyForMappedProperties(nestedResultMap, rs, cacheKey, nestedResultMap.getConstructorResultMappings(),
             prependPrefix(resultMapping.getColumnPrefix(), columnPrefix), resultColumnCache);
       } else if (resultMapping.getNestedQueryId() == null) {
-        final String column = prependPrefix(resultMapping.getColumn(), columnPrefix);
-        final TypeHandler<?> th = resultMapping.getTypeHandler();
+        final String columnName=resultMapping.getColumn();
+        final String column = prependPrefix(columnName, columnPrefix);
         List<String> mappedColumnNames = resultColumnCache.getMappedColumnNames(resultMap, columnPrefix);
         if (column != null && mappedColumnNames.contains(column.toUpperCase(Locale.ENGLISH))) { // Issue #114
+          TypeHandler<?> th = resultMapping.getTypeHandler();
+          if(th==null){
+             final Class<?> resultType=resultMap.getType();
+             //handle bean property so no prefix needed in columnName
+             th=resultColumnCache.getTypeHandler(resultType, columnName);
+          }            
           final Object value = th.getResult(rs, column);
           if (value != null) {
             cacheKey.update(column);

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/CreateDB.sql
@@ -16,6 +16,7 @@
 
 drop table persons if exists;
 drop table items if exists;
+drop table orderDetail if exists;
 
 create table persons (
   id int,
@@ -27,6 +28,11 @@ create table items (
   owner int,
   name varchar(20)
 );
+
+create table orderDetail (
+  order_id int,
+  product_id int
+);
  
 insert into persons (id, name) values (1, 'grandma');
 insert into persons (id, name) values (2, 'sister');
@@ -37,3 +43,7 @@ insert into items (id, owner, name) values (2, 1, 'tv');
 insert into items (id, owner, name) values (3, 2, 'shoes');
 insert into items (id, owner, name) values (4, 3, 'car');
 insert into items (id, owner, name) values (5, 2, 'phone');
+
+insert into orderDetail (order_id, product_id) values (1, 1);
+insert into orderDetail (order_id, product_id) values (1, 2);
+insert into orderDetail (order_id, product_id) values (2, 1);

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Mapper.java
@@ -20,4 +20,5 @@ import java.util.List;
 public interface Mapper {
   List<Person> getPersons();
   List<Person> getPersonsWithItemsOrdered();
+  List<Product> getProducts();
 }

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Mapper.xml
@@ -40,4 +40,26 @@
 		where p.id = i.owner
 		order by i.name
 	</select>
+  
+    <resultMap id="productResult" type="org.apache.ibatis.submitted.nestedresulthandler.Product">
+		<result property="id" column="product_id" />
+        <!-- use resultMap="referOrdersMap" instead of column="ref_id" to verify NPE in NestResultHandler-->
+		<collection property="referOrders"  resultMap="referOrdersMap" javaType="list" ofType="java.lang.String"/> 
+	</resultMap>
+  
+    <resultMap id="referOrdersMap" type="java.lang.String">
+      <result property="value" column="ref_id"/>
+    </resultMap>
+
+    <select id="getProducts" resultMap="productResult">
+      select 'ID:'||order_id ref_id ,product_id
+      from orderDetail
+      order by product_id
+    </select>
+
+    <select id="getSimpleResult" resultMap="referOrdersMap">
+      select 'ID:'||order_id ref_id from orderDetail
+    </select>
+  
 </mapper>
+

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/NestedResultHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/NestedResultHandlerTest.java
@@ -149,5 +149,19 @@ public class NestedResultHandlerTest {
       sqlSession.close();
     }
   }
-
+  
+  @Test
+  public void testProducts() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      List<String> simpleResults=sqlSession.selectList("getSimpleResult");
+      Assert.assertEquals(3, simpleResults.size());
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<Product> products = mapper.getProducts();
+      Assert.assertTrue("the first product id is 1", 1==products.get(0).getId());
+      Assert.assertEquals("ID:2", products.get(0).getReferOrder().get(1));
+    } finally {
+      sqlSession.close();
+    }
+  }  
 }

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Product.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Product.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.submitted.nestedresulthandler;
+
+import java.util.List;
+
+public class Product {
+  Integer id;
+  List<String> referOrders;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public List<String> getReferOrder() {
+    return referOrders;
+  }
+
+  public void setReferOrder(List<String> referOrders) {
+    this.referOrders = referOrders;
+  }
+  
+}


### PR DESCRIPTION
Nested results were handled differently, a resultMap can run in simple query but not in netsted map, e.g.

``` xml

    <resultMap id="referOrdersMap" type="java.lang.String">
      <result property="value" column="ref_id"/>
    </resultMap>

    <resultMap id="productResult" type="org.apache.ibatis.submitted.nestedresulthandler.Product">
        <result property="id" column="product_id" />
        <!-- use resultMap="referOrdersMap" instead of column="ref_id" to verify NPE in NestResultHandler-->
        <collection property="referOrders"  resultMap="referOrdersMap" javaType="list" ofType="java.lang.String"/> 
    </resultMap>

     <select id="getProducts" resultMap="productResult">
        select 'ID:'||order_id ref_id ,product_id
        from orderDetail
        order by product_id
     </select>

    <select id="getSimpleResult" resultMap="referOrdersMap">
        select 'ID:'||order_id ref_id from orderDetail
    </select>
```

getSimpleResult can run successfully but getProducts will throw null point exception.

The fix added null checking in createRowKeyForMappedProperties method and fall back to resultColumnCache.getTypeHandler if no type handler found.
