### PR TITLE
Support lazy init to customize a log impl using configuration

### DIFF
--- a/src/main/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehavior.java
+++ b/src/main/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehavior.java
@@ -42,9 +42,20 @@ public enum AutoMappingUnknownColumnBehavior {
    * Note: The log level of {@code 'org.apache.ibatis.session.AutoMappingUnknownColumnBehavior'} must be set to {@code WARN}.
    */
   WARNING {
+    private Log log = null;
     @Override
     public void doAction(MappedStatement mappedStatement, String columnName, String property, Class<?> propertyType) {
-      log.warn(buildMessage(mappedStatement, columnName, property, propertyType));
+      initializeLog();
+      this.log.warn(buildMessage(mappedStatement, columnName, property, propertyType));
+    }
+    private void initializeLog() {
+      if (this.log == null) {
+        synchronized (AutoMappingUnknownColumnBehavior.WARNING) {
+          if (this.log == null) {
+            this.log = LogFactory.getLog(AutoMappingUnknownColumnBehavior.class);
+          }
+        }
+      }
     }
   },
 
@@ -58,11 +69,6 @@ public enum AutoMappingUnknownColumnBehavior {
       throw new SqlSessionException(buildMessage(mappedStatement, columnName, property, propertyType));
     }
   };
-
-  /**
-   * Logger
-   */
-  private static final Log log = LogFactory.getLog(AutoMappingUnknownColumnBehavior.class);
 
   /**
    * Perform the action when detects an unknown column (or unknown property type) of automatic mapping target.

--- a/src/test/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehaviorTest.java
+++ b/src/test/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehaviorTest.java
@@ -19,6 +19,7 @@ import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.domain.blog.Author;
 import org.apache.ibatis.exceptions.PersistenceException;
+import org.apache.ibatis.logging.LogFactory;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.transaction.TransactionFactory;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
@@ -95,6 +96,7 @@ public class AutoMappingUnknownColumnBehaviorTest {
 
     @BeforeClass
     public static void setup() throws Exception {
+        LogFactory.useSlf4jLogging();
         DataSource dataSource = BaseDataTest.createBlogDataSource();
         TransactionFactory transactionFactory = new JdbcTransactionFactory();
         Environment environment = new Environment("Production", transactionFactory, dataSource);


### PR DESCRIPTION
In current implementation, a customized log impl specified by configuration does not apply to a `Log` instance at the `AutoMappingUnknownColumnBehavior` class.
I've fixed to initialize a `Log` instance lazily for applying a custom log impl.

Please review. 