### PR TITLE
includeColumns element for select

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLIncludeTransformer.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLIncludeTransformer.java
@@ -45,6 +45,22 @@ public class XMLIncludeTransformer {
         toInclude.getParentNode().insertBefore(toInclude.getFirstChild(), toInclude);
       }
       toInclude.getParentNode().removeChild(toInclude);
+    } else if (source.getNodeName().equals("includeColumns")) {
+      Node toInclude = findSqlFragment(getStringAttribute(source, "refid"));
+      String tableAlias = getStringAttribute(source, "tableAlias");
+      String columnAliasPrefix = getOptionalStringAttribute(source, "columnAliasPrefix");
+      applyIncludes(toInclude);
+      if (toInclude.getOwnerDocument() != source.getOwnerDocument()) {
+        toInclude = source.getOwnerDocument().importNode(toInclude, true);
+      }
+      source.getParentNode().replaceChild(toInclude, source);
+      while (toInclude.hasChildNodes()) {
+        Node firstChild = toInclude.getFirstChild();
+        String transformedColumnList = transformColumnList(firstChild.getTextContent(), tableAlias, columnAliasPrefix);
+        firstChild.setTextContent(transformedColumnList);
+        toInclude.getParentNode().insertBefore(firstChild, toInclude);
+      }
+      toInclude.getParentNode().removeChild(toInclude);
     } else if (source.getNodeType() == Node.ELEMENT_NODE) {
       NodeList children = source.getChildNodes();
       for (int i=0; i<children.getLength(); i++) {
@@ -67,5 +83,36 @@ public class XMLIncludeTransformer {
 
   private String getStringAttribute(Node node, String name) {
     return node.getAttributes().getNamedItem(name).getNodeValue();
+  }
+
+  private String getOptionalStringAttribute(Node node, String name) {
+    Node namedItem = node.getAttributes().getNamedItem(name);
+    if (namedItem == null) {
+      return null;
+    }
+
+    return namedItem.getNodeValue();
+  }
+
+  private String transformColumnList(String columns, String tableAlias, String columnAliasPrefix) {
+    if (columnAliasPrefix == null) {
+      columnAliasPrefix = tableAlias;
+    }
+    StringBuilder stringBuilder = new StringBuilder();
+    String textContent = columns.trim();
+    String[] tokens = textContent.split(",");
+    for (int i = 0; i < tokens.length; i++) {
+      String token = tokens[i].trim();
+      stringBuilder.append(tableAlias).append(".").append(token);
+      if (!token.toLowerCase().contains(" ")) {
+        stringBuilder.append(" as ").append(columnAliasPrefix).append("_").append(token);
+      }
+
+      if (i < tokens.length - 1) {
+        stringBuilder.append(", ");
+      }
+    }
+
+    return stringBuilder.toString();
   }
 }

--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
@@ -162,7 +162,7 @@ alias CDATA #REQUIRED
 type CDATA #REQUIRED
 >
 
-<!ELEMENT select (#PCDATA | include | trim | where | set | foreach | choose | if | bind)*>
+<!ELEMENT select (#PCDATA | include | includeColumns | trim | where | set | foreach | choose | if | bind)*>
 <!ATTLIST select
 id CDATA #REQUIRED
 parameterMap CDATA #IMPLIED
@@ -234,6 +234,13 @@ lang CDATA #IMPLIED
 <!ELEMENT include EMPTY>
 <!ATTLIST include
 refid CDATA #REQUIRED
+>
+
+<!ELEMENT includeColumns EMPTY>
+<!ATTLIST includeColumns
+refid CDATA #REQUIRED
+tableAlias CDATA #REQUIRED
+columnAliasPrefix CDATA #IMPLIED
 >
 
 <!ELEMENT bind EMPTY>

--- a/src/test/java/org/apache/ibatis/builder/IncludeMapper.xml
+++ b/src/test/java/org/apache/ibatis/builder/IncludeMapper.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2012 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.domain.IncludeMapper">
+
+  <sql id="Base_Column_List">
+    a, b, c
+  </sql>
+
+  <sql id="Second_Base_Column_List">
+    p as z, q as y, r
+  </sql>
+
+  <select id="selectInclude">
+    select
+    <includeColumns refid="Base_Column_List" tableAlias="x"/>,
+    <includeColumns refid="Base_Column_List" tableAlias="y" columnAliasPrefix="q"/>,
+    <includeColumns refid="Second_Base_Column_List" tableAlias="z"/>
+    from dual x
+    join dual y
+  </select>
+</mapper>

--- a/src/test/java/org/apache/ibatis/builder/IncludeMapperXmlBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/IncludeMapperXmlBuilderTest.java
@@ -1,0 +1,44 @@
+/*
+ *    Copyright 2009-2012 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder;
+
+import java.io.InputStream;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class IncludeMapperXmlBuilderTest {
+
+  @Test
+  public void shouldSuccessfullyLoadIncludeXMLMapperFile() throws Exception {
+    Configuration configuration = new Configuration();
+    String resource = "org/apache/ibatis/builder/IncludeMapper.xml";
+    InputStream inputStream = Resources.getResourceAsStream(resource);
+    XMLMapperBuilder builder = new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments());
+    builder.parse();
+
+    String sqlOutput = configuration.getMappedStatement("com.domain.IncludeMapper.selectInclude").getSqlSource().getBoundSql(null).getSql();
+
+    String[] lines = sqlOutput.split("\n");
+    Assert.assertEquals("x.a as x_a, x.b as x_b, x.c as x_c ,", lines[1].trim());
+    Assert.assertEquals("y.a as q_a, y.b as q_b, y.c as q_c ,", lines[2].trim());
+    Assert.assertEquals("z.p as z, z.q as y, z.r as z_r", lines[3].trim());
+  }
+
+}


### PR DESCRIPTION
Collections and assocations have the option to specify a columnPrefix, making resultMaps easier to reuse.
However, column lists such as the Base_Column_List generated by Mybatis Generator don't have that option.

I created a separate includeColumns element which takes a tableAlias and an optional columnAliasPrefix. I chose not to fold this functionality into the generic include element, because it's only useful for very specific cases.

If you have the following column list:

``` xml
<sql> a, b, c</sql>
```

and you include it in the select statement as follows:

``` xml
<select>
select
<includeColumns tableAlias="comment"/>
from tab comment
</select>
```

it will render (on one line to save space):

``` sql
select comment.a as comment_a, comment.b as comment_b, comment.c as comment_c
```

with an optional columnAliasPrefix "c" it will render:

``` sql
select comment.a as c_a, comment.b as c_b, comment.c as c_c
```

This functionality will make reuse of column lists much easier, especially when working with associations or when linking the same table more than once in the same query.
