### PR TITLE
Correct spelling mistake: not 'plan',should be 'plain'

### DIFF
--- a/src/site/zh/xdoc/index.xml
+++ b/src/site/zh/xdoc/index.xml
@@ -32,7 +32,7 @@
         <p>
         MyBatis 是支持普通 SQL 查询,存储过程和高级映射的优秀持久层框架。MyBatis 消除
 了几乎所有的 JDBC 代码和参数的手工设置以及结果集的检索。MyBatis 使用简单的 XML
-或注解用于配置和原始映射,将接口和 Java 的 POJOs(Plan Old Java Objects,普通的 Java
+或注解用于配置和原始映射,将接口和 Java 的 POJOs(Plain Old Java Objects,普通的 Java
 对象)映射成数据库中的记录。
         </p>
       </subsection>


### PR DESCRIPTION
Correct spelling mistake.
Not 'plan',should be 'plain' .
