### PR TITLE
Add properties attribute at '@CacheNamespace'

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/CacheNamespace.java
+++ b/src/main/java/org/apache/ibatis/annotations/CacheNamespace.java
@@ -26,6 +26,7 @@ import org.apache.ibatis.cache.impl.PerpetualCache;
 
 /**
  * @author Clinton Begin
+ * @author Kazuki Shimizu
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
@@ -42,5 +43,11 @@ public @interface CacheNamespace {
   boolean readWrite() default true;
   
   boolean blocking() default false;
+
+  /**
+   * Property values for a implementation object.
+   * @since 3.4.2
+   */
+  Property[] properties() default {};
   
 }

--- a/src/main/java/org/apache/ibatis/annotations/Property.java
+++ b/src/main/java/org/apache/ibatis/annotations/Property.java
@@ -13,20 +13,30 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.submitted.global_variables;
+package org.apache.ibatis.annotations;
 
-import org.apache.ibatis.annotations.CacheNamespace;
-import org.apache.ibatis.annotations.Property;
-import org.apache.ibatis.annotations.Select;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
-@CacheNamespace(implementation = CustomCache.class, properties = {
-    @Property(name = "stringValue", value = "${stringProperty}")
-    ,@Property(name = "integerValue", value = "${integerProperty}")
-    ,@Property(name = "longValue", value = "${longProperty}")
-})
-public interface AnnotationMapper {
-
-  @Select("select * from ${table} where id = #{id}")
-  User getUser(Integer id);
-
+/**
+ * The annotation that inject a property value.
+ *
+ * @since 3.4.2
+ * @author Kazuki Shimizu
+ * @see CacheNamespace
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({})
+public @interface Property {
+  /**
+   * A target property name
+   */
+  String name();
+  /**
+   * A property value or placeholder
+   */
+  String value();
 }

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -31,6 +31,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import org.apache.ibatis.annotations.Arg;
@@ -45,6 +46,8 @@ import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Lang;
 import org.apache.ibatis.annotations.MapKey;
 import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Options.FlushCachePolicy;
+import org.apache.ibatis.annotations.Property;
 import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.ResultType;
@@ -55,7 +58,6 @@ import org.apache.ibatis.annotations.SelectProvider;
 import org.apache.ibatis.annotations.TypeDiscriminator;
 import org.apache.ibatis.annotations.Update;
 import org.apache.ibatis.annotations.UpdateProvider;
-import org.apache.ibatis.annotations.Options.FlushCachePolicy;
 import org.apache.ibatis.binding.BindingException;
 import org.apache.ibatis.binding.MapperMethod.ParamMap;
 import org.apache.ibatis.builder.BuilderException;
@@ -77,6 +79,7 @@ import org.apache.ibatis.mapping.ResultSetType;
 import org.apache.ibatis.mapping.SqlCommandType;
 import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.mapping.StatementType;
+import org.apache.ibatis.parsing.PropertyParser;
 import org.apache.ibatis.reflection.TypeParameterResolver;
 import org.apache.ibatis.scripting.LanguageDriver;
 import org.apache.ibatis.session.Configuration;
@@ -177,8 +180,21 @@ public class MapperAnnotationBuilder {
     if (cacheDomain != null) {
       Integer size = cacheDomain.size() == 0 ? null : cacheDomain.size();
       Long flushInterval = cacheDomain.flushInterval() == 0 ? null : cacheDomain.flushInterval();
-      assistant.useNewCache(cacheDomain.implementation(), cacheDomain.eviction(), flushInterval, size, cacheDomain.readWrite(), cacheDomain.blocking(), null);
+      Properties props = convertToProperties(cacheDomain.properties());
+      assistant.useNewCache(cacheDomain.implementation(), cacheDomain.eviction(), flushInterval, size, cacheDomain.readWrite(), cacheDomain.blocking(), props);
     }
+  }
+
+  private Properties convertToProperties(Property[] properties) {
+    if (properties.length == 0) {
+      return null;
+    }
+    Properties props = new Properties();
+    for (Property property : properties) {
+      props.setProperty(property.name(),
+          PropertyParser.parse(property.value(), configuration.getVariables()));
+    }
+    return props;
   }
 
   private void parseCacheRef() {

--- a/src/test/java/org/apache/ibatis/submitted/cache/CacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cache/CacheTest.java
@@ -16,8 +16,10 @@
 package org.apache.ibatis.submitted.cache;
 
 import java.io.Reader;
+import java.lang.reflect.Field;
 import java.sql.Connection;
 
+import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
@@ -302,4 +304,30 @@ public class CacheTest {
       }
     }
   }
+
+  @Test
+  public void shouldApplyCustomCacheProperties() {
+    CustomCache customCache = unwrap(sqlSessionFactory.getConfiguration().getCache(CustomCacheMapper.class.getName()));
+    Assert.assertEquals("bar", customCache.getStringValue());
+    Assert.assertEquals(99, customCache.getIntegerValue().intValue());
+    Assert.assertEquals(9999, customCache.getLongValue());
+  }
+
+  private CustomCache unwrap(Cache cache){
+    Field field;
+    try {
+      field = cache.getClass().getDeclaredField("delegate");
+    } catch (NoSuchFieldException e) {
+      throw new IllegalStateException(e);
+    }
+    try {
+      field.setAccessible(true);
+      return (CustomCache)field.get(cache);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(e);
+    } finally {
+      field.setAccessible(false);
+    }
+  }
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/cache/CustomCache.java
+++ b/src/test/java/org/apache/ibatis/submitted/cache/CustomCache.java
@@ -1,0 +1,54 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.cache;
+
+import org.apache.ibatis.cache.impl.PerpetualCache;
+
+public class CustomCache extends PerpetualCache {
+
+  private String stringValue;
+  private Integer integerValue;
+  private long longValue;
+
+  public CustomCache(String id) {
+    super(id);
+  }
+
+  public String getStringValue() {
+    return stringValue;
+  }
+
+  public void setStringValue(String stringValue) {
+    this.stringValue = stringValue;
+  }
+
+  public Integer getIntegerValue() {
+    return integerValue;
+  }
+
+  public void setIntegerValue(Integer integerValue) {
+    this.integerValue = integerValue;
+  }
+
+  public long getLongValue() {
+    return longValue;
+  }
+
+  public void setLongValue(long longValue) {
+    this.longValue = longValue;
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/cache/CustomCacheMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/cache/CustomCacheMapper.java
@@ -13,20 +13,17 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.submitted.global_variables;
+package org.apache.ibatis.submitted.cache;
 
-import org.apache.ibatis.annotations.CacheNamespace;
-import org.apache.ibatis.annotations.Property;
-import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.*;
+import org.apache.ibatis.annotations.Options.FlushCachePolicy;
+
+import java.util.List;
 
 @CacheNamespace(implementation = CustomCache.class, properties = {
-    @Property(name = "stringValue", value = "${stringProperty}")
-    ,@Property(name = "integerValue", value = "${integerProperty}")
-    ,@Property(name = "longValue", value = "${longProperty}")
+    @Property(name = "stringValue", value = "bar")
+    ,@Property(name = "integerValue", value = "99")
+    ,@Property(name = "longValue", value = "9999")
 })
-public interface AnnotationMapper {
-
-  @Select("select * from ${table} where id = #{id}")
-  User getUser(Integer id);
-
+public interface CustomCacheMapper {
 }

--- a/src/test/java/org/apache/ibatis/submitted/cache/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/cache/mybatis-config.xml
@@ -44,5 +44,6 @@
 	<mappers>
 		<mapper class="org.apache.ibatis.submitted.cache.PersonMapper"/>
 		<mapper class="org.apache.ibatis.submitted.cache.ImportantPersonMapper"/>
+		<mapper class="org.apache.ibatis.submitted.cache.CustomCacheMapper"/>
 	</mappers>
 </configuration> 

--- a/src/test/java/org/apache/ibatis/submitted/global_variables/BaseTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables/BaseTest.java
@@ -73,7 +73,11 @@ public class BaseTest {
     try {
       AnnotationMapper mapper = sqlSession.getMapper(AnnotationMapper.class);
       User user = mapper.getUser(1);
+      CustomCache customCache = unwrap(sqlSessionFactory.getConfiguration().getCache(Mapper.class.getName()));
       Assert.assertEquals("User1", user.getName());
+      Assert.assertEquals("foo", customCache.getStringValue());
+      Assert.assertEquals(10, customCache.getIntegerValue().intValue());
+      Assert.assertEquals(1000, customCache.getLongValue());
     } finally {
       sqlSession.close();
     }


### PR DESCRIPTION
I've allowed to inject property values to a custom cache implementation using annotation driven configuration.

In this changes, we can customize a custom cache implementation as follow:

```java
@CacheNamespace(implementation = CustomCache.class, properties = {
    @Property(name = "stringValue", value = "bar")
    ,@Property(name = "integerValue", value = "99")
    ,@Property(name = "longValue", value = "9999")
})
public interface CustomCacheMapper {
    // ...
}
```

```java
public class CustomCache implements Cache {
  // ...
  private String stringValue; // inject "bar"
  private Integer integerValue; // inject 99
  private long longValue; // inject 9999

  public CustomCache(String id) {
    this.id = id;
  }

  // setter/getter and implementation methods ..

}
```

And we can use placeholder as follow:

```xml
<properties>
    <property name="stringProperty" value="bar"/>
    <property name="integerProperty" value="99"/>
    <property name="longProperty" value="9999"/>
</properties>
```

```java
@CacheNamespace(implementation = CustomCache.class, properties = {
    @Property(name = "stringValue", value = "${stringProperty}") // inject "bar"
    ,@Property(name = "integerValue", value = "${integerProperty}") // inject 99
    ,@Property(name = "longValue", value = "${longProperty}") // inject 9999
})
public interface CustomCacheMapper {
    // ...
}
```
