### PR TITLE
When insert a list or array,resolve the useGeneratedKeys error.

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
+++ b/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
@@ -99,7 +99,7 @@ public class Jdbc3KeyGenerator implements KeyGenerator {
       } else if (parameterMap.containsKey("list")) {
         parameters = (Collection) parameterMap.get("list");
       } else if (parameterMap.containsKey("array")) {
-        parameters = Arrays.asList(parameterMap.get("array"));
+        parameters = Arrays.asList((Object[])parameterMap.get("array"));
       }
     }
     if (parameters == null) {


### PR DESCRIPTION
When insert a list or array,resolve the useGeneratedKeys error.
# The Sample:

Mapper.xml File:

``` xml
<insert id="insertAll" keyProperty="id" useGeneratedKeys="true">
  insert into country(countryname,countrycode)
  VALUES
  <foreach collection="list" item="country" separator=",">
    (#{country.countryname},#{country.countrycode})
  </foreach>
</insert>
```

The Java code File:

``` java
List<Country> countryList = new ArrayList<Country>();
Country country = new Country();
country.setCountryname("Name1");
country.setCountrycode("N1");
countryList.add(country);

country = new Country();
country.setCountryname("Name2");
country.setCountrycode("N2");
countryList.add(country);

country = new Country();
country.setCountryname("Name3");
country.setCountrycode("N3");
countryList.add(country);

country = new Country();
country.setCountryname("Name4");
country.setCountrycode("N4");
countryList.add(country);
//ERROR:
//Caused by: org.apache.ibatis.binding.BindingException: 
//Parameter 'id' not found. Available parameters are [list]
int result = sqlSession.insert("insertAll",countryList);

for (Country country1 : countryList) {
    System.out.println(country1.getId());
}
```
# Solution

Add a method to handle the parameters:

``` java
private Collection<Object> getParameters(Object parameter)
```

Add a first Key `keys`,and then developer can use `keys` to specify the reveive param.

If not specif,find `list`or`array`.If not existed,use the `parameter` only.

**Note**:use `Collection`support more than `List`,like `Set`.
