### PR TITLE
Add link to snapshot on readme and add back some gitignores for IDE junit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@
 /nb*
 /release.properties
 /target
+
+# These are needed if running in IDE without properties set
+/ibderby
+derby.log

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Essentials
 
 * [See the docs](http://mybatis.github.io/mybatis-3)
 * [Download Latest](https://github.com/mybatis/mybatis-3/releases)
+* [Download Snapshot](https://oss.sonatype.org/content/repositories/snapshots/org/mybatis/mybatis/)


### PR DESCRIPTION
Some users have asked for latest so makes sense to make it easy to get to by adding a direct link.  This is done in generic way so we don't need to keep changing it later.

Upon further testing within eclipse, it became obvious that without setting up properties for derby, the root of the project is still used.  So added back gitignores with note as to why.