### PR TITLE
Add missing standard JDBC types and SQL Server DATETIMEOFFSET type (3.2.x branch)

### DIFF
--- a/src/main/java/org/apache/ibatis/type/JdbcType.java
+++ b/src/main/java/org/apache/ibatis/type/JdbcType.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2012 the original author or authors.
+ *    Copyright 2009-2015 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -57,7 +57,15 @@ public enum JdbcType {
   NVARCHAR(Types.NVARCHAR), // JDK6
   NCHAR(Types.NCHAR), // JDK6
   NCLOB(Types.NCLOB), // JDK6
-  STRUCT(Types.STRUCT);
+  STRUCT(Types.STRUCT),
+  JAVA_OBJECT(Types.JAVA_OBJECT),
+  DISTINCT(Types.DISTINCT),
+  REF(Types.REF),
+  DATALINK(Types.DATALINK),
+  ROWID(Types.ROWID), // JDK6
+  LONGNVARCHAR(Types.LONGNVARCHAR), // JDK6
+  SQLXML(Types.SQLXML), // JDK6
+  DATETIMEOFFSET(-155); // SQL Server 2008
 
   public final int TYPE_CODE;
   private static Map<Integer,JdbcType> codeLookup = new HashMap<Integer,JdbcType>();

--- a/src/test/java/org/apache/ibatis/type/JdbcTypeTest.java
+++ b/src/test/java/org/apache/ibatis/type/JdbcTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ *    Copyright 2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import static org.junit.Assert.assertEquals;
+
+import java.sql.Types;
+
+import org.junit.Test;
+
+public class JdbcTypeTest {
+  private static final String[] requiredStandardTypeNames = {
+    "ARRAY", "BIGINT", "BINARY", "BIT", "BLOB", "BOOLEAN", "CHAR", "CLOB",
+    "DATALINK", "DATE", "DECIMAL", "DISTINCT", "DOUBLE", "FLOAT", "INTEGER",
+    "JAVA_OBJECT", "LONGNVARCHAR", "LONGVARBINARY", "LONGVARCHAR", "NCHAR",
+    "NCLOB", "NULL", "NUMERIC","NVARCHAR", "OTHER", "REAL", "REF", "ROWID",
+    "SMALLINT", "SQLXML", "STRUCT", "TIME", "TIMESTAMP", "TINYINT",
+    "VARBINARY", "VARCHAR"
+  };
+
+  @Test
+  public void shouldHaveRequiredStandardConstants() throws Exception {
+    for (String typeName : requiredStandardTypeNames) {
+      int typeCode = Types.class.getField(typeName).getInt(null);
+      JdbcType jdbcType = JdbcType.valueOf(typeName);
+      assertEquals(typeCode, jdbcType.TYPE_CODE);
+    }
+  }
+
+  @Test
+  public void shouldHaveDateTimeOffsetConstant() throws Exception {
+    JdbcType jdbcType = JdbcType.valueOf("DATETIMEOFFSET");
+    assertEquals(-155, jdbcType.TYPE_CODE);
+  }
+}


### PR DESCRIPTION
Adds all the missing standard types present in JDBC 4 / Java 6 (java.sql.Types.*) plus the Microsoft SQL Server 2008 DATETIMEOFFSET constant (microsoft.sql.Types.DATETIMEOFFSET). Note that a custom type handler is still required to fully utilize these new types.