### PR TITLE
Add explanations for defaultFetchSize in documentation

### DIFF
--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -228,6 +228,21 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
             </tr>
             <tr>
               <td>
+                defaultFetchSize
+              </td>
+              <td>
+                Sets the driver a hint as to control fetching size for return results.
+                This parameter value can be override by a query setting.
+              </td>
+              <td>
+                Cualquier entero positivo
+              </td>
+              <td>
+                Sin valor (null)
+              </td>
+            </tr>
+            <tr>
+              <td>
                 safeRowBoundsEnabled
               </td>
               <td>Habilita el uso de RowBounds en statements anidados.
@@ -384,6 +399,7 @@ A continuación se muestra un ejemplo del elemento settings al completo:
   <setting name="autoMappingBehavior" value="PARTIAL"/>
   <setting name="defaultExecutorType" value="SIMPLE"/>
   <setting name="defaultStatementTimeout" value="25"/>
+  <setting name="defaultFetchSize" value="100"/>
   <setting name="safeRowBoundsEnabled" value="false"/>
   <setting name="mapUnderscoreToCamelCase" value="false"/>
   <setting name="localCacheScope" value="SESSION"/>

--- a/src/site/ja/xdoc/configuration.xml
+++ b/src/site/ja/xdoc/configuration.xml
@@ -259,6 +259,21 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
             </tr>
             <tr>
               <td>
+                defaultFetchSize
+              </td>
+              <td>
+                検索結果のフェッチサイズを制御するためのドライバヒントを設定します。
+                このパラメータ値はクエリ毎の設定で上書きできます。
+              </td>
+              <td>
+                正の整数
+              </td>
+              <td>
+                なし (null)
+              </td>
+            </tr>
+            <tr>
+              <td>
                 safeRowBoundsEnabled
               </td>
               <td>
@@ -414,6 +429,7 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
   <setting name="autoMappingBehavior" value="PARTIAL"/>
   <setting name="defaultExecutorType" value="SIMPLE"/>
   <setting name="defaultStatementTimeout" value="25"/>
+  <setting name="defaultFetchSize" value="100"/>
   <setting name="safeRowBoundsEnabled" value="false"/>
   <setting name="mapUnderscoreToCamelCase" value="false"/>
   <setting name="localCacheScope" value="SESSION"/>

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -211,6 +211,21 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
             </tr>
             <tr>
               <td>
+                defaultFetchSize
+              </td>
+              <td>
+                Sets the driver a hint as to control fetching size for return results.
+                This parameter value can be override by a query setting.
+              </td>
+              <td>
+                양수
+              </td>
+              <td>
+                셋팅되지 않음(null)
+              </td>
+            </tr>
+            <tr>
+              <td>
                 safeRowBoundsEnabled
               </td>
               <td>
@@ -367,6 +382,7 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
   <setting name="autoMappingBehavior" value="PARTIAL"/>
   <setting name="defaultExecutorType" value="SIMPLE"/>
   <setting name="defaultStatementTimeout" value="25"/>
+  <setting name="defaultFetchSize" value="100"/>
   <setting name="safeRowBoundsEnabled" value="false"/>
   <setting name="mapUnderscoreToCamelCase" value="false"/>
   <setting name="localCacheScope" value="SESSION"/>

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -317,6 +317,21 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
             </tr>
             <tr>
               <td>
+                defaultFetchSize
+              </td>
+              <td>
+                Sets the driver a hint as to control fetching size for return results.
+                This parameter value can be override by a query setting.
+              </td>
+              <td>
+                Any positive integer
+              </td>
+              <td>
+                Not Set (null)
+              </td>
+            </tr>
+            <tr>
+              <td>
                 safeRowBoundsEnabled
               </td>
               <td>
@@ -476,6 +491,7 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
   <setting name="autoMappingBehavior" value="PARTIAL"/>
   <setting name="defaultExecutorType" value="SIMPLE"/>
   <setting name="defaultStatementTimeout" value="25"/>
+  <setting name="defaultFetchSize" value="100"/>
   <setting name="safeRowBoundsEnabled" value="false"/>
   <setting name="mapUnderscoreToCamelCase" value="false"/>
   <setting name="localCacheScope" value="SESSION"/>

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -240,6 +240,21 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
             </tr>
             <tr>
               <td>
+                defaultFetchSize
+              </td>
+              <td>
+                Sets the driver a hint as to control fetching size for return results.
+                This parameter value can be override by a query setting.
+              </td>
+              <td>
+                Any positive integer
+              </td>
+              <td>
+                Not Set (null)
+              </td>
+            </tr>
+            <tr>
+              <td>
                 safeRowBoundsEnabled
               </td>
               <td>
@@ -395,6 +410,7 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
   <setting name="autoMappingBehavior" value="PARTIAL"/>
   <setting name="defaultExecutorType" value="SIMPLE"/>
   <setting name="defaultStatementTimeout" value="25"/>
+  <setting name="defaultFetchSize" value="100"/>
   <setting name="safeRowBoundsEnabled" value="false"/>
   <setting name="mapUnderscoreToCamelCase" value="false"/>
   <setting name="localCacheScope" value="SESSION"/>


### PR DESCRIPTION
I've improve documentation for `defaultFetchSize`. 
Please check it.

**Note:**
* There may be wrong grammars and expressions because English is not good.
* Translation is Japanese only.
