### PR TITLE
Remove cobertura and site deploy changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,8 +119,9 @@
   </ciManagement>
   <distributionManagement>
     <site>
-      <id>github</id>
-      <url>gitsite:git@github.com/mybatis/mybatis-3.git</url>
+      <id>gh-pages</id>
+      <name>Mybatis GitHub Pages</name>
+      <url>git:ssh://git@github.com/mybatis/mybatis-3.git?gh-pages#</url>
     </site>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.19.0-GA</version>
+      <version>3.20.0-GA</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
@@ -303,8 +303,8 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <configuration>
-			<exclude>org.apache.ibatis.ognl.*</exclude>
-			<exclude>org.apache.ibatis.javassist.*</exclude>
+          <exclude>org.apache.ibatis.ognl.*</exclude>
+          <exclude>org.apache.ibatis.javassist.*</exclude>
         </configuration>
       </plugin>      
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -306,29 +306,6 @@
           <exclude>org.apache.ibatis.ognl.*</exclude>
           <exclude>org.apache.ibatis.javassist.*</exclude>
         </configuration>
-      </plugin>      
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <configuration>
-          <instrumentation>
-            <ignores>
-              <ignore>org.apache.ibatis.ognl.*</ignore>
-              <ignore>org.apache.ibatis.javassist.*</ignore>
-            </ignores>
-            <excludes>
-              <exclude>org/apache/ibatis/ognl/**/*.class</exclude>
-              <exclude>org/apache/ibatis/javassist/**/*.class</exclude>
-            </excludes>
-          </instrumentation>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <site>
       <id>gh-pages</id>
       <name>Mybatis GitHub Pages</name>
-      <url>git:ssh://git@github.com/mybatis/mybatis-3.git?gh-pages#</url>
+      <url>github:ssh://mybatis.github.io/mybatis-3/</url>
     </site>
   </distributionManagement>
 


### PR DESCRIPTION
Before merging this in, this needs a slight discussion.  With cobertura being removed and site deploy changing, its important every mybatis module get the updates all at once.  Initially, I'm putting up the parent and mybatis-3.  Once these are approved as go forwards, I'll go through remainder and start merging them all at once.

Check out usage of 'mvn site:deploy' as done to the following to verify this is what is needed.

http://hazendaz.github.io/parent/
http://hazendaz.github.io/mybatis-3/

The above are on my fork.  The real PR will be targetted for mybatis gh-pages.

The steps to perform this are pretty simple.

'mvn site' will continue to build the site out and should be run before a deploy.  This is local only.
'mvn site:deploy' will deploy out to mybatis gh site pages.

In .m2/settings.xml, this is required in order to pull this off.  There are other options so see the main website for the new plugin.  In this case below it assumes ssh usage which is exactly how i've setup the parent & mybatis-3.
    <server>
      <id>gh-pages</id>
      <password>SOME_SSH_PASSWORD_HERE</password>
    </server>

Plugin site is here for learning how this works.

https://github.com/trajano/wagon-git

Now the good stuff.  Last full mybatis site was released it sounded like that took many hours to accomplish.  With this method, it took 6 minutes 43 seconds.  Timings may very but this is significantly faster and required me to do nothing more than issue the commands I mentioned in a git shell.

Now for cobertura.  Removal of this in parent pretty much means we need to do this across the board at once.  Not doing so runs into maven warnings and build issues becuase of configurations without versions and skipped steps.  So it is best to just get this out all at once.

As soon as both the parent and mybatis-3 are verified, I'll spin through all the same day and merge them on my own.  Until then, please just review.