### PR TITLE
Fix association hashing when data is in nested result

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
+++ b/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
@@ -39,6 +39,7 @@ import org.apache.ibatis.mapping.ParameterMode;
 import org.apache.ibatis.mapping.ResultFlag;
 import org.apache.ibatis.mapping.ResultMap;
 import org.apache.ibatis.mapping.ResultMapping;
+import org.apache.ibatis.mapping.ResultRelation;
 import org.apache.ibatis.mapping.ResultSetType;
 import org.apache.ibatis.mapping.SqlCommandType;
 import org.apache.ibatis.mapping.SqlSource;
@@ -172,6 +173,17 @@ public class MapperBuilderAssistant extends BaseBuilder {
         .typeHandler(typeHandlerInstance)
         .build();
   }
+  
+  public ResultMap addResultMap(
+      String id,
+      Class<?> type,
+      String extend,
+      Discriminator discriminator,
+      List<ResultMapping> resultMappings,
+      Boolean autoMapping) {
+      
+      return addResultMap(id, type, extend, discriminator, resultMappings, ResultRelation.NONE, autoMapping);
+  }
 
   public ResultMap addResultMap(
       String id,
@@ -179,6 +191,7 @@ public class MapperBuilderAssistant extends BaseBuilder {
       String extend,
       Discriminator discriminator,
       List<ResultMapping> resultMappings,
+      ResultRelation resultRelation,
       Boolean autoMapping) {
     id = applyCurrentNamespace(id, false);
     extend = applyCurrentNamespace(extend, true);
@@ -210,6 +223,7 @@ public class MapperBuilderAssistant extends BaseBuilder {
     }
     ResultMap resultMap = new ResultMap.Builder(configuration, id, type, resultMappings, autoMapping)
         .discriminator(discriminator)
+        .resultRelation(resultRelation)
         .build();
     configuration.addResultMap(resultMap);
     return resultMap;

--- a/src/main/java/org/apache/ibatis/builder/ResultMapResolver.java
+++ b/src/main/java/org/apache/ibatis/builder/ResultMapResolver.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.apache.ibatis.mapping.Discriminator;
 import org.apache.ibatis.mapping.ResultMap;
 import org.apache.ibatis.mapping.ResultMapping;
+import org.apache.ibatis.mapping.ResultRelation;
 
 /**
  * @author Eduardo Macarron
@@ -32,8 +33,13 @@ public class ResultMapResolver {
   private Discriminator discriminator;
   private List<ResultMapping> resultMappings;
   private Boolean autoMapping;
+  private ResultRelation resultRelation;
 
   public ResultMapResolver(MapperBuilderAssistant assistant, String id, Class<?> type, String extend, Discriminator discriminator, List<ResultMapping> resultMappings, Boolean autoMapping) {
+      this(assistant, id, type, extend, discriminator, resultMappings, autoMapping, ResultRelation.NONE);
+  }
+  
+  public ResultMapResolver(MapperBuilderAssistant assistant, String id, Class<?> type, String extend, Discriminator discriminator, List<ResultMapping> resultMappings, Boolean autoMapping, ResultRelation resultRelation) {
     this.assistant = assistant;
     this.id = id;
     this.type = type;
@@ -41,10 +47,11 @@ public class ResultMapResolver {
     this.discriminator = discriminator;
     this.resultMappings = resultMappings;
     this.autoMapping = autoMapping;
+    this.resultRelation = resultRelation;
   }
 
   public ResultMap resolve() {
-    return assistant.addResultMap(this.id, this.type, this.extend, this.discriminator, this.resultMappings, this.autoMapping);
+    return assistant.addResultMap(this.id, this.type, this.extend, this.discriminator, this.resultMappings, this.resultRelation, this.autoMapping);
   }
 
 }

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -46,6 +46,7 @@ import org.apache.ibatis.mapping.ParameterMode;
 import org.apache.ibatis.mapping.ResultFlag;
 import org.apache.ibatis.mapping.ResultMap;
 import org.apache.ibatis.mapping.ResultMapping;
+import org.apache.ibatis.mapping.ResultRelation;
 import org.apache.ibatis.reflection.MetaClass;
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.ReflectorFactory;
@@ -831,7 +832,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
         resultObject = foundValues ? resultObject : null;
       }
       if (combinedKey != CacheKey.NULL_CACHE_KEY) {
-        nestedResultObjects.put(combinedKey, resultObject);
+          nestedResultObjects.put(combinedKey, resultObject);
       }
     }
     return resultObject;
@@ -971,7 +972,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
         final ResultMap nestedResultMap = configuration.getResultMap(resultMapping.getNestedResultMapId());
         if (!refList.contains(nestedResultMap)) {
             refList.add(nestedResultMap);
-            if (resultMapping.getFlags().contains(ResultFlag.CONSTRUCTOR)) {
+            if (resultMapping.getFlags().contains(ResultFlag.CONSTRUCTOR) || nestedResultMap.getResultRelation() == ResultRelation.COLLECTION) {
                 createRowKeyForMappedProperties(nestedResultMap, rsw, cacheKey, nestedResultMap.getConstructorResultMappings(),
                     prependPrefix(resultMapping.getColumnPrefix(), columnPrefix), refList);
             } else {

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -43,6 +43,7 @@ import org.apache.ibatis.mapping.Discriminator;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.mapping.ParameterMapping;
 import org.apache.ibatis.mapping.ParameterMode;
+import org.apache.ibatis.mapping.ResultFlag;
 import org.apache.ibatis.mapping.ResultMap;
 import org.apache.ibatis.mapping.ResultMapping;
 import org.apache.ibatis.reflection.MetaClass;
@@ -960,12 +961,25 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   }
 
   private void createRowKeyForMappedProperties(ResultMap resultMap, ResultSetWrapper rsw, CacheKey cacheKey, List<ResultMapping> resultMappings, String columnPrefix) throws SQLException {
+      createRowKeyForMappedProperties(resultMap, rsw, cacheKey, resultMappings, columnPrefix, new ArrayList<ResultMap>());
+  }
+
+  private void createRowKeyForMappedProperties(ResultMap resultMap, ResultSetWrapper rsw, CacheKey cacheKey, List<ResultMapping> resultMappings, String columnPrefix, List<ResultMap> refList) throws SQLException {
     for (ResultMapping resultMapping : resultMappings) {
       if (resultMapping.getNestedResultMapId() != null && resultMapping.getResultSet() == null) {
         // Issue #392
         final ResultMap nestedResultMap = configuration.getResultMap(resultMapping.getNestedResultMapId());
-        createRowKeyForMappedProperties(nestedResultMap, rsw, cacheKey, nestedResultMap.getConstructorResultMappings(),
-            prependPrefix(resultMapping.getColumnPrefix(), columnPrefix));
+        if (!refList.contains(nestedResultMap)) {
+            refList.add(nestedResultMap);
+            if (resultMapping.getFlags().contains(ResultFlag.CONSTRUCTOR)) {
+                createRowKeyForMappedProperties(nestedResultMap, rsw, cacheKey, nestedResultMap.getConstructorResultMappings(),
+                    prependPrefix(resultMapping.getColumnPrefix(), columnPrefix), refList);
+            } else {
+                createRowKeyForMappedProperties(nestedResultMap, rsw, cacheKey, nestedResultMap.getPropertyResultMappings(),
+                    prependPrefix(resultMapping.getColumnPrefix(), columnPrefix), refList);
+            }
+        }
+
       } else if (resultMapping.getNestedQueryId() == null) {
         final String column = prependPrefix(resultMapping.getColumn(), columnPrefix);
         final TypeHandler<?> th = resultMapping.getTypeHandler();

--- a/src/main/java/org/apache/ibatis/mapping/ResultMap.java
+++ b/src/main/java/org/apache/ibatis/mapping/ResultMap.java
@@ -34,6 +34,7 @@ public class ResultMap {
   private List<ResultMapping> idResultMappings;
   private List<ResultMapping> constructorResultMappings;
   private List<ResultMapping> propertyResultMappings;
+  private ResultRelation resultRelation;
   private Set<String> mappedColumns;
   private Discriminator discriminator;
   private boolean hasNestedResultMaps;
@@ -60,6 +61,11 @@ public class ResultMap {
     public Builder discriminator(Discriminator discriminator) {
       resultMap.discriminator = discriminator;
       return this;
+    }
+    
+    public Builder resultRelation(ResultRelation resultRelations) {
+        resultMap.resultRelation = resultRelations;
+        return this;
     }
 
     public Class<?> type() {
@@ -124,6 +130,10 @@ public class ResultMap {
 
   public Class<?> getType() {
     return type;
+  }
+
+  public ResultRelation getResultRelation() {
+      return resultRelation;
   }
 
   public List<ResultMapping> getResultMappings() {

--- a/src/main/java/org/apache/ibatis/mapping/ResultRelation.java
+++ b/src/main/java/org/apache/ibatis/mapping/ResultRelation.java
@@ -13,14 +13,8 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.submitted.nested_entity_hashing;
+package org.apache.ibatis.mapping;
 
-import java.util.List;
-
-public interface Mapper {
-
-  List<Parent> getWithAssociation();
-  List<Parent> getWithCollection();
-  List<Parent> getWithAssociationAndCollection();
-
+public enum ResultRelation {
+  COLLECTION, ASSOCIATION, NONE
 }

--- a/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/Child.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/Child.java
@@ -1,0 +1,30 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.nested_entity_hashing;
+
+public class Child {
+
+  private Integer id;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/CreateDB.sql
@@ -1,0 +1,26 @@
+--
+--    Copyright 2009-2012 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table ParentChild if exists;
+
+create table ParentChild (
+  parent_id int,
+  child_id int
+);
+
+insert into ParentChild (parent_id, child_id) values(1, 1);
+insert into ParentChild (parent_id, child_id) values(1, 2);
+insert into ParentChild (parent_id, child_id) values(2, 3);

--- a/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/Mapper.java
@@ -1,0 +1,25 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.nested_entity_hashing;
+
+import java.util.List;
+
+public interface Mapper {
+
+  List<Parent> getWithAssociation();
+  List<Parent> getWithCollection();
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/Mapper.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+       Copyright 2009-2013 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.nested_entity_hashing.Mapper">
+
+    <select id="getWithCollection" resultMap="collectionResultMap">
+        select * from ParentChild
+    </select>
+
+    <select id="getWithAssociation" resultMap="associationResultMap">
+        select * from ParentChild
+    </select>
+
+    <resultMap id="collectionResultMap" type="Parent">
+        <result column="parent_id" property="id" />
+        <collection property="children" ofType="Child">
+            <result property="id" column="child_id"/>
+        </collection>
+    </resultMap>
+
+    <resultMap id="associationResultMap" type="Parent">
+        <result column="parent_id" property="id" />
+        <association property="child" javaType="Child">
+            <result property="id" column="child_id"/>
+        </association>
+    </resultMap>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/Mapper.xml
@@ -27,9 +27,23 @@
     <select id="getWithAssociation" resultMap="associationResultMap">
         select * from ParentChild
     </select>
+    
+    <select id="getWithAssociationAndCollection" resultMap="associationCollectionResultMap">
+        select * from ParentChild
+    </select>
 
     <resultMap id="collectionResultMap" type="Parent">
         <result column="parent_id" property="id" />
+        <collection property="children" ofType="Child">
+            <result property="id" column="child_id"/>
+        </collection>
+    </resultMap>
+    
+    <resultMap id="associationCollectionResultMap" type="Parent">
+        <result column="parent_id" property="id" />
+        <association property="child" javaType="Child">
+            <result property="id" column="child_id"/>
+        </association>
         <collection property="children" ofType="Child">
             <result property="id" column="child_id"/>
         </collection>

--- a/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/NestedEntityHashingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/NestedEntityHashingTest.java
@@ -81,5 +81,25 @@ public class NestedEntityHashingTest {
       sqlSession.close();
     }
   }
+  
+  @Test
+  public void shouldGetNObjects() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<Parent> parents = mapper.getWithAssociationAndCollection();
+      for (Parent parent: parents) {
+          Assert.assertNotNull(parent);
+          Assert.assertFalse(parent.getChildren().isEmpty());
+      }
+      Assert.assertEquals(3, parents.size());
+      Assert.assertEquals(2, parents.get(0).getChildren().size());
+      Assert.assertEquals(2, parents.get(1).getChildren().size());
+      Assert.assertEquals(1, parents.get(2).getChildren().size());
+      System.out.println();
+    } finally {
+      sqlSession.close();
+    }
+  }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/NestedEntityHashingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/NestedEntityHashingTest.java
@@ -1,0 +1,85 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.nested_entity_hashing;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.util.List;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class NestedEntityHashingTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nested_entity_hashing/mybatis-config.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
+
+    // populate in-memory database
+    SqlSession session = sqlSessionFactory.openSession();
+    Connection conn = session.getConnection();
+    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nested_entity_hashing/CreateDB.sql");
+    ScriptRunner runner = new ScriptRunner(conn);
+    runner.setLogWriter(null);
+    runner.runScript(reader);
+    reader.close();
+    session.close();
+  }
+
+  @Test
+  public void shouldGet3DistinctObjects() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<Parent> parents = mapper.getWithAssociation();
+      for (Parent parent: parents) {
+          Assert.assertNotNull(parent);
+          Assert.assertNotNull(parent.getChild());
+      }
+      Assert.assertEquals(3, parents.size());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldGet2Objects() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<Parent> parents = mapper.getWithCollection();
+      for (Parent parent: parents) {
+          Assert.assertNotNull(parent);
+          Assert.assertFalse(parent.getChildren().isEmpty());
+      }
+      Assert.assertEquals(2, parents.size());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/Parent.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/Parent.java
@@ -1,0 +1,50 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.nested_entity_hashing;
+
+import java.util.Collection;
+
+public class Parent {
+
+    private Integer id;
+    private Child child;
+    private Collection<Child> children;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public Child getChild() {
+        return child;
+    }
+
+    public void setChild(Child child) {
+        this.child = child;
+    }
+
+    public Collection<Child> getChildren() {
+        return children;
+    }
+
+    public void setChildren(Collection<Child> children) {
+        this.children = children;
+    }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/nested_entity_hashing/mybatis-config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+       Copyright 2009-2013 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <typeAliases>
+        <package name="org.apache.ibatis.submitted.nested_entity_hashing" />
+    </typeAliases>
+
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value="" />
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="org.hsqldb.jdbcDriver" />
+                <property name="url" value="jdbc:hsqldb:mem:nested_entity_hashing" />
+                <property name="username" value="sa" />
+            </dataSource>
+        </environment>
+    </environments>
+
+    <mappers>
+        <mapper class="org.apache.ibatis.submitted.nested_entity_hashing.Mapper" />
+    </mappers>
+
+</configuration>


### PR DESCRIPTION
Hi,

currently when an `<association />` has data by means of "Nested Results" - it does not add them to the cache key, which leads to cache collisions and missing objects.

This fix makes sure the values are added to the cache key. Infinite recursion protection is also implemented by checking for when the recursion loop restarts and ending cache key generation.