### PR TITLE
Add new option for specify the behavior when detects an unknown column of automatic mapping target

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -37,6 +37,7 @@ import org.apache.ibatis.reflection.ReflectorFactory;
 import org.apache.ibatis.reflection.factory.ObjectFactory;
 import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
 import org.apache.ibatis.session.AutoMappingBehavior;
+import org.apache.ibatis.session.AutoMappingUnknownColumnBehavior;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.LocalCacheScope;
@@ -230,6 +231,7 @@ public class XMLConfigBuilder extends BaseBuilder {
 
   private void settingsElement(Properties props) throws Exception {
     configuration.setAutoMappingBehavior(AutoMappingBehavior.valueOf(props.getProperty("autoMappingBehavior", "PARTIAL")));
+    configuration.setAutoMappingUnknownColumnBehavior(AutoMappingUnknownColumnBehavior.valueOf(props.getProperty("autoMappingUnknownColumnBehavior", "NONE")));
     configuration.setCacheEnabled(booleanValueOf(props.getProperty("cacheEnabled"), true));
     configuration.setProxyFactory((ProxyFactory) createInstance(props.getProperty("proxyFactory")));
     configuration.setLazyLoadingEnabled(booleanValueOf(props.getProperty("lazyLoadingEnabled"), false));

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -478,11 +478,11 @@ public class DefaultResultSetHandler implements ResultSetHandler {
             autoMapping.add(new UnMappedColumAutoMapping(columnName, property, typeHandler, propertyType.isPrimitive()));
           } else {
             configuration.getAutoMappingUnknownColumnBehavior()
-                    .doAction(columnName, property, propertyType);
+                    .doAction(mappedStatement, columnName, property, propertyType);
           }
         } else{
           configuration.getAutoMappingUnknownColumnBehavior()
-                  .doAction(columnName, (property != null) ? property : propertyName, null);
+                  .doAction(mappedStatement, columnName, (property != null) ? property : propertyName, null);
         }
       }
       autoMappingsCache.put(mapKey, autoMapping);

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -476,7 +476,13 @@ public class DefaultResultSetHandler implements ResultSetHandler {
           if (typeHandlerRegistry.hasTypeHandler(propertyType, rsw.getJdbcType(columnName))) {
             final TypeHandler<?> typeHandler = rsw.getTypeHandler(propertyType, columnName);
             autoMapping.add(new UnMappedColumAutoMapping(columnName, property, typeHandler, propertyType.isPrimitive()));
+          } else {
+            configuration.getAutoMappingUnknownColumnBehavior()
+                    .doAction(columnName, property, propertyType);
           }
+        } else{
+          configuration.getAutoMappingUnknownColumnBehavior()
+                  .doAction(columnName, (property != null) ? property : propertyName, null);
         }
       }
       autoMappingsCache.put(mapKey, autoMapping);

--- a/src/main/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehavior.java
+++ b/src/main/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehavior.java
@@ -1,0 +1,87 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.session;
+
+import org.apache.ibatis.logging.Log;
+import org.apache.ibatis.logging.LogFactory;
+
+/**
+ * Specify the behavior when detects an unknown column (or unknown property type) of automatic mapping target.
+ *
+ * @author Kazuki Shimizu
+ * @since 3.3.2
+ */
+public enum AutoMappingUnknownColumnBehavior {
+
+  /**
+   * Do nothing (Default).
+   */
+  NONE {
+    @Override
+    public void doAction(String columnName, String property, Class<?> propertyType) {
+      // do nothing
+    }
+  },
+
+  /**
+   * Output warning log.
+   * Note: The log level of {@code 'org.apache.ibatis.session.AutoMappingUnknownColumnBehavior'} must be set to {@code WARN}.
+   */
+  WARNING {
+    @Override
+    public void doAction(String columnName, String property, Class<?> propertyType) {
+      log.warn(buildMessage(columnName, property, propertyType));
+    }
+  },
+
+  /**
+   * Fail mapping.
+   * Note: throw {@link SqlSessionException}.
+   */
+  FAILING {
+    @Override
+    public void doAction(String columnName, String property, Class<?> propertyType) {
+      throw new SqlSessionException(buildMessage(columnName, property, propertyType));
+    }
+  };
+
+  /**
+   * Logger
+   */
+  private static final Log log = LogFactory.getLog(AutoMappingUnknownColumnBehavior.class);
+
+  /**
+   * Perform the action when detects an unknown column (or unknown property type) of automatic mapping target.
+   * @param columnName column name for mapping target
+   * @param propertyName property name for mapping target
+   * @param propertyType property type for mapping target (If this argument is not null, {@link org.apache.ibatis.type.TypeHandler} for property type is not registered)
+     */
+  public abstract void doAction(String columnName, String propertyName, Class<?> propertyType);
+
+  /**
+   * build error message.
+   */
+  private static String buildMessage(String columnName, String property, Class<?> propertyType) {
+    return new StringBuilder("Unknown column is detected on auto-mapping. Mapping parameters are ")
+      .append("[")
+      .append("columnName=").append(columnName)
+      .append(",").append("propertyName=").append(property)
+      .append(",").append("propertyType=").append(propertyType != null ? propertyType.getName() : null)
+      .append("]")
+      .toString();
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehavior.java
+++ b/src/main/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehavior.java
@@ -17,6 +17,7 @@ package org.apache.ibatis.session;
 
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.logging.LogFactory;
+import org.apache.ibatis.mapping.MappedStatement;
 
 /**
  * Specify the behavior when detects an unknown column (or unknown property type) of automatic mapping target.
@@ -31,7 +32,7 @@ public enum AutoMappingUnknownColumnBehavior {
    */
   NONE {
     @Override
-    public void doAction(String columnName, String property, Class<?> propertyType) {
+    public void doAction(MappedStatement mappedStatement, String columnName, String property, Class<?> propertyType) {
       // do nothing
     }
   },
@@ -42,8 +43,8 @@ public enum AutoMappingUnknownColumnBehavior {
    */
   WARNING {
     @Override
-    public void doAction(String columnName, String property, Class<?> propertyType) {
-      log.warn(buildMessage(columnName, property, propertyType));
+    public void doAction(MappedStatement mappedStatement, String columnName, String property, Class<?> propertyType) {
+      log.warn(buildMessage(mappedStatement, columnName, property, propertyType));
     }
   },
 
@@ -53,8 +54,8 @@ public enum AutoMappingUnknownColumnBehavior {
    */
   FAILING {
     @Override
-    public void doAction(String columnName, String property, Class<?> propertyType) {
-      throw new SqlSessionException(buildMessage(columnName, property, propertyType));
+    public void doAction(MappedStatement mappedStatement, String columnName, String property, Class<?> propertyType) {
+      throw new SqlSessionException(buildMessage(mappedStatement, columnName, property, propertyType));
     }
   };
 
@@ -65,17 +66,20 @@ public enum AutoMappingUnknownColumnBehavior {
 
   /**
    * Perform the action when detects an unknown column (or unknown property type) of automatic mapping target.
+   * @param mappedStatement current mapped statement
    * @param columnName column name for mapping target
    * @param propertyName property name for mapping target
    * @param propertyType property type for mapping target (If this argument is not null, {@link org.apache.ibatis.type.TypeHandler} for property type is not registered)
      */
-  public abstract void doAction(String columnName, String propertyName, Class<?> propertyType);
+  public abstract void doAction(MappedStatement mappedStatement, String columnName, String propertyName, Class<?> propertyType);
 
   /**
    * build error message.
    */
-  private static String buildMessage(String columnName, String property, Class<?> propertyType) {
-    return new StringBuilder("Unknown column is detected on auto-mapping. Mapping parameters are ")
+  private static String buildMessage(MappedStatement mappedStatement, String columnName, String property, Class<?> propertyType) {
+    return new StringBuilder("Unknown column is detected on '")
+      .append(mappedStatement.getId())
+      .append("' auto-mapping. Mapping parameters are ")
       .append("[")
       .append("columnName=").append(columnName)
       .append(",").append("propertyName=").append(property)

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -117,6 +117,7 @@ public class Configuration {
   protected Integer defaultFetchSize;
   protected ExecutorType defaultExecutorType = ExecutorType.SIMPLE;
   protected AutoMappingBehavior autoMappingBehavior = AutoMappingBehavior.PARTIAL;
+  protected AutoMappingUnknownColumnBehavior autoMappingUnknownColumnBehavior = AutoMappingUnknownColumnBehavior.NONE;
 
   protected Properties variables = new Properties();
   protected ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
@@ -303,6 +304,20 @@ public class Configuration {
 
   public void setAutoMappingBehavior(AutoMappingBehavior autoMappingBehavior) {
     this.autoMappingBehavior = autoMappingBehavior;
+  }
+
+  /**
+   * @since 3.3.2
+   */
+  public AutoMappingUnknownColumnBehavior getAutoMappingUnknownColumnBehavior() {
+    return autoMappingUnknownColumnBehavior;
+  }
+
+  /**
+   * @since 3.3.2
+   */
+  public void setAutoMappingUnknownColumnBehavior(AutoMappingUnknownColumnBehavior autoMappingUnknownColumnBehavior) {
+    this.autoMappingUnknownColumnBehavior = autoMappingUnknownColumnBehavior;
   }
 
   public boolean isLazyLoadingEnabled() {

--- a/src/test/java/log4j.properties
+++ b/src/test/java/log4j.properties
@@ -20,7 +20,11 @@ log4j.rootLogger=ERROR, stdout
 ### Uncomment for MyBatis logging
 log4j.logger.org.apache.ibatis=ERROR
 
+log4j.logger.org.apache.ibatis.session.AutoMappingUnknownColumnBehavior=WARN, lastEventSavedAppender
+
 ### Console output...
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n
+
+log4j.appender.lastEventSavedAppender=org.apache.ibatis.session.AutoMappingUnknownColumnBehaviorTest$LastEventSavedAppender

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -25,6 +25,7 @@
 
   <settings>
     <setting name="autoMappingBehavior" value="NONE"/>
+    <setting name="autoMappingUnknownColumnBehavior" value="WARNING"/>
     <setting name="cacheEnabled" value="false"/>
     <setting name="proxyFactory" value="CGLIB"/>
     <setting name="lazyLoadingEnabled" value="true"/>

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -34,6 +34,7 @@ import org.apache.ibatis.logging.slf4j.Slf4jImpl;
 import org.apache.ibatis.scripting.defaults.RawLanguageDriver;
 import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
 import org.apache.ibatis.session.AutoMappingBehavior;
+import org.apache.ibatis.session.AutoMappingUnknownColumnBehavior;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.LocalCacheScope;
@@ -57,6 +58,7 @@ public class XmlConfigBuilderTest {
     Configuration config = builder.parse();
     assertNotNull(config);
     assertThat(config.getAutoMappingBehavior(), is(AutoMappingBehavior.PARTIAL));
+    assertThat(config.getAutoMappingUnknownColumnBehavior(), is(AutoMappingUnknownColumnBehavior.NONE));
     assertThat(config.isCacheEnabled(), is(true));
     assertThat(config.getProxyFactory(), is(instanceOf(JavassistProxyFactory.class)));
     assertThat(config.isLazyLoadingEnabled(), is(false));
@@ -145,6 +147,7 @@ public class XmlConfigBuilderTest {
       Configuration config = builder.parse();
 
       assertThat(config.getAutoMappingBehavior(), is(AutoMappingBehavior.NONE));
+      assertThat(config.getAutoMappingUnknownColumnBehavior(), is(AutoMappingUnknownColumnBehavior.WARNING));
       assertThat(config.isCacheEnabled(), is(false));
       assertThat(config.getProxyFactory(), is(instanceOf(CglibProxyFactory.class)));
       assertThat(config.isLazyLoadingEnabled(), is(true));

--- a/src/test/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehaviorTest.java
+++ b/src/test/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehaviorTest.java
@@ -1,0 +1,141 @@
+package org.apache.ibatis.session;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.domain.blog.Author;
+import org.apache.ibatis.exceptions.PersistenceException;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.transaction.TransactionFactory;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.varia.NullAppender;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.sql.DataSource;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Kazuki Shimizu
+ * @since 3.3.2
+ */
+public class AutoMappingUnknownColumnBehaviorTest {
+
+    interface Mapper {
+        @Select({
+                "SELECT ",
+                "  ID,",
+                "  USERNAME as USERNAMEEEE,", // unknown column
+                "  PASSWORD,",
+                "  EMAIL,",
+                "  BIO",
+                "FROM AUTHOR WHERE ID = #{id}"})
+        Author selectAuthor(int id);
+
+        @Select({
+                "SELECT ",
+                "  ID,", // unknown property type
+                "  USERNAME",
+                "FROM AUTHOR WHERE ID = #{id}"})
+        SimpleAuthor selectSimpleAuthor(int id);
+    }
+
+    static class SimpleAuthor {
+        private AtomicInteger id; // unknown property type
+        private String username;
+
+        public AtomicInteger getId() {
+            return id;
+        }
+
+        public void setId(AtomicInteger id) {
+            this.id = id;
+        }
+
+        public String getUsername() {
+            return username;
+        }
+
+        public void setUsername(String username) {
+            this.username = username;
+        }
+    }
+
+    public static class LastEventSavedAppender extends NullAppender {
+        private static LoggingEvent event;
+
+        public void doAppend(LoggingEvent event) {
+            LastEventSavedAppender.event = event;
+        }
+    }
+
+    private static SqlSessionFactory sqlSessionFactory;
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        DataSource dataSource = BaseDataTest.createBlogDataSource();
+        TransactionFactory transactionFactory = new JdbcTransactionFactory();
+        Environment environment = new Environment("Production", transactionFactory, dataSource);
+        Configuration configuration = new Configuration(environment);
+        configuration.addMapper(Mapper.class);
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+    }
+
+    @Test
+    public void none() {
+        sqlSessionFactory.getConfiguration().setAutoMappingUnknownColumnBehavior(AutoMappingUnknownColumnBehavior.NONE);
+        SqlSession session = sqlSessionFactory.openSession();
+        try {
+            Mapper mapper = session.getMapper(Mapper.class);
+            Author author = mapper.selectAuthor(101);
+            assertThat(author.getId(), is(101));
+            assertThat(author.getUsername(), nullValue());
+        } finally {
+            session.close();
+        }
+
+    }
+
+    @Test
+    public void warningCauseByUnknownPropertyType() {
+        sqlSessionFactory.getConfiguration().setAutoMappingUnknownColumnBehavior(AutoMappingUnknownColumnBehavior.WARNING);
+
+        SqlSession session = sqlSessionFactory.openSession();
+
+        try {
+            Mapper mapper = session.getMapper(Mapper.class);
+            SimpleAuthor author = mapper.selectSimpleAuthor(101);
+            assertThat(author.getId(), nullValue());
+            assertThat(author.getUsername(), is("jim"));
+            assertThat(LastEventSavedAppender.event.getMessage().toString(), is("Unknown column is detected on auto-mapping. Mapping parameters are [columnName=ID,propertyName=id,propertyType=java.util.concurrent.atomic.AtomicInteger]"));
+
+        } finally {
+            session.close();
+        }
+
+    }
+
+    @Test
+    public void failingCauseByUnknownColumn() {
+        sqlSessionFactory.getConfiguration().setAutoMappingUnknownColumnBehavior(AutoMappingUnknownColumnBehavior.FAILING);
+
+        SqlSession session = sqlSessionFactory.openSession();
+
+        try {
+            Mapper mapper = session.getMapper(Mapper.class);
+            mapper.selectAuthor(101);
+        } catch (PersistenceException e) {
+            assertThat(e.getCause(), instanceOf(SqlSessionException.class));
+            assertThat(e.getCause().getMessage(), is("Unknown column is detected on auto-mapping. Mapping parameters are [columnName=USERNAMEEEE,propertyName=USERNAMEEEE,propertyType=null]"));
+        } finally {
+            session.close();
+        }
+
+    }
+
+}

--- a/src/test/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehaviorTest.java
+++ b/src/test/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehaviorTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.session;
 
 import org.apache.ibatis.BaseDataTest;
@@ -21,6 +36,8 @@ import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
 
 /**
+ * Tests for specify the behavior when detects an unknown column (or unknown property type) of automatic mapping target.
+ *
  * @author Kazuki Shimizu
  * @since 3.3.2
  */
@@ -112,7 +129,7 @@ public class AutoMappingUnknownColumnBehaviorTest {
             SimpleAuthor author = mapper.selectSimpleAuthor(101);
             assertThat(author.getId(), nullValue());
             assertThat(author.getUsername(), is("jim"));
-            assertThat(LastEventSavedAppender.event.getMessage().toString(), is("Unknown column is detected on auto-mapping. Mapping parameters are [columnName=ID,propertyName=id,propertyType=java.util.concurrent.atomic.AtomicInteger]"));
+            assertThat(LastEventSavedAppender.event.getMessage().toString(), is("Unknown column is detected on 'org.apache.ibatis.session.AutoMappingUnknownColumnBehaviorTest$Mapper.selectSimpleAuthor' auto-mapping. Mapping parameters are [columnName=ID,propertyName=id,propertyType=java.util.concurrent.atomic.AtomicInteger]"));
 
         } finally {
             session.close();
@@ -131,7 +148,7 @@ public class AutoMappingUnknownColumnBehaviorTest {
             mapper.selectAuthor(101);
         } catch (PersistenceException e) {
             assertThat(e.getCause(), instanceOf(SqlSessionException.class));
-            assertThat(e.getCause().getMessage(), is("Unknown column is detected on auto-mapping. Mapping parameters are [columnName=USERNAMEEEE,propertyName=USERNAMEEEE,propertyType=null]"));
+            assertThat(e.getCause().getMessage(), is("Unknown column is detected on 'org.apache.ibatis.session.AutoMappingUnknownColumnBehaviorTest$Mapper.selectAuthor' auto-mapping. Mapping parameters are [columnName=USERNAMEEEE,propertyName=USERNAMEEEE,propertyType=null]"));
         } finally {
             session.close();
         }


### PR DESCRIPTION
I added a new option for specify the behavior when detects an unknown column (or unknown property type) of automatic mapping target.

Options are as follow:

* NONE : Do nothing (Default) -> Same with current implementation
* WARNING : Output warning log with detail
* FAILING : Fail mapping (throw `SqlSessionException` with detail)

I think this option is useful for detects a type mistake during development.

What do you think ?


