### PR TITLE
Added failing test-case for overloaded mapper method

### DIFF
--- a/src/test/java/org/apache/ibatis/submitted/overload/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/overload/CreateDB.sql
@@ -1,0 +1,28 @@
+--
+--    Copyright 2009-2016 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+create table names (
+id int,
+firstName varchar(20),
+lastName varchar(20)
+);
+
+insert into names (id, firstName, lastName) values(1, 'Fred', 'Flintstone');
+insert into names (id, firstName, lastName) values(2, 'Wilma', 'Flintstone');
+insert into names (id, firstName, lastName) values(3, 'Pebbles', 'Flintstone');
+insert into names (id, firstName, lastName) values(4, 'Barney', 'Rubble');
+insert into names (id, firstName, lastName) values(5, 'Betty', 'Rubble');
+insert into names (id, firstName, lastName) values(6, 'Bamm Bamm', 'Rubble');

--- a/src/test/java/org/apache/ibatis/submitted/overload/Overload.xml
+++ b/src/test/java/org/apache/ibatis/submitted/overload/Overload.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2016 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.overload.OverloadedMapper">
+  <select id="find" resultType="string">
+    select concat(firstName,' ', lastName)
+    from names
+    <where>
+        <if test="firstName !=null">firstName = #{firstName}</if>
+        <if test="lastName !=null">AND lastName = #{lastName}</if>
+    </where>
+  </select>
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/overload/OverloadTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/overload/OverloadTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2016 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/overload/OverloadTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/overload/OverloadTest.java
@@ -1,0 +1,82 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.overload;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.List;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class OverloadTest {
+
+    protected static SqlSessionFactory sqlSessionFactory;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Connection conn = null;
+
+        try {
+            Class.forName("org.hsqldb.jdbcDriver");
+            conn = DriverManager.getConnection("jdbc:hsqldb:mem:overload", "sa", "");
+
+            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/overload/CreateDB.sql");
+
+            final ScriptRunner runner = new ScriptRunner(conn);
+            runner.setLogWriter(null);
+            runner.setErrorLogWriter(null);
+            runner.runScript(reader);
+            conn.commit();
+            reader.close();
+
+            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/overload/mybatis-config.xml");
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+            reader.close();
+        } finally {
+            if (conn != null) {
+                conn.close();
+            }
+        }
+    }
+
+    @Test
+    public void testOverloadedMapperMethod() {
+        final SqlSession sqlSession = sqlSessionFactory.openSession();
+        try {
+            final OverloadedMapper mapper = sqlSession.getMapper(OverloadedMapper.class);
+            final List<String> resultsByLastName = mapper.find("Flintstone");
+            final List<String> resultsByNullFirstNameAndLastName = mapper.find(null, "Flintstone");
+            assertNotEquals(0, resultsByLastName.size());
+            assertEquals(resultsByLastName.size(), resultsByNullFirstNameAndLastName.size());
+
+            final List<String> resultsByNullLastNameAndFirstName = mapper.find("Fred", null);
+            assertNotEquals(0, resultsByNullLastNameAndFirstName.size());
+
+        } finally {
+            sqlSession.close();
+        }
+    }
+}

--- a/src/test/java/org/apache/ibatis/submitted/overload/OverloadedMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/overload/OverloadedMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2016 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/overload/OverloadedMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/overload/OverloadedMapper.java
@@ -1,0 +1,26 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.overload;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Param;
+
+public interface OverloadedMapper {
+    List<String> find(@Param("lastName") String lastName);
+
+    List<String> find(@Param("firstName") String firstName, @Param("lastName") String lastName);
+}

--- a/src/test/java/org/apache/ibatis/submitted/overload/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/overload/mybatis-config.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2016 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value=""/>
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver"/>
+        <property name="url" value="jdbc:hsqldb:mem:overload"/>
+        <property name="username" value="sa"/>
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper resource="org/apache/ibatis/submitted/overload/Overload.xml"/>
+  </mappers>
+
+</configuration>


### PR DESCRIPTION
Added a new failing test-case to verify that two methods with the same name but different parameter sets are not usable, due to a binding exception, even if the mapper method would handle the different parameter sets correctly.
- The easy (but possibly incorrect fix) is not throwing BindingException from MapperMethod.ParamMap
- The tests broken by the above change are obviously the ones testing for behaviour on non-existent params, namely o.a.i.submitted.nonexistentvariables.testWrongParameter and o.a.i.binding.BindingTestshouldFailWhenSelectingOneBlogWithNonExistentNestedParam (a comment on this even mentions that "Decided that maps are dynamic so no existent params do not fail")
- Possible solutions would be either a configuration variable to allow inexistent parameters, with default value causing the current behaviour, but an option to allow inexistent parameters or possibly checking for overloaded mapper methods and not failing if there is a mapper method with the "inexistent" mapping parameter.
- After discussing a possible solution I could come up with a fix.
- The relevant commit introducing this seems to be c8c41bef1a9531a4499ef05a2488883b1fcc7a85
