### PR TITLE
Support a custom method execution via Mapper interface

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/CustomMethod.java
+++ b/src/main/java/org/apache/ibatis/annotations/CustomMethod.java
@@ -15,6 +15,8 @@
  */
 package org.apache.ibatis.annotations;
 
+import org.apache.ibatis.binding.CustomMethodStrategy;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -22,11 +24,11 @@ import java.lang.annotation.Target;
 
 /**
  * The maker annotation that invoke a custom method.
- * <p/>
+ * <p>
  * <h2>How to define :</h2>
  * Define this annotation as method level annotation.<br>
  * Note that this annotation can not mix with another annotations({@link Select}, {@link Insert}, {@link Update}, {@link Delete}, {@link Flush}, etc..}).
- * <p/>
+ * <p>
  * e.g.)
  * <pre class="code">
  *   package com.example.domain.mapper;
@@ -36,12 +38,13 @@ import java.lang.annotation.Target;
  *     Page&lt;Person&gt; findPage(RowBounds rowBounds);
  *   }
  * </pre>
- * <p/>
+ * <p>
  * <h2>How to implement a custom method :</h2>
  * Implements a custom method at default implementation class("FQCN of Mapper interface" + "Impl") or
  * user defined implementation class which specify using annotation attributes ({@link #type} and {@link #method}).<br>
  * Note that first argument needs to define {@link org.apache.ibatis.session.SqlSession}, and subsequent arguments needs to define same signatures with mapper interface.
- * <p/>
+ * <strong>This behavior can customize using {@link CustomMethodStrategy}.</strong>
+ * <p>
  * e.g.)
  * <pre class="code">
  *   package com.example.domain.mapper;
@@ -61,15 +64,16 @@ public @interface CustomMethod {
 
   /**
    * Sets class which implements custom method.
-   * <p/>
-   * Default is "FQCN of Mapper interface" + "Impl".
+   *
+   * Default is "FQCN of Mapper interface" + "Impl",
+   * <strong>it can customize using {@link CustomMethodStrategy}.</strong>
    * @return Class that implements custom method
    */
   Class<?> type() default void.class;
 
   /**
    * Sets implementation method name of custom method.
-   * <p/>
+   *
    * Default is same method name with method which annotated.
    * @return Method name of custom method
    */

--- a/src/main/java/org/apache/ibatis/annotations/CustomMethod.java
+++ b/src/main/java/org/apache/ibatis/annotations/CustomMethod.java
@@ -1,0 +1,78 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The maker annotation that invoke a custom method.
+ * <p/>
+ * <h2>How to define :</h2>
+ * Define this annotation as method level annotation.<br>
+ * Note that this annotation can not mix with another annotations({@link Select}, {@link Insert}, {@link Update}, {@link Delete}, {@link Flush}, etc..}).
+ * <p/>
+ * e.g.)
+ * <pre class="code">
+ *   package com.example.domain.mapper;
+ *
+ *   public interface PersonMapper {
+ *     &#064;CustomMethod
+ *     Page&lt;Person&gt; findPage(RowBounds rowBounds);
+ *   }
+ * </pre>
+ * <p/>
+ * <h2>How to implement a custom method :</h2>
+ * Implements a custom method at default implementation class("FQCN of Mapper interface" + "Impl") or
+ * user defined implementation class which specify using annotation attributes ({@link #type} and {@link #method}).<br>
+ * Note that first argument needs to define {@link org.apache.ibatis.session.SqlSession}, and subsequent arguments needs to define same signatures with mapper interface.
+ * <p/>
+ * e.g.)
+ * <pre class="code">
+ *   package com.example.domain.mapper;
+ *
+ *   public class PersonMapperImpl {
+ *     public Page&lt;Person&gt; findPage(SqlSession sqlSession, RowBounds rowBounds) {
+ *       // ...
+ *     }
+ *   }
+ * </pre>
+ * @author Kazuki Shimizu
+ * @since 3.4.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface CustomMethod {
+
+  /**
+   * Sets class which implements custom method.
+   * <p/>
+   * Default is "FQCN of Mapper interface" + "Impl".
+   * @return Class that implements custom method
+   */
+  Class<?> type() default void.class;
+
+  /**
+   * Sets implementation method name of custom method.
+   * <p/>
+   * Default is same method name with method which annotated.
+   * @return Method name of custom method
+   */
+  String method() default "";
+
+}

--- a/src/main/java/org/apache/ibatis/binding/CustomMethodStrategy.java
+++ b/src/main/java/org/apache/ibatis/binding/CustomMethodStrategy.java
@@ -1,0 +1,71 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.binding;
+
+import org.apache.ibatis.session.SqlSession;
+
+import java.lang.reflect.Method;
+
+/**
+ * Strategy interface that invoke a custom method.
+ * <p>
+ * This interface provide three strategies.
+ * <ul>
+ *   <li>Method that lookup a target object which implements a custom method</li>
+ *   <li>Method that lookup a custom method from the target object</li>
+ *   <li>Method that invoke a custom method</li>
+ * </ul>
+ * @author Kazuki Shimizu
+ * @since 3.4.0
+ * @see DefaultCustomMethodStrategy
+ */
+public interface CustomMethodStrategy {
+
+  /**
+   * Lookup a target object which implements a custom method.
+   *
+   * @param mapperInterface Mapper interface which define mapper method under execution
+   * @param customType Custom type which specified by developer using {@link org.apache.ibatis.annotations.CustomMethod#type} (Default is {@code null})
+   * @return A target object
+   * @throws Exception Target object not found
+   */
+  Object lookupTargetObject(Class<?> mapperInterface, Class<?> customType) throws Exception;
+
+  /**
+   * Lookup a custom method from the target object.
+   *
+   * @param targetObject A target object which implements a custom method
+   * @param methodName Method name of custom method (Default is same with mapper method name,
+   *                   it can customize using {@link org.apache.ibatis.annotations.CustomMethod#method})
+   * @param mapperMethodArgTypes Method argument types of mapper method under execution
+   * @return A custom method
+   * @throws Exception Target method not found
+   */
+  Method lookupTargetMethod(Object targetObject, String methodName, Class<?>[] mapperMethodArgTypes) throws Exception;
+
+  /**
+   * Invoke a custom method.
+   *
+   * @param targetObject A target object which implements a custom method
+   * @param targetMethod A custom method
+   * @param sqlSession A {@link SqlSession} under execution
+   * @param mapperMethodArgs Method argument values of mapper method under execution
+   * @return Return value of custom method
+   * @throws Exception Custom method invocation is failed, or an exception is occurred under a custom method execution
+   */
+  Object invoke(Object targetObject, Method targetMethod, SqlSession sqlSession, Object[] mapperMethodArgs) throws Exception;
+
+}

--- a/src/main/java/org/apache/ibatis/binding/DefaultCustomMethodStrategy.java
+++ b/src/main/java/org/apache/ibatis/binding/DefaultCustomMethodStrategy.java
@@ -1,0 +1,89 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.binding;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+
+import java.lang.reflect.Method;
+
+/**
+ * Default implementation class of {@link CustomMethodStrategy}.
+ * <p>
+ * Implements a custom method at default implementation class("FQCN of Mapper interface" + "Impl") or
+ * user defined implementation class which specify using annotation attributes
+ * ({@link org.apache.ibatis.annotations.CustomMethod#type} and {@link org.apache.ibatis.annotations.CustomMethod#method}).<br>
+ * Note that first argument needs to define {@link org.apache.ibatis.session.SqlSession},
+ * and subsequent arguments needs to define same signatures with mapper interface.
+ *
+ * @author Kazuki Shimizu
+ * @since 3.4.0
+ */
+public class DefaultCustomMethodStrategy implements CustomMethodStrategy {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Object lookupTargetObject(Class<?> mapperInterface, Class<?> customType) throws Exception {
+    Class<?> targetType;
+    if (customType == null) {
+      targetType = Resources.classForName(generateDefaultImplementationClassName(mapperInterface));
+    } else {
+      targetType = customType;
+    }
+    return targetType.getConstructor().newInstance();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Method lookupTargetMethod(Object targetObject, String methodName, Class<?>[] mapperMethodArgTypes) throws Exception {
+    int argsCount = mapperMethodArgTypes.length;
+    Class<?>[] methodArgTypes = new Class<?>[argsCount + 1];
+    methodArgTypes[0] = SqlSession.class;
+    System.arraycopy(mapperMethodArgTypes, 0, methodArgTypes, 1, argsCount);
+    return targetObject.getClass().getDeclaredMethod(methodName, methodArgTypes);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public Object invoke(Object targetObject, Method targetMethod, SqlSession sqlSession, Object[] mapperMethodArgs) throws Exception {
+    Object[] methodArgs;
+    if (mapperMethodArgs == null) {
+      methodArgs = new Object[]{sqlSession};
+    } else {
+      methodArgs = new Object[mapperMethodArgs.length + 1];
+      methodArgs[0] = sqlSession;
+      System.arraycopy(mapperMethodArgs, 0, methodArgs, 1, mapperMethodArgs.length);
+    }
+    return targetMethod.invoke(targetObject, methodArgs);
+  }
+
+  /**
+   * Generate default implementation class name (FQCN).
+   * @param mapperInterface Mapper interface which define mapper method under execution
+   * @return "FQCN of Mapper interface" + "Impl"
+   *         (e.g. {@code com.example.PersonMapper} -&gt; {@code com.example.PersonMapperImpl})
+   */
+  protected String generateDefaultImplementationClassName(Class<?> mapperInterface) {
+    return mapperInterface.getName() + "Impl";
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -20,6 +20,7 @@ import java.io.Reader;
 import java.util.Properties;
 import javax.sql.DataSource;
 
+import org.apache.ibatis.binding.CustomMethodStrategy;
 import org.apache.ibatis.builder.BaseBuilder;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.datasource.DataSourceFactory;
@@ -251,6 +252,7 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setLogPrefix(props.getProperty("logPrefix"));
     configuration.setLogImpl(resolveClass(props.getProperty("logImpl")));
     configuration.setConfigurationFactory(resolveClass(props.getProperty("configurationFactory")));
+    configuration.setCustomMethodStrategy((CustomMethodStrategy) createInstance(props.getProperty("customMethodStrategy")));
   }
 
   private void environmentsElement(XNode context) throws Exception {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -26,6 +26,8 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.apache.ibatis.binding.MapperRegistry;
+import org.apache.ibatis.binding.CustomMethodStrategy;
+import org.apache.ibatis.binding.DefaultCustomMethodStrategy;
 import org.apache.ibatis.builder.CacheRefResolver;
 import org.apache.ibatis.builder.ResultMapResolver;
 import org.apache.ibatis.builder.annotation.MethodResolver;
@@ -126,6 +128,8 @@ public class Configuration {
 
   protected boolean lazyLoadingEnabled = false;
   protected ProxyFactory proxyFactory = new JavassistProxyFactory(); // #224 Using internal Javassist instead of OGNL
+
+  protected CustomMethodStrategy customMethodStrategy = new DefaultCustomMethodStrategy();
 
   protected String databaseId;
   /**
@@ -322,6 +326,27 @@ public class Configuration {
       proxyFactory = new JavassistProxyFactory();
     }
     this.proxyFactory = proxyFactory;
+  }
+
+  /**
+   * Get a strategy of custom method.
+   * @return a strategy of custom method
+   * @since 3.4.0
+   */
+  public CustomMethodStrategy getCustomMethodStrategy() {
+    return customMethodStrategy;
+  }
+
+  /**
+   * Sets a strategy of custom method.
+   * @param customMethodStrategy a strategy of custom method
+   * @since 3.4.0
+   */
+  public void setCustomMethodStrategy(CustomMethodStrategy customMethodStrategy) {
+    if (customMethodStrategy == null) {
+      customMethodStrategy = new DefaultCustomMethodStrategy();
+    }
+    this.customMethodStrategy = customMethodStrategy;
   }
 
   public boolean isAggressiveLazyLoading() {

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -47,6 +47,7 @@
     <setting name="logImpl" value="SLF4J"/>
     <setting name="vfsImpl" value="org.apache.ibatis.io.JBoss6VFS"/>
     <setting name="configurationFactory" value="java.lang.String"/>
+    <setting name="customMethodStrategy" value="org.apache.ibatis.builder.XmlConfigBuilderTest$MyCustomMethodStrategy"/>
   </settings>
 
 </configuration>

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.ibatis.binding.DefaultCustomMethodStrategy;
 import org.apache.ibatis.builder.xml.XMLConfigBuilder;
 import org.apache.ibatis.executor.loader.cglib.CglibProxyFactory;
 import org.apache.ibatis.executor.loader.javassist.JavassistProxyFactory;
@@ -78,6 +79,7 @@ public class XmlConfigBuilderTest {
     assertNull(config.getLogPrefix());
     assertNull(config.getLogImpl());
     assertNull(config.getConfigurationFactory());
+    assertThat(config.getCustomMethodStrategy(), is(instanceOf(DefaultCustomMethodStrategy.class)));
   }
 
   enum MyEnum {
@@ -137,37 +139,41 @@ public class XmlConfigBuilderTest {
     assertArrayEquals(MyEnum.values(), ((EnumOrderTypeHandler) typeHandler).constants);
   }
 
-    @Test
-    public void shouldSuccessfullyLoadXMLConfigFile() throws Exception {
-      String resource = "org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml";
-      InputStream inputStream = Resources.getResourceAsStream(resource);
-      XMLConfigBuilder builder = new XMLConfigBuilder(inputStream);
-      Configuration config = builder.parse();
+  @Test
+  public void shouldSuccessfullyLoadXMLConfigFile() throws Exception {
+    String resource = "org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml";
+    InputStream inputStream = Resources.getResourceAsStream(resource);
+    XMLConfigBuilder builder = new XMLConfigBuilder(inputStream);
+    Configuration config = builder.parse();
 
-      assertThat(config.getAutoMappingBehavior(), is(AutoMappingBehavior.NONE));
-      assertThat(config.isCacheEnabled(), is(false));
-      assertThat(config.getProxyFactory(), is(instanceOf(CglibProxyFactory.class)));
-      assertThat(config.isLazyLoadingEnabled(), is(true));
-      assertThat(config.isAggressiveLazyLoading(), is(false));
-      assertThat(config.isMultipleResultSetsEnabled(), is(false));
-      assertThat(config.isUseColumnLabel(), is(false));
-      assertThat(config.isUseGeneratedKeys(), is(true));
-      assertThat(config.getDefaultExecutorType(), is(ExecutorType.BATCH));
-      assertThat(config.getDefaultStatementTimeout(), is(10));
-      assertThat(config.getDefaultFetchSize(), is(100));
-      assertThat(config.isMapUnderscoreToCamelCase(), is(true));
-      assertThat(config.isSafeRowBoundsEnabled(), is(true));
-      assertThat(config.getLocalCacheScope(), is(LocalCacheScope.STATEMENT));
-      assertThat(config.getJdbcTypeForNull(), is(JdbcType.NULL));
-      assertThat(config.getLazyLoadTriggerMethods(), is((Set<String>) new HashSet<String>(Arrays.asList("equals", "clone", "hashCode", "toString", "xxx"))));
-      assertThat(config.isSafeResultHandlerEnabled(), is(false));
-      assertThat(config.getDefaultScriptingLanuageInstance(), is(instanceOf(RawLanguageDriver.class)));
-      assertThat(config.isCallSettersOnNulls(), is(true));
-      assertThat(config.getLogPrefix(), is("mybatis_"));
-      assertThat(config.getLogImpl().getName(), is(Slf4jImpl.class.getName()));
-      assertThat(config.getVfsImpl().getName(), is(JBoss6VFS.class.getName()));
-      assertThat(config.getConfigurationFactory().getName(), is(String.class.getName()));
+    assertThat(config.getAutoMappingBehavior(), is(AutoMappingBehavior.NONE));
+    assertThat(config.isCacheEnabled(), is(false));
+    assertThat(config.getProxyFactory(), is(instanceOf(CglibProxyFactory.class)));
+    assertThat(config.isLazyLoadingEnabled(), is(true));
+    assertThat(config.isAggressiveLazyLoading(), is(false));
+    assertThat(config.isMultipleResultSetsEnabled(), is(false));
+    assertThat(config.isUseColumnLabel(), is(false));
+    assertThat(config.isUseGeneratedKeys(), is(true));
+    assertThat(config.getDefaultExecutorType(), is(ExecutorType.BATCH));
+    assertThat(config.getDefaultStatementTimeout(), is(10));
+    assertThat(config.getDefaultFetchSize(), is(100));
+    assertThat(config.isMapUnderscoreToCamelCase(), is(true));
+    assertThat(config.isSafeRowBoundsEnabled(), is(true));
+    assertThat(config.getLocalCacheScope(), is(LocalCacheScope.STATEMENT));
+    assertThat(config.getJdbcTypeForNull(), is(JdbcType.NULL));
+    assertThat(config.getLazyLoadTriggerMethods(), is((Set<String>) new HashSet<String>(Arrays.asList("equals", "clone", "hashCode", "toString", "xxx"))));
+    assertThat(config.isSafeResultHandlerEnabled(), is(false));
+    assertThat(config.getDefaultScriptingLanuageInstance(), is(instanceOf(RawLanguageDriver.class)));
+    assertThat(config.isCallSettersOnNulls(), is(true));
+    assertThat(config.getLogPrefix(), is("mybatis_"));
+    assertThat(config.getLogImpl().getName(), is(Slf4jImpl.class.getName()));
+    assertThat(config.getVfsImpl().getName(), is(JBoss6VFS.class.getName()));
+    assertThat(config.getConfigurationFactory().getName(), is(String.class.getName()));
+    assertThat(config.getCustomMethodStrategy(), is(instanceOf(MyCustomMethodStrategy.class)));
 
-    }
+  }
+
+  public static class MyCustomMethodStrategy extends DefaultCustomMethodStrategy {
+  }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_method/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/custom_method/CreateDB.sql
@@ -1,0 +1,24 @@
+--
+--    Copyright 2009-2015 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+create table person (
+  id int,
+  firstName varchar(100),
+  lastName varchar(100)
+);
+
+INSERT INTO person (id, firstName, lastName) VALUES (1, 'John', 'Smith');
+INSERT INTO person (id, firstName, lastName) VALUES (2, 'Mike', 'Jordan');

--- a/src/test/java/org/apache/ibatis/submitted/custom_method/CustomMethodTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_method/CustomMethodTest.java
@@ -1,0 +1,240 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.custom_method;
+
+import org.apache.ibatis.binding.BindingException;
+import org.apache.ibatis.exceptions.PersistenceException;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.*;
+import org.hamcrest.core.Is;
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for custom method implementation.
+ *
+ * @author Kazuki Shimizu
+ */
+public class CustomMethodTest {
+
+    private static SqlSessionFactory sqlSessionFactory;
+    private SqlSession sqlSession;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @BeforeClass
+    public static void initDatabase() throws Exception {
+        Connection conn = null;
+
+        try {
+            Class.forName("org.hsqldb.jdbcDriver");
+            conn = DriverManager.getConnection("jdbc:hsqldb:mem:custom_method", "sa", "");
+
+            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/custom_method/CreateDB.sql");
+
+            ScriptRunner runner = new ScriptRunner(conn);
+            runner.setLogWriter(null);
+            runner.setErrorLogWriter(null);
+            runner.runScript(reader);
+            conn.commit();
+            reader.close();
+
+            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/custom_method/mybatis-config.xml");
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+            sqlSessionFactory.getConfiguration().getMapperRegistry().addMapper(PersonMapper.class);
+            sqlSessionFactory.getConfiguration().getMapperRegistry().addMapper(EmployeeMapper.class);
+            reader.close();
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+        }
+    }
+
+    @Before
+    public void openSqlSession() {
+        this.sqlSession = sqlSessionFactory.openSession();
+    }
+
+    @After
+    public void closeSqlSession() {
+        sqlSession.close();
+    }
+
+    @Test
+    public void testArgIsNone() {
+        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+        Page<Person> persons = personMapper.findPage();
+        assertThat(persons.getTotal(), is(2L));
+        assertThat(persons.getContent().get(0).getId(),is(1));
+        assertThat(persons.getContent().get(0).getFirstName(),is("John"));
+        assertThat(persons.getContent().get(0).getLastName(),is("Smith"));
+        assertThat(persons.getContent().get(1).getId(),is(2));
+    }
+
+    @Test
+    public void testArgIsRowBounds() {
+        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+        {
+            RowBounds rowBounds = new RowBounds(0, 1);
+            Page<Person> persons = personMapper.findPage(rowBounds);
+            assertThat(persons.getTotal(), is(2L));
+            assertThat(persons.getContent().get(0).getId(), is(1));
+            assertThat(persons.getContent().get(0).getFirstName(), is("John"));
+            assertThat(persons.getContent().get(0).getLastName(), is("Smith"));
+        }
+        {
+            RowBounds rowBounds = new RowBounds(1, 1);
+            Page<Person> persons = personMapper.findPage(rowBounds);
+            assertThat(persons.getTotal(), is(2L));
+            assertThat(persons.getContent().get(0).getId(), is(2));
+            assertThat(persons.getContent().get(0).getFirstName(), is("Mike"));
+            assertThat(persons.getContent().get(0).getLastName(), is("Jordan"));
+        }
+    }
+
+    @Test
+    public void testArgIsAnyObject() {
+        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+        {
+            RowBounds rowBounds = new RowBounds(0, 1);
+            Page<Person> persons = personMapper.findPageByName("Joh", rowBounds);
+            assertThat(persons.getTotal(), is(1L));
+            assertThat(persons.getContent().get(0).getId(), is(1));
+        }
+        {
+            RowBounds rowBounds = new RowBounds(0, 1);
+            Page<Person> persons = personMapper.findPageByName("Jor", rowBounds);
+            assertThat(persons.getTotal(), is(1L));
+            assertThat(persons.getContent().get(0).getId(), is(2));
+        }
+    }
+
+    @Test
+    public void testArgIsResultHandlerOnCustomizeImplementation() {
+        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+        final List<Person> persons = new ArrayList<Person>();
+        ResultHandler<Person> resultHandler = new ResultHandler<Person>() {
+            @Override
+            public void handleResult(ResultContext<? extends Person> resultContext) {
+                persons.add(resultContext.getResultObject());
+            }
+        };
+        RowBounds rowBounds = new RowBounds(1,1);
+        long total = personMapper.collectPage(rowBounds, resultHandler);
+        assertThat(total, is(2L));
+        assertThat(persons.size(), is(1));
+        assertThat(persons.get(0).getId(), is(2));
+    }
+
+
+    @Test
+    public void testDelegatingMapperInterface() {
+        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+        RowBounds rowBounds = new RowBounds(1,1);
+        Page<Person> persons = personMapper.findPageDelegatingMapperInterface(rowBounds);
+        assertThat(persons.getTotal(), is(2L));
+        assertThat(persons.getContent().get(0).getId(), is(2));
+    }
+
+    @Test
+    public void testErrorForNotImplementDefaultClass() {
+        EmployeeMapper employeeMapper = sqlSession.getMapper(EmployeeMapper.class);
+
+        expectedException.expect(BindingException.class);
+        expectedException.expectMessage("Custom method does not found.");
+        expectedException.expectCause(Is.isA(ClassNotFoundException.class));
+
+        employeeMapper.countNotFoundDefaultImplementationType();
+    }
+
+    @Test
+    public void testErrorForNotImplementCustomMethod() {
+        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+
+        expectedException.expect(BindingException.class);
+        expectedException.expectMessage("Custom method does not found.");
+        expectedException.expectCause(Is.isA(NoSuchMethodException.class));
+
+        personMapper.findPageNotImplementCustomMethod();
+    }
+
+    @Test
+    public void testErrorForHandlingRuntimeException() {
+
+        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+
+        expectedException.expect(PersistenceException.class);
+        expectedException.expectMessage("Test for handling a runtime exception.");
+        expectedException.expectCause(Is.isA(SQLException.class));
+
+        personMapper.findPageThrowRuntimeException();
+    }
+
+    @Test
+    public void testErrorForHandlingError() {
+
+        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+
+        expectedException.expect(OutOfMemoryError.class);
+        expectedException.expectMessage("Test for handling an error.");
+
+        personMapper.findPageThrowError();
+    }
+
+    @Test
+    public void testErrorForHandlingException() {
+
+        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+
+        expectedException.expect(BindingException.class);
+        expectedException.expectMessage("Custom method invocation is failed.");
+        expectedException.expectCause(Is.isA(IllegalAccessException.class));
+
+        personMapper.findPageThrowException();
+    }
+
+    /**
+     * Test for normal mapper methods
+     */
+    @Test
+    public void testCallMapperMethod() {
+        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+        {
+            List<Person> persons = personMapper.findList(new RowBounds());
+            assertThat(persons.size(), is(2));
+            assertThat(persons.get(0).getId(), is(1));
+            assertThat(persons.get(1).getId(), is(2));
+        }
+        {
+            long count = personMapper.countAll();
+            assertThat(count, is(2L));
+        }
+    }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/custom_method/EmployeeMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_method/EmployeeMapper.java
@@ -13,11 +13,17 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.mapping;
+package org.apache.ibatis.submitted.custom_method;
+
+import org.apache.ibatis.annotations.CustomMethod;
 
 /**
- * @author Clinton Begin
+ * Mapper interface for test that default implementation class does not found.
+ * @author Kazuki Shimizu
  */
-public enum SqlCommandType {
-  UNKNOWN, INSERT, UPDATE, DELETE, SELECT, FLUSH, CUSTOM;
+public interface EmployeeMapper {
+
+    @CustomMethod
+    long countNotFoundDefaultImplementationType();
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_method/Page.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_method/Page.java
@@ -1,0 +1,49 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.custom_method;
+
+import org.apache.ibatis.session.RowBounds;
+
+import java.io.Serializable;
+import java.util.List;
+
+public class Page<E> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<E> content;
+    private final long total;
+    private final RowBounds rowBounds;
+
+    public Page(List<E> content, long total, RowBounds rowBounds) {
+        this.content = content;
+        this.total = total;
+        this.rowBounds = rowBounds;
+    }
+
+    public List<E> getContent() {
+        return content;
+    }
+
+    public long getTotal() {
+        return total;
+    }
+
+    public RowBounds getRowBounds() {
+        return rowBounds;
+    }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/custom_method/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_method/Person.java
@@ -13,11 +13,34 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.mapping;
+package org.apache.ibatis.submitted.custom_method;
 
 /**
- * @author Clinton Begin
+ * @author Kazuki Shimizu
  */
-public enum SqlCommandType {
-  UNKNOWN, INSERT, UPDATE, DELETE, SELECT, FLUSH, CUSTOM;
+public class Person {
+
+    private Integer id;
+    private String firstName;
+    private String lastName;
+
+    public String getFirstName() {
+        return firstName;
+    }
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+    public String getLastName() {
+        return lastName;
+    }
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+    public Integer getId() {
+        return id;
+    }
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_method/PersonCollector.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_method/PersonCollector.java
@@ -1,0 +1,38 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.custom_method;
+
+import org.apache.ibatis.session.ResultHandler;
+import org.apache.ibatis.session.RowBounds;
+import org.apache.ibatis.session.SqlSession;
+
+/**
+ * Custom implementation class which implements a custom method.
+ * @author Kazuki Shimizu
+ */
+public class PersonCollector {
+
+    private static final String MAPPER_NAME = PersonMapper.class.getName();
+
+    public long collect(SqlSession sqlSession, RowBounds rowBounds, ResultHandler resultHandler) {
+        Long count = sqlSession.selectOne(MAPPER_NAME + ".countAll");
+        if (0 < count) {
+            sqlSession.select(MAPPER_NAME + ".collect", null, rowBounds, resultHandler);
+        }
+        return count;
+    }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/custom_method/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_method/PersonMapper.java
@@ -1,0 +1,62 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.custom_method;
+
+import org.apache.ibatis.annotations.CustomMethod;
+import org.apache.ibatis.session.ResultHandler;
+import org.apache.ibatis.session.RowBounds;
+
+import java.util.List;
+
+/**
+ * Mapper interface which defined some custom methods.
+ * @author Kazuki Shimizu
+ */
+public interface PersonMapper {
+
+    // Mapper methods
+    long countAll();
+    List<Person> findList(RowBounds rowBounds);
+
+    // Custom methods
+    @CustomMethod
+    Page<Person> findPage();
+
+    @CustomMethod
+    Page<Person> findPage(RowBounds rowBounds);
+
+    @CustomMethod
+    Page<Person> findPageByName(String name, RowBounds rowBounds);
+
+    @CustomMethod(type = PersonCollector.class, method = "collect")
+    long collectPage(RowBounds rowBounds, ResultHandler resultHandler);
+
+    @CustomMethod
+    Page<Person> findPageDelegatingMapperInterface(RowBounds rowBounds);
+
+    @CustomMethod
+    long findPageNotImplementCustomMethod();
+
+    @CustomMethod
+    long findPageThrowRuntimeException();
+
+    @CustomMethod
+    long findPageThrowError();
+
+    @CustomMethod
+    long findPageThrowException();
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/custom_method/PersonMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/custom_method/PersonMapper.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+       Copyright 2009-2012 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.custom_method.PersonMapper">
+    
+    <select id="countAll" resultType="_long">
+        SELECT
+          count(*)
+        FROM
+          person
+    </select>
+    <select id="findList" resultType="Person">
+        SELECT
+          id
+          ,firstName
+          ,lastName
+        FROM
+          person
+    </select>
+
+    <select id="collect" resultType="Person">
+        SELECT
+          id
+          ,firstName
+          ,lastName
+        FROM
+          person
+        ORDER BY
+          id
+    </select>
+
+    <select id="countByName" resultType="_long">
+        SELECT
+          count(*)
+        FROM
+          person
+        WHERE
+          firstName LIKE ('%' || #{name} || '%')
+        OR
+          lastName LIKE ('%' || #{name} || '%')
+    </select>
+    <select id="findListByName" resultType="Person">
+        SELECT
+          id
+          ,firstName
+          ,lastName
+        FROM
+          person
+        WHERE
+          firstName LIKE ('%' || #{name} || '%')
+        OR
+          lastName LIKE ('%' || #{name} || '%')
+        ORDER BY
+          id
+    </select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/custom_method/PersonMapperImpl.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_method/PersonMapperImpl.java
@@ -1,0 +1,86 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.custom_method;
+
+import org.apache.ibatis.exceptions.PersistenceException;
+import org.apache.ibatis.session.RowBounds;
+import org.apache.ibatis.session.SqlSession;
+
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Default implementation class which implements a custom method.
+ * @author Kazuki Shimizu
+ */
+public class PersonMapperImpl {
+
+    private static final String MAPPER_NAME = PersonMapper.class.getName();
+
+    public Page<Person> findPage(SqlSession sqlSession) {
+        return findPage(sqlSession, new RowBounds());
+    }
+
+    public Page<Person> findPage(SqlSession sqlSession, RowBounds rowBounds) {
+        Long count = sqlSession.selectOne(MAPPER_NAME + ".countAll");
+        List<Person> content;
+        if (0 < count) {
+            content = sqlSession.selectList(MAPPER_NAME + ".findList", null, rowBounds);
+        } else {
+            content = Collections.emptyList();
+        }
+        return new Page<Person>(content, count, rowBounds);
+    }
+
+    public Page<Person> findPageByName(SqlSession sqlSession, String name, RowBounds rowBounds) {
+        Long count = sqlSession.selectOne(MAPPER_NAME + ".countByName", name);
+        List<Person> content;
+        if (0 < count) {
+            content = sqlSession.selectList(MAPPER_NAME + ".findListByName", name, rowBounds);
+        } else {
+            content = Collections.emptyList();
+        }
+        return new Page<Person>(content, count, rowBounds);
+    }
+
+
+    public Page<Person> findPageDelegatingMapperInterface(SqlSession sqlSession, RowBounds rowBounds) {
+        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+        Long count = personMapper.countAll();
+        List<Person> content;
+        if (0 < count) {
+            content = personMapper.findList(rowBounds);
+        } else {
+            content = Collections.emptyList();
+        }
+        return new Page<Person>(content, count, rowBounds);
+    }
+
+    public long findPageThrowRuntimeException(SqlSession sqlSession) {
+        throw new PersistenceException("Test for handling a runtime exception.", new SQLException());
+    }
+
+    public long findPageThrowError(SqlSession sqlSession) {
+        throw new OutOfMemoryError("Test for handling an error.");
+    }
+
+    // Not access from other class
+    private long findPageThrowException(SqlSession sqlSession) {
+        return 0;
+    }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/custom_method/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/custom_method/mybatis-config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+       Copyright 2009-2015 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <settings>
+        <setting name="logImpl" value="STDOUT_LOGGING"/>
+    </settings>
+
+    <typeAliases>
+        <typeAlias type="org.apache.ibatis.submitted.custom_method.Person"/>
+    </typeAliases>
+
+    <environments default="test">
+        <environment id="test">
+            <transactionManager type="JDBC" />
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="org.hsqldb.jdbcDriver"/>
+                <property name="url" value="jdbc:hsqldb:mem:custom_method"/>
+                <property name="username" value="sa"/>
+            </dataSource>
+        </environment>
+    </environments>
+    
+</configuration>


### PR DESCRIPTION
Hi MyBatis developers and users,

I've implemented mechanism for adding custom implementation method.

I use a Mapper interface of MyBatis to implement a Repository of DDD design.
Hence; i hope to add mechanism for adding custom method in Mapper interface.

For example, i plan to add following custom method using this mechanism.

* Fetch page object which contain total count and page content.
* Save a Entity with hide actual operation(insert or update)
* Save with entity and related entity at same time.
* etc ...

My prototype is below:

For details, refer to [javadoc of `@CustomMethod`](https://github.com/kazuki43zoo/mybatis-3/blob/custom-method/src/main/java/org/apache/ibatis/annotations/CustomMethod.java).
Note that English might be wrong because it is not native language.

How to define : 
```java
public interface PersonRepository {

    Person findOne(int id); // Normal mapper method

    @CustomMethod // Mark a custom method using annotation
    Page<Person> findPage(Pageable pageable);

    @CustomMethod
    Person save(Person person);

}
```
How to implement a custom method : 
```java
public class PersonRepositoryImpl {
    public Page<Person> findPage(SqlSession sqlSession, Pageable pageable) {
        // fetch total count and page content using SqlSession APIs or Mapper interface
        // ...
        return new PageImpl(content, pageable, totalCount);
    }

    public Person save(SqlSession sqlSession, Person person) {
        // insert or update suing SqlSession APIs or Mapper interface
        // ... 
        return person;
    }

}
```

Please give me free opinions.

Thanks.
