### PR TITLE
Add name attribute at '@CacheNamespaceRef'

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/CacheNamespaceRef.java
+++ b/src/main/java/org/apache/ibatis/annotations/CacheNamespaceRef.java
@@ -22,11 +22,24 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * The annotation that reference a cache.
+ * <p>
+ * If you use this annotation, should be specified either {@link #value()} and {@link #name()} attribute.
+ * </p>
  * @author Clinton Begin
+ * @author Kazuki Shimizu
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface CacheNamespaceRef {
-  Class<?> value();
+  /**
+   * A namespace type to reference a cache (the namespace name become a FQCN of specified type)
+   */
+  Class<?> value() default void.class;
+  /**
+   * A namespace name to reference a cache
+   * @since 3.4.2
+   */
+  String name() default "";
 }

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -200,7 +200,16 @@ public class MapperAnnotationBuilder {
   private void parseCacheRef() {
     CacheNamespaceRef cacheDomainRef = type.getAnnotation(CacheNamespaceRef.class);
     if (cacheDomainRef != null) {
-      assistant.useCacheRef(cacheDomainRef.value().getName());
+      Class<?> refType = cacheDomainRef.value();
+      String refName = cacheDomainRef.name();
+      if (refType == void.class && refName.isEmpty()) {
+        throw new BuilderException("Should be specified either value() and namespace() attribute in the @CacheNamespaceRef");
+      }
+      if (refType != void.class && !refName.isEmpty()) {
+        throw new BuilderException("Cannot use both value() and namespace() attribute in the @CacheNamespaceRef");
+      }
+      String namespace = (refType != void.class) ? refType.getName() : refName;
+      assistant.useCacheRef(namespace);
     }
   }
 

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -203,10 +203,10 @@ public class MapperAnnotationBuilder {
       Class<?> refType = cacheDomainRef.value();
       String refName = cacheDomainRef.name();
       if (refType == void.class && refName.isEmpty()) {
-        throw new BuilderException("Should be specified either value() and namespace() attribute in the @CacheNamespaceRef");
+        throw new BuilderException("Should be specified either value() or name() attribute in the @CacheNamespaceRef");
       }
       if (refType != void.class && !refName.isEmpty()) {
-        throw new BuilderException("Cannot use both value() and namespace() attribute in the @CacheNamespaceRef");
+        throw new BuilderException("Cannot use both value() and name() attribute in the @CacheNamespaceRef");
       }
       String namespace = (refType != void.class) ? refType.getName() : refName;
       assistant.useCacheRef(namespace);

--- a/src/test/java/org/apache/ibatis/submitted/cache/CacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cache/CacheTest.java
@@ -358,7 +358,7 @@ public class CacheTest {
   @Test
   public void shouldErrorInvalidCacheNamespaceRefAttributesSpecifyBoth() {
     expectedException.expect(BuilderException.class);
-    expectedException.expectMessage("Cannot use both value() and namespace() attribute in the @CacheNamespaceRef");
+    expectedException.expectMessage("Cannot use both value() and name() attribute in the @CacheNamespaceRef");
 
     sqlSessionFactory.getConfiguration().getMapperRegistry()
         .addMapper(InvalidCacheNamespaceRefBothMapper.class);
@@ -367,7 +367,7 @@ public class CacheTest {
   @Test
   public void shouldErrorInvalidCacheNamespaceRefAttributesIsEmpty() {
     expectedException.expect(BuilderException.class);
-    expectedException.expectMessage("Should be specified either value() and namespace() attribute in the @CacheNamespaceRef");
+    expectedException.expectMessage("Should be specified either value() or name() attribute in the @CacheNamespaceRef");
 
     sqlSessionFactory.getConfiguration().getMapperRegistry()
         .addMapper(InvalidCacheNamespaceRefEmptyMapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/cache/SpecialPersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/cache/SpecialPersonMapper.java
@@ -22,8 +22,8 @@ import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
 
-@CacheNamespaceRef(PersonMapper.class) // by type
-public interface ImportantPersonMapper {
+@CacheNamespaceRef(name = "org.apache.ibatis.submitted.cache.PersonMapper") // by name
+public interface SpecialPersonMapper {
 
   @Select("select id, firstname, lastname from person")
   @Options(flushCache = FlushCachePolicy.TRUE)

--- a/src/test/java/org/apache/ibatis/submitted/cache/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/cache/mybatis-config.xml
@@ -45,5 +45,6 @@
 		<mapper class="org.apache.ibatis.submitted.cache.PersonMapper"/>
 		<mapper class="org.apache.ibatis.submitted.cache.ImportantPersonMapper"/>
 		<mapper class="org.apache.ibatis.submitted.cache.CustomCacheMapper"/>
+		<mapper class="org.apache.ibatis.submitted.cache.SpecialPersonMapper"/>
 	</mappers>
 </configuration> 


### PR DESCRIPTION
I've allowed to specify a namespace by name instead of by type.

In this changes, we can share a cache object by name as follow:

```java
Configuration configuration = new Configuration();
// ...
configuration.addCache(new PerpetualCache("masterCache"));
configuration.addMapper(CategoryMapper.class);
configuration.addMapper(ItemMapper.class);
// ...
SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);

```

```java
@CacheNamespaceRef(name = "masterCache")
public interface CategoryMapper {
  // ...
}

@CacheNamespaceRef(name = "masterCache")
public interface ItemMapper {
  // ...
}
```

Please review this.