### PR TITLE
upgrade javassist version to 3.21.0-GA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.20.0-GA</version>
+      <version>3.21.0-GA</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
see https://github.com/jboss-javassist/javassist/commit/0e40ca2a33a9f01dd9ca813ef4b5dea60267fd09

```version 3.21 on October 4, 2016```
- JIRA JASSIST-244, 245, 248, 250, 255, 256, 259, 262.
- javassist.tools.Callback was modified to be Java 1.4 compatible. The parameter type of Callback#result() was changed.
- The algorithm for generating a stack-map table was modified to fix github issue ```#83```.
- A bug of ProxyFactory related to default methods was fixed. It is github issue ```#45```.

