### PR TITLE
Add missing standard JDBC types and SQL Server DATETIMEOFFSET type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -25,7 +24,7 @@
   </parent>
 
   <artifactId>mybatis</artifactId>
-  <version>3.3.0-SNAPSHOT</version>
+  <version>3.3.0</version>
   <packaging>jar</packaging>
 
   <name>mybatis</name>
@@ -108,7 +107,7 @@
     <url>http://github.com/mybatis/mybatis-3</url>
     <connection>scm:git:ssh://github.com/mybatis/mybatis-3.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/mybatis/mybatis-3.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>mybatis-3.3.0</tag>
   </scm>
   <issueManagement>
     <system>GitHub Issue Management</system>


### PR DESCRIPTION
Adds all the missing standard types present in JDBC 4 / Java 6 (java.sql.Types.*) plus the Microsoft SQL Server 2008 DATETIMEOFFSET constant (microsoft.sql.Types.DATETIMEOFFSET). Note that a custom type handler is still required to fully utilize these new types.

If it's not too much trouble, I would love to see this backported into 3.2.x and 3.3.x. Mapper XML and custom TypeHandler implementations that reference the missing standard JDBC constants would then be compatible with all 3 versions. These existing pull requests should make it painless: [#466](https://github.com/mybatis/mybatis-3/pull/466), [#467](https://github.com/mybatis/mybatis-3/pull/467)