### PR TITLE
Improve setter method on Configuration

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -26,6 +26,8 @@ import org.apache.ibatis.datasource.DataSourceFactory;
 import org.apache.ibatis.executor.ErrorContext;
 import org.apache.ibatis.executor.loader.ProxyFactory;
 import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.io.VFS;
+import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.mapping.DatabaseIdProvider;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.parsing.XNode;
@@ -139,7 +141,9 @@ public class XMLConfigBuilder extends BaseBuilder {
       String[] clazzes = value.split(",");
       for (String clazz : clazzes) {
         if (!clazz.isEmpty()) {
-          configuration.setVfsImpl(Resources.classForName(clazz));
+          @SuppressWarnings("unchecked")
+          Class<? extends VFS> vfsImpl = (Class<? extends VFS>)Resources.classForName(clazz);
+          configuration.setVfsImpl(vfsImpl);
         }
       }
     }
@@ -251,7 +255,9 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setDefaultScriptingLanguage(resolveClass(props.getProperty("defaultScriptingLanguage")));
     configuration.setCallSettersOnNulls(booleanValueOf(props.getProperty("callSettersOnNulls"), false));
     configuration.setLogPrefix(props.getProperty("logPrefix"));
-    configuration.setLogImpl(resolveClass(props.getProperty("logImpl")));
+    @SuppressWarnings("unchecked")
+    Class<? extends Log> logImpl = (Class<? extends Log>)resolveClass(props.getProperty("logImpl"));
+    configuration.setLogImpl(logImpl);
     configuration.setConfigurationFactory(resolveClass(props.getProperty("configurationFactory")));
   }
 

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -214,10 +214,9 @@ public class Configuration {
     return logImpl;
   }
 
-  @SuppressWarnings("unchecked")
-  public void setLogImpl(Class<?> logImpl) {
+  public void setLogImpl(Class<? extends Log> logImpl) {
     if (logImpl != null) {
-      this.logImpl = (Class<? extends Log>) logImpl;
+      this.logImpl = logImpl;
       LogFactory.useCustomLogging(this.logImpl);
     }
   }
@@ -226,10 +225,9 @@ public class Configuration {
     return this.vfsImpl;
   }
 
-  @SuppressWarnings("unchecked")
-  public void setVfsImpl(Class<?> vfsImpl) {
+  public void setVfsImpl(Class<? extends VFS> vfsImpl) {
     if (vfsImpl != null) {
-      this.vfsImpl = (Class<? extends VFS>) vfsImpl;
+      this.vfsImpl = vfsImpl;
       VFS.addImplClass(this.vfsImpl);
     }
   }


### PR DESCRIPTION
I've improved setter method on `Configuration`.
In this changes, `logImpl` and `vfsImpl` can export to the `spring-configuration-metadata.json` on `mybatis-spring-boot-autoconfigure`.

Please review.