### PR TITLE
fix foreach bug : non-prefixed item should not bind to context

### DIFF
--- a/src/main/java/org/apache/ibatis/scripting/xmltags/ForEachSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/ForEachSqlNode.java
@@ -99,7 +99,6 @@ public class ForEachSqlNode implements SqlNode {
 
   private void applyItem(DynamicContext context, Object o, int i) {
     if (item != null) {
-      context.bind(item, o);
       context.bind(itemizeItem(item, i), o);
     }
   }


### PR DESCRIPTION
Here is a [demo](https://github.com/Youmoo/mybatis-foreach-bug) to reproduce the bug.
Due to the bug, The two following xmls result in different results(which are supposed to be identical):
```xml
<select id="flavorOne" resultType="mybatis.TestModal">
        select id,bill_no as billNo from test
        <where>
            <trim suffixOverrides=",">
                <if test="id!=null">
                    id=#{id},
                </if>
                <if test="idList!=null">
                    and id in
                    <foreach collection="idList" item="id" open="(" close=")" separator=",">
                        #{id}
                    </foreach>
                </if>
            </trim>
        </where>
    </select>
```
vs
```xml

    <select id="flavorTwo" resultType="mybatis.TestModal">
        select id,bill_no as billNo from test
        <where>
            <trim suffixOverrides=",">
                <if test="idList!=null">
                    id in
                    <foreach collection="idList" item="id" open="(" close=")" separator=",">
                        #{id}
                    </foreach>
                </if>
                <if test="id!=null">
                    and id=#{id},
                </if>
            </trim>
        </where>
    </select>
```
