### PR TITLE
Cursor implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </parent>
 
   <artifactId>mybatis</artifactId>
-  <version>3.3.1-SNAPSHOT</version>
+  <version>3.4.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>mybatis</name>

--- a/src/main/java/org/apache/ibatis/cursor/Cursor.java
+++ b/src/main/java/org/apache/ibatis/cursor/Cursor.java
@@ -1,0 +1,45 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.cursor;
+
+import java.io.Closeable;
+
+/**
+ * Cursor contract to handle fetching items lazily using an Iterator.
+ * Cursors are a perfect fit to handle millions of items queries that would not normally fits in memory.
+ * Cursor SQL queries must be ordered (resultOrdered="true") using the id columns of the resultMap.
+ *
+ * @author Guillaume Darmont / guillaume@dropinocean.com
+ */
+public interface Cursor<T> extends Closeable, Iterable<T> {
+
+    /**
+     * @return true if the cursor has started to fetch items from database.
+     */
+    boolean isOpen();
+
+    /**
+     *
+     * @return true if the cursor is fully consumed and has returned all elements matching the query.
+     */
+    boolean isConsumed();
+
+    /**
+     * Get the current item index. The first item has the index 0.
+     * @return -1 if the cursor is not open and has not been consumed. The index of the current item retrieved.
+     */
+    int getCurrentIndex();
+}

--- a/src/main/java/org/apache/ibatis/cursor/defaults/DefaultCursor.java
+++ b/src/main/java/org/apache/ibatis/cursor/defaults/DefaultCursor.java
@@ -1,0 +1,189 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.cursor.defaults;
+
+import org.apache.ibatis.cursor.Cursor;
+import org.apache.ibatis.executor.resultset.DefaultResultSetHandler;
+import org.apache.ibatis.executor.resultset.ResultSetWrapper;
+import org.apache.ibatis.mapping.ResultMap;
+import org.apache.ibatis.session.ResultContext;
+import org.apache.ibatis.session.ResultHandler;
+import org.apache.ibatis.session.RowBounds;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * @author Guillaume Darmont / guillaume@dropinocean.com
+ */
+public class DefaultCursor<T> implements Cursor<T> {
+
+    // ResultSetHandler stuff
+    private final DefaultResultSetHandler resultSetHandler;
+    private final ResultMap resultMap;
+    private final ResultSetWrapper rsw;
+    private final RowBounds rowBounds;
+    private final ObjectWrapperResultHandler<T> objectWrapperResultHandler = new ObjectWrapperResultHandler<T>();
+
+    private int currentIndex = -1;
+
+    private boolean iteratorAlreadyOpened = false;
+
+    private boolean opened = false;
+
+    private boolean resultSetConsumed = false;
+
+    public DefaultCursor(DefaultResultSetHandler resultSetHandler, ResultMap resultMap, ResultSetWrapper rsw, RowBounds rowBounds) {
+        this.resultSetHandler = resultSetHandler;
+        this.resultMap = resultMap;
+        this.rsw = rsw;
+        this.rowBounds = rowBounds;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return opened;
+    }
+
+    @Override
+    public boolean isConsumed() {
+        return resultSetConsumed;
+    }
+
+    @Override
+    public int getCurrentIndex() {
+        return currentIndex;
+    }
+
+    @Override
+    public Iterator<T> iterator() {
+        return new CursorIterator();
+    }
+
+    @Override
+    public void close() {
+        ResultSet rs = rsw.getResultSet();
+        try {
+            if (rs != null) {
+                Statement statement = rs.getStatement();
+
+                rs.close();
+                if (statement != null) {
+                    statement.close();
+                }
+            }
+            opened = false;
+        } catch (SQLException e) {
+            // ignore
+        }
+    }
+
+    protected T fetchNextUsingRowBound() {
+        T result = fetchNextObjectFromDatabase();
+        while (currentIndex < rowBounds.getOffset()) {
+            result = fetchNextObjectFromDatabase();
+        }
+        return result;
+    }
+
+    protected T fetchNextObjectFromDatabase() {
+        if (resultSetConsumed) {
+            return null;
+        }
+
+        try {
+            opened = true;
+            resultSetHandler.handleRowValues(rsw, resultMap, objectWrapperResultHandler, RowBounds.DEFAULT, null);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+
+        T next = objectWrapperResultHandler.result;
+        if (next != null) {
+            currentIndex++;
+        }
+        // No more object or limit reached
+        if (next == null || (getReadItemsCount() == rowBounds.getOffset() + rowBounds.getLimit())) {
+            close();
+            resultSetConsumed = true;
+        }
+        objectWrapperResultHandler.result = null;
+
+        return next;
+    }
+
+    private int getReadItemsCount() {
+        return currentIndex + 1;
+    }
+
+    private static class ObjectWrapperResultHandler<E> implements ResultHandler {
+
+        private E result;
+
+        @Override
+        public void handleResult(ResultContext context) {
+            this.result = (E) context.getResultObject();
+            context.stop();
+        }
+    }
+
+    private class CursorIterator implements Iterator<T> {
+
+        /**
+         * Holder for the next objet to be returned
+         */
+        T object;
+
+        public CursorIterator() {
+            if (iteratorAlreadyOpened) {
+                throw new IllegalStateException("Cannot open more than one iterator on a Cursor");
+            }
+            iteratorAlreadyOpened = true;
+        }
+
+        @Override
+        public boolean hasNext() {
+            if (object == null) {
+                object = fetchNextUsingRowBound();
+            }
+            return object != null;
+        }
+
+        @Override
+        public T next() {
+            // Fill next with object fetched from hasNext()
+            T next = object;
+
+            if (next == null) {
+                next = fetchNextUsingRowBound();
+            }
+
+            if (next != null) {
+                object = null;
+                return next;
+            }
+            throw new NoSuchElementException();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException("Cannot currently remove element from Cursor");
+        }
+    }
+}

--- a/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
@@ -25,6 +25,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.apache.ibatis.cache.CacheKey;
 import org.apache.ibatis.cache.impl.PerpetualCache;
+import org.apache.ibatis.cursor.Cursor;
+import org.apache.ibatis.jdbc.SQL;
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.logging.LogFactory;
 import org.apache.ibatis.logging.jdbc.ConnectionLogger;
@@ -171,6 +173,12 @@ public abstract class BaseExecutor implements Executor {
   }
 
   @Override
+  public <E> Cursor<E> queryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds) throws SQLException {
+    BoundSql boundSql = ms.getBoundSql(parameter);
+    return doQueryCursor(ms, parameter, rowBounds, boundSql);
+  }
+
+  @Override
   public void deferLoad(MappedStatement ms, MetaObject resultObject, String property, CacheKey key, Class<?> targetType) {
     if (closed) {
       throw new ExecutorException("Executor was closed.");
@@ -219,7 +227,7 @@ public abstract class BaseExecutor implements Executor {
       cacheKey.update(configuration.getEnvironment().getId());
     }
     return cacheKey;
-  }    
+  }
 
   @Override
   public boolean isCached(MappedStatement ms, CacheKey key) {
@@ -267,6 +275,9 @@ public abstract class BaseExecutor implements Executor {
       throws SQLException;
 
   protected abstract <E> List<E> doQuery(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql)
+      throws SQLException;
+
+  protected abstract <E> Cursor<E> doQueryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds, BoundSql boundSql)
       throws SQLException;
 
   protected void closeStatement(Statement statement) {

--- a/src/main/java/org/apache/ibatis/executor/BatchExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BatchExecutor.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.keygen.Jdbc3KeyGenerator;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
 import org.apache.ibatis.executor.keygen.NoKeyGenerator;
@@ -92,6 +93,17 @@ public class BatchExecutor extends BaseExecutor {
     } finally {
       closeStatement(stmt);
     }
+  }
+
+  @Override
+  protected <E> Cursor<E> doQueryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds, BoundSql boundSql) throws SQLException {
+    flushStatements();
+    Configuration configuration = ms.getConfiguration();
+    StatementHandler handler = configuration.newStatementHandler(wrapper, ms, parameter, rowBounds, null, boundSql);
+    Connection connection = getConnection(ms.getStatementLog());
+    Statement stmt = handler.prepare(connection);
+    handler.parameterize(stmt);
+    return handler.<E>queryCursor(stmt);
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/executor/CachingExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/CachingExecutor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.cache.CacheKey;
 import org.apache.ibatis.cache.TransactionalCacheManager;
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.mapping.ParameterMapping;
@@ -80,6 +81,12 @@ public class CachingExecutor implements Executor {
     BoundSql boundSql = ms.getBoundSql(parameterObject);
     CacheKey key = createCacheKey(ms, parameterObject, rowBounds, boundSql);
     return query(ms, parameterObject, rowBounds, resultHandler, key, boundSql);
+  }
+
+  @Override
+  public <E> Cursor<E> queryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds) throws SQLException {
+    flushCacheIfRequired(ms);
+    return delegate.queryCursor(ms, parameter, rowBounds);
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/executor/Executor.java
+++ b/src/main/java/org/apache/ibatis/executor/Executor.java
@@ -19,6 +19,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 import org.apache.ibatis.cache.CacheKey;
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.reflection.MetaObject;
@@ -38,6 +39,8 @@ public interface Executor {
   <E> List<E> query(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, CacheKey cacheKey, BoundSql boundSql) throws SQLException;
 
   <E> List<E> query(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler) throws SQLException;
+
+  <E> Cursor<E> queryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds) throws SQLException;
 
   List<BatchResult> flushStatements() throws SQLException;
 

--- a/src/main/java/org/apache/ibatis/executor/ReuseExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/ReuseExecutor.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.statement.StatementHandler;
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.mapping.BoundSql;
@@ -57,6 +58,14 @@ public class ReuseExecutor extends BaseExecutor {
     StatementHandler handler = configuration.newStatementHandler(wrapper, ms, parameter, rowBounds, resultHandler, boundSql);
     Statement stmt = prepareStatement(handler, ms.getStatementLog());
     return handler.<E>query(stmt, resultHandler);
+  }
+
+  @Override
+  protected <E> Cursor<E> doQueryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds, BoundSql boundSql) throws SQLException {
+    Configuration configuration = ms.getConfiguration();
+    StatementHandler handler = configuration.newStatementHandler(wrapper, ms, parameter, rowBounds, null, boundSql);
+    Statement stmt = prepareStatement(handler, ms.getStatementLog());
+    return handler.<E>queryCursor(stmt);
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/executor/SimpleExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/SimpleExecutor.java
@@ -15,12 +15,7 @@
  */
 package org.apache.ibatis.executor;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.Collections;
-import java.util.List;
-
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.statement.StatementHandler;
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.mapping.BoundSql;
@@ -29,6 +24,12 @@ import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.RowBounds;
 import org.apache.ibatis.transaction.Transaction;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * @author Clinton Begin
@@ -63,6 +64,14 @@ public class SimpleExecutor extends BaseExecutor {
     } finally {
       closeStatement(stmt);
     }
+  }
+
+  @Override
+  protected <E> Cursor<E> doQueryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds, BoundSql boundSql) throws SQLException {
+    Configuration configuration = ms.getConfiguration();
+    StatementHandler handler = configuration.newStatementHandler(wrapper, ms, parameter, rowBounds, null, boundSql);
+    Statement stmt = prepareStatement(handler, ms.getStatementLog());
+    return handler.<E>queryCursor(stmt);
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/executor/loader/ResultLoaderMap.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/ResultLoaderMap.java
@@ -28,6 +28,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.BaseExecutor;
 import org.apache.ibatis.executor.BatchResult;
 import org.apache.ibatis.executor.ExecutorException;
@@ -298,6 +299,11 @@ public class ResultLoaderMap {
 
     @Override
     protected <E> List<E> doQuery(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) throws SQLException {
+      throw new UnsupportedOperationException("Not supported.");
+    }
+
+    @Override
+    protected <E> Cursor<E> doQueryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds, BoundSql boundSql) throws SQLException {
       throw new UnsupportedOperationException("Not supported.");
     }
   }

--- a/src/main/java/org/apache/ibatis/executor/resultset/ResultSetWrapper.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/ResultSetWrapper.java
@@ -38,7 +38,7 @@ import org.apache.ibatis.type.UnknownTypeHandler;
 /**
  * @author Iwao AVE!
  */
-class ResultSetWrapper {
+public class ResultSetWrapper {
 
   private final ResultSet resultSet;
   private final TypeHandlerRegistry typeHandlerRegistry;

--- a/src/main/java/org/apache/ibatis/executor/statement/CallableStatementHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/statement/CallableStatementHandler.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.executor.ExecutorException;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
@@ -65,6 +66,15 @@ public class CallableStatementHandler extends BaseStatementHandler {
     CallableStatement cs = (CallableStatement) statement;
     cs.execute();
     List<E> resultList = resultSetHandler.<E>handleResultSets(cs);
+    resultSetHandler.handleOutputParameters(cs);
+    return resultList;
+  }
+
+  @Override
+  public <E> Cursor<E> queryCursor(Statement statement) throws SQLException {
+    CallableStatement cs = (CallableStatement) statement;
+    cs.execute();
+    Cursor<E> resultList = resultSetHandler.<E>handleCursorResultSets(cs);
     resultSetHandler.handleOutputParameters(cs);
     return resultList;
   }

--- a/src/main/java/org/apache/ibatis/executor/statement/PreparedStatementHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/statement/PreparedStatementHandler.java
@@ -22,6 +22,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.executor.keygen.Jdbc3KeyGenerator;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
@@ -61,6 +62,13 @@ public class PreparedStatementHandler extends BaseStatementHandler {
     PreparedStatement ps = (PreparedStatement) statement;
     ps.execute();
     return resultSetHandler.<E> handleResultSets(ps);
+  }
+
+  @Override
+  public <E> Cursor<E> queryCursor(Statement statement) throws SQLException {
+    PreparedStatement ps = (PreparedStatement) statement;
+    ps.execute();
+    return resultSetHandler.<E> handleCursorResultSets(ps);
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/executor/statement/RoutingStatementHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/statement/RoutingStatementHandler.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.executor.ExecutorException;
 import org.apache.ibatis.executor.parameter.ParameterHandler;
@@ -76,6 +77,11 @@ public class RoutingStatementHandler implements StatementHandler {
   @Override
   public <E> List<E> query(Statement statement, ResultHandler resultHandler) throws SQLException {
     return delegate.<E>query(statement, resultHandler);
+  }
+
+  @Override
+  public <E> Cursor<E> queryCursor(Statement statement) throws SQLException {
+    return delegate.queryCursor(statement);
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/executor/statement/SimpleStatementHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/statement/SimpleStatementHandler.java
@@ -16,11 +16,13 @@
 package org.apache.ibatis.executor.statement;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.executor.keygen.Jdbc3KeyGenerator;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
@@ -71,6 +73,13 @@ public class SimpleStatementHandler extends BaseStatementHandler {
     String sql = boundSql.getSql();
     statement.execute(sql);
     return resultSetHandler.<E>handleResultSets(statement);
+  }
+
+  @Override
+  public <E> Cursor<E> queryCursor(Statement statement) throws SQLException {
+    String sql = boundSql.getSql();
+    statement.execute(sql);
+    return resultSetHandler.<E>handleCursorResultSets(statement);
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/executor/statement/StatementHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/statement/StatementHandler.java
@@ -20,6 +20,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.parameter.ParameterHandler;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.session.ResultHandler;
@@ -42,6 +43,9 @@ public interface StatementHandler {
       throws SQLException;
 
   <E> List<E> query(Statement statement, ResultHandler resultHandler)
+      throws SQLException;
+
+  <E> Cursor<E> queryCursor(Statement statement)
       throws SQLException;
 
   BoundSql getBoundSql();

--- a/src/main/java/org/apache/ibatis/session/SqlSession.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSession.java
@@ -20,6 +20,7 @@ import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.BatchResult;
 
 /**
@@ -114,6 +115,33 @@ public interface SqlSession extends Closeable {
    * @return Map containing key pair data.
    */
   <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, RowBounds rowBounds);
+
+  /**
+   * A Cursor offers the same results as a List, except it fetches data lazily using an Iterator.
+   * @param <T> the returned cursor element type.
+   * @param statement Unique identifier matching the statement to use.
+   * @return Cursor of mapped objects
+   */
+  <T> Cursor<T> selectCursor(String statement);
+
+  /**
+   * A Cursor offers the same results as a List, except it fetches data lazily using an Iterator.
+   * @param <T> the returned cursor element type.
+   * @param statement Unique identifier matching the statement to use.
+   * @param parameter A parameter object to pass to the statement.
+   * @return Cursor of mapped objects
+   */
+  <T> Cursor<T> selectCursor(String statement, Object parameter);
+
+  /**
+   * A Cursor offers the same results as a List, except it fetches data lazily using an Iterator.
+   * @param <T> the returned cursor element type.
+   * @param statement Unique identifier matching the statement to use.
+   * @param parameter A parameter object to pass to the statement.
+   * @param rowBounds  Bounds to limit object retrieval
+   * @return Cursor of mapped objects
+   */
+  <T> Cursor<T> selectCursor(String statement, Object parameter, RowBounds rowBounds);
 
   /**
    * Retrieve a single row mapped from the statement key and parameter

--- a/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.BatchResult;
 import org.apache.ibatis.reflection.ExceptionUtil;
 
@@ -178,6 +179,21 @@ public class SqlSessionManager implements SqlSessionFactory, SqlSession {
   @Override
   public <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, RowBounds rowBounds) {
     return sqlSessionProxy.<K, V> selectMap(statement, parameter, mapKey, rowBounds);
+  }
+
+  @Override
+  public <T> Cursor<T> selectCursor(String statement) {
+    return sqlSessionProxy.selectCursor(statement);
+  }
+
+  @Override
+  public <T> Cursor<T> selectCursor(String statement, Object parameter) {
+    return sqlSessionProxy.selectCursor(statement, parameter);
+  }
+
+  @Override
+  public <T> Cursor<T> selectCursor(String statement, Object parameter, RowBounds rowBounds) {
+    return sqlSessionProxy.selectCursor(statement, parameter, rowBounds);
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/CreateDB.sql
@@ -1,0 +1,41 @@
+
+--
+--    Copyright 2009-2012 The MyBatis Team
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(20),
+  group_id int,
+  rol_id int
+);
+
+insert into users values(1, 'User1', 1, 1);
+insert into users values(1, 'User1', 1, 2);
+insert into users values(1, 'User1', 2, 1);
+insert into users values(1, 'User1', 2, 2);
+insert into users values(1, 'User1', 2, 3);
+insert into users values(2, 'User2', 1, 1);
+insert into users values(2, 'User2', 1, 2);
+insert into users values(2, 'User2', 1, 3);
+insert into users values(3, 'User3', 1, 1);
+insert into users values(3, 'User3', 2, 1);
+insert into users values(3, 'User3', 3, 1);
+insert into users values(4, 'User4', 1, 1);
+insert into users values(4, 'User4', 1, 2);
+insert into users values(4, 'User4', 2, 1);
+insert into users values(4, 'User4', 2, 2);

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
@@ -1,0 +1,117 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.cursor_nested;
+
+import org.apache.ibatis.cursor.Cursor;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.RowBounds;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.util.Iterator;
+
+public class CursorNestedTest {
+
+    private static SqlSessionFactory sqlSessionFactory;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // create a SqlSessionFactory
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cursor_nested/mybatis-config.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
+
+        // populate in-memory database
+        SqlSession session = sqlSessionFactory.openSession();
+        Connection conn = session.getConnection();
+        reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cursor_nested/CreateDB.sql");
+        ScriptRunner runner = new ScriptRunner(conn);
+        runner.setLogWriter(null);
+        runner.runScript(reader);
+        reader.close();
+        session.close();
+    }
+
+    @Test
+    public void shouldGetAllUser() {
+        SqlSession sqlSession = sqlSessionFactory.openSession();
+        Mapper mapper = sqlSession.getMapper(Mapper.class);
+        Cursor<User> usersCursor = mapper.getAllUsers();
+
+        try {
+            Assert.assertFalse(usersCursor.isOpen());
+            // Retrieving iterator, fetching is not started
+            Iterator<User> iterator = usersCursor.iterator();
+
+            // Check if hasNext, fetching is started
+            Assert.assertTrue(iterator.hasNext());
+            Assert.assertTrue(usersCursor.isOpen());
+            Assert.assertFalse(usersCursor.isConsumed());
+
+            User user = iterator.next();
+            Assert.assertEquals(2, user.getGroups().size());
+            Assert.assertEquals(3, user.getRoles().size());
+
+            user = iterator.next();
+            Assert.assertEquals(1, user.getGroups().size());
+            Assert.assertEquals(3, user.getRoles().size());
+
+            user = iterator.next();
+            Assert.assertEquals(3, user.getGroups().size());
+            Assert.assertEquals(1, user.getRoles().size());
+
+            user = iterator.next();
+            Assert.assertEquals(2, user.getGroups().size());
+            Assert.assertEquals(2, user.getRoles().size());
+
+            // Check no more elements
+            Assert.assertFalse(iterator.hasNext());
+            Assert.assertFalse(usersCursor.isOpen());
+            Assert.assertTrue(usersCursor.isConsumed());
+        } finally {
+            sqlSession.close();
+        }
+        Assert.assertFalse(usersCursor.isOpen());
+    }
+
+    @Test
+    public void testCursorWithRowBound() {
+        SqlSession sqlSession = sqlSessionFactory.openSession();
+
+        try {
+            Cursor<User> usersCursor = sqlSession.selectCursor("getAllUsers", null, new RowBounds(2, 1));
+
+            Iterator<User> iterator = usersCursor.iterator();
+
+            User user = iterator.next();
+            Assert.assertEquals("User3", user.getName());
+            Assert.assertEquals(2, usersCursor.getCurrentIndex());
+
+            Assert.assertFalse(iterator.hasNext());
+            Assert.assertFalse(usersCursor.isOpen());
+            Assert.assertTrue(usersCursor.isConsumed());
+        } finally {
+            sqlSession.close();
+        }
+    }
+}

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/Mapper.java
@@ -13,24 +13,14 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.executor.resultset;
+package org.apache.ibatis.submitted.cursor_nested;
 
 import org.apache.ibatis.cursor.Cursor;
 
-import java.sql.CallableStatement;
-import java.sql.SQLException;
-import java.sql.Statement;
 import java.util.List;
 
-/**
- * @author Clinton Begin
- */
-public interface ResultSetHandler {
+public interface Mapper {
 
-  <E> List<E> handleResultSets(Statement stmt) throws SQLException;
-
-  <E> Cursor<E> handleCursorResultSets(Statement stmt) throws SQLException;
-
-  void handleOutputParameters(CallableStatement cs) throws SQLException;
+  Cursor<User> getAllUsers();
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/Mapper.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+       Copyright 2009-2012 The MyBatis Team
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.cursor_nested.Mapper">
+
+	<select id="getAllUsers" resultMap="results" resultOrdered="true">
+		select * from users order by id
+	</select>
+	
+	<resultMap type="org.apache.ibatis.submitted.cursor_nested.User" id="results">
+		<id column="id" property="id"/>
+    <result property="name" column="name"/>
+		<collection property="groups" ofType="string">
+			<result column="group_id"/>
+		</collection>
+		<collection property="roles" ofType="string">
+			<result column="rol_id"/>
+		</collection>
+	</resultMap>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/User.java
@@ -1,0 +1,68 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.cursor_nested;
+
+import java.util.List;
+
+public class User {
+
+  private Integer id;
+  private String name;
+  private List<String> groups;
+  private List<String> roles;
+
+  public List<String> getRoles() {
+    return roles;
+  }
+
+  public void setRoles(List<String> roles) {
+    this.roles = roles;
+  }
+
+  public List<String> getGroups() {
+    return groups;
+  }
+
+  public void setGroups(List<String> groups) {
+    this.groups = groups;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return "User{" +
+            "id=" + id +
+            ", name='" + name + '\'' +
+            ", groups=" + groups +
+            ", roles=" + roles +
+            '}';
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/mybatis-config.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+       Copyright 2009-2012 The MyBatis Team
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+	<environments default="development">
+		<environment id="development">
+			<transactionManager type="JDBC">
+				<property name="" value="" />
+			</transactionManager>
+			<dataSource type="UNPOOLED">
+				<property name="driver" value="org.hsqldb.jdbcDriver" />
+				<property name="url" value="jdbc:hsqldb:mem:cursor_nested" />
+				<property name="username" value="sa" />
+			</dataSource>
+		</environment>
+	</environments>
+
+	<mappers>
+		<mapper resource="org/apache/ibatis/submitted/cursor_nested/Mapper.xml" />
+	</mappers>
+
+</configuration>

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/CreateDB.sql
@@ -1,0 +1,27 @@
+--
+--    Copyright 2009-2012 The MyBatis Team
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(20)
+);
+
+insert into users values(1, 'User1');
+insert into users values(2, 'User2');
+insert into users values(3, 'User3');
+insert into users values(4, 'User4');

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
@@ -1,0 +1,151 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.cursor_simple;
+
+import org.apache.ibatis.cursor.Cursor;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.RowBounds;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.util.Iterator;
+
+public class CursorSimpleTest {
+
+    private static SqlSessionFactory sqlSessionFactory;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // create a SqlSessionFactory
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cursor_simple/mybatis-config.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
+
+        // populate in-memory database
+        SqlSession session = sqlSessionFactory.openSession();
+        Connection conn = session.getConnection();
+        reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cursor_simple/CreateDB.sql");
+        ScriptRunner runner = new ScriptRunner(conn);
+        runner.setLogWriter(null);
+        runner.runScript(reader);
+        reader.close();
+        session.close();
+    }
+
+    @Test
+    public void shouldGetAllUser() {
+        SqlSession sqlSession = sqlSessionFactory.openSession();
+        Mapper mapper = sqlSession.getMapper(Mapper.class);
+        Cursor<User> usersCursor = mapper.getAllUsers();
+        try {
+            Assert.assertFalse(usersCursor.isOpen());
+
+            Iterator<User> iterator = usersCursor.iterator();
+
+            // Check if hasNext, fetching is started
+            Assert.assertTrue(iterator.hasNext());
+            Assert.assertTrue(usersCursor.isOpen());
+            Assert.assertFalse(usersCursor.isConsumed());
+
+            User user = iterator.next();
+            Assert.assertEquals("User1", user.getName());
+            Assert.assertEquals(0, usersCursor.getCurrentIndex());
+
+            user = iterator.next();
+            Assert.assertEquals("User2", user.getName());
+            Assert.assertEquals(1, usersCursor.getCurrentIndex());
+
+            user = iterator.next();
+            Assert.assertEquals("User3", user.getName());
+            Assert.assertEquals(2, usersCursor.getCurrentIndex());
+
+            user = iterator.next();
+            Assert.assertEquals("User4", user.getName());
+            Assert.assertEquals(3, usersCursor.getCurrentIndex());
+
+            // Check no more elements
+            Assert.assertFalse(iterator.hasNext());
+            Assert.assertFalse(usersCursor.isOpen());
+            Assert.assertTrue(usersCursor.isConsumed());
+        } finally {
+            sqlSession.close();
+        }
+    }
+
+    @Test
+    public void testCursorClosedOnSessionClose() {
+        SqlSession sqlSession = sqlSessionFactory.openSession();
+        Mapper mapper = sqlSession.getMapper(Mapper.class);
+        Cursor<User> usersCursor = mapper.getAllUsers();
+        try {
+            Assert.assertFalse(usersCursor.isOpen());
+
+            Iterator<User> iterator = usersCursor.iterator();
+
+            // Check if hasNext, fetching is started
+            Assert.assertTrue(iterator.hasNext());
+            Assert.assertTrue(usersCursor.isOpen());
+            Assert.assertFalse(usersCursor.isConsumed());
+
+            // Consume only the first result
+            User user = iterator.next();
+            Assert.assertEquals("User1", user.getName());
+
+            // Check there is still remaining elements
+            Assert.assertTrue(iterator.hasNext());
+            Assert.assertTrue(usersCursor.isOpen());
+            Assert.assertFalse(usersCursor.isConsumed());
+        } finally {
+            sqlSession.close();
+        }
+
+        // The cursor was not fully consumed, but it should be close since we closed the session
+        Assert.assertFalse(usersCursor.isOpen());
+        Assert.assertFalse(usersCursor.isConsumed());
+    }
+
+    @Test
+    public void testCursorWithRowBound() {
+        SqlSession sqlSession = sqlSessionFactory.openSession();
+
+        try {
+            Cursor<User> usersCursor = sqlSession.selectCursor("getAllUsers", null, new RowBounds(1, 2));
+
+            Iterator<User> iterator = usersCursor.iterator();
+
+            User user = iterator.next();
+            Assert.assertEquals("User2", user.getName());
+            Assert.assertEquals(1, usersCursor.getCurrentIndex());
+
+            user = iterator.next();
+            Assert.assertEquals("User3", user.getName());
+            Assert.assertEquals(2, usersCursor.getCurrentIndex());
+
+            Assert.assertFalse(iterator.hasNext());
+            Assert.assertFalse(usersCursor.isOpen());
+            Assert.assertTrue(usersCursor.isConsumed());
+        } finally {
+            sqlSession.close();
+        }
+    }
+}

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/Mapper.java
@@ -13,24 +13,12 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.executor.resultset;
+package org.apache.ibatis.submitted.cursor_simple;
 
 import org.apache.ibatis.cursor.Cursor;
 
-import java.sql.CallableStatement;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.List;
+public interface Mapper {
 
-/**
- * @author Clinton Begin
- */
-public interface ResultSetHandler {
-
-  <E> List<E> handleResultSets(Statement stmt) throws SQLException;
-
-  <E> Cursor<E> handleCursorResultSets(Statement stmt) throws SQLException;
-
-  void handleOutputParameters(CallableStatement cs) throws SQLException;
+  Cursor<User> getAllUsers();
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/Mapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+       Copyright 2009-2012 The MyBatis Team
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.cursor_simple.Mapper">
+
+	<select id="getAllUsers" resultMap="results" resultOrdered="true">
+		select * from users order by id
+	</select>
+	
+	<resultMap type="org.apache.ibatis.submitted.cursor_simple.User" id="results">
+		<id column="id" property="id"/>
+    <result property="name" column="name"/>
+	</resultMap>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/User.java
@@ -13,24 +13,34 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.executor.resultset;
+package org.apache.ibatis.submitted.cursor_simple;
 
-import org.apache.ibatis.cursor.Cursor;
+public class User {
 
-import java.sql.CallableStatement;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.List;
+  private Integer id;
+  private String name;
 
-/**
- * @author Clinton Begin
- */
-public interface ResultSetHandler {
+  public Integer getId() {
+    return id;
+  }
 
-  <E> List<E> handleResultSets(Statement stmt) throws SQLException;
+  public void setId(Integer id) {
+    this.id = id;
+  }
 
-  <E> Cursor<E> handleCursorResultSets(Statement stmt) throws SQLException;
+  public String getName() {
+    return name;
+  }
 
-  void handleOutputParameters(CallableStatement cs) throws SQLException;
+  public void setName(String name) {
+    this.name = name;
+  }
 
+  @Override
+  public String toString() {
+    return "User{" +
+            "id=" + id +
+            ", name='" + name + '\'' +
+            '}';
+  }
 }

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/mybatis-config.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+       Copyright 2009-2012 The MyBatis Team
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+	<environments default="development">
+		<environment id="development">
+			<transactionManager type="JDBC">
+				<property name="" value="" />
+			</transactionManager>
+			<dataSource type="UNPOOLED">
+				<property name="driver" value="org.hsqldb.jdbcDriver" />
+				<property name="url" value="jdbc:hsqldb:mem:cursor_simple" />
+				<property name="username" value="sa" />
+			</dataSource>
+		</environment>
+	</environments>
+
+	<mappers>
+		<mapper resource="org/apache/ibatis/submitted/cursor_simple/Mapper.xml" />
+	</mappers>
+
+</configuration>


### PR DESCRIPTION
Hi mybatis dev team,

Here's an up to date version of a minimalist Cursor implementation. This PR replaces the previous implementation I made in PR 52 (https://github.com/mybatis/mybatis-3/pull/52).
I bumped the version to 3.4.0-SNAPSHOT as SqlSession gets new methods.

This PR adds the Cursor feature which is needed to implement a MyBatisCursorItemReader for Spring Batch.

Features
* Added new SqlSession methods selectCursor()
* Cursors extends Iterable to be easily used with foreach Statement and implements Closeable to be used with try-with-resources in Java 7+
* Cursors are automatically closed when fully fetched or on SqlSession close

A Cursor does not retain any fetched element, so it is a perfect choice for iterating over a ResultSet with several millions rows, without exhausting memory.

**Usage :**

XML mapping :
```xml
    <select id="getEmployeeNestedCursor" resultMap="results" resultOrdered="true">
       select id,name,salary,skill from employees order by id
    </select>
```
Java code :
```java
// Get a list which can have millions of rows
Cursor<Employee> employees = sqlSession.selectCursor("getEmployeeNestedCursor");

// Get an iterator on employees
Iterator<Employee> iter = employees.iterator();

List<Employee> smallChunk = new ArrayList(10);
while (iter.hasNext()) {
    // Fetch next 10 employees
    for(int i = 0; i<10 && iter.hasNext(); i++) {
        smallChunk.add(iter.next());
    }
    doSomethingWithAlreadyFetchedEmployees(smallChunk);
    smallChunk.clear();
}
```


Best regards,
Guillaume