### PR TITLE
solve mysql invalid connection

### DIFF
--- a/src/main/java/org/apache/ibatis/datasource/pooled/PooledDataSource.java
+++ b/src/main/java/org/apache/ibatis/datasource/pooled/PooledDataSource.java
@@ -52,7 +52,7 @@ public class PooledDataSource implements DataSource {
   protected int poolTimeToWait = 20000;
   protected String poolPingQuery = "NO PING QUERY SET";
   protected boolean poolPingEnabled = false;
-  protected int poolPingConnectionsNotUsedFor = 0;
+  protected int poolPingConnectionsNotUsedFor = -1;
 
   private int expectedConnectionTypeCode;
 
@@ -483,7 +483,7 @@ public class PooledDataSource implements DataSource {
 
     if (result) {
       if (poolPingEnabled) {
-        if (poolPingConnectionsNotUsedFor >= 0 && conn.getTimeElapsedSinceLastUse() > poolPingConnectionsNotUsedFor) {
+        if (poolPingConnectionsNotUsedFor >= 0 && conn.getTimeElapsedSinceLastUse() >= poolPingConnectionsNotUsedFor) {
           try {
             if (log.isDebugEnabled()) {
               log.debug("Testing connection " + conn.getRealHashCode() + " ...");

--- a/src/test/java/org/apache/ibatis/jdbc/PooledDataSourceTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/PooledDataSourceTest.java
@@ -95,40 +95,8 @@ public class PooledDataSourceTest extends BaseDataTest {
     ds.setPoolPingConnectionsNotUsedFor(0);
     ds.setPoolPingEnabled(true);
     ds.setPoolPingQuery("SELECT * FROM PRODUCT");
-    
-    ThreadPoolExecutor pool = (ThreadPoolExecutor)Executors.newFixedThreadPool(2);
-    runThreadPool(ds, pool);
-    runThreadPool(ds, pool);
-    runThreadPool(ds, pool);
-    
-    pool.shutdownNow();
+    Connection c = ds.getConnection();
+    c.close();
   }
   
-  private void runThreadPool(PooledDataSource ds, ThreadPoolExecutor pool){
-    for(int i=0;i<50;i++){
-      pool.execute(()->{
-        Connection c = null;
-        try {
-          c = ds.getConnection();
-        } catch (Exception e) {
-          System.out.println("getConnection exception:" + e.getMessage());
-        }finally{
-          if(c!=null){
-            try {
-              c.close();
-            } catch (Exception e) {
-              System.out.println("close exception:" + e.getMessage());
-            }
-          }
-        }
-      });
-    }
-    while(pool.getActiveCount()>0){
-      try {
-        Thread.sleep(5000);
-      } catch (InterruptedException e) {
-        System.out.println("Thread exception:" + e.getMessage());
-      }
-    }
-  }
 }


### PR DESCRIPTION
use the mysql offen occur this Error. Error querying database.  Cause:
com.mysql.jdbc.exceptions.jdbc4.CommunicationsException: The last packet
successfully received from the server was 19,800,056 milliseconds ago.
The last packet sent successfully to the server was 19,800,056
milliseconds ago. is longer than the server configured value of
'wait_timeout'. You should consider either expiring and/or testing
connection validity before use in your application, increasing the
server configured values for client timeouts, or using the Connector/J
connection property 'autoReconnect=true' to avoid this problem.

Reason:
Use pooled datasource ,the idle connection could be invalid, when access
the msyql 'wait_timeout'. When call the close method to close this
connection, sometimes skip the 'pingConnection' method, so put a invalid
connection to idle Map.

my test:
2016-06-17 17:45:55,818 DEBUG [pool-1-thread-2] - Closing JDBC
Connection [com.mysql.jdbc.JDBC4Connection@7646d452] 1984353362
2016-06-17 17:45:55,818 DEBUG [pool-1-thread-2] -
============1984353362============= 0 0
(conn.getTimeElapsedSinceLastUse():0 poolPingConnectionsNotUsedFor:0)
2016-06-17 17:45:55,819 DEBUG [pool-1-thread-2] - Returned connection
1984353362 to pool.


solve this to ping connection before use.