### PR TITLE
Add option that use global variables on sql bind parameter

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2016 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ public class SqlSourceBuilder extends BaseBuilder {
       super(configuration);
       this.parameterType = parameterType;
       this.metaParameters = configuration.newMetaObject(additionalParameters);
+      configuration.takeOverVariables(additionalParameters);
     }
 
     public List<ParameterMapping> getParameterMappings() {

--- a/src/main/java/org/apache/ibatis/builder/StaticSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/StaticSqlSource.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2016 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.builder;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.ParameterMapping;
@@ -43,7 +44,13 @@ public class StaticSqlSource implements SqlSource {
 
   @Override
   public BoundSql getBoundSql(Object parameterObject) {
-    return new BoundSql(configuration, sql, parameterMappings, parameterObject);
+    BoundSql boundSql = new BoundSql(configuration, sql, parameterMappings, parameterObject);
+    if (configuration.isUseVariablesOnBindParameter()) {
+      for (Map.Entry<Object, Object> entry : configuration.getVariables().entrySet()) {
+        boundSql.setAdditionalParameter(String.valueOf(entry.getKey()), entry.getValue());
+      }
+    }
+    return boundSql;
   }
 
 }

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -256,6 +256,7 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setDefaultScriptingLanguage(resolveClass(props.getProperty("defaultScriptingLanguage")));
     configuration.setCallSettersOnNulls(booleanValueOf(props.getProperty("callSettersOnNulls"), false));
     configuration.setUseActualParamName(booleanValueOf(props.getProperty("useActualParamName"), true));
+    configuration.setUseVariablesOnBindParameter(booleanValueOf(props.getProperty("useVariablesOnBindParameter"), false));
     configuration.setLogPrefix(props.getProperty("logPrefix"));
     @SuppressWarnings("unchecked")
     Class<? extends Log> logImpl = (Class<? extends Log>)resolveClass(props.getProperty("logImpl"));

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -107,6 +107,7 @@ public class Configuration {
   protected boolean cacheEnabled = true;
   protected boolean callSettersOnNulls = false;
   protected boolean useActualParamName = true;
+  protected boolean useVariablesOnBindParameter = false;
 
   protected String logPrefix;
   protected Class <? extends Log> logImpl;
@@ -247,6 +248,33 @@ public class Configuration {
 
   public void setUseActualParamName(boolean useActualParamName) {
     this.useActualParamName = useActualParamName;
+  }
+
+  /**
+   * @since 3.4.2
+   */
+  public boolean isUseVariablesOnBindParameter() {
+    return useVariablesOnBindParameter;
+  }
+
+  /**
+   * @since 3.4.2
+   */
+  public void setUseVariablesOnBindParameter(boolean useVariablesOnBindParameter) {
+    this.useVariablesOnBindParameter = useVariablesOnBindParameter;
+  }
+
+  /**
+   * Take over variables to a specified destination {@link Map}.
+   * @param destination a destination {@link Map}
+   * @since 3.4.2
+   */
+  public void takeOverVariables(Map<String, Object> destination) {
+    if (isUseVariablesOnBindParameter()) {
+      for (Map.Entry<Object, Object> entry : getVariables().entrySet()) {
+        destination.put(String.valueOf(entry.getKey()), entry.getValue());
+      }
+    }
   }
 
   public String getDatabaseId() {

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -52,6 +52,8 @@
     <setting name="logImpl" value="SLF4J"/>
     <setting name="vfsImpl" value="org.apache.ibatis.io.JBoss6VFS"/>
     <setting name="configurationFactory" value="java.lang.String"/>
+    <setting name="useActualParamName" value="false"/>
+    <setting name="useVariablesOnBindParameter" value="true"/>
   </settings>
 
   <typeAliases>

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -99,6 +99,8 @@ public class XmlConfigBuilderTest {
     assertNull(config.getLogPrefix());
     assertNull(config.getLogImpl());
     assertNull(config.getConfigurationFactory());
+    assertThat(config.isUseActualParamName(), is(true));
+    assertThat(config.isUseVariablesOnBindParameter(), is(false));
   }
 
   enum MyEnum {
@@ -191,6 +193,8 @@ public class XmlConfigBuilderTest {
       assertThat(config.getLogImpl().getName(), is(Slf4jImpl.class.getName()));
       assertThat(config.getVfsImpl().getName(), is(JBoss6VFS.class.getName()));
       assertThat(config.getConfigurationFactory().getName(), is(String.class.getName()));
+      assertThat(config.isUseActualParamName(), is(false));
+      assertThat(config.isUseVariablesOnBindParameter(), is(true));
 
       assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("blogauthor").equals(Author.class));
       assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("blog").equals(Blog.class));

--- a/src/test/java/org/apache/ibatis/submitted/global_variables/BindParameterMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables/BindParameterMapper.java
@@ -1,0 +1,44 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.global_variables;
+
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.SelectProvider;
+
+import java.util.List;
+
+public interface BindParameterMapper {
+
+  List<User> getUsers();
+
+  List<User> getUsersUsingDyna(String name);
+
+  @Select("select * from users where status = #{userStatus.valid}")
+  List<User> getUsersFromAnnotation();
+
+  @Select("<script>select * from users <where> <if test=\"value != null\">name = #{value}</if>AND status = #{userStatus-invalid}</where></script>")
+  List<User> getUsersFromAnnotationUsingDyna(String name);
+
+  @SelectProvider(type = SqlProvider.class, method = "getUsersFromAnnotationUsingSqlProvider")
+  List<User> getUsersFromAnnotationUsingSqlProvider(String name);
+
+  class SqlProvider {
+    public String getUsersFromAnnotationUsingSqlProvider() {
+      return "select * from users where status = #{userStatus.valid}";
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/global_variables/BindParameterMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables/BindParameterMapper.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2016 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.global_variables.BindParameterMapper">
+
+	<select id="getUsers" resultType="org.apache.ibatis.submitted.global_variables.User">
+		select * from users where status = #{userStatus.valid}
+	</select>
+
+	<select id="getUsersUsingDyna" resultType="org.apache.ibatis.submitted.global_variables.User">
+		select * from users <where> <if test="value != null">name = #{value}</if>AND status = #{userStatus-invalid}</where>
+	</select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/global_variables/BindParameterTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables/BindParameterTest.java
@@ -1,0 +1,112 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.global_variables;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.Reader;
+import java.sql.Connection;
+
+public class BindParameterTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/global_variables/mybatis-config.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
+
+    // populate in-memory database
+    SqlSession session = sqlSessionFactory.openSession();
+    Connection conn = session.getConnection();
+    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/global_variables/CreateDB.sql");
+    ScriptRunner runner = new ScriptRunner(conn);
+    runner.setLogWriter(null);
+    runner.runScript(reader);
+    reader.close();
+    session.close();
+  }
+
+  @Test
+  public void shouldGetUsers() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      BindParameterMapper mapper = sqlSession.getMapper(BindParameterMapper.class);
+      User user = mapper.getUsers().get(0);
+      Assert.assertEquals("User2", user.getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldGetUsersUsingDyna() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      BindParameterMapper mapper = sqlSession.getMapper(BindParameterMapper.class);
+      User user = mapper.getUsersUsingDyna("User1").get(0);
+      Assert.assertEquals("User1", user.getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldGetUsersFromAnnotation() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      BindParameterMapper mapper = sqlSession.getMapper(BindParameterMapper.class);
+      User user = mapper.getUsersFromAnnotation().get(0);
+      Assert.assertEquals("User2", user.getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldGetAUsersFromAnnotationUsingDyna() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      BindParameterMapper mapper = sqlSession.getMapper(BindParameterMapper.class);
+      User user = mapper.getUsersFromAnnotationUsingDyna("User1").get(0);
+      Assert.assertEquals("User1", user.getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldGetAUsersFromAnnotationUsingSqlProvider() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      BindParameterMapper mapper = sqlSession.getMapper(BindParameterMapper.class);
+      User user = mapper.getUsersFromAnnotationUsingSqlProvider("User2").get(0);
+      Assert.assertEquals("User2", user.getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/global_variables/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables/CreateDB.sql
@@ -18,7 +18,9 @@ drop table users if exists;
 
 create table users (
   id int,
-  name varchar(20)
+  name varchar(20),
+  status char(1)
 );
 
-insert into users (id, name) values(1, 'User1');
+insert into users (id, name, status) values(1, 'User1', '0');
+insert into users (id, name, status) values(2, 'User2', '1');

--- a/src/test/java/org/apache/ibatis/submitted/global_variables/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables/User.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2016 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ public class User {
 
   private Integer id;
   private String name;
+  private String status;
 
   public Integer getId() {
     return id;
@@ -34,5 +35,13 @@ public class User {
 
   public void setName(String name) {
     this.name = name;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/global_variables/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables/mybatis-config.xml
@@ -24,7 +24,13 @@
 
 	<properties>
 		<property name="table" value="users"/>
+		<property name="userStatus.valid" value="1"/>
+		<property name="userStatus-invalid" value="0"/>
 	</properties>
+
+	<settings>
+		<setting name="useVariablesOnBindParameter" value="true"/>
+	</settings>
 
 	<environments default="development">
 		<environment id="development">
@@ -41,6 +47,7 @@
 
 	<mappers>
 		<mapper class="org.apache.ibatis.submitted.global_variables.Mapper" />
+		<mapper class="org.apache.ibatis.submitted.global_variables.BindParameterMapper" />
 	</mappers>
 
 </configuration>


### PR DESCRIPTION
I've added new option that use global variables on sql bind parameter.

Usage:

MyBatis configuration:

```xml
<configuration>
    <properties>
        <property name="userStatus.valid" value="1"/> <!-- global variable -->
    </properties>
    <settings>
        <setting name="useVariablesOnBindParameter" value="true"/> <!-- default is false -->
    </settings>
</configuration>
```

Mapper interface:

```java
@Select("select * from users where status = #{userStatus.valid} order by id")
List<User> getValidUsers();
```

What do you think about new option ?
Please review.
