### PR TITLE
Allow to use getters and setters without get- or set- prefix to serialize/deserialize DB data, 2nd attempt

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/Reflector.java
+++ b/src/main/java/org/apache/ibatis/reflection/Reflector.java
@@ -97,6 +97,10 @@ public class Reflector {
     Map<String, List<Method>> conflictingGetters = new HashMap<String, List<Method>>();
     Method[] methods = getClassMethods(cls);
     for (Method method : methods) {
+      if (Modifier.isStatic(method.getModifiers())) {
+        // static method is not a getter
+        continue;
+      }
       String name = method.getName();
       if (name.startsWith("get") && name.length() > 3) {
         if (method.getParameterTypes().length == 0) {
@@ -158,6 +162,10 @@ public class Reflector {
     Map<String, List<Method>> conflictingSetters = new HashMap<String, List<Method>>();
     Method[] methods = getClassMethods(cls);
     for (Method method : methods) {
+      if (Modifier.isStatic(method.getModifiers())) {
+        // static method is not a setter
+        continue;
+      }
       String name = method.getName();
       if (name.startsWith("set") && name.length() > 3) {
         if (method.getParameterTypes().length == 1) {

--- a/src/main/java/org/apache/ibatis/reflection/Reflector.java
+++ b/src/main/java/org/apache/ibatis/reflection/Reflector.java
@@ -42,9 +42,13 @@ import org.apache.ibatis.reflection.property.PropertyNamer;
  * This class represents a cached set of class definition information that
  * allows for easy mapping between property names and getter/setter methods.
  *
+ * Though the class was exposed in public API as a return value of {@link ReflectorFactory#findForClass(Class)},
+ * it is not intended to be public. This class is used in the most frequently changed part of MyBatis,
+ * so it should not be inheritable in application code.
+ *
  * @author Clinton Begin
  */
-public class Reflector {
+public final class Reflector {
 
   private static final String[] EMPTY_STRING_ARRAY = new String[0];
 

--- a/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
@@ -160,4 +160,35 @@ public class ReflectorTest {
 
   static class Child extends Parent<String> {
   }
+
+
+  @Test
+  public void shouldResolveWriteOnlyProperty() throws Exception {
+    ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
+    Reflector reflector = reflectorFactory.findForClass(Child2.class);
+    Assert.assertEquals(Long.class, reflector.getSetterType("id"));
+  }
+
+  static class Parent2<T extends Serializable> {
+    T id;
+
+    /**
+     * A setter for write-only property according to
+     * Java Beans Specification 1.01
+     * http://download.oracle.com/otn-pub/jcp/7224-javabeans-1.01-fr-spec-oth-JSpec/beans.101.pdf
+     * Section 8.3.1
+     */
+    public void setId(T id) {
+      this.id = id;
+    }
+  }
+
+  static class Child2 extends Parent2<Long> {
+    int counter;
+
+    public void setId(Long id) {
+      ++counter;
+      super.setId(id);
+    }
+  }
 }

--- a/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
@@ -15,13 +15,14 @@
  */
 package org.apache.ibatis.reflection;
 
-import static org.junit.Assert.*;
-
 import java.io.Serializable;
 import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class ReflectorTest {
 
@@ -189,6 +190,36 @@ public class ReflectorTest {
     public void setId(Long id) {
       ++counter;
       super.setId(id);
+    }
+  }
+
+  @Test
+  public void shouldHaveNoStaticGetters() throws Exception {
+    ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
+    Reflector reflector = reflectorFactory.findForClass(Anxious.class);
+    Assert.assertFalse(reflector.hasGetter("thereAnybodyOutThere"));
+  }
+
+  static abstract class Anxious {
+    private static boolean any;
+
+    static boolean isThereAnybodyOutThere() {
+      return any;
+    }
+  }
+
+  @Test
+  public void shouldHaveNoStaticSetters() throws Exception {
+    ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
+    Reflector reflector = reflectorFactory.findForClass(Happy.class);
+    Assert.assertFalse(reflector.hasSetter("upset"));
+  }
+
+  static abstract class Happy {
+    private static String focus;
+
+    static void setUpset(String reason) {
+      focus = reason;
     }
   }
 }


### PR DESCRIPTION
[First attempt with comments](https://github.com/mybatis/mybatis-3/pull/722) is here.

This branch contains:

-  two small fixes:

  1) static method could not be getter or setter
  2) fixed a corner case of write-only property reflection with setter inherited using generics

- a small change: Reflector is final, so it is not possible to define custom reflection in the client code
- a feature that anything getting and setting goes (single-Reflector implementation)

I see three implied regressions here:

1) static getters or setters will stop working
2) custom Reflectors stop working
3) when a few setters with single argument of different types found for a write-only property, MyBatis will silently skip the property instead of bailing out.

The latter worries me the most. Should Reflector write some log information in this case?