### PR TITLE
Raise a exception when keyProperty is not found

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
+++ b/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
@@ -115,10 +115,14 @@ public class Jdbc3KeyGenerator implements KeyGenerator {
 
   private void populateKeys(ResultSet rs, MetaObject metaParam, String[] keyProperties, TypeHandler<?>[] typeHandlers) throws SQLException {
     for (int i = 0; i < keyProperties.length; i++) {
+      String property = keyProperties[i];
+      if (!metaParam.hasSetter(property)) {
+        throw new ExecutorException("No setter found for the keyProperty '" + property + "' in " + metaParam.getOriginalObject().getClass().getName() + ".");
+      }
       TypeHandler<?> th = typeHandlers[i];
       if (th != null) {
         Object value = th.getResult(rs, i + 1);
-        metaParam.setValue(keyProperties[i], value);
+        metaParam.setValue(property, value);
       }
     }
   }

--- a/src/test/java/org/apache/ibatis/submitted/keygen/CountryMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/CountryMapper.java
@@ -20,5 +20,6 @@ import java.util.List;
 public interface CountryMapper {
 
   int insertList(List<Country> countries);
+  int insertUndefineKeyProperty(Country country);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/keygen/CountryMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/CountryMapper.xml
@@ -27,4 +27,7 @@
           (#{country.countryname},#{country.countrycode})
       </foreach>
   </insert>
+  <insert id="insertUndefineKeyProperty" parameterType="org.apache.ibatis.submitted.keygen.Country" useGeneratedKeys="true" keyProperty="country_id">
+      insert into country (countryname,countrycode) values (#{countryname},#{countrycode})
+  </insert>
 </mapper>


### PR DESCRIPTION
I've improved to raise a exception when property that specified at `keyProperty` is not found on `Jdbc3KeyGenerator`. This change is with reference to the implementation of `SelectKeyGenerator`.
Please review.

