### PR TITLE
A new setting "prefixQueriesWithStatementId" for XML configuration

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -214,7 +214,8 @@ public class XMLConfigBuilder extends BaseBuilder {
       configuration.setSafeResultHandlerEnabled(booleanValueOf(props.getProperty("safeResultHandlerEnabled"), true));
       configuration.setDefaultScriptingLanguage(resolveClass(props.getProperty("defaultScriptingLanguage")));
       configuration.setCallSettersOnNulls(booleanValueOf(props.getProperty("callSettersOnNulls"), false));
-      configuration.setLogPrefix(props.getProperty("logPrefix"));
+      configuration.setPrefixQueriesWithStatementId(booleanValueOf(props.getProperty("prefixQueriesWithStatementId"), false));
+	  configuration.setLogPrefix(props.getProperty("logPrefix"));
       configuration.setLogImpl(resolveClass(props.getProperty("logImpl")));
       configuration.setConfigurationFactory(resolveClass(props.getProperty("configurationFactory")));
     }

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -103,6 +103,7 @@ public class Configuration {
   protected boolean useColumnLabel = true;
   protected boolean cacheEnabled = true;
   protected boolean callSettersOnNulls = false;
+  protected boolean prefixQueriesWithStatementId = false;
   protected String logPrefix;
   protected Class <? extends Log> logImpl;
   protected LocalCacheScope localCacheScope = LocalCacheScope.SESSION;
@@ -192,6 +193,14 @@ public class Configuration {
 
     languageRegistry.setDefaultDriverClass(XMLLanguageDriver.class);
     languageRegistry.register(RawLanguageDriver.class);
+  }
+
+  public boolean isPrefixQueriesWithStatementId() {
+    return prefixQueriesWithStatementId;
+  }
+
+  public void setPrefixQueriesWithStatementId(boolean prefixQueriesWithStatementId) {
+    this.prefixQueriesWithStatementId = prefixQueriesWithStatementId;
   }
 
   public String getLogPrefix() {

--- a/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/AnnotatedMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/AnnotatedMapper.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright 2014 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.prefix_queries_with_statement_id;
+
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.SelectProvider;
+
+import java.util.Map;
+
+public interface AnnotatedMapper {
+  @Select("select * from users where id = #{id}")
+  User getUserUsingParameterMarker(Map<String, Object> parameterMap);
+
+  @Select("select * from users where id = ${id}")
+  User getUserUsingStringSubstitution(Map<String, Object> parameterMap);
+
+  @SelectProvider(type = UserSqlProvider.class, method = "getUserUsingDynamicSQL")
+  User getUserUsingDynamicSQL(Map<String, Object> parameterMap);
+
+  public static class UserSqlProvider {
+    public String getUserUsingDynamicSQL() {
+      return "select * from users where id = #{id}";
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/CreateDB.sql
@@ -1,0 +1,24 @@
+--
+--    Copyright 2009-2012 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(20)
+);
+
+insert into users (id, name) values(1, 'User1');

--- a/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/PrefixQueriesWithStatementIdTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/PrefixQueriesWithStatementIdTest.java
@@ -1,0 +1,115 @@
+/*
+ *    Copyright 2014 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.prefix_queries_with_statement_id;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PrefixQueriesWithStatementIdTest {
+  private static final String resourcesPath = "org/apache/ibatis/submitted/prefix_queries_with_statement_id/";
+  private static SqlSessionFactory sqlSessionFactory;
+  private static Map<String, String> expectationMap;
+  private static Map<String, Object> parameterMap;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    Reader reader = Resources.getResourceAsReader(resourcesPath + "mybatis-config.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
+
+    // populate in-memory database
+    SqlSession session = sqlSessionFactory.openSession();
+    Connection conn = session.getConnection();
+    reader = Resources.getResourceAsReader(resourcesPath + "CreateDB.sql");
+    ScriptRunner runner = new ScriptRunner(conn);
+    runner.setLogWriter(null);
+    runner.runScript(reader);
+    reader.close();
+    session.close();
+
+    // prepare expectation map
+    expectationMap = new HashMap<String, String>();
+    expectationMap.put("getUserUsingParameterMarker", "select * from users where id = ?");
+    expectationMap.put("getUserUsingStringSubstitution", "select * from users where id = 1");
+    expectationMap.put("getUserUsingDynamicSQL", "select * from users where id = ?");
+
+    // prepare parameter map
+    parameterMap = new HashMap<String, Object>();
+    parameterMap.put("id", 1);
+  }
+
+  @Test
+  public void shouldPrefixXmlBasedMappers() {
+    testPrefix("org.apache.ibatis.submitted.prefix_queries_with_statement_id.XmlBasedMapper");
+  }
+
+  @Test
+  public void shouldPrefixAnnotatedMappers() {
+    testPrefix("org.apache.ibatis.submitted.prefix_queries_with_statement_id.AnnotatedMapper");
+  }
+
+  private void testPrefix(String mapperNamespace) {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      for (Map.Entry<String, String> e : expectationMap.entrySet()) {
+        String statementId = mapperNamespace + "." + e.getKey();
+        String expected = "/* " + statementId + " */\n" + e.getValue();
+        String actual = sqlSession.getConfiguration().getMappedStatement(statementId).getBoundSql(parameterMap).getSql();
+        Assert.assertEquals(expected, actual.trim());
+      }
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldGetAUserThroughXmlBasedMapper() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      XmlBasedMapper mapper = sqlSession.getMapper(XmlBasedMapper.class);
+      Assert.assertEquals("User1", mapper.getUserUsingParameterMarker(parameterMap).getName());
+      Assert.assertEquals("User1", mapper.getUserUsingStringSubstitution(parameterMap).getName());
+      Assert.assertEquals("User1", mapper.getUserUsingDynamicSQL(parameterMap).getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldGetAUserThroughAnnotatedMapper() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      AnnotatedMapper mapper = sqlSession.getMapper(AnnotatedMapper.class);
+      Assert.assertEquals("User1", mapper.getUserUsingParameterMarker(parameterMap).getName());
+      Assert.assertEquals("User1", mapper.getUserUsingStringSubstitution(parameterMap).getName());
+      Assert.assertEquals("User1", mapper.getUserUsingDynamicSQL(parameterMap).getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/User.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright 2014 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.prefix_queries_with_statement_id;
+
+public class User {
+
+  private Integer id;
+  private String name;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/XmlBasedMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/XmlBasedMapper.java
@@ -1,0 +1,24 @@
+/*
+ *    Copyright 2014 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.prefix_queries_with_statement_id;
+
+import java.util.Map;
+
+public interface XmlBasedMapper {
+  User getUserUsingParameterMarker(Map<String, Object> parameterMap);
+  User getUserUsingStringSubstitution(Map<String, Object> parameterMap);
+  User getUserUsingDynamicSQL(Map<String, Object> parameterMap);
+}

--- a/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/XmlBasedMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/XmlBasedMapper.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+       Copyright 2014 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.prefix_queries_with_statement_id.XmlBasedMapper">
+
+	<select id="getUserUsingParameterMarker" resultType="org.apache.ibatis.submitted.prefix_queries_with_statement_id.User">
+		select * from users where id = #{id}
+	</select>
+
+    <select id="getUserUsingStringSubstitution" resultType="org.apache.ibatis.submitted.prefix_queries_with_statement_id.User">
+		select * from users where id = ${id}
+	</select>
+
+    <select id="getUserUsingDynamicSQL" resultType="org.apache.ibatis.submitted.prefix_queries_with_statement_id.User">
+        <if test="true">
+            select * from users where id = #{id}
+        </if>
+	</select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/prefix_queries_with_statement_id/mybatis-config.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+       Copyright 2014 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <settings>
+        <setting name="prefixQueriesWithStatementId" value="true"/>
+    </settings>
+
+	<environments default="development">
+		<environment id="development">
+			<transactionManager type="JDBC">
+				<property name="" value="" />
+			</transactionManager>
+			<dataSource type="UNPOOLED">
+				<property name="driver" value="org.hsqldb.jdbcDriver" />
+				<property name="url" value="jdbc:hsqldb:mem:basetest" />
+				<property name="username" value="sa" />
+			</dataSource>
+		</environment>
+	</environments>
+
+	<mappers>
+		<mapper class="org.apache.ibatis.submitted.prefix_queries_with_statement_id.XmlBasedMapper" />
+        <mapper class="org.apache.ibatis.submitted.prefix_queries_with_statement_id.AnnotatedMapper"/>
+	</mappers>
+
+</configuration>


### PR DESCRIPTION
Hi mybatis team,

I implemented a new setting "prefixQueriesWithStatementId" for XML configuration and would like to ask you to take a look and say your opinion.

This setting solves a problem which our team faced. We use mybatis in many applications, and all these apps have one more thing in common - they work with the same database. When you see the slow query log, it's not so easy to find out what application sent an inefficient query. This is the problem. I suggest adding a special comment to queries as a solution, and using statement id can help us.

Here is an example of mybatis-config.xml with the new feature

``` xml
<configuration>
    <settings>
        <setting name="prefixQueriesWithStatementId" value="true"/>
    </settings>
</configuration>
```

And if we have the following mapper configuration

``` xml
<mapper namespace="org.apache.ibatis.submitted.prefix_queries_with_statement_id.XmlBasedMapper">
    <select id="getUserUsingParameterMarker" resultType="org.apache.ibatis.submitted.prefix_queries_with_statement_id.User">
        select * from users where id = #{id}
    </select>
</mapper>
```

the query will be

``` sql
/* org.apache.ibatis.submitted.prefix_queries_with_statement_id.XmlBasedMapper.getUserUsingParameterMarker */
select * from users where id = ?
```

Please, let me know what do you think.
## 

Best wishes,
Vlad.
