### PR TITLE
update the site doc .

### DIFF
--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -359,7 +359,7 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
                 Un type alias o una nombre de clase completamente cualificado
               </td>
               <td>
-                org.apache.ibatis.scripting.xmltags.XMLDynamicLanguageDriver
+                org.apache.ibatis.scripting.xmltags.XMLLanguageDriver
               </td>
             </tr>
             <tr>

--- a/src/site/ja/xdoc/configuration.xml
+++ b/src/site/ja/xdoc/configuration.xml
@@ -389,7 +389,7 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
                 タイプエイリアスまたは完全修飾クラス名
               </td>
               <td>
-                org.apache.ibatis.scripting.xmltags.XMLDynamicLanguageDriver
+                org.apache.ibatis.scripting.xmltags.XMLLanguageDriver
               </td>
             </tr>
             <tr>

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -367,7 +367,7 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
                 타입별칭이나 패키지 경로를 포함한 클래스명
               </td>
               <td>
-                org.apache.ibatis.scripting.xmltags.XMLDynamicLanguageDriver
+                org.apache.ibatis.scripting.xmltags.XMLLanguageDriver
               </td>
             </tr>
             <tr>

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -451,7 +451,7 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
                 A type alias or fully qualified class name.
               </td>
               <td>
-                org.apache.ibatis.scripting.xmltags.XMLDynamicLanguageDriver
+                org.apache.ibatis.scripting.xmltags.XMLLanguageDriver
               </td>
             </tr>
             <tr>

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -371,7 +371,7 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
                 A type alias or fully qualified class name.
               </td>
               <td>
-                org.apache.ibatis.scripting.xmltags.XMLDynamicLanguageDriver
+                org.apache.ibatis.scripting.xmltags.XMLLanguageDriver
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
fix the defaultScriptingLanguage
from 
> org.apache.ibatis.scripting.xmltags.XMLDynamicLanguageDriver 

to

> org.apache.ibatis.scripting.xmltags.XMLLanguageDriver

the class  org.apache.ibatis.scripting.xmltags.XMLDynamicLanguageDriver  is not exist.

In the Class Configuration, we can set the method setDefaultScriptingLanguage(Class<?> driver)

the setDefaultScriptingLanguage is the class org.apache.ibatis.scripting.xmltags.XMLLanguageDriver.

```java
  public void setDefaultScriptingLanguage(Class<?> driver) {                                                                                                                                                                            
         if (driver == null) {
             driver = XMLLanguageDriver.class;
         }             
           getLanguageRegistry().setDefaultDriverClass(driver);
   } 
```