### PR TITLE
Solves build problems after cloning the repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>22-SNAPSHOT</version>
+    <version>27-SNAPSHOT</version>
   </parent>
 
   <artifactId>mybatis</artifactId>
@@ -264,6 +264,7 @@
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>jarjar-maven-plugin</artifactId>
+        <version>1.9</version>
         <configuration>
           <input>{classes}</input>
           <input>{test-classes}</input>
@@ -319,6 +320,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
+        <version>2.7</version>
         <configuration>
           <instrumentation>
             <ignores>


### PR DESCRIPTION
I ran into a problem building MyBatis 3.3.0-SNAPSHOT after cloning the repo.

`mvn clean install` yields two errors:


### Non-resolvable parent POM
```
...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for org.mybatis:mybatis:3.3.0-SNAPSHOT: Could not find artifact org.mybatis:mybatis-parent:pom:22-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 21, column 11
 @ 
[ERROR] 
...
```
To resolve I checked out [mybatis-parent](https://github.com/mybatis/parent), did a `mvn install` there and changed the parent-pom version from 22-SNAPSHOT to 27-SNAPSHOT.
```
<parent>
    <groupId>org.mybatis</groupId>
    <artifactId>mybatis-parent</artifactId>
    <version>27-SNAPSHOT</version>
  </parent>
```
Unfortunately now the builds fails because of the enforcer plugin.
### Missing valid versions
```
...
[WARNING] Rule 2: org.apache.maven.plugins.enforcer.RequirePluginVersions failed with message:
Some plugins are missing valid versions:(LATEST RELEASE SNAPSHOT are not allowed )
org.codehaus.mojo:cobertura-maven-plugin. 	The version currently in use is 2.7
org.sonatype.plugins:jarjar-maven-plugin. 	The version currently in use is 1.9
[ERROR] Best Practice is to always define plugin versions!
...
```
After I added the version tag to both plugins the builds runs without problems.
