### PR TITLE
[3.2.x] #356: Support flush statements via Mapper interface

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/Flush.java
+++ b/src/main/java/org/apache/ibatis/annotations/Flush.java
@@ -1,5 +1,5 @@
-/*
- *    Copyright 2009-2012 the original author or authors.
+/**
+ *    Copyright 2009-2015 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,11 +13,19 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.mapping;
+package org.apache.ibatis.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * @author Clinton Begin
+ * The maker annotation that invoke a flush statements via Mapper interface.
+ *
+ * @author Kazuki Shimizu
  */
-public enum SqlCommandType {
-  UNKNOWN, INSERT, UPDATE, DELETE, SELECT, FLUSH;
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Flush {
 }

--- a/src/main/java/org/apache/ibatis/binding/MapperMethod.java
+++ b/src/main/java/org/apache/ibatis/binding/MapperMethod.java
@@ -15,6 +15,7 @@
  */
 package org.apache.ibatis.binding;
 
+import org.apache.ibatis.annotations.Flush;
 import org.apache.ibatis.annotations.MapKey;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.mapping.MappedStatement;
@@ -67,6 +68,8 @@ public class MapperMethod {
         Object param = method.convertArgsToSqlCommandParam(args);
         result = sqlSession.selectOne(command.getName(), param);
       }
+    } else if (SqlCommandType.FLUSH == command.getType()) {
+        result = sqlSession.flushStatements();
     } else {
       throw new BindingException("Unknown execution method for: " + command.getName());
     }
@@ -186,12 +189,18 @@ public class MapperMethod {
         }
       }
       if (ms == null) {
-        throw new BindingException("Invalid bound statement (not found): " + statementName);
-      }
-      name = ms.getId();
-      type = ms.getSqlCommandType();
-      if (type == SqlCommandType.UNKNOWN) {
-        throw new BindingException("Unknown execution method for: " + name);
+        if(method.getAnnotation(Flush.class) != null){
+          name = null;
+          type = SqlCommandType.FLUSH;
+        } else {
+          throw new BindingException("Invalid bound statement (not found): " + statementName);
+        }
+      } else {
+        name = ms.getId();
+        type = ms.getSqlCommandType();
+        if (type == SqlCommandType.UNKNOWN) {
+          throw new BindingException("Unknown execution method for: " + name);
+        }
       }
     }
 

--- a/src/test/java/org/apache/ibatis/binding/BoundAuthorMapper.java
+++ b/src/test/java/org/apache/ibatis/binding/BoundAuthorMapper.java
@@ -19,6 +19,10 @@ import domain.blog.Author;
 import domain.blog.Post;
 import domain.blog.Section;
 import org.apache.ibatis.annotations.*;
+import domain.blog.Author;
+import domain.blog.Post;
+import domain.blog.Section;
+import org.apache.ibatis.executor.BatchResult;
 import org.apache.ibatis.session.RowBounds;
 
 import java.util.List;
@@ -88,4 +92,8 @@ public interface BoundAuthorMapper {
                                     RowBounds rowBounds,
                                     @Param("two") int two,
                                     int three);
+
+  @Flush
+  List<BatchResult> flush();
+
 }

--- a/src/test/java/org/apache/ibatis/binding/FlushTest.java
+++ b/src/test/java/org/apache/ibatis/binding/FlushTest.java
@@ -1,0 +1,93 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.binding;
+
+import org.apache.ibatis.BaseDataTest;
+import domain.blog.Author;
+import domain.blog.Post;
+import domain.blog.Section;
+import org.apache.ibatis.executor.BatchResult;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.*;
+import org.apache.ibatis.transaction.TransactionFactory;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.sql.DataSource;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+public class FlushTest {
+    private static SqlSessionFactory sqlSessionFactory;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        DataSource dataSource = BaseDataTest.createBlogDataSource();
+        TransactionFactory transactionFactory = new JdbcTransactionFactory();
+        Environment environment = new Environment("Production", transactionFactory, dataSource);
+        Configuration configuration = new Configuration(environment);
+        configuration.setDefaultExecutorType(ExecutorType.BATCH);
+        configuration.getTypeAliasRegistry().registerAlias(Post.class);
+        configuration.getTypeAliasRegistry().registerAlias(Author.class);
+        configuration.addMapper(BoundAuthorMapper.class);
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+    }
+
+    @Test
+    public void invokeFlushStatementsViaMapper() {
+
+        SqlSession session = sqlSessionFactory.openSession();
+
+        try {
+
+            BoundAuthorMapper mapper = session.getMapper(BoundAuthorMapper.class);
+            Author author = new Author(-1, "cbegin", "******", "cbegin@nowhere.com", "N/A", Section.NEWS);
+            List<Integer> ids = new ArrayList<Integer>();
+            mapper.insertAuthor(author);
+            ids.add(author.getId());
+            mapper.insertAuthor(author);
+            ids.add(author.getId());
+            mapper.insertAuthor(author);
+            ids.add(author.getId());
+            mapper.insertAuthor(author);
+            ids.add(author.getId());
+            mapper.insertAuthor(author);
+            ids.add(author.getId());
+
+            // test
+            List<BatchResult> results = mapper.flush();
+
+            assertThat(results.size(), is(1));
+            assertThat(results.get(0).getUpdateCounts().length, is(ids.size()));
+
+            for (int id : ids) {
+                Author selectedAuthor = mapper.selectAuthor(id);
+                assertNotNull(id + " is not found.", selectedAuthor);
+            }
+
+            session.rollback();
+        } finally {
+            session.close();
+        }
+
+    }
+
+}


### PR DESCRIPTION
(cherry picked from commit 56198b2aec73631b3fc0520405bc5a175c9e8c7a)

Note: Conflicts resolve by manually.

Conflicts:
    src/test/java/org/apache/ibatis/binding/BoundAuthorMapper.java

Backport to 3.2.x.
Please review #356 .