### PR TITLE
Bug when mapping use association and recursive SQL request

### DIFF
--- a/src/test/java/org/apache/ibatis/submitted/association_nested/Folder.java
+++ b/src/test/java/org/apache/ibatis/submitted/association_nested/Folder.java
@@ -1,0 +1,17 @@
+package org.apache.ibatis.submitted.association_nested;
+
+/**
+ * @author Loïc Guerrin <guerrin@fullsix.com>
+ */
+public class Folder {
+
+   public Long id;
+   public String name;
+
+   @Override
+   public String toString() {
+     return name;
+   }
+
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/association_nested/FolderFlatTree.java
+++ b/src/test/java/org/apache/ibatis/submitted/association_nested/FolderFlatTree.java
@@ -1,0 +1,18 @@
+package org.apache.ibatis.submitted.association_nested;
+
+/**
+ * @author Loïc Guerrin <guerrin@fullsix.com>
+ */
+public class FolderFlatTree {
+
+  public Folder root;
+  public Folder level1;
+  public Folder level2;
+
+  @Override
+  public String toString() {
+    return root
+            + "\n\t" + level1
+            + "\n\t\t" + level2;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/association_nested/FolderMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/association_nested/FolderMapper.java
@@ -1,0 +1,14 @@
+package org.apache.ibatis.submitted.association_nested;
+
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * @author Loïc Guerrin <guerrin@fullsix.com>
+ */
+public interface FolderMapper {
+
+  List<FolderFlatTree> findWithSubFolders(@Param("name") String name);
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/association_nested/FolderMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/association_nested/FolderMapper.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.submitted.association_nested.FolderMapper">
+
+  <resultMap id="folderResultMap" type="org.apache.ibatis.submitted.association_nested.FolderFlatTree">
+    <association property="root" javaType="org.apache.ibatis.submitted.association_nested.Folder">
+      <result property="id" column="id"/>
+      <result property="name" column="name"/>
+    </association>
+    <association property="level1" javaType="org.apache.ibatis.submitted.association_nested.Folder">
+      <result property="id" column="lvl1_id"/>
+      <result property="name" column="lvl1_name"/>
+    </association>
+    <association property="level2" javaType="org.apache.ibatis.submitted.association_nested.Folder">
+      <result property="id" column="lvl2_id"/>
+      <result property="name" column="lvl2_name"/>
+    </association>
+  </resultMap>
+
+
+  <select id="findWithSubFolders" resultMap="folderResultMap">
+		select f.id, f.name, f1.id as lvl1_id, f1.name as lvl1_name, f2.id as lvl2_id, f2.name as lvl2_name from folder f
+		left join folder f1 on f1.parent_id = f.id
+		left join folder f2 on f2.parent_id = f1.id
+		where name = #{name}
+		order by f.id, f1.id, f2.id
+	</select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/association_nested/FolderMapperTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/association_nested/FolderMapperTest.java
@@ -1,0 +1,61 @@
+package org.apache.ibatis.submitted.association_nested;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.List;
+
+/**
+ * @author Loïc Guerrin <guerrin@fullsix.com>
+ */
+public class FolderMapperTest {
+
+  @Test
+  public void testFindWithChildren() throws Exception {
+    Connection conn = DriverManager.getConnection("jdbc:hsqldb:mem:association_nested", "SA", "");
+    Statement stmt = conn.createStatement();
+    stmt.execute("create table folder (id int, name varchar(100), parent_id int)");
+
+
+    stmt.execute("insert into folder (id, name) values(1, 'Root')");
+    stmt.execute("insert into folder values(2, 'Folder 1', 1)");
+    stmt.execute("insert into folder values(3, 'Folder 2', 1)");
+    stmt.execute("insert into folder values(4, 'Folder 2_1', 3)");
+    stmt.execute("insert into folder values(5, 'Folder 2_2', 3)");
+
+    /**
+     * Root/
+     *    Folder 1/
+     *    Folder 2/
+     *      Folder 2_2
+     */
+
+
+    String resource = "org/apache/ibatis/submitted/association_nested/mybatis-config.xml";
+    InputStream inputStream = Resources.getResourceAsStream(resource);
+    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream);
+
+    SqlSession session = sqlSessionFactory.openSession();
+    FolderMapper postMapper = session.getMapper(FolderMapper.class);
+
+    List<FolderFlatTree> folders = postMapper.findWithSubFolders("Root");
+
+    for (FolderFlatTree folder : folders) {
+      System.out.println(folder);
+      System.out.println("=================================");
+    }
+
+    Assert.assertEquals(3, folders.size());
+
+    session.close();
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/association_nested/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/association_nested/mybatis-config.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN" "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+	<environments default="development">
+		<environment id="development">
+			<transactionManager type="JDBC" />
+			<dataSource type="POOLED">
+				<property name="driver" value="org.hsqldb.jdbc.JDBCDriver" />
+				<property name="url" value="jdbc:hsqldb:mem:association_nested" />
+				<property name="username" value="SA" />
+				<property name="password" value="" />
+			</dataSource>
+		</environment>
+	</environments>
+	<mappers>
+		<mapper class="org.apache.ibatis.submitted.association_nested.FolderMapper" />
+	</mappers>
+</configuration>


### PR DESCRIPTION
Hi,

I think there is a bug where a mapper use association, and sql query use join on same table.
The same test with mybatis 3.1.1 is ok.

But when upgrade to mybatis 3.2.7, the test fails: expect a list of three elements but only one is present: the last of the resultset.

The bug is similar to issue 215, but here the resultMap is not recursive.
