### PR TITLE
Configuration variables are not expanded when parsing <include> nodes.

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLIncludeTransformer.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLIncludeTransformer.java
@@ -17,6 +17,7 @@ package org.apache.ibatis.builder.xml;
 
 import org.apache.ibatis.builder.IncompleteElementException;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.ibatis.parsing.PropertyParser;
 import org.apache.ibatis.parsing.XNode;
 import org.apache.ibatis.session.Configuration;
 import org.w3c.dom.Node;
@@ -53,6 +54,7 @@ public class XMLIncludeTransformer {
   }
 
   private Node findSqlFragment(String refid) {
+    refid = PropertyParser.parse(refid, configuration.getVariables());
     refid = builderAssistant.applyCurrentNamespace(refid, true);
     try {
       XNode nodeToInclude = configuration.getSqlFragments().get(refid);

--- a/src/test/java/org/apache/ibatis/submitted/includes/Fragments.xml
+++ b/src/test/java/org/apache/ibatis/submitted/includes/Fragments.xml
@@ -28,4 +28,7 @@
   <sql id="update">
     update
   </sql>
+  <sql id="values">
+    VALUES (1);
+  </sql>
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/includes/IncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/includes/IncludeTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertNotNull;
 import org.junit.Test;
 
 import java.io.Reader;
+import org.apache.ibatis.session.SqlSession;
+import org.junit.Assert;
 
 public class IncludeTest {
 
@@ -32,5 +34,13 @@ public class IncludeTest {
     SqlSessionFactoryBuilder builder = new SqlSessionFactoryBuilder();
     SqlSessionFactory sqlMapper = builder.build(reader);
     assertNotNull(sqlMapper);
+
+    final SqlSession sqlSession = sqlMapper.openSession();
+    try {
+      final int result = sqlSession.selectOne("org.apache.ibatis.submitted.includes.mapper.selectWithProperty");
+      Assert.assertEquals(1, result);
+    } finally {
+      sqlSession.close();
+    }
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/includes/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/includes/Mapper.xml
@@ -33,6 +33,10 @@
     <include refid="sometable"/>
   </select>
 
+  <select id="selectWithProperty" resultType="_int">
+    <include refid="${ns}.values"/>
+  </select>
+
   <update id="update" parameterType="map">
     <include refid="org.apache.ibatis.submitted.includes.fragments.update"/>
     <include refid="org.apache.ibatis.submitted.includes.mapper.sometable"/>

--- a/src/test/java/org/apache/ibatis/submitted/includes/MapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/includes/MapperConfig.xml
@@ -23,6 +23,23 @@
 
 <configuration>
 
+  <properties>
+    <property name="ns" value="org.apache.ibatis.submitted.includes.fragments" />
+  </properties>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url" value="jdbc:hsqldb:mem:includes" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
   <mappers>
     <mapper resource="org/apache/ibatis/submitted/includes/Fragments.xml"/>
     <mapper resource="org/apache/ibatis/submitted/includes/Mapper.xml"/>


### PR DESCRIPTION
This is a regression from 3.1.1.
