### PR TITLE
Create stored procedures/functions in LineByLine execution mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 language: java
 jdk:
-  - oraclejdk7
-  - openjdk7
-  - openjdk6
+- oraclejdk7
+- openjdk7
+- openjdk6
 after_success:
-  - "mvn clean"
-  - "git clone -b travis `git config --get remote.origin.url` target/travis"
-  - "mvn deploy -Dmaven.test.skip=true --settings target/travis/settings.xml"
-
+- mvn clean
+- git clone -b travis `git config --get remote.origin.url` target/travis
+- mvn deploy -Dmaven.test.skip=true --settings target/travis/settings.xml
 branches:
   except:
-    - travis
-
+  - travis
 env:
   global:
-    - secure: "jWLfOryabB89R5v7nD3V/8ke6+B26UW8E5wjwKj7dDhjfmGUg+KbOShqWrq4\nEAnyE4GltwDLxKErZ5aAPWcT47C3GJYocKtmTcec2sblqMdVVUd3udylrM1d\n66Yb0XZoqri9JJ9pb8ObDp5XRV+ZQ5xP0w1gboNY6SynJg/1FKk="
-    - secure: "UV14rAITDqou5jObPInlIS3IYdf45LihGal9/+C4TLyhXLaVktbT/arFAAIF\ndpv9OM+YgeA7ZeRZLJ8vbgipO+rxizPNL1DqK1rp9s5B2F2y9+ir47nTwayL\n0RN7TgdswjzZZKOukWF2CVK1hjk+n8iFkCrorU22trmXlHc0aoE="
+  - secure: "V0GyQGPhAyyz/p5DQsnC8Ty4vn8VsVeOBtd1ameQ5K0j/pITgEIONHmee3xoVxpUufl26dhJUDG55p+xkNYYusSQkbXqT3qL4xkAonPeG7ED51xUBZM5LkXQ8cgxZnJqyFT4+FvDijwa5OGTxLyU0UGSwK0tjYt/I8jAaez7s7A="

--- a/src/main/java/org/apache/ibatis/jdbc/ScriptRunner.java
+++ b/src/main/java/org/apache/ibatis/jdbc/ScriptRunner.java
@@ -183,7 +183,7 @@ public class ScriptRunner {
       String line;
       final String endOfProcPattern = ("\\s*END(?:\\s+" + procName + ")?\\s*;$");
       Pattern endPattern = Pattern.compile(endOfProcPattern, Pattern.CASE_INSENSITIVE);
-      Pattern beginPattern = Pattern.compile("BEGIN(?:\\s+\\w+)", Pattern.CASE_INSENSITIVE);
+      Pattern beginPattern = Pattern.compile("BEGIN(?:\\s+\\w+)?", Pattern.CASE_INSENSITIVE);
       int blockCount = 0;
       boolean mainBlockStarted = false;
       

--- a/src/test/java/org/apache/ibatis/jdbc/CreateStoredProceduresAndFunctions.sql
+++ b/src/test/java/org/apache/ibatis/jdbc/CreateStoredProceduresAndFunctions.sql
@@ -1,0 +1,56 @@
+--
+--    Copyright 2009-2012 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+CREATE PROCEDURE GET_PRODUCT(IN name VARCHAR(100))
+  MODIFIES SQL DATA DYNAMIC RESULT SETS 1
+  BEGIN ATOMIC
+    DECLARE result CURSOR FOR SELECT * FROM product WHERE product.name = name;
+    
+    BEGIN ATOMIC
+    	DECLARE result2 CURSOR FOR SELECT * FROM product WHERE product.name like concat(name, '%');
+    	OPEN result2;
+    END;
+    
+    OPEN result;
+  END;
+  
+INSERT INTO product VALUES ('AV-XB-01','BIRDS','Amazon Parrot1','<image src="../images/bird2.gif">Great companion for up to 75 years');
+INSERT INTO product VALUES ('AV-XB-02','BIRDS','Amazon Parrot2','<image src="../images/bird2.gif">Great companion for up to 75 years');
+INSERT INTO product VALUES ('AV-XB-03','BIRDS','Amazon Parrot3','<image src="../images/bird2.gif">Great companion for up to 75 years');
+
+CREATE PROCEDURE delete_product(IN productId_p VARCHAR(80)) 
+ MODIFIES SQL DATA
+ BEGIN ATOMIC
+   DECLARE val_v    INTEGER;
+   DECLARE prodId_v VARCHAR(10);
+   
+   SET val_v = 0;
+  
+   FOR SELECT productId FROM product WHERE product.productId like productId_p DO
+     SET prodId_v = productId;
+     
+     DELETE FROM item WHERE item.productId = prodId_v;
+     DELETE FROM product WHERE product.productId = prodId_v;
+     SET val_v = val_v + 1;
+   END FOR;
+   
+ END;
+ 
+ 
+--CALL delete_product('AV-XB-%');
+
+
+
+ 


### PR DESCRIPTION
Recently I got into a situation where it was required to version control migration (using mybatis migrations) of stored procedures along with other scripts (a lot) containing both DDL and DML statements. 

Unfortunately, when "send_full_script" was enabled, it worked for the script with stored procedure, but failed other scripts with the same exception mentioned in https://code.google.com/p/mybatis/issues/detail?id=582

This modification in ScriptRunner facilitates the creation of stored procedures & functions with "send_full_script" disabled.

Please review and let me know if this is worthy to be included in a future release. Thanks!
