### PR TITLE
New setting : return empty instance for an empty row (i.e. every column is NULL)

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -256,6 +256,7 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setDefaultScriptingLanguage(resolveClass(props.getProperty("defaultScriptingLanguage")));
     configuration.setCallSettersOnNulls(booleanValueOf(props.getProperty("callSettersOnNulls"), false));
     configuration.setUseActualParamName(booleanValueOf(props.getProperty("useActualParamName"), true));
+    configuration.setReturnInstanceForEmptyRow(booleanValueOf(props.getProperty("returnInstanceForEmptyRow"), false));
     configuration.setLogPrefix(props.getProperty("logPrefix"));
     @SuppressWarnings("unchecked")
     Class<? extends Log> logImpl = (Class<? extends Log>)resolveClass(props.getProperty("logImpl"));

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -385,7 +385,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
       }
       foundValues = applyPropertyMappings(rsw, resultMap, metaObject, lazyLoader, null) || foundValues;
       foundValues = lazyLoader.size() > 0 || foundValues;
-      resultObject = foundValues ? resultObject : null;
+      resultObject = foundValues || configuration.isReturnInstanceForEmptyRow() ? resultObject : null;
       return resultObject;
     }
     return resultObject;
@@ -862,7 +862,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
         foundValues = applyNestedResultMappings(rsw, resultMap, metaObject, columnPrefix, combinedKey, true) || foundValues;
         ancestorObjects.remove(resultMapId);
         foundValues = lazyLoader.size() > 0 || foundValues;
-        resultObject = foundValues ? resultObject : null;
+        resultObject = foundValues || configuration.isReturnInstanceForEmptyRow() ? resultObject : null;
       }
       if (combinedKey != CacheKey.NULL_CACHE_KEY) {
         nestedResultObjects.put(combinedKey, resultObject);
@@ -1015,7 +1015,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
         // Issue #114
         if (column != null && mappedColumnNames.contains(column.toUpperCase(Locale.ENGLISH))) {
           final Object value = th.getResult(rsw.getResultSet(), column);
-          if (value != null) {
+          if (value != null || configuration.isReturnInstanceForEmptyRow()) {
             cacheKey.update(column);
             cacheKey.update(value);
           }

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -107,6 +107,7 @@ public class Configuration {
   protected boolean cacheEnabled = true;
   protected boolean callSettersOnNulls = false;
   protected boolean useActualParamName = true;
+  protected boolean returnInstanceForEmptyRow = false;
 
   protected String logPrefix;
   protected Class <? extends Log> logImpl;
@@ -247,6 +248,14 @@ public class Configuration {
 
   public void setUseActualParamName(boolean useActualParamName) {
     this.useActualParamName = useActualParamName;
+  }
+
+  public boolean isReturnInstanceForEmptyRow() {
+    return returnInstanceForEmptyRow;
+  }
+
+  public void setReturnInstanceForEmptyRow(boolean returnEmptyInstance) {
+    this.returnInstanceForEmptyRow = returnEmptyInstance;
   }
 
   public String getDatabaseId() {

--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -379,6 +379,22 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
             </tr>
             <tr>
               <td>
+                returnInstanceForEmptyRow
+              </td>
+              <td>
+                MyBatis, by default, returns <code>null</code> when all the columns of a returned row are NULL.
+                When this setting is enabled, MyBatis returns an empty instance instead.
+                Note that it is also applied to nested results (i.e. collectioin and association). Since: 3.4.2
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
+              </td>
+            </tr>
+            <tr>
+              <td>
                 logPrefix
               </td>
               <td>

--- a/src/site/ja/xdoc/configuration.xml
+++ b/src/site/ja/xdoc/configuration.xml
@@ -409,6 +409,20 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
             </tr>
             <tr>
               <td>
+                returnInstanceForEmptyRow
+              </td>
+              <td>
+                取得した列が全て NULL だった場合、デフォルトの動作では <code>null</code> が返りますが、 returnInstanceForEmptyRow に true を設定すると空のインスタンスが返るようになります。この動作はネストされた結果をマッピングする際にも適用されます。導入されたバージョン: 3.4.2
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
+              </td>
+            </tr>
+            <tr>
+              <td>
                 logPrefix
               </td>
               <td>

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -388,6 +388,22 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
             </tr>
             <tr>
               <td>
+                returnInstanceForEmptyRow
+              </td>
+              <td>
+                MyBatis, by default, returns <code>null</code> when all the columns of a returned row are NULL.
+                When this setting is enabled, MyBatis returns an empty instance instead.
+                Note that it is also applied to nested results (i.e. collectioin and association). Since: 3.4.2
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
+              </td>
+            </tr>
+            <tr>
+              <td>
                 logPrefix
               </td>
               <td>

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -470,6 +470,22 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
             </tr>
             <tr>
               <td>
+                returnInstanceForEmptyRow
+              </td>
+              <td>
+                MyBatis, by default, returns <code>null</code> when all the columns of a returned row are NULL.
+                When this setting is enabled, MyBatis returns an empty instance instead.
+                Note that it is also applied to nested results (i.e. collectioin and association). Since: 3.4.2
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
+              </td>
+            </tr>
+            <tr>
+              <td>
                 logPrefix
               </td>
               <td>

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -389,6 +389,22 @@ SqlSessionFactory factory = sqlSessionFactoryBuilder.build(reader, environment, 
             </tr>
             <tr>
               <td>
+                returnInstanceForEmptyRow
+              </td>
+              <td>
+                MyBatis, by default, returns <code>null</code> when all the columns of a returned row are NULL.
+                When this setting is enabled, MyBatis returns an empty instance instead.
+                Note that it is also applied to nested results (i.e. collectioin and association). Since: 3.4.2
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
+              </td>
+            </tr>
+            <tr>
+              <td>
                 logPrefix
               </td>
               <td>

--- a/src/test/java/org/apache/ibatis/submitted/empty_row/Child.java
+++ b/src/test/java/org/apache/ibatis/submitted/empty_row/Child.java
@@ -1,0 +1,48 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.submitted.empty_row;
+
+public class Child {
+  private Integer id;
+  private String name;
+
+  private Child grandchild;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Child getGrandchild() {
+    return grandchild;
+  }
+
+  public void setGrandchild(Child grandchild) {
+    this.grandchild = grandchild;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/empty_row/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/empty_row/CreateDB.sql
@@ -1,0 +1,45 @@
+--
+--    Copyright 2009-2016 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table parent if exists;
+drop table child if exists;
+drop table pet if exists;
+
+create table parent (
+id int,
+col1 varchar(20),
+col2 varchar(20)
+);
+
+create table child (
+id int,
+parent_id int,
+name varchar(20)
+);
+
+create table pet (
+id int,
+parent_id int,
+name varchar(20)
+);
+
+insert into parent (id, col1, col2) values
+(1, null, null),
+(2, null, null);
+
+insert into child (id, parent_id, name) values
+(1, 2, 'john'),
+(2, 2, 'mary');

--- a/src/test/java/org/apache/ibatis/submitted/empty_row/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/empty_row/Mapper.java
@@ -1,0 +1,59 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.empty_row;
+
+import java.util.Map;
+
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+
+public interface Mapper {
+
+  @Select("select null from (values(0))")
+  String getString();
+
+  @ResultMap("parentRM")
+  @Select("select col1, col2 from parent where id = #{id}")
+  Parent getBean(Integer id);
+
+  @Select("select col1, col2 from parent where id = #{id}")
+  Map<String, String> getMap(Integer id);
+
+  @ResultMap("associationRM")
+  @Select({ "select p.id, c.name child_name from parent p",
+      "left join child c on c.parent_id = p.id where p.id = #{id}" })
+  Parent getAssociation(Integer id);
+
+  @ResultMap("associationWithNotNullColumnRM")
+  @Select({ "select p.id, c.id child_id, c.name child_name from parent p",
+      "left join child c on c.parent_id = p.id where p.id = #{id}" })
+  Parent getAssociationWithNotNullColumn(Integer id);
+
+  @ResultMap("nestedAssociationRM")
+  @Select("select 1 id, null child_name, null grandchild_name from (values(0))")
+  Parent getNestedAssociation();
+
+  @ResultMap("collectionRM")
+  @Select({ "select p.id, c.name child_name from parent p",
+      "left join child c on c.parent_id = p.id where p.id = #{id}" })
+  Parent getCollection(Integer id);
+
+  @ResultMap("twoCollectionsRM")
+  @Select({ "select p.id, c.name child_name, e.name pet_name from parent p",
+      "left join child c on c.parent_id = p.id",
+      "left join pet e on e.parent_id = p.id", "where p.id = #{id}" })
+  Parent getTwoCollections(Integer id);
+}

--- a/src/test/java/org/apache/ibatis/submitted/empty_row/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/empty_row/Mapper.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2016 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.submitted.empty_row.Mapper">
+
+  <resultMap type="org.apache.ibatis.submitted.empty_row.Parent"
+    id="parentRM">
+    <result property="col1" column="col1" />
+    <result property="col2" column="col2" />
+  </resultMap>
+
+  <resultMap type="org.apache.ibatis.submitted.empty_row.Parent"
+    id="associationRM">
+    <id property="id" column="id" />
+    <association property="child"
+      javaType="org.apache.ibatis.submitted.empty_row.Child">
+      <result property="name" column="child_name" />
+    </association>
+  </resultMap>
+
+  <resultMap type="org.apache.ibatis.submitted.empty_row.Parent"
+    id="associationWithNotNullColumnRM" extends="parentRM">
+    <association property="child"
+      javaType="org.apache.ibatis.submitted.empty_row.Child"
+      notNullColumn="child_id">
+      <result column="child_id" />
+      <result property="name" column="child_name" />
+    </association>
+  </resultMap>
+
+  <resultMap type="org.apache.ibatis.submitted.empty_row.Parent"
+    id="nestedAssociationRM" extends="parentRM">
+    <association property="child"
+      javaType="org.apache.ibatis.submitted.empty_row.Child">
+      <result property="name" column="child_name" />
+      <association property="grandchild"
+        javaType="org.apache.ibatis.submitted.empty_row.Child">
+        <result property="name" column="grandchild_name" />
+      </association>
+    </association>
+  </resultMap>
+
+  <resultMap type="org.apache.ibatis.submitted.empty_row.Parent"
+    id="collectionRM">
+    <id property="id" column="id" />
+    <collection property="children"
+      ofType="org.apache.ibatis.submitted.empty_row.Child">
+      <result property="name" column="child_name" />
+    </collection>
+  </resultMap>
+
+  <resultMap type="org.apache.ibatis.submitted.empty_row.Parent"
+    id="twoCollectionsRM">
+    <id property="id" column="id" />
+    <collection property="children"
+      ofType="org.apache.ibatis.submitted.empty_row.Child">
+      <result property="name" column="child_name" />
+    </collection>
+    <collection property="pets"
+      ofType="org.apache.ibatis.submitted.empty_row.Pet">
+      <result property="name" column="pet_name" />
+    </collection>
+  </resultMap>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/empty_row/Parent.java
+++ b/src/test/java/org/apache/ibatis/submitted/empty_row/Parent.java
@@ -1,0 +1,76 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.empty_row;
+
+import java.util.List;
+
+public class Parent {
+  private Integer id;
+  private String col1;
+  private String col2;
+
+  private Child child;
+  private List<Child> children;
+  private List<Pet> pets;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getCol1() {
+    return col1;
+  }
+
+  public void setCol1(String col1) {
+    this.col1 = col1;
+  }
+
+  public String getCol2() {
+    return col2;
+  }
+
+  public void setCol2(String col2) {
+    this.col2 = col2;
+  }
+
+  public Child getChild() {
+    return child;
+  }
+
+  public void setChild(Child child) {
+    this.child = child;
+  }
+
+  public List<Child> getChildren() {
+    return children;
+  }
+
+  public void setChildren(List<Child> children) {
+    this.children = children;
+  }
+
+  public List<Pet> getPets() {
+    return pets;
+  }
+
+  public void setPets(List<Pet> pets) {
+    this.pets = pets;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/empty_row/Pet.java
+++ b/src/test/java/org/apache/ibatis/submitted/empty_row/Pet.java
@@ -1,0 +1,48 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.submitted.empty_row;
+
+public class Pet {
+  private Integer id;
+  private String name;
+
+  private Pet grandchild;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Pet getGrandchild() {
+    return grandchild;
+  }
+
+  public void setGrandchild(Pet grandchild) {
+    this.grandchild = grandchild;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/empty_row/ReturnInstanceForEmptyRowTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/empty_row/ReturnInstanceForEmptyRowTest.java
@@ -1,0 +1,177 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.empty_row;
+
+import static org.junit.Assert.*;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.util.Map;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ReturnInstanceForEmptyRowTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/empty_row/mybatis-config.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
+
+    // populate in-memory database
+    SqlSession session = sqlSessionFactory.openSession();
+    Connection conn = session.getConnection();
+    reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/empty_row/CreateDB.sql");
+    ScriptRunner runner = new ScriptRunner(conn);
+    runner.setLogWriter(null);
+    runner.runScript(reader);
+    reader.close();
+    session.close();
+  }
+
+  @Before
+  public void resetCallSettersOnNulls() {
+    sqlSessionFactory.getConfiguration().setCallSettersOnNulls(false);
+  }
+
+  @Test
+  public void shouldSimpleTypeBeNull() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      String result = mapper.getString();
+      assertNull(result);
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldObjectTypeNotBeNull() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Parent parent = mapper.getBean(1);
+      assertNotNull(parent);
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldMapBeEmpty() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Map<String, String> map = mapper.getMap(1);
+      assertNotNull(map);
+      assertTrue(map.isEmpty());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldMapHaveColumnNamesIfCallSettersOnNullsEnabled() {
+    sqlSessionFactory.getConfiguration().setCallSettersOnNulls(true);
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Map<String, String> map = mapper.getMap(1);
+      assertEquals(2, map.size());
+      assertTrue(map.containsKey("COL1"));
+      assertTrue(map.containsKey("COL2"));
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldAssociationNotBeNull() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Parent parent = mapper.getAssociation(1);
+      assertNotNull(parent.getChild());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldAssociationBeNullIfNotNullColumnSpecified() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Parent parent = mapper.getAssociationWithNotNullColumn(1);
+      assertNotNull(parent);
+      assertNull(parent.getChild());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldNestedAssociationNotBeNull() {
+    // #420
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Parent parent = mapper.getNestedAssociation();
+      assertNotNull(parent.getChild().getGrandchild());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void testCollection() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Parent parent = mapper.getCollection(1);
+      assertEquals(1, parent.getChildren().size());
+      assertNotNull(parent.getChildren().get(0));
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldSquashMultipleEmptyResults() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Parent parent = mapper.getTwoCollections(2);
+      assertEquals(1, parent.getPets().size());
+      assertNotNull(parent.getPets().get(0));
+    } finally {
+      sqlSession.close();
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/empty_row/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/empty_row/mybatis-config.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2016 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <settings>
+    <setting name="returnInstanceForEmptyRow" value="true" />
+  </settings>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url" value="jdbc:hsqldb:mem:emptyrow" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper class="org.apache.ibatis.submitted.empty_row.Mapper" />
+  </mappers>
+
+</configuration>


### PR DESCRIPTION
When a query returns a row with all columns being `null` (= an empty row), MyBatis returns `null` by default.
As per users requests, a new configuration option `returnInstanceForEmptyRow` is added to change this behavior.
With this option enabled, MyBatis returns an empty instance instead of `null` for an empty row.

Note that this option also generates an empty instance for nested results (i.e. `<collection />` and `<association />`) to meet a requirement like #420 .
To control this behavior individually, you may have to specify `notNullColumn`.

Please refer to the attached test cases for how it works and test your solutions with the latest 3.4.2-SNAPSHOT.

:small_blue_diamond: The existing option `callSettersOnNulls` is whether to call the property's setter method when the column value is `null`, so it has no effect on the above behavior. In version 3.2.x, it affected the returned value unintentionally.
