### PR TITLE
Bad connection issue if autoCommit = false

### DIFF
--- a/src/main/java/org/apache/ibatis/datasource/pooled/PooledDataSource.java
+++ b/src/main/java/org/apache/ibatis/datasource/pooled/PooledDataSource.java
@@ -397,7 +397,11 @@ public class PooledDataSource implements DataSource {
               state.accumulatedCheckoutTime += longestCheckoutTime;
               state.activeConnections.remove(oldestActiveConnection);
               if (!oldestActiveConnection.getRealConnection().getAutoCommit()) {
-                oldestActiveConnection.getRealConnection().rollback();
+                try {
+                  oldestActiveConnection.getRealConnection().rollback();
+                } catch (SQLException e) {
+                  log.debug("Bad connection. Could not roll back");
+                }  
               }
               conn = new PooledConnection(oldestActiveConnection.getRealConnection(), this);
               oldestActiveConnection.invalidate();


### PR DESCRIPTION
The issue appears in the flowing case:
- if autoCommit = false
- poolPingEnabled = true and poolPingQuery is set
- number of connections in the pool = poolMaximumActiveConnections
- connection state.activeConnections.get(0) is bad, for example database was restarted.

Currently the following is happened:

we are trying to execute sql query (query1) with the new connection getting and have the following:

 state.activeConnections.remove(oldestActiveConnection);
              if (!oldestActiveConnection.getRealConnection().getAutoCommit()) {
                  oldestActiveConnection.getRealConnection().rollback();
                } 

so the old connection is removed from the pool and we are trying to rollback it. But connection is bad and it throws an exception so method stops execution.   

The issue here: sql query (query1) execution will never be executed - we lost it forever.

if AutoCommit = true - rollback is not needed and method will continue execution and connection will be reconnected at the end and query1 will not be lost.

Thanks,
Natalia