### PR TITLE
Update Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <dependency>
       <groupId>ognl</groupId>
       <artifactId>ognl</artifactId>
-      <version>3.0.8</version>
+      <version>3.0.11</version>
       <scope>provided</scope>
       <optional>true</optional>
       <exclusions>
@@ -147,6 +147,7 @@
          </exclusion>
       </exclusions>
     </dependency>
+    <!-- 3.19.0 causes significant failures in unit tests.  Review why... -->
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
@@ -157,13 +158,13 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.10</version>
+      <version>1.7.12</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.10</version>
+      <version>1.7.12</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -175,7 +176,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.1</version>
+      <version>2.2</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
ognl to 3.0.11 -> this might be speeding things up as I"ve seen one test
fail due to expected timings being faster now.  Will monitor.
slf4j to 1.7.12
log4j 2 to 2.2
Note about javassist not being updated.