### PR TITLE
mybatis #355 PL/SQL is not fully suppported

### DIFF
--- a/src/main/java/org/apache/ibatis/jdbc/ScriptRunner.java
+++ b/src/main/java/org/apache/ibatis/jdbc/ScriptRunner.java
@@ -187,9 +187,9 @@ public class ScriptRunner {
   private StringBuilder handleLine(StringBuilder command, String line) throws SQLException, UnsupportedEncodingException {
     String trimmedLine = line.trim();
     if (lineIsComment(trimmedLine)) {
-        final String cleanedString = trimmedLine.substring(2).trim();
-        if(cleanedString.toUpperCase().startsWith("//@DELIMITER")) {
-            delimiter = cleanedString.substring(13,14);
+        final String cleanedString = trimmedLine.substring(2).trim().replaceFirst("//", "");
+        if(cleanedString.toUpperCase().startsWith("@DELIMITER")) {
+            delimiter = cleanedString.substring(11,12);
             return command;
         }
       println(trimmedLine);


### PR DESCRIPTION
fix for using #355 with mybatis-migrations
MigrationReader does  line.replaceFirst("--\\s*//", "-- ");
so we need to be prepared for that