### PR TITLE
EnumOrdinalTypeHandler register issue

### DIFF
--- a/src/main/java/org/apache/ibatis/type/EnumOrdinalTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/EnumOrdinalTypeHandler.java
@@ -39,6 +39,10 @@ public class EnumOrdinalTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E
     }
   }
 
+  public Class<E> getType() {
+    return type;
+  }
+
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, E parameter, JdbcType jdbcType) throws SQLException {
     ps.setInt(i, parameter.ordinal());

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -255,6 +255,10 @@ public final class TypeHandlerRegistry {
     if (javaType != null) {
       Map<JdbcType, TypeHandler<?>> map = TYPE_HANDLER_MAP.get(javaType);
       if (map == null) {
+        if (handler instanceof EnumOrdinalTypeHandler) {
+          EnumOrdinalTypeHandler enumOrdinalTypeHandler = (EnumOrdinalTypeHandler) handler;
+          javaType = enumOrdinalTypeHandler.getType();
+        }
         map = new HashMap<JdbcType, TypeHandler<?>>();
         TYPE_HANDLER_MAP.put(javaType, map);
       }

--- a/src/test/java/org/apache/ibatis/type/TypeHandlerRegistryTest.java
+++ b/src/test/java/org/apache/ibatis/type/TypeHandlerRegistryTest.java
@@ -28,12 +28,24 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.ibatis.domain.misc.RichType;
-import org.junit.Ignore;
+import org.apache.ibatis.mapping.FetchType;
+import org.apache.ibatis.session.ExecutorType;
 import org.junit.Test;
 
 public class TypeHandlerRegistryTest {
 
   private TypeHandlerRegistry typeHandlerRegistry = new TypeHandlerRegistry();
+
+  @Test
+  public void shouldRegisterEnumOrdinalTypeHandler() {
+    EnumOrdinalTypeHandler<FetchType> FetchTypeEnumHandler = new EnumOrdinalTypeHandler<FetchType>(FetchType.class);
+    typeHandlerRegistry.register(FetchTypeEnumHandler);
+    EnumOrdinalTypeHandler<ExecutorType> ExecutorTypeEnumHanler = new EnumOrdinalTypeHandler<ExecutorType>(ExecutorType.class);
+    typeHandlerRegistry.register(ExecutorTypeEnumHanler);
+
+    assertEquals(FetchTypeEnumHandler, typeHandlerRegistry.getTypeHandler(FetchType.class));
+    assertEquals(ExecutorTypeEnumHanler, typeHandlerRegistry.getTypeHandler(ExecutorType.class));
+  }
 
   @Test
   public void shouldRegisterAndRetrieveTypeHandler() {

--- a/src/test/java/org/apache/ibatis/type/TypeHandlerRegistryTest.java
+++ b/src/test/java/org/apache/ibatis/type/TypeHandlerRegistryTest.java
@@ -38,13 +38,13 @@ public class TypeHandlerRegistryTest {
 
   @Test
   public void shouldRegisterEnumOrdinalTypeHandler() {
-    EnumOrdinalTypeHandler<FetchType> FetchTypeEnumHandler = new EnumOrdinalTypeHandler<FetchType>(FetchType.class);
-    typeHandlerRegistry.register(FetchTypeEnumHandler);
-    EnumOrdinalTypeHandler<ExecutorType> ExecutorTypeEnumHanler = new EnumOrdinalTypeHandler<ExecutorType>(ExecutorType.class);
-    typeHandlerRegistry.register(ExecutorTypeEnumHanler);
+    EnumOrdinalTypeHandler<FetchType> fetchTypeEnumHandler = new EnumOrdinalTypeHandler<FetchType>(FetchType.class);
+    typeHandlerRegistry.register(fetchTypeEnumHandler);
+    EnumOrdinalTypeHandler<ExecutorType> executorTypeEnumHanler = new EnumOrdinalTypeHandler<ExecutorType>(ExecutorType.class);
+    typeHandlerRegistry.register(executorTypeEnumHanler);
 
-    assertEquals(FetchTypeEnumHandler, typeHandlerRegistry.getTypeHandler(FetchType.class));
-    assertEquals(ExecutorTypeEnumHanler, typeHandlerRegistry.getTypeHandler(ExecutorType.class));
+    assertEquals(fetchTypeEnumHandler, typeHandlerRegistry.getTypeHandler(FetchType.class));
+    assertEquals(executorTypeEnumHanler, typeHandlerRegistry.getTypeHandler(ExecutorType.class));
   }
 
   @Test


### PR DESCRIPTION
Using TypeHandlerRegistry register to the EnumOrdinalTypeHandler, will make a  `{E : HashMap}` in `TypeHandlerRegistry.TYPE_HANDLER_MAP`

```
    EnumOrdinalTypeHandler<FetchType> fetchTypeEnumHandler = new EnumOrdinalTypeHandler<FetchType>(FetchType.class);
    TypeReference<FetchType> typeReference = (TypeReference<FetchType>) fetchTypeEnumHandler;
    System.out.println(typeReference.getRawType());  // TypeVariableImpl E
```

which make many EnumOrdinalTypeHandler registry once, and that one can't not be found By `typeHandlerRegistry.getTypeHandler(SomeEnum.class)`, I make a quick fix, hope there are some elgant way to fix it.