### PR TITLE
Using select in constructor/arg ignores that arg in duplicate checks

### DIFF
--- a/src/test/java/domain/blog/BlogLite.java
+++ b/src/test/java/domain/blog/BlogLite.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013 MyBatis.org.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package domain.blog;
+
+import java.util.List;
+
+public class BlogLite {
+
+  private int id;
+  private List<PostLite> posts;
+
+  public int getId() {
+    return id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public List<PostLite> getPosts() {
+    return posts;
+  }
+
+  public void setPosts(List<PostLite> posts) {
+    this.posts = posts;
+  }
+}

--- a/src/test/java/org/apache/ibatis/builder/PostMapper.xml
+++ b/src/test/java/org/apache/ibatis/builder/PostMapper.xml
@@ -35,6 +35,26 @@
       </constructor>
   </resultMap>
 
+  <resultMap id="postLiteMap2NestedWithSelect" type="domain.blog.BlogLite">
+    <id column="blog_id" property="id" />
+    <collection property="posts" ofType="domain.blog.PostLite">
+      <constructor>
+          <arg javaType="domain.blog.PostLiteId" column="{id=id}" select="selectPostLiteId" />
+          <arg javaType="_int" column="blog_id"/>
+      </constructor>
+    </collection>
+  </resultMap>
+
+  <resultMap id="postLiteMap2NestedWithoutSelect" type="domain.blog.BlogLite">
+    <id column="blog_id" property="id" />
+    <collection property="posts" ofType="domain.blog.PostLite">
+      <constructor>
+          <arg javaType="domain.blog.PostLiteId" resultMap="postLiteIdMap" />
+          <arg javaType="_int" column="blog_id"/>
+      </constructor>
+    </collection>
+  </resultMap>
+
   <resultMap id="mutablePostLiteMap" type="domain.blog.PostLite">
       <result property="blogId" column="blog_id"/>
       <association property="id" column="id" resultMap="postLiteIdMap"/>
@@ -46,6 +66,18 @@
 
   <select id="selectPostLite" resultMap="postLiteMap">
       select id, blog_id from post where blog_id is not null
+  </select>
+
+  <select id="selectPostLite2NestedWithSelect" resultMap="postLiteMap2NestedWithSelect">
+      select id, 1 as blog_id from post where blog_id is not null
+  </select>
+
+  <select id="selectPostLite2NestedWithoutSelect" resultMap="postLiteMap2NestedWithoutSelect">
+      select id, 1 as blog_id from post where blog_id is not null
+  </select>
+
+  <select id="selectPostLiteId" resultMap="postLiteIdMap">
+      select ${id} as id from (values(0)) as t
   </select>
 
   <select id="selectMutablePostLite" resultMap="mutablePostLiteMap">

--- a/src/test/java/org/apache/ibatis/session/SqlSessionManagerTest.java
+++ b/src/test/java/org/apache/ibatis/session/SqlSessionManagerTest.java
@@ -480,6 +480,20 @@ public class SqlSessionManagerTest extends BaseDataTest {
   }
 
   @Test
+  public void shouldFindAllPostLitesWithNestedSelect() throws Exception {
+    final BlogLite blog = manager.selectOne("domain.blog.mappers.PostMapper.selectPostLite2NestedWithSelect");
+    assertNotNull(blog);
+    assertEquals(4, blog.getPosts().size());
+  }
+
+  @Test
+  public void shouldFindAllPostLitesWithNestedResultMap() throws Exception {
+    final BlogLite blog = manager.selectOne("domain.blog.mappers.PostMapper.selectPostLite2NestedWithoutSelect");
+    assertNotNull(blog);
+    assertEquals(4, blog.getPosts().size());
+  }
+
+  @Test
   public void shouldFindAllMutablePostLites() throws Exception {
     List<PostLite> posts = manager.selectList("domain.blog.mappers.PostMapper.selectMutablePostLite");
     assertEquals(4, posts.size());


### PR DESCRIPTION
It's similar to [Issue 392](https://code.google.com/p/mybatis/issues/detail?id=392).
If you have resultMap like:

``` xml
<resultMap id="postLiteMap2NestedWithSelect" type="domain.blog.BlogLite">
  <id column="blog_id" property="id" />
  <collection property="posts" ofType="domain.blog.PostLite">
    <constructor>
      <arg javaType="domain.blog.PostLiteId" column="{id=id}" select="selectPostLiteId" />
      <arg javaType="_int" column="blog_id"/>
    </constructor>
  </collection>
</resultMap>
```

then the `arg` with `select` is ignored and posts are unique based on `blog_id` (which, in this case, is the same). Hence all posts but one are ignored.
