### PR TITLE
Support insert multiple rows and write-back id.More about insert multipl...

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
+++ b/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
@@ -15,13 +15,6 @@
  */
 package org.apache.ibatis.executor.keygen;
 
-import java.sql.ResultSet;
-import java.sql.ResultSetMetaData;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.executor.ExecutorException;
 import org.apache.ibatis.mapping.MappedStatement;
@@ -29,6 +22,12 @@ import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
 
 /**
  * @author Clinton Begin
@@ -42,12 +41,10 @@ public class Jdbc3KeyGenerator implements KeyGenerator {
 
   @Override
   public void processAfter(Executor executor, MappedStatement ms, Statement stmt, Object parameter) {
-    List<Object> parameters = new ArrayList<Object>();
-    parameters.add(parameter);
-    processBatch(ms, stmt, parameters);
+    processBatch(ms, stmt, getParameters(parameter));
   }
 
-  public void processBatch(MappedStatement ms, Statement stmt, List<Object> parameters) {
+  public void processBatch(MappedStatement ms, Statement stmt, Collection<Object> parameters) {
     ResultSet rs = null;
     try {
       rs = stmt.getGeneratedKeys();
@@ -80,6 +77,27 @@ public class Jdbc3KeyGenerator implements KeyGenerator {
         }
       }
     }
+  }
+
+  private Collection<Object> getParameters(Object parameter) {
+    Collection<Object> parameters = null;
+    if (parameter instanceof Collection) {
+      parameters = (Collection) parameter;
+    } else if (parameter instanceof Map) {
+      Map parameterMap = (Map) parameter;
+      if (parameterMap.containsKey("collection")) {
+        parameters = (Collection) parameterMap.get("collection");
+      } else if (parameterMap.containsKey("list")) {
+        parameters = (List) parameterMap.get("list");
+      } else if (parameterMap.containsKey("array")) {
+        parameters = Arrays.asList((Object[])parameterMap.get("array"));
+      }
+    }
+    if (parameters == null) {
+      parameters = new ArrayList<Object>();
+      parameters.add(parameter);
+    }
+    return parameters;
   }
 
   private TypeHandler<?>[] getTypeHandlers(TypeHandlerRegistry typeHandlerRegistry, MetaObject metaParam, String[] keyProperties) {


### PR DESCRIPTION
Support insert multiple rows and write-back id.

Multirow inserts

A SQL feature (since SQL-92) is the use of row value constructors to insert multiple rows at a time in a single SQL statement:

```sql
INSERT INTO tablename (column-a, [column-b, ...])
VALUES ('value-1a', ['value-1b', ...]),
       ('value-2a', ['value-2b', ...]),
       ...
```

This feature is supported by DB2, SQL Server (since version 10.0 - i.e. 2008), PostgreSQL (since version 8.2), MySQL, sqlite (since version 3.7.11) and H2.

More about insert see here:

>http://en.wikipedia.org/wiki/Insert_(SQL)

More details of this pull request see here: https://github.com/mybatis/mybatis-3/pull/324