### PR TITLE
Support transaction timeout on BatchExecutor and ReuseExecutor mybatis/spring#115

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import org.apache.ibatis.cache.CacheKey;
 import org.apache.ibatis.cache.impl.PerpetualCache;
 import org.apache.ibatis.cursor.Cursor;
+import org.apache.ibatis.executor.statement.StatementUtil;
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.logging.LogFactory;
 import org.apache.ibatis.logging.jdbc.ConnectionLogger;
@@ -287,6 +288,17 @@ public abstract class BaseExecutor implements Executor {
         // ignore
       }
     }
+  }
+
+  /**
+   * Apply a transaction timeout.
+   * @param statement a current statement
+   * @exception SQLException if a database access error occurs, this method is called on a closed <code>Statement</code>
+   * @see StatementUtil#applyTransactionTimeout(Statement, Integer, Integer)
+   * @since 3.4.0
+   */
+  protected void applyTransactionTimeout(Statement statement) throws SQLException {
+    StatementUtil.applyTransactionTimeout(statement, statement.getQueryTimeout(), transaction.getTimeout());
   }
 
   private void handleLocallyCachedOutputParameters(MappedStatement ms, CacheKey key, Object parameter, BoundSql boundSql) {

--- a/src/main/java/org/apache/ibatis/executor/BatchExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BatchExecutor.java
@@ -61,6 +61,7 @@ public class BatchExecutor extends BaseExecutor {
     if (sql.equals(currentSql) && ms.equals(currentStatement)) {
       int last = statementList.size() - 1;
       stmt = statementList.get(last);
+      applyTransactionTimeout(stmt);
      handler.parameterize(stmt);//fix Issues 322
       BatchResult batchResult = batchResultList.get(last);
       batchResult.addParameterObject(parameterObject);
@@ -115,6 +116,7 @@ public class BatchExecutor extends BaseExecutor {
       }
       for (int i = 0, n = statementList.size(); i < n; i++) {
         Statement stmt = statementList.get(i);
+        applyTransactionTimeout(stmt);
         BatchResult batchResult = batchResultList.get(i);
         try {
           batchResult.setUpdateCounts(stmt.executeBatch());

--- a/src/main/java/org/apache/ibatis/executor/ReuseExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/ReuseExecutor.java
@@ -83,6 +83,7 @@ public class ReuseExecutor extends BaseExecutor {
     String sql = boundSql.getSql();
     if (hasStatementFor(sql)) {
       stmt = getStatement(sql);
+      applyTransactionTimeout(stmt);
     } else {
       Connection connection = getConnection(statementLog);
       stmt = handler.prepare(connection, transaction.getTimeout());

--- a/src/main/java/org/apache/ibatis/executor/statement/BaseStatementHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/statement/BaseStatementHandler.java
@@ -101,25 +101,16 @@ public abstract class BaseStatementHandler implements StatementHandler {
   protected abstract Statement instantiateStatement(Connection connection) throws SQLException;
 
   protected void setStatementTimeout(Statement stmt, Integer transactionTimeout) throws SQLException {
-    // determine a query timeout of setting
     Integer queryTimeout = null;
     if (mappedStatement.getTimeout() != null) {
       queryTimeout = mappedStatement.getTimeout();
     } else if (configuration.getDefaultStatementTimeout() != null) {
       queryTimeout = configuration.getDefaultStatementTimeout();
     }
-    // determine a time to live of query
-    Integer timeToLiveOfQuery;
     if (queryTimeout != null) {
-      timeToLiveOfQuery = (transactionTimeout == null) ? queryTimeout
-              : Math.min(queryTimeout, transactionTimeout);
-    } else {
-      timeToLiveOfQuery = transactionTimeout;
+      stmt.setQueryTimeout(queryTimeout);
     }
-    // set a time to live of query
-    if (timeToLiveOfQuery != null) {
-      stmt.setQueryTimeout(timeToLiveOfQuery);
-    }
+    StatementUtil.applyTransactionTimeout(stmt, queryTimeout, transactionTimeout);
   }
 
   protected void setFetchSize(Statement stmt) throws SQLException {

--- a/src/main/java/org/apache/ibatis/executor/statement/StatementUtil.java
+++ b/src/main/java/org/apache/ibatis/executor/statement/StatementUtil.java
@@ -1,0 +1,58 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor.statement;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Utility for {@link java.sql.Statement}.
+ *
+ * @author Kazuki Shimizu
+ * @since 3.4.0
+ */
+public class StatementUtil {
+
+  private StatementUtil() {
+    // NOP
+  }
+
+  /**
+   * Apply a transaction timeout.
+   * <p>
+   * Update a query timeout to apply a transaction timeout.
+   * </p>
+   * @param statement a target statement
+   * @param queryTimeout a query timeout
+   * @param transactionTimeout a transaction timeout
+   * @exception SQLException if a database access error occurs, this method is called on a closed <code>Statement</code>
+   */
+  public static void applyTransactionTimeout(Statement statement, Integer queryTimeout, Integer transactionTimeout) throws SQLException {
+    if (transactionTimeout == null){
+      return;
+    }
+    Integer timeToLiveOfQuery = null;
+    if (queryTimeout == null || queryTimeout == 0) {
+      timeToLiveOfQuery = transactionTimeout;
+    } else if (transactionTimeout < queryTimeout) {
+      timeToLiveOfQuery = transactionTimeout;
+    }
+    if (timeToLiveOfQuery != null) {
+      statement.setQueryTimeout(timeToLiveOfQuery);
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/executor/statement/BaseStatementHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/executor/statement/BaseStatementHandlerTest.java
@@ -83,6 +83,16 @@ public class BaseStatementHandlerTest {
     }
 
     @Test
+    public void specifyQueryTimeoutZeroAndTransactionTimeout() throws SQLException {
+        doReturn(0).when(configuration).getDefaultStatementTimeout();
+
+        BaseStatementHandler handler = new SimpleStatementHandler(null, mappedStatementBuilder.build(), null, null, null, null);
+        handler.setStatementTimeout(statement, 5);
+
+        verify(statement).setQueryTimeout(5); // apply a transaction timeout
+    }
+
+    @Test
     public void specifyMappedStatementTimeoutAndDefaultTimeout() throws SQLException {
         doReturn(20).when(configuration).getDefaultStatementTimeout();
         mappedStatementBuilder.timeout(30);
@@ -110,6 +120,7 @@ public class BaseStatementHandlerTest {
         BaseStatementHandler handler = new SimpleStatementHandler(null, mappedStatementBuilder.build(), null, null, null, null);
         handler.setStatementTimeout(statement, 5);
 
+        verify(statement).setQueryTimeout(10);
         verify(statement).setQueryTimeout(5); // apply a transaction timeout
     }
 


### PR DESCRIPTION
I've applied transaction timeout mechanism to `BatchExecutor` and `ReuseExecutor`. (mybatis/spring#115)
Please review.