### PR TITLE
Fix if parameterType is simple type, then throws java.lang.NoSuchMeth…

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/factory/DefaultObjectFactory.java
+++ b/src/main/java/org/apache/ibatis/reflection/factory/DefaultObjectFactory.java
@@ -29,6 +29,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 import org.apache.ibatis.reflection.ReflectionException;
+import org.apache.ibatis.type.SimpleTypeRegistry;
 
 /**
  * @author Clinton Begin
@@ -95,7 +96,7 @@ public class DefaultObjectFactory implements ObjectFactory, Serializable {
     Class<?> classToCreate;
     if (type == List.class || type == Collection.class || type == Iterable.class) {
       classToCreate = ArrayList.class;
-    } else if (type == Map.class) {
+    } else if (type == Map.class || SimpleTypeRegistry.isSimpleType(type)) {
       classToCreate = HashMap.class;
     } else if (type == SortedSet.class) { // issue #510 Collections Support
       classToCreate = TreeSet.class;


### PR DESCRIPTION
Fix if parameterType is simple type, then throws java.lang.NoSuchMethodException: xxx.<init>();

Recreate the problem, in nested query:
```xml
<resultMap id="userRoleMapSelect" extends="userMap" type="tk.mybatis.simple.model.SysUser">
	<association property="role" 
		 select="selectRoleById" 
		 javaType="tk.mybatis.simple.model.SysRole"
	         column="{id=role_id}"/>
</resultMap>
<!-- if you doesn't set parameterType, the default value is null, then it will use HashMap -->
<select id="selectRoleById" parameterType="long" 
            resultMap="tk.mybatis.simple.mapper.RoleMapper.roleMap">
    select * from sys_role where id = #{id}
</select>
```

the selectRoleById also can be use in annotation:
```java
@Select({"select id,role_name roleName, enabled, create_by createBy, create_time createTime",
		 "from sys_role",
		 "where id = #{id}"})
//default parameterType is Long
SysRole selectById(Long id);
```