### PR TITLE
Fix auto mapping using constructor args

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -1101,7 +1101,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
     return typeHandlerRegistry.hasTypeHandler(resultType);
   }
 
-  private class ResultObject {
+  private static class ResultObject {
     private final Object value;
     private final boolean useConstructorMappings;
     private ResultObject(Object value, boolean useConstructorMappings) {

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -582,8 +582,8 @@ public class DefaultResultSetHandler implements ResultSetHandler {
         }
       }
     }
-    final boolean useConstructorResultMappings = (resultObject != null && !constructorArgTypes.isEmpty());
-    return new ResultObject(resultObject, useConstructorResultMappings);
+    final boolean useConstructorMappings = (resultObject != null && !constructorArgTypes.isEmpty());
+    return new ResultObject(resultObject, useConstructorMappings);
   }
 
   private Object createResultObject(ResultSetWrapper rsw, ResultMap resultMap, List<Class<?>> constructorArgTypes, List<Object> constructorArgs, String columnPrefix)

--- a/src/test/java/org/apache/ibatis/submitted/immutable_constructor/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/immutable_constructor/CreateDB.sql
@@ -15,9 +15,9 @@
 --
 
 CREATE TABLE immutables (
-    id          INTEGER PRIMARY KEY,
-    description VARCHAR (30) NOT NULL
+    immutable_id          INTEGER PRIMARY KEY,
+    immutable_description VARCHAR (30) NOT NULL
 );
 
-INSERT INTO immutables (id, description) VALUES (1, 'Description of immutable');
-INSERT INTO immutables (id, description) VALUES (2, 'Another immutable');
+INSERT INTO immutables (immutable_id, immutable_description) VALUES (1, 'Description of immutable');
+INSERT INTO immutables (immutable_id, immutable_description) VALUES (2, 'Another immutable');

--- a/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJO.java
+++ b/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJO.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2016 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,20 +20,20 @@ import java.io.Serializable;
 public class ImmutablePOJO implements Serializable {
 
   private static final long serialVersionUID = -7086198701202598455L;
-  private final Integer id;
-  private final String description;
+  private final Integer immutableId;
+  private final String immutableDescription;
 
-  public ImmutablePOJO(Integer id, String description) {
-    this.id = id;
-    this.description = description;
+  public ImmutablePOJO(Integer immutableId, String immutableDescription) {
+    this.immutableId = immutableId;
+    this.immutableDescription = immutableDescription;
   }
 
-  public String getDescription() {
-    return description;
+  public Integer getImmutableId() {
+    return immutableId;
   }
 
-  public Integer getId() {
-    return id;
+  public String getImmutableDescription() {
+    return immutableDescription;
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOMapper.xml
@@ -24,17 +24,17 @@
 
     <select id="getImmutablePOJO" parameterType="int" resultType="ImmutablePOJO">
         SELECT
-            i.id            AS id,
-            i.description   AS description
+            i.immutable_id,
+            i.immutable_description
         FROM immutables AS i
-        WHERE i.id = #{pojoID}
+        WHERE i.immutable_id = #{pojoID}
     </select>
-    
+
     <select id="getImmutablePOJONoMatchingConstructor" parameterType="int" resultType="ImmutablePOJO">
         SELECT
-            i.id            AS id
+            i.immutable_id
         FROM immutables AS i
-        WHERE i.id = #{pojoID}
+        WHERE i.immutable_id = #{pojoID}
     </select>
         
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOTest.java
@@ -73,8 +73,8 @@ public final class ImmutablePOJOTest {
       final ImmutablePOJOMapper mapper = session.getMapper(ImmutablePOJOMapper.class);
       final ImmutablePOJO pojo = mapper.getImmutablePOJO(POJO_ID);
 
-      assertEquals(POJO_ID, pojo.getId());
-      assertEquals(POJO_DESCRIPTION, pojo.getDescription());
+      assertEquals(POJO_ID, pojo.getImmutableId());
+      assertEquals(POJO_DESCRIPTION, pojo.getImmutableDescription());
     } finally {
       session.close();
     }


### PR DESCRIPTION
I've fixed to set the `foundValues` to `true`, when a result object created by constructor mappings.

#830 

