### PR TITLE
Allow variable length argument on SQL's methods

### DIFF
--- a/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
+++ b/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2016 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,12 +17,14 @@ package org.apache.ibatis.jdbc;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
  * @author Clinton Begin
  * @author Jeff Butler
  * @author Adam Gent
+ * @author Kazuki Shimizu
  */
 public abstract class AbstractSQL<T> {
 
@@ -44,6 +46,14 @@ public abstract class AbstractSQL<T> {
     return getSelf();
   }
 
+  /**
+   * @since 3.4.2
+   */
+  public T SET(String... sets) {
+    sql().sets.addAll(Arrays.asList(sets));
+    return getSelf();
+  }
+
   public T INSERT_INTO(String tableName) {
     sql().statementType = SQLStatement.StatementType.INSERT;
     sql().tables.add(tableName);
@@ -62,7 +72,25 @@ public abstract class AbstractSQL<T> {
     return getSelf();
   }
 
+  /**
+   * @since 3.4.2
+   */
+  public T SELECT(String... columns) {
+    sql().statementType = SQLStatement.StatementType.SELECT;
+    sql().select.addAll(Arrays.asList(columns));
+    return getSelf();
+  }
+
   public T SELECT_DISTINCT(String columns) {
+    sql().distinct = true;
+    SELECT(columns);
+    return getSelf();
+  }
+
+  /**
+   * @since 3.4.2
+   */
+  public T SELECT_DISTINCT(String... columns) {
     sql().distinct = true;
     SELECT(columns);
     return getSelf();
@@ -79,8 +107,24 @@ public abstract class AbstractSQL<T> {
     return getSelf();
   }
 
+  /**
+   * @since 3.4.2
+   */
+  public T FROM(String... tables) {
+    sql().tables.addAll(Arrays.asList(tables));
+    return getSelf();
+  }
+
   public T JOIN(String join) {
     sql().join.add(join);
+    return getSelf();
+  }
+
+  /**
+   * @since 3.4.2
+   */
+  public T JOIN(String... joins) {
+    sql().join.addAll(Arrays.asList(joins));
     return getSelf();
   }
 
@@ -89,8 +133,24 @@ public abstract class AbstractSQL<T> {
     return getSelf();
   }
 
+  /**
+   * @since 3.4.2
+   */
+  public T INNER_JOIN(String... joins) {
+    sql().innerJoin.addAll(Arrays.asList(joins));
+    return getSelf();
+  }
+
   public T LEFT_OUTER_JOIN(String join) {
     sql().leftOuterJoin.add(join);
+    return getSelf();
+  }
+
+  /**
+   * @since 3.4.2
+   */
+  public T LEFT_OUTER_JOIN(String... joins) {
+    sql().leftOuterJoin.addAll(Arrays.asList(joins));
     return getSelf();
   }
 
@@ -99,13 +159,38 @@ public abstract class AbstractSQL<T> {
     return getSelf();
   }
 
+  /**
+   * @since 3.4.2
+   */
+  public T RIGHT_OUTER_JOIN(String... joins) {
+    sql().rightOuterJoin.addAll(Arrays.asList(joins));
+    return getSelf();
+  }
+
   public T OUTER_JOIN(String join) {
     sql().outerJoin.add(join);
     return getSelf();
   }
 
+  /**
+   * @since 3.4.2
+   */
+  public T OUTER_JOIN(String... joins) {
+    sql().outerJoin.addAll(Arrays.asList(joins));
+    return getSelf();
+  }
+
   public T WHERE(String conditions) {
     sql().where.add(conditions);
+    sql().lastList = sql().where;
+    return getSelf();
+  }
+
+  /**
+   * @since 3.4.2
+   */
+  public T WHERE(String... conditions) {
+    sql().where.addAll(Arrays.asList(conditions));
     sql().lastList = sql().where;
     return getSelf();
   }
@@ -125,14 +210,39 @@ public abstract class AbstractSQL<T> {
     return getSelf();
   }
 
+  /**
+   * @since 3.4.2
+   */
+  public T GROUP_BY(String... columns) {
+    sql().groupBy.addAll(Arrays.asList(columns));
+    return getSelf();
+  }
+
   public T HAVING(String conditions) {
     sql().having.add(conditions);
     sql().lastList = sql().having;
     return getSelf();
   }
 
+  /**
+   * @since 3.4.2
+   */
+  public T HAVING(String... conditions) {
+    sql().having.addAll(Arrays.asList(conditions));
+    sql().lastList = sql().having;
+    return getSelf();
+  }
+
   public T ORDER_BY(String columns) {
     sql().orderBy.add(columns);
+    return getSelf();
+  }
+
+  /**
+   * @since 3.4.2
+   */
+  public T ORDER_BY(String... columns) {
+    sql().orderBy.addAll(Arrays.asList(columns));
     return getSelf();
   }
 

--- a/src/test/java/org/apache/ibatis/jdbc/SQLTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/SQLTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2016 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -177,6 +177,130 @@ public class SQLTest {
       }
       ORDER_BY("P.LAST_NAME");
     }}.toString();
+  }
+
+
+  @Test
+  public void variableLengthArgumentOnSelect() {
+    final String sql = new SQL() {{
+      SELECT("P.ID", "P.USERNAME");
+    }}.toString();
+
+    assertEquals("SELECT P.ID, P.USERNAME", sql);
+  }
+
+  @Test
+  public void variableLengthArgumentOnSelectDistinct() {
+    final String sql = new SQL() {{
+      SELECT_DISTINCT("P.ID", "P.USERNAME");
+    }}.toString();
+
+    assertEquals("SELECT DISTINCT P.ID, P.USERNAME", sql);
+  }
+
+  @Test
+  public void variableLengthArgumentOnFrom() {
+    final String sql = new SQL() {{
+      SELECT().FROM("TABLE_A a", "TABLE_B b");
+    }}.toString();
+
+    assertEquals("FROM TABLE_A a, TABLE_B b", sql);
+  }
+
+  @Test
+  public void variableLengthArgumentOnJoin() {
+    final String sql = new SQL() {{
+      SELECT().JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
+    }}.toString();
+
+    assertEquals("JOIN TABLE_A b ON b.id = a.id\n" +
+            "JOIN TABLE_C c ON c.id = a.id", sql);
+  }
+
+  @Test
+  public void variableLengthArgumentOnInnerJoin() {
+    final String sql = new SQL() {{
+      SELECT().INNER_JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
+    }}.toString();
+
+    assertEquals("INNER JOIN TABLE_A b ON b.id = a.id\n" +
+            "INNER JOIN TABLE_C c ON c.id = a.id", sql);
+  }
+
+  @Test
+  public void variableLengthArgumentOnOuterJoin() {
+    final String sql = new SQL() {{
+      SELECT().OUTER_JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
+    }}.toString();
+
+    assertEquals("OUTER JOIN TABLE_A b ON b.id = a.id\n" +
+            "OUTER JOIN TABLE_C c ON c.id = a.id", sql);
+  }
+
+  @Test
+  public void variableLengthArgumentOnLeftOuterJoin() {
+    final String sql = new SQL() {{
+      SELECT().LEFT_OUTER_JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
+    }}.toString();
+
+    assertEquals("LEFT OUTER JOIN TABLE_A b ON b.id = a.id\n" +
+            "LEFT OUTER JOIN TABLE_C c ON c.id = a.id", sql);
+  }
+
+  @Test
+  public void variableLengthArgumentOnRightOuterJoin() {
+    final String sql = new SQL() {{
+      SELECT().RIGHT_OUTER_JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
+    }}.toString();
+
+    assertEquals("RIGHT OUTER JOIN TABLE_A b ON b.id = a.id\n" +
+            "RIGHT OUTER JOIN TABLE_C c ON c.id = a.id", sql);
+  }
+
+  @Test
+  public void variableLengthArgumentOnWhere() {
+    final String sql = new SQL() {{
+      SELECT().WHERE("a = #{a}", "b = #{b}");
+    }}.toString();
+
+    assertEquals("WHERE (a = #{a} AND b = #{b})", sql);
+  }
+
+  @Test
+  public void variableLengthArgumentOnGroupBy() {
+    final String sql = new SQL() {{
+      SELECT().GROUP_BY("a", "b");
+    }}.toString();
+
+    assertEquals("GROUP BY a, b", sql);
+  }
+
+  @Test
+  public void variableLengthArgumentOnHaving() {
+    final String sql = new SQL() {{
+      SELECT().HAVING("a = #{a}", "b = #{b}");
+    }}.toString();
+
+    assertEquals("HAVING (a = #{a} AND b = #{b})", sql);
+  }
+
+  @Test
+  public void variableLengthArgumentOnOrderBy() {
+    final String sql = new SQL() {{
+      SELECT().ORDER_BY("a", "b");
+    }}.toString();
+
+    assertEquals("ORDER BY a, b", sql);
+  }
+
+  @Test
+  public void variableLengthArgumentOnSet() {
+    final String sql = new SQL() {{
+      UPDATE("TABLE_A").SET("a = #{a}", "b = #{b}");
+    }}.toString();
+
+    assertEquals("UPDATE TABLE_A\n" +
+            "SET a = #{a}, b = #{b}", sql);
   }
 
 }


### PR DESCRIPTION
I've supported variable length argument on `SQL`'s methods.
I think these methods is useful and more safely.
Please review.