### PR TITLE
inappropriate translation

### DIFF
--- a/src/site/ko/xdoc/sqlmap-xml.xml
+++ b/src/site/ko/xdoc/sqlmap-xml.xml
@@ -145,12 +145,12 @@ ps.setInt(1,id);]]></source>
             </tr>
             <tr>
               <td><code>flushCache</code></td>
-              <td>이 값을 true 로 셋팅하면 구문이 호출될때마다 캐시가 지원질것이다(flush). 
+              <td>이 값을 true 로 셋팅하면 구문이 호출될때마다 로컬, 2nd 레벨 캐시가 지워질것이다(flush). 
 			  디폴트는 false이다.</td>
             </tr>
             <tr>
               <td><code>useCache</code></td>
-              <td>이 값을 true 로 셋팅하면 구문의 결과가 캐시될 것이다. 
+              <td>이 값을 true 로 셋팅하면 구문의 결과가 2nd 레벨 캐시에 캐시 될 것이다. 
 			  디폴트는 true이다.</td>
             </tr>
             <tr>


### PR DESCRIPTION
It did not specify for level of cache. (local cache and 2nd cache)
typo(지원질) is fixed.