### PR TITLE
Allow multiple arguments at a Sql Provider method

### DIFF
--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/Mapper.java
@@ -16,7 +16,9 @@
 package org.apache.ibatis.submitted.sqlprovider;
 
 import java.util.List;
+import java.util.Map;
 
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.SelectProvider;
 
 public interface Mapper {
@@ -25,4 +27,23 @@ public interface Mapper {
 
   @SelectProvider(type = OurSqlBuilder.class, method = "buildGetUserQuery")
   User getUser(Integer userId);
+
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildGetAllUsersQuery")
+  List<User> getAllUsers();
+
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildGetUsersByCriteriaQuery")
+  List<User> getUsersByCriteria(User criteria);
+
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildGetUsersByCriteriaMapQuery")
+  List<User> getUsersByCriteriaMap(Map<String, Object> criteria);
+
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildGetUsersByNameQuery")
+  List<User> getUsersByName(String name, String orderByColumn);
+
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildGetUsersByNameUsingMap")
+  List<User> getUsersByNameUsingMap(String name, String orderByColumn);
+
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildGetUsersByNameWithParamNameQuery")
+  List<User> getUsersByNameWithParamName(@Param("name") String name, @Param("orderByColumn") String orderByColumn);
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/OurSqlBuilder.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/OurSqlBuilder.java
@@ -15,6 +15,9 @@
  */
 package org.apache.ibatis.submitted.sqlprovider;
 
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.jdbc.SQL;
+
 import java.util.List;
 import java.util.Map;
 
@@ -44,4 +47,82 @@ public class OurSqlBuilder {
     // so it is passed as is from the mapper
     return "select * from users where id = #{value}";
   }
+  public String buildGetAllUsersQuery() {
+    return "select * from users order by id";
+  }
+
+  public String buildGetUsersByCriteriaQuery(final User criteria) {
+    return new SQL(){{
+      SELECT("*");
+      FROM("users");
+      if (criteria.getId() != null) {
+        WHERE("id = #{id}");
+      }
+      if (criteria.getName() != null) {
+        WHERE("name like #{name} || '%'");
+      }
+    }}.toString();
+  }
+
+  public String buildGetUsersByCriteriaMapQuery(final Map<String, Object> criteria) {
+    return new SQL(){{
+      SELECT("*");
+      FROM("users");
+      if (criteria.get("id") != null) {
+        WHERE("id = #{id}");
+      }
+      if (criteria.get("name") != null) {
+        WHERE("name like #{name} || '%'");
+      }
+    }}.toString();
+  }
+
+  public String buildGetUsersByNameQuery(final String name, final String orderByColumn) {
+    return new SQL(){{
+      SELECT("*");
+      FROM("users");
+      if (name != null) {
+        WHERE("name like #{param1} || '%'");
+      }
+      ORDER_BY(orderByColumn);
+    }}.toString();
+  }
+
+  public String buildGetUsersByNameUsingMap(Map<String, Object> params) {
+    final String name = String.class.cast(params.get("param1"));
+    final String orderByColumn = String.class.cast(params.get("param2"));
+    return new SQL(){{
+      SELECT("*");
+      FROM("users");
+      if (name != null) {
+        WHERE("name like #{param1} || '%'");
+      }
+      ORDER_BY(orderByColumn);
+    }}.toString();
+  }
+
+  public String buildGetUsersByNameWithParamNameQuery(@Param("orderByColumn") final String orderByColumn, @Param("name") final String name) {
+    return new SQL(){{
+      SELECT("*");
+      FROM("users");
+      if (name != null) {
+        WHERE("name like #{name} || '%'");
+      }
+      ORDER_BY(orderByColumn);
+    }}.toString();
+  }
+
+  public String buildGetUsersByNameWithParamNameQueryUsingMap(Map<String, Object> params) {
+    final String name = String.class.cast(params.get("name"));
+    final String orderByColumn = String.class.cast(params.get("orderByColumn"));
+    return new SQL(){{
+      SELECT("*");
+      FROM("users");
+      if (name != null) {
+        WHERE("name like #{param1} || '%'");
+      }
+      ORDER_BY(orderByColumn);
+    }}.toString();
+  }
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
@@ -15,25 +15,37 @@
  */
 package org.apache.ibatis.submitted.sqlprovider;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.Reader;
 import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.builder.BuilderException;
+import org.apache.ibatis.builder.annotation.ProviderSqlSource;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class SqlProviderTest {
 
   private static SqlSessionFactory sqlSessionFactory;
+
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
 
   @BeforeClass
   public static void setUp() throws Exception {
@@ -55,6 +67,7 @@ public class SqlProviderTest {
     session.close();
   }
 
+  // Test for list
   @Test
   public void shouldGetTwoUsers() {
     SqlSession sqlSession = sqlSessionFactory.openSession();
@@ -72,6 +85,7 @@ public class SqlProviderTest {
     }
   }
 
+  // Test for simple value
   @Test
   public void shouldGetOneUser() {
     SqlSession sqlSession = sqlSessionFactory.openSession();
@@ -84,4 +98,216 @@ public class SqlProviderTest {
       sqlSession.close();
     }
   }
+
+  // Test for empty
+  @Test
+  public void shouldGetAllUsers() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<User> users = mapper.getAllUsers();
+      assertEquals(4, users.size());
+      assertEquals("User1", users.get(0).getName());
+      assertEquals("User2", users.get(1).getName());
+      assertEquals("User3", users.get(2).getName());
+      assertEquals("User4", users.get(3).getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  // Test for single JavaBean
+  @Test
+  public void shouldGetUsersByCriteria() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      {
+        User criteria = new User();
+        criteria.setId(1);
+        List<User> users = mapper.getUsersByCriteria(criteria);
+        assertEquals(1, users.size());
+        assertEquals("User1", users.get(0).getName());
+      }
+      {
+        User criteria = new User();
+        criteria.setName("User");
+        List<User> users = mapper.getUsersByCriteria(criteria);
+        assertEquals(4, users.size());
+        assertEquals("User1", users.get(0).getName());
+        assertEquals("User2", users.get(1).getName());
+        assertEquals("User3", users.get(2).getName());
+        assertEquals("User4", users.get(3).getName());
+      }
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  // Test for single map
+  @Test
+  public void shouldGetUsersByCriteriaMap() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      {
+        Map<String, Object> criteria = new HashMap<String, Object>();
+        criteria.put("id", 1);
+        List<User> users = mapper.getUsersByCriteriaMap(criteria);
+        assertEquals(1, users.size());
+        assertEquals("User1", users.get(0).getName());
+      }
+      {
+        Map<String, Object> criteria = new HashMap<String, Object>();
+        criteria.put("name", "User");
+        List<User> users = mapper.getUsersByCriteriaMap(criteria);
+        assertEquals(4, users.size());
+        assertEquals("User1", users.get(0).getName());
+        assertEquals("User2", users.get(1).getName());
+        assertEquals("User3", users.get(2).getName());
+        assertEquals("User4", users.get(3).getName());
+      }
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  // Test for multiple parameter without @Param
+  @Test
+  public void shouldGetUsersByName() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<User> users = mapper.getUsersByName("User", "id DESC");
+      assertEquals(4, users.size());
+      assertEquals("User4", users.get(0).getName());
+      assertEquals("User3", users.get(1).getName());
+      assertEquals("User2", users.get(2).getName());
+      assertEquals("User1", users.get(3).getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  // Test for map without @Param
+  @Test
+  public void shouldGetUsersByNameUsingMap() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<User> users = mapper.getUsersByNameUsingMap("User", "id DESC");
+      assertEquals(4, users.size());
+      assertEquals("User4", users.get(0).getName());
+      assertEquals("User3", users.get(1).getName());
+      assertEquals("User2", users.get(2).getName());
+      assertEquals("User1", users.get(3).getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  // Test for multiple parameter with @Param
+  @Test
+  public void shouldGetUsersByNameWithParamName() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<User> users = mapper.getUsersByNameWithParamName("User", "id DESC");
+      assertEquals(4, users.size());
+      assertEquals("User4", users.get(0).getName());
+      assertEquals("User3", users.get(1).getName());
+      assertEquals("User2", users.get(2).getName());
+      assertEquals("User1", users.get(3).getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  // Test for map with @Param
+  @Test
+  public void shouldGetUsersByNameWithParamNameUsingMap() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<User> users = mapper.getUsersByNameWithParamName("User", "id DESC");
+      assertEquals(4, users.size());
+      assertEquals("User4", users.get(0).getName());
+      assertEquals("User3", users.get(1).getName());
+      assertEquals("User2", users.get(2).getName());
+      assertEquals("User1", users.get(3).getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void methodNotFound() throws NoSuchMethodException {
+    expectedException.expect(BuilderException.class);
+    expectedException.expectMessage(is("Error creating SqlSource for SqlProvider. Method 'methodNotFound' not found in SqlProvider 'org.apache.ibatis.submitted.sqlprovider.SqlProviderTest$ErrorSqlBuilder'."));
+    new ProviderSqlSource(new Configuration(),
+            ErrorMapper.class.getMethod("methodNotFound").getAnnotation(SelectProvider.class));
+  }
+
+  @Test
+  public void methodOverload() throws NoSuchMethodException {
+    expectedException.expect(BuilderException.class);
+    expectedException.expectMessage(is("Error creating SqlSource for SqlProvider. Method 'overload' is found multiple in SqlProvider 'org.apache.ibatis.submitted.sqlprovider.SqlProviderTest$ErrorSqlBuilder'. Sql provider method can not overload."));
+    new ProviderSqlSource(new Configuration(),
+            ErrorMapper.class.getMethod("methodOverload", String.class).getAnnotation(SelectProvider.class));
+  }
+
+  @Test
+  public void notSqlProvider() throws NoSuchMethodException {
+    expectedException.expect(BuilderException.class);
+    expectedException.expectMessage(is("Error creating SqlSource for SqlProvider.  Cause: java.lang.NoSuchMethodException: java.lang.Object.type()"));
+    new ProviderSqlSource(new Configuration(), new Object());
+  }
+
+  @Test
+  public void notSupportParameterObject() throws NoSuchMethodException {
+    expectedException.expect(BuilderException.class);
+    expectedException.expectMessage(is("Error invoking SqlProvider method (org.apache.ibatis.submitted.sqlprovider.OurSqlBuilder.buildGetUsersByNameQuery). Cannot invoke a method that holds multiple arguments using a specifying parameterObject. In this case, please specify a 'java.util.Map' object."));
+    new ProviderSqlSource(new Configuration(),
+            Mapper.class.getMethod("getUsersByName", String.class, String.class).getAnnotation(SelectProvider.class))
+            .getBoundSql(new Object());
+  }
+
+  @Test
+  public void invokeError() throws NoSuchMethodException {
+    expectedException.expect(BuilderException.class);
+    expectedException.expectMessage(is("Error invoking SqlProvider method (org.apache.ibatis.submitted.sqlprovider.SqlProviderTest$ErrorSqlBuilder.invokeError).  Cause: java.lang.reflect.InvocationTargetException"));
+    new ProviderSqlSource(new Configuration(),
+            ErrorMapper.class.getMethod("invokeError").getAnnotation(SelectProvider.class))
+            .getBoundSql(new Object());
+  }
+
+  public interface ErrorMapper {
+    @SelectProvider(type = ErrorSqlBuilder.class, method = "methodNotFound")
+    void methodNotFound();
+
+    @SelectProvider(type = ErrorSqlBuilder.class, method = "overload")
+    void methodOverload(String value);
+
+    @SelectProvider(type = ErrorSqlBuilder.class, method = "invokeError")
+    void invokeError();
+  }
+
+  public static class ErrorSqlBuilder {
+    public void methodNotFound() {
+      throw new UnsupportedOperationException("methodNotFound");
+    }
+
+    public String overload() {
+      throw new UnsupportedOperationException("overload");
+    }
+
+    public String overload(String value) {
+      throw new UnsupportedOperationException("overload");
+    }
+
+    public String invokeError() {
+      throw new UnsupportedOperationException("invokeError");
+    }
+  }
+
 }


### PR DESCRIPTION
I've supported to allow multiple arguments at a SqlProvider method.

* Mapper method

```java
@SelectProvider(type = UserSqlBuilder.class, method = "buildGetUsersByName")
List<User> getUsersByName(
    @Param("name") String name,
    @Param("orderByColumn") String orderByColumn); // Multiple arguments
```

* SqlProvider method (Current style)

```java
public String buildGetUsersByName(Map<String, Object> params) { // Support Map only
    final String name = String.class.cast(params.get("name"));
    final String orderByColumn = String.class.cast(params.get("orderByColumn"));
    return new SQL(){{
        SELECT("*");
        FROM("users");
        if (name != null) {
            WHERE("name like #{param1} || '%'");
        }
        ORDER_BY(orderByColumn);
    }}.toString();
}
```

* SqlProvider method (New style)

```java
public String buildGetUsersByName(
    @Param("name") final String name
    @Param("orderByColumn") final String orderByColumn) { // Allow multiple arguments
    return new SQL(){{
        SELECT("*");
        FROM("users");
        if (name != null) {
            WHERE("name like #{name} || '%'");
        }
        ORDER_BY(orderByColumn);
    }}.toString();
}
```

Please review this.