### PR TITLE
Correct logging of 'N' parameters

### DIFF
--- a/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
@@ -59,6 +59,7 @@ public abstract class BaseJdbcLogger {
 
   static {
     SET_METHODS.add("setString");
+    SET_METHODS.add("setNString");
     SET_METHODS.add("setInt");
     SET_METHODS.add("setByte");
     SET_METHODS.add("setShort");
@@ -76,7 +77,9 @@ public abstract class BaseJdbcLogger {
     SET_METHODS.add("setBoolean");
     SET_METHODS.add("setBytes");
     SET_METHODS.add("setCharacterStream");
+    SET_METHODS.add("setNCharacterStream");
     SET_METHODS.add("setClob");
+    SET_METHODS.add("setNClob");
     SET_METHODS.add("setObject");
     SET_METHODS.add("setNull");
 


### PR DESCRIPTION
With the reintroduction of the setNString, setNCharacterStream, and
setNClob the BaseJdbcLogger needs to be updated to recognize these and
emit them in the logging stream to be consistent with other character
types.