### PR TITLE
Support insert multiple rows and write-back id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,6 +244,12 @@
       <version>9.1-901-1.jdbc4</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>5.1.29</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/org/apache/ibatis/executor/keygen/Country.java
+++ b/src/test/java/org/apache/ibatis/executor/keygen/Country.java
@@ -1,0 +1,48 @@
+package org.apache.ibatis.executor.keygen;
+
+/**
+ * @author liuzh
+ */
+public class Country {
+  private Integer id;
+  private String countryname;
+  private String countrycode;
+
+  public Country() {
+  }
+
+  public Country(String countryname, String countrycode) {
+    this.countryname = countryname;
+    this.countrycode = countrycode;
+  }
+
+  public Country(Integer id, String countryname, String countrycode) {
+    this.id = id;
+    this.countryname = countryname;
+    this.countrycode = countrycode;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getCountryname() {
+    return countryname;
+  }
+
+  public void setCountryname(String countryname) {
+    this.countryname = countryname;
+  }
+
+  public String getCountrycode() {
+    return countrycode;
+  }
+
+  public void setCountrycode(String countrycode) {
+    this.countrycode = countrycode;
+  }
+}

--- a/src/test/java/org/apache/ibatis/executor/keygen/CountryMapper.java
+++ b/src/test/java/org/apache/ibatis/executor/keygen/CountryMapper.java
@@ -1,0 +1,9 @@
+package org.apache.ibatis.executor.keygen;
+
+import java.util.List;
+
+public interface CountryMapper {
+
+  int insertList(List<Country> countries);
+
+}

--- a/src/test/java/org/apache/ibatis/executor/keygen/CountryMapper.xml
+++ b/src/test/java/org/apache/ibatis/executor/keygen/CountryMapper.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.executor.keygen.CountryMapper" >
+  <insert id="insertList" parameterType="org.apache.ibatis.executor.keygen.Country" useGeneratedKeys="true" keyProperty="id" keyColumn="id">
+      insert into country (countryname,countrycode)
+      values
+      <foreach collection="list" separator="," item="country">
+          (#{country.countryname},#{country.countrycode})
+      </foreach>
+  </insert>
+</mapper>

--- a/src/test/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGeneratorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGeneratorTest.java
@@ -1,0 +1,42 @@
+package org.apache.ibatis.executor.keygen;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author liuzh
+ */
+@Ignore("See setupdb.txt for instructions on how to run the tests in this class")
+public class Jdbc3KeyGeneratorTest {
+
+  @Test
+  public void shouldInsertListAndRetrieveId() throws Exception {
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/executor/keygen/MapperConfig.xml");
+    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+      List<Country> countries = new ArrayList<Country>();
+      countries.add(new Country("China", "CN"));
+      countries.add(new Country("United Kiongdom", "GB"));
+      countries.add(new Country("United States of America", "US"));
+      mapper.insertList(countries);
+      for (Country country : countries) {
+        assertNotNull(country.getId());
+      }
+    } finally {
+      sqlSession.rollback();
+      sqlSession.close();
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/executor/keygen/MapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/executor/keygen/MapperConfig.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value=""/>
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="com.mysql.jdbc.Driver"/>
+        <property name="url" value="jdbc:mysql://localhost:3306/mbtest"/>
+        <property name="username" value="root"/>
+        <property name="password" value=""/>
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper resource="org/apache/ibatis/executor/keygen/CountryMapper.xml"/>
+  </mappers>
+</configuration>

--- a/src/test/java/org/apache/ibatis/executor/keygen/setupdb.txt
+++ b/src/test/java/org/apache/ibatis/executor/keygen/setupdb.txt
@@ -1,0 +1,21 @@
+The tests in this package are dependent on a local install
+of MySql.  This file contains instructions for setting up
+MySql so that the tests will run successfully.  To run the tests,
+follow the database setup instructions in this file, then remove the
+@Ignore annotation on the test class and run the tests with Maven
+or a local JUnit test runner.
+
+DO NOT commit the test class without the @Ignore annotation or it will
+break the MyBatis build on machines that don't have MySql setup.
+
+1. Download and install MySql.
+2. Create a database called "mbtest"
+3. Create the following table:
+
+  DROP TABLE IF EXISTS `country`;
+  CREATE TABLE `country` (
+    `Id` int(11) NOT NULL AUTO_INCREMENT,
+    `countryname` varchar(255) DEFAULT NULL,
+    `countrycode` varchar(255) DEFAULT NULL,
+    PRIMARY KEY (`Id`)
+  ) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Support insert multiple rows and write-back id.

Multirow inserts

A SQL feature (since SQL-92) is the use of row value constructors to insert multiple rows at a time in a single SQL statement:

INSERT INTO tablename (column-a, [column-b, ...])
VALUES ('value-1a', ['value-1b', ...]),
       ('value-2a', ['value-2b', ...]),
       ...
This feature is supported by DB2, SQL Server (since version 10.0 - i.e. 2008), PostgreSQL (since version 8.2), MySQL, sqlite (since version 3.7.11) and H2.

More about insert see here:

http://en.wikipedia.org/wiki/Insert_(SQL)
More details of this pull request see here: #350 