### PR TITLE
Failing test case for nested select with @Param attributes

### DIFF
--- a/src/test/java/org/apache/ibatis/submitted/complex_column/ComplexColumnTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_column/ComplexColumnTest.java
@@ -15,19 +15,18 @@
  */
 package org.apache.ibatis.submitted.complex_column;
 
-import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
-
-import org.junit.Assert;
-
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.sql.DriverManager;
 
 public class ComplexColumnTest {
     
@@ -140,5 +139,20 @@ public class ComplexColumnTest {
       Assert.assertEquals("John", parent.getFirstName());
       Assert.assertEquals("Smith", parent.getLastName());
       sqlSession.close();
+    }
+
+    @Test
+    public void testWithParamAttributes() {
+        SqlSession sqlSession = sqlSessionFactory.openSession();
+        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+        Person person = personMapper.getComplexWithParamAttributes(2l);
+        Assert.assertNotNull("person must not be null", person);
+        Assert.assertEquals("Christian", person.getFirstName());
+        Assert.assertEquals("Poitras", person.getLastName());
+        Person parent = person.getParent();
+        Assert.assertNotNull("parent must not be null", parent);
+        Assert.assertEquals("John", parent.getFirstName());
+        Assert.assertEquals("Smith", parent.getLastName());
+        sqlSession.close();
     }
 }

--- a/src/test/java/org/apache/ibatis/submitted/complex_column/Person.xml
+++ b/src/test/java/org/apache/ibatis/submitted/complex_column/Person.xml
@@ -28,6 +28,7 @@
         <result property="lastName" column="lastName"/>
         <association property="parent" column="parent_id" select="getParentWithoutComplex"/>
     </resultMap>
+
     <resultMap id="personMapComplex" type="Person">
         <id property="id" column="id"/>
         <result property="firstName" column="firstName"/>

--- a/src/test/java/org/apache/ibatis/submitted/complex_column/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_column/PersonMapper.java
@@ -15,8 +15,7 @@
  */
 package org.apache.ibatis.submitted.complex_column;
 
-import org.apache.ibatis.annotations.ResultMap;
-import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.*;
 
 public interface PersonMapper {
     
@@ -39,4 +38,24 @@ public interface PersonMapper {
       })
     @ResultMap("org.apache.ibatis.submitted.complex_column.PersonMapper.personMapComplex")
     public Person getWithComplex3(Long id);
+
+
+    @Select({
+            "SELECT id, firstName, lastName, parent_id, parent_firstName, parent_lastName",
+            "FROM Person",
+            "WHERE id = #{id,jdbcType=INTEGER}"
+    })
+    @Results({
+            @Result(id=true, column = "id", property = "id"),
+            @Result(property = "parent", column="{firstName=parent_firstName,lastName=parent_lastName}", one=@One(select="getParentWithParamAttributes"))
+
+    })
+    Person getComplexWithParamAttributes(Long id);
+
+    @Select("SELECT id, firstName, lastName, parent_id, parent_firstName, parent_lastName" +
+            " FROM Person" +
+            " WHERE firstName = #{firstName,jdbcType=VARCHAR}" +
+            " AND lastName = #{lastName,jdbcType=VARCHAR}" +
+            " LIMIT 1")
+    Person getParentWithParamAttributes(@Param("firstName") String firstName, @Param("lastName") String lastname);
 }


### PR DESCRIPTION
I have modified the existing complex column test suite to add a failing test case that uses an association to a mapped statement that uses @Param annotations.  Other than the query being defined in the java interface and using @Param instead of being in the XML the test is the same as the existing scenarios.