### PR TITLE
Allow variable length argument on SQL's methods. related with #726

### DIFF
--- a/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
+++ b/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
@@ -66,6 +66,22 @@ public abstract class AbstractSQL<T> {
     return getSelf();
   }
 
+  /**
+   * @since 3.4.2
+   */
+  public T INTO_COLUMNS(String... columns) {
+    sql().columns.addAll(Arrays.asList(columns));
+    return getSelf();
+  }
+
+  /**
+   * @since 3.4.2
+   */
+  public T INTO_VALUES(String... values) {
+    sql().values.addAll(Arrays.asList(values));
+    return getSelf();
+  }
+
   public T SELECT(String columns) {
     sql().statementType = SQLStatement.StatementType.SELECT;
     sql().select.add(columns);

--- a/src/test/java/org/apache/ibatis/jdbc/SQLTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/SQLTest.java
@@ -303,4 +303,15 @@ public class SQLTest {
             "SET a = #{a}, b = #{b}", sql);
   }
 
+  @Test
+  public void variableLengthArgumentOnIntoColumnsAndValues() {
+    final String sql = new SQL() {{
+      INSERT_INTO("TABLE_A").INTO_COLUMNS("a","b").INTO_VALUES("#{a}","#{b}");
+    }}.toString();
+
+    System.out.println(sql);
+
+    assertEquals("INSERT INTO TABLE_A\n (a, b)\nVALUES (#{a}, #{b})", sql);
+  }
+
 }


### PR DESCRIPTION
I've added methods for insert values.

* `INTO_COLUMNS(String... columns)`
* `INTO_VALUES(String... values)`

I wanted to add `COLUMNS(String ... columns)` and `VALUES(String... values)`. However, `VALUES(String... values)` is not compatibility for `VALUES(String columns, String values)`.

Please review.

#726