### PR TITLE
Update DynamicContext.java

### DIFF
--- a/src/main/java/org/apache/ibatis/scripting/xmltags/DynamicContext.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/DynamicContext.java
@@ -62,7 +62,7 @@ public class DynamicContext {
 
   public void appendSql(String sql) {
     sqlBuilder.append(sql);
-    sqlBuilder.append(" ");
+    //sqlBuilder.append(" ");
   }
 
   public String getSql() {


### PR DESCRIPTION
Proposal :
Removed trailing space on sql fragments since this alter the sql code that the user typed in the sqlmap file preventing the use of static text to be used as value, label or whatever the user might need it for.

Ex : 
`<sql id="bar">${@com.packacge.whatever.the.heck.this.might.be.Globals@BAR_TEXT}</sql>
<select id="exemple">
select bar "bar end with <include refid="bar"/>" from foo where bar = '%<include refid="bar"/>'
</select>`

This will fail since the space added at the sql fragment's end will corrupt the where filter (as well as the column title). This trailing space just alter the code the user did write and thus should be removed.

Cheers.
