### PR TITLE
Support TypeHandler for Blob/InputStream and Clob/Reader using method supported at JDBC 4.0

### DIFF
--- a/src/main/java/org/apache/ibatis/type/BlobInputStreamTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BlobInputStreamTypeHandler.java
@@ -1,0 +1,76 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.io.InputStream;
+import java.sql.*;
+
+/**
+ * The {@link TypeHandler} for {@link Blob}/{@link InputStream} using method supported at JDBC 4.0.
+ * @author Kazuki Shimizu
+ * @since 3.4.0
+ */
+public class BlobInputStreamTypeHandler extends BaseTypeHandler<InputStream> {
+
+  /**
+   * Set an {@link InputStream} into {@link PreparedStatement}.
+   * @see PreparedStatement#setBlob(int, InputStream)
+   */
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, InputStream parameter, JdbcType jdbcType)
+      throws SQLException {
+    ps.setBlob(i, parameter);
+  }
+
+  /**
+   * Get an {@link InputStream} that corresponds to a specified column name from {@link ResultSet}.
+   * @see ResultSet#getBlob(String)
+   */
+  @Override
+  public InputStream getNullableResult(ResultSet rs, String columnName)
+      throws SQLException {
+    return toInputStream(rs.getBlob(columnName));
+  }
+
+  /**
+   * Get an {@link InputStream} that corresponds to a specified column index from {@link ResultSet}.
+   * @see ResultSet#getBlob(int)
+   */
+  @Override
+  public InputStream getNullableResult(ResultSet rs, int columnIndex)
+      throws SQLException {
+    return toInputStream(rs.getBlob(columnIndex));
+  }
+
+  /**
+   * Get an {@link InputStream} that corresponds to a specified column index from {@link CallableStatement}.
+   * @see CallableStatement#getBlob(int)
+   */
+  @Override
+  public InputStream getNullableResult(CallableStatement cs, int columnIndex)
+      throws SQLException {
+    return toInputStream(cs.getBlob(columnIndex));
+  }
+
+  private InputStream toInputStream(Blob blob) throws SQLException {
+    if (blob == null) {
+      return null;
+    } else {
+      return blob.getBinaryStream();
+    }
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/type/ClobReaderTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ClobReaderTypeHandler.java
@@ -1,0 +1,76 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.io.Reader;
+import java.sql.*;
+
+/**
+ * The {@link TypeHandler} for {@link Clob}/{@link Reader} using method supported at JDBC 4.0.
+ * @author Kazuki Shimizu
+ * @since 3.4.0
+ */
+public class ClobReaderTypeHandler extends BaseTypeHandler<Reader> {
+
+  /**
+   * Set a {@link Reader} into {@link PreparedStatement}.
+   * @see PreparedStatement#setClob(int, Reader)
+   */
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, Reader parameter, JdbcType jdbcType)
+      throws SQLException {
+    ps.setClob(i, parameter);
+  }
+
+  /**
+   * Get a {@link Reader} that corresponds to a specified column name from {@link ResultSet}.
+   * @see ResultSet#getClob(String)
+   */
+  @Override
+  public Reader getNullableResult(ResultSet rs, String columnName)
+      throws SQLException {
+    return toReader(rs.getClob(columnName));
+  }
+
+  /**
+   * Get a {@link Reader} that corresponds to a specified column index from {@link ResultSet}.
+   * @see ResultSet#getClob(int)
+   */
+  @Override
+  public Reader getNullableResult(ResultSet rs, int columnIndex)
+      throws SQLException {
+    return toReader(rs.getClob(columnIndex));
+  }
+
+  /**
+   * Get a {@link Reader} that corresponds to a specified column index from {@link CallableStatement}.
+   * @see CallableStatement#getClob(int)
+   */
+  @Override
+  public Reader getNullableResult(CallableStatement cs, int columnIndex)
+      throws SQLException {
+    return toReader(cs.getClob(columnIndex));
+  }
+
+  private Reader toReader(Clob clob) throws SQLException {
+    if (clob == null) {
+      return null;
+    } else {
+      return clob.getCharacterStream();
+    }
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -15,6 +15,8 @@
  */
 package org.apache.ibatis.type;
 
+import java.io.InputStream;
+import java.io.Reader;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
@@ -70,6 +72,7 @@ public final class TypeHandlerRegistry {
     register(double.class, new DoubleTypeHandler());
     register(JdbcType.DOUBLE, new DoubleTypeHandler());
 
+    register(Reader.class, new ClobReaderTypeHandler());
     register(String.class, new StringTypeHandler());
     register(String.class, JdbcType.CHAR, new StringTypeHandler());
     register(String.class, JdbcType.CLOB, new ClobTypeHandler());
@@ -97,6 +100,7 @@ public final class TypeHandlerRegistry {
     register(JdbcType.DECIMAL, new BigDecimalTypeHandler());
     register(JdbcType.NUMERIC, new BigDecimalTypeHandler());
 
+    register(InputStream.class, new BlobInputStreamTypeHandler());
     register(Byte[].class, new ByteObjectArrayTypeHandler());
     register(Byte[].class, JdbcType.BLOB, new BlobByteObjectArrayTypeHandler());
     register(Byte[].class, JdbcType.LONGVARBINARY, new BlobByteObjectArrayTypeHandler());

--- a/src/test/java/org/apache/ibatis/type/BlobInputStreamTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/BlobInputStreamTypeHandlerTest.java
@@ -1,0 +1,161 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.transaction.TransactionFactory;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import javax.sql.DataSource;
+import java.io.*;
+import java.sql.Blob;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link BlobInputStreamTypeHandler}.
+ *
+ * @author Kazuki Shimizu
+ * @since 3.4.0
+ */
+public class BlobInputStreamTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<InputStream> TYPE_HANDLER = new BlobInputStreamTypeHandler();
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @Mock
+  protected Blob blob;
+
+  @BeforeClass
+  public static void setupSqlSessionFactory() throws Exception {
+    DataSource dataSource = BaseDataTest.createUnpooledDataSource("org/apache/ibatis/type/jdbc.properties");
+    BaseDataTest.runScript(dataSource, "org/apache/ibatis/type/BlobInputStreamTypeHandlerTest.sql");
+    TransactionFactory transactionFactory = new JdbcTransactionFactory();
+    Environment environment = new Environment("Production", transactionFactory, dataSource);
+    Configuration configuration = new Configuration(environment);
+    configuration.addMapper(Mapper.class);
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+  }
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    InputStream in = new ByteArrayInputStream("Hello".getBytes());
+    TYPE_HANDLER.setParameter(ps, 1, in, null);
+    verify(ps).setBlob(1, in);
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSet() throws Exception {
+    InputStream in = new ByteArrayInputStream("Hello".getBytes());
+    when(rs.getBlob("column")).thenReturn(blob);
+    when(rs.getBlob(1)).thenReturn(blob);
+    when(rs.wasNull()).thenReturn(false);
+    when(blob.getBinaryStream()).thenReturn(in);
+    assertThat(TYPE_HANDLER.getResult(rs, "column"), is(in));
+    assertThat(TYPE_HANDLER.getResult(rs, 1), is(in));
+
+    when(rs.getBlob("column")).thenReturn(null);
+    when(rs.getBlob(1)).thenReturn(null);
+    assertThat(TYPE_HANDLER.getResult(rs, "column"), nullValue());
+    assertThat(TYPE_HANDLER.getResult(rs, 1), nullValue());
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    InputStream in = new ByteArrayInputStream("Hello".getBytes());
+    when(cs.getBlob(1)).thenReturn(blob);
+    when(cs.wasNull()).thenReturn(false);
+    when(blob.getBinaryStream()).thenReturn(in);
+    assertThat(TYPE_HANDLER.getResult(cs, 1), is(in));
+
+    when(cs.getBlob(1)).thenReturn(null);
+    assertThat(TYPE_HANDLER.getResult(cs, 1), nullValue());
+
+  }
+
+  @Test
+  public void integrationTest() throws IOException {
+    SqlSession session = sqlSessionFactory.openSession();
+
+    try {
+      Mapper mapper = session.getMapper(Mapper.class);
+      // insert (InputStream -> Blob)
+      {
+        BlobContent blobContent = new BlobContent();
+        blobContent.setId(1);
+        blobContent.setContent(new ByteArrayInputStream("Hello".getBytes()));
+        mapper.insert(blobContent);
+        session.commit();
+      }
+      // select (Blob -> InputStream)
+      {
+        BlobContent blobContent = mapper.findOne(1);
+        assertThat(new BufferedReader(new InputStreamReader(blobContent.getContent())).readLine(), is("Hello"));
+      }
+    } finally {
+      session.close();
+    }
+
+  }
+
+  interface Mapper {
+    @Select("SELECT ID, CONTENT FROM TEST_BLOB WHERE ID = #{id}")
+    BlobContent findOne(int id);
+
+    @Insert("INSERT INTO TEST_BLOB (ID, CONTENT) VALUES(#{id}, #{content})")
+    void insert(BlobContent blobContent);
+  }
+
+  static class BlobContent {
+    private int id;
+    private InputStream content;
+
+    public int getId() {
+      return id;
+    }
+
+    public void setId(int id) {
+      this.id = id;
+    }
+
+    public InputStream getContent() {
+      return content;
+    }
+
+    public void setContent(InputStream content) {
+      this.content = content;
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/type/BlobInputStreamTypeHandlerTest.sql
+++ b/src/test/java/org/apache/ibatis/type/BlobInputStreamTypeHandlerTest.sql
@@ -1,0 +1,6 @@
+DROP TABLE test_blob;
+
+CREATE TABLE test_blob (
+  id INT PRIMARY KEY,
+  content BLOB
+);

--- a/src/test/java/org/apache/ibatis/type/ClobReaderTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ClobReaderTypeHandlerTest.java
@@ -1,0 +1,163 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.transaction.TransactionFactory;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import javax.sql.DataSource;
+import java.io.*;
+import java.sql.Clob;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link ClobReaderTypeHandler}.
+ *
+ * @author Kazuki Shimizu
+ * @since 3.4.0
+ */
+public class ClobReaderTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<Reader> TYPE_HANDLER = new ClobReaderTypeHandler();
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @Mock
+  protected Clob clob;
+
+  @BeforeClass
+  public static void setupSqlSessionFactory() throws Exception {
+    DataSource dataSource = BaseDataTest.createUnpooledDataSource("org/apache/ibatis/type/jdbc.properties");
+    BaseDataTest.runScript(dataSource, "org/apache/ibatis/type/ClobReaderTypeHandlerTest.sql");
+    TransactionFactory transactionFactory = new JdbcTransactionFactory();
+    Environment environment = new Environment("Production", transactionFactory, dataSource);
+    Configuration configuration = new Configuration(environment);
+    configuration.addMapper(Mapper.class);
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+  }
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    Reader reader = new StringReader("Hello");
+    TYPE_HANDLER.setParameter(ps, 1, reader, null);
+    verify(ps).setClob(1, reader);
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSet() throws Exception {
+    Reader reader = new StringReader("Hello");
+    when(rs.getClob("column")).thenReturn(clob);
+    when(rs.getClob(1)).thenReturn(clob);
+    when(rs.wasNull()).thenReturn(false);
+    when(clob.getCharacterStream()).thenReturn(reader);
+    assertEquals(reader, TYPE_HANDLER.getResult(rs, "column"));
+    assertEquals(reader, TYPE_HANDLER.getResult(rs, 1));
+
+    when(rs.getClob("column")).thenReturn(null);
+    when(rs.getClob(1)).thenReturn(null);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    Reader reader = new StringReader("Hello");
+    when(cs.getClob(1)).thenReturn(clob);
+    when(cs.wasNull()).thenReturn(false);
+    when(clob.getCharacterStream()).thenReturn(reader);
+    assertEquals(reader, TYPE_HANDLER.getResult(cs, 1));
+
+    when(cs.getClob(1)).thenReturn(null);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+
+  }
+
+
+  @Test
+  public void integrationTest() throws IOException {
+    SqlSession session = sqlSessionFactory.openSession();
+
+    try {
+      Mapper mapper = session.getMapper(Mapper.class);
+      // insert (Reader -> Clob)
+      {
+        ClobContent clobContent = new ClobContent();
+        clobContent.setId(1);
+        clobContent.setContent(new StringReader("Hello"));
+        mapper.insert(clobContent);
+        session.commit();
+      }
+      // select (Clob -> Reader)
+      {
+        ClobContent clobContent = mapper.findOne(1);
+        assertThat(new BufferedReader(clobContent.getContent()).readLine(), is("Hello"));
+      }
+    } finally {
+      session.close();
+    }
+
+  }
+
+  interface Mapper {
+    @Select("SELECT ID, CONTENT FROM TEST_CLOB WHERE ID = #{id}")
+    ClobContent findOne(int id);
+
+    @Insert("INSERT INTO TEST_CLOB (ID, CONTENT) VALUES(#{id}, #{content})")
+    void insert(ClobContent blobContent);
+  }
+
+  static class ClobContent {
+    private int id;
+    private Reader content;
+
+    public int getId() {
+      return id;
+    }
+
+    public void setId(int id) {
+      this.id = id;
+    }
+
+    public Reader getContent() {
+      return content;
+    }
+
+    public void setContent(Reader content) {
+      this.content = content;
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/type/ClobReaderTypeHandlerTest.sql
+++ b/src/test/java/org/apache/ibatis/type/ClobReaderTypeHandlerTest.sql
@@ -1,0 +1,6 @@
+DROP TABLE test_clob;
+
+CREATE TABLE test_clob (
+  id INT PRIMARY KEY,
+  content CLOB
+);

--- a/src/test/java/org/apache/ibatis/type/jdbc.properties
+++ b/src/test/java/org/apache/ibatis/type/jdbc.properties
@@ -1,0 +1,4 @@
+driver=org.apache.derby.jdbc.EmbeddedDriver
+url=jdbc:derby:ibderby;create=true
+username=
+password=


### PR DESCRIPTION
I've added type handlers for `java.sql.Blob`/`java.io.InputStream` and `java.sql.Clob`/`java.io.Reader`.
These type handlers require a JDBC driver that implements method supported at JDBC 4.0.

Please review.