### PR TITLE
Minor Optimization in TypeHandlerRegistry#getTypeHandler

### DIFF
--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -195,10 +195,15 @@ public final class TypeHandlerRegistry {
     Map<JdbcType, TypeHandler<?>> jdbcHandlerMap = TYPE_HANDLER_MAP.get(type);
     TypeHandler<?> handler = null;
     if (jdbcHandlerMap != null) {
-      handler = jdbcHandlerMap.get(jdbcType);
-      if (handler == null) {
+      if(jdbcType == null){
         handler = jdbcHandlerMap.get(null);
+      }else{
+        handler = jdbcHandlerMap.get(jdbcType);
+        if (handler == null) {
+          handler = jdbcHandlerMap.get(null);
+        }
       }
+
       if (handler == null) {
         // #591
         handler = pickSoleHandler(jdbcHandlerMap);


### PR DESCRIPTION
 1) In case where the argument `jdbcType` is null. We can ignore calling `jdbcHandlerMap.get(null)` in case if `handler` is also null.
 Previously we would have called `jdbcHandlerMap.get` twice (if `jdbcType` and `handler` was null)
 2) Refactored code so that the above is easy to read.