### PR TITLE
Allow customize a ReflectorFactory using mybatis configuration xml file #675

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -48,6 +48,7 @@ import org.apache.ibatis.type.JdbcType;
 
 /**
  * @author Clinton Begin
+ * @author Kazuki Shimizu
  */
 public class XMLConfigBuilder extends BaseBuilder {
 
@@ -108,7 +109,7 @@ public class XMLConfigBuilder extends BaseBuilder {
       pluginElement(root.evalNode("plugins"));
       objectFactoryElement(root.evalNode("objectFactory"));
       objectWrapperFactoryElement(root.evalNode("objectWrapperFactory"));
-      reflectionFactoryElement(root.evalNode("reflectionFactory"));
+      reflectorFactoryElement(root.evalNode("reflectorFactory"));
       settingsElement(settings);
       // read it after objectFactory and objectWrapperFactory issue #631
       environmentsElement(root.evalNode("environments"));
@@ -203,7 +204,7 @@ public class XMLConfigBuilder extends BaseBuilder {
     }
   }
 
-  private void reflectionFactoryElement(XNode context) throws Exception {
+  private void reflectorFactoryElement(XNode context) throws Exception {
     if (context != null) {
        String type = context.getStringAttribute("type");
        ReflectorFactory factory = (ReflectorFactory) resolveClass(type).newInstance();

--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-config.dtd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-config.dtd
@@ -16,7 +16,7 @@
        limitations under the License.
 
 -->
-<!ELEMENT configuration (properties?, settings?, typeAliases?, typeHandlers?, objectFactory?, objectWrapperFactory?, plugins?, environments?, databaseIdProvider?, mappers?)>
+<!ELEMENT configuration (properties?, settings?, typeAliases?, typeHandlers?, objectFactory?, objectWrapperFactory?, reflectorFactory?, plugins?, environments?, databaseIdProvider?, mappers?)>
 
 <!ELEMENT databaseIdProvider (property*)>
 <!ATTLIST databaseIdProvider
@@ -67,6 +67,11 @@ type CDATA #REQUIRED
 
 <!ELEMENT objectWrapperFactory (property*)>
 <!ATTLIST objectWrapperFactory
+type CDATA #REQUIRED
+>
+
+<!ELEMENT reflectorFactory EMPTY>
+<!ATTLIST reflectorFactory
 type CDATA #REQUIRED
 >
 

--- a/src/test/java/org/apache/ibatis/builder/CustomReflectorFactory.java
+++ b/src/test/java/org/apache/ibatis/builder/CustomReflectorFactory.java
@@ -1,0 +1,22 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder;
+
+import org.apache.ibatis.reflection.DefaultReflectorFactory;
+
+public class CustomReflectorFactory extends DefaultReflectorFactory {
+
+}

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -72,6 +72,8 @@
   </objectFactory>
 
   <objectWrapperFactory type="org.apache.ibatis.builder.CustomObjectWrapperFactory" />
+  
+  <reflectorFactory type="org.apache.ibatis.builder.CustomReflectorFactory"/>
 
   <plugins>
     <plugin interceptor="org.apache.ibatis.builder.ExamplePlugin">

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -207,6 +207,8 @@ public class XmlConfigBuilderTest {
 
       assertThat(config.getObjectWrapperFactory(), is(instanceOf(CustomObjectWrapperFactory.class)));
 
+      assertThat(config.getReflectorFactory(), is(instanceOf(CustomReflectorFactory.class)));
+
       ExamplePlugin plugin = (ExamplePlugin)config.getInterceptors().get(0);
       assertThat(plugin.getProperties().size(), is(1));
       assertThat(plugin.getProperties().getProperty("pluginProperty"), is("100"));


### PR DESCRIPTION
I've fixed #675.
Note that element name is changed to `reflectionFactory` from `reflectionFactory`.
Please review.