### PR TITLE
Fixes #660 : Can not fetch an object from Cursor when a RowBounds is used

### DIFF
--- a/src/main/java/org/apache/ibatis/cursor/defaults/DefaultCursor.java
+++ b/src/main/java/org/apache/ibatis/cursor/defaults/DefaultCursor.java
@@ -191,10 +191,6 @@ public class DefaultCursor<T> implements Cursor<T> {
 
         @Override
         public boolean hasNext() {
-            if (isClosed()) {
-                return false;
-            }
-
             if (object == null) {
                 object = fetchNextUsingRowBound();
             }
@@ -203,10 +199,6 @@ public class DefaultCursor<T> implements Cursor<T> {
 
         @Override
         public T next() {
-            if (isClosed()) {
-                throw new CursorException("Cursor is closed");
-            }
-
             // Fill next with object fetched from hasNext()
             T next = object;
 

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
@@ -103,6 +103,7 @@ public class CursorNestedTest {
 
             Iterator<User> iterator = usersCursor.iterator();
 
+            Assert.assertTrue(iterator.hasNext());
             User user = iterator.next();
             Assert.assertEquals("User3", user.getName());
             Assert.assertEquals(2, usersCursor.getCurrentIndex());

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/CreateDB.sql
@@ -25,3 +25,4 @@ insert into users values(1, 'User1');
 insert into users values(2, 'User2');
 insert into users values(3, 'User3');
 insert into users values(4, 'User4');
+insert into users values(5, 'User5');


### PR DESCRIPTION
* Removes redundant isClosed() checks. This check is done by fetchNextObjectFromDatabase(). Having redundant checks leads to the bug describe in issue #660.
* Added more tests to check behaviors when using iterator.next() with or without a previous hasNext() call.