### PR TITLE
The better way to add native paging support for MyBatis.

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -24,6 +24,7 @@ import org.apache.ibatis.builder.BaseBuilder;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.datasource.DataSourceFactory;
 import org.apache.ibatis.executor.ErrorContext;
+import org.apache.ibatis.executor.dialect.Dialect;
 import org.apache.ibatis.executor.loader.ProxyFactory;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.io.VFS;
@@ -257,11 +258,17 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setCallSettersOnNulls(booleanValueOf(props.getProperty("callSettersOnNulls"), false));
     configuration.setUseActualParamName(booleanValueOf(props.getProperty("useActualParamName"), true));
     configuration.setReturnInstanceForEmptyRow(booleanValueOf(props.getProperty("returnInstanceForEmptyRow"), false));
+    configuration.setUsePagingExcutor(booleanValueOf(props.getProperty("usePagingExcutor"), false));
     configuration.setLogPrefix(props.getProperty("logPrefix"));
     @SuppressWarnings("unchecked")
     Class<? extends Log> logImpl = (Class<? extends Log>)resolveClass(props.getProperty("logImpl"));
     configuration.setLogImpl(logImpl);
     configuration.setConfigurationFactory(resolveClass(props.getProperty("configurationFactory")));
+    if(configuration.isUsePagingExcutor()){
+      Class<? extends Dialect> dialectClass = (Class<? extends Dialect>)resolveClass(props.getProperty("dialect"));
+      Dialect dialect = dialectClass.newInstance();
+      configuration.setDialect(dialect);
+    }
   }
 
   private void environmentsElement(XNode context) throws Exception {

--- a/src/main/java/org/apache/ibatis/executor/PagingExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/PagingExecutor.java
@@ -1,0 +1,200 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor;
+
+import org.apache.ibatis.cache.CacheKey;
+import org.apache.ibatis.cursor.Cursor;
+import org.apache.ibatis.executor.dialect.Dialect;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.mapping.ResultMap;
+import org.apache.ibatis.mapping.ResultMapping;
+import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.session.ResultHandler;
+import org.apache.ibatis.session.RowBounds;
+import org.apache.ibatis.transaction.Transaction;
+
+import java.lang.reflect.Field;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author liuzenghui
+ */
+public class PagingExecutor implements Executor {
+
+  private Executor delegate;
+
+  private Dialect dialect;
+
+  private Field additionalParametersField;
+
+  public PagingExecutor(Executor delegate, Dialect dialect) {
+    this.delegate = delegate;
+    this.dialect = dialect;
+    try {
+      additionalParametersField = BoundSql.class.getDeclaredField("additionalParameters");
+      additionalParametersField.setAccessible(true);
+    } catch (NoSuchFieldException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public Transaction getTransaction() {
+    return delegate.getTransaction();
+  }
+
+  @Override
+  public void close(boolean forceRollback) {
+    delegate.close(forceRollback);
+  }
+
+  @Override
+  public boolean isClosed() {
+    return delegate.isClosed();
+  }
+
+  @Override
+  public int update(MappedStatement ms, Object parameterObject) throws SQLException {
+    return delegate.update(ms, parameterObject);
+  }
+
+  @Override
+  public <E> List<E> query(MappedStatement ms, Object parameterObject, RowBounds rowBounds, ResultHandler resultHandler) throws SQLException {
+    BoundSql boundSql = ms.getBoundSql(parameterObject);
+    Map<String, Object> additionalParameters = null;
+    try {
+      additionalParameters = (Map<String, Object>) additionalParametersField.get(boundSql);
+    } catch (IllegalAccessException e) {
+      e.printStackTrace();
+    }
+    if(dialect.doCount(ms, parameterObject, rowBounds)){
+      //create a Long resultType ms from ms
+      MappedStatement countMappedStatement = newCountMappedStatement(ms);
+      CacheKey countKey = createCacheKey(countMappedStatement, parameterObject, RowBounds.DEFAULT, boundSql);
+      String countSql = dialect.getCountSql(ms, boundSql, parameterObject, rowBounds, countKey);
+      BoundSql countBoundSql = new BoundSql(ms.getConfiguration(), countSql, boundSql.getParameterMappings(), parameterObject);
+      for (String key : additionalParameters.keySet()) {
+        countBoundSql.setAdditionalParameter(key, additionalParameters.get(key));
+      }
+      List<Long> countList = query(countMappedStatement, parameterObject, RowBounds.DEFAULT, resultHandler, countKey, countBoundSql);
+      Long count = countList.get(0);
+      dialect.afterCount(count, parameterObject, rowBounds);
+      //if count is 0, direct return.
+      if (count == 0L) {
+        return dialect.afterPage(new ArrayList(), parameterObject, rowBounds);
+      }
+    }
+    if(dialect.doPage(ms, parameterObject, rowBounds)){
+      CacheKey pageKey = createCacheKey(ms, parameterObject, rowBounds, boundSql);
+      parameterObject = dialect.processParameterObject(ms, parameterObject, boundSql, pageKey);
+      String pageSql = dialect.getPageSql(ms, boundSql, parameterObject, rowBounds, pageKey);
+      BoundSql pageBoundSql = new BoundSql(ms.getConfiguration(), pageSql, boundSql.getParameterMappings(), parameterObject);
+      for (String key : additionalParameters.keySet()) {
+        pageBoundSql.setAdditionalParameter(key, additionalParameters.get(key));
+      }
+      List<E> pageList = query(ms, parameterObject, RowBounds.DEFAULT, resultHandler, pageKey, pageBoundSql);
+      return dialect.afterPage(pageList, parameterObject, rowBounds);
+    } else {
+      CacheKey key = createCacheKey(ms, parameterObject, rowBounds, boundSql);
+      List<E> list = query(ms, parameterObject, rowBounds, resultHandler, key, boundSql);
+      return dialect.afterPage(list, parameterObject, rowBounds);
+    }
+  }
+
+  @Override
+  public <E> Cursor<E> queryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds) throws SQLException {
+    return delegate.queryCursor(ms, parameter, rowBounds);
+  }
+
+  @Override
+  public <E> List<E> query(MappedStatement ms, Object parameterObject, RowBounds rowBounds, ResultHandler resultHandler, CacheKey key, BoundSql boundSql)
+          throws SQLException {
+    return delegate.query(ms, parameterObject, rowBounds, resultHandler, key, boundSql);
+  }
+
+  @Override
+  public List<BatchResult> flushStatements() throws SQLException {
+    return delegate.flushStatements();
+  }
+
+  @Override
+  public void commit(boolean required) throws SQLException {
+    delegate.commit(required);
+  }
+
+  @Override
+  public void rollback(boolean required) throws SQLException {
+    delegate.rollback(required);
+  }
+
+  @Override
+  public CacheKey createCacheKey(MappedStatement ms, Object parameterObject, RowBounds rowBounds, BoundSql boundSql) {
+    return delegate.createCacheKey(ms, parameterObject, rowBounds, boundSql);
+  }
+
+  @Override
+  public boolean isCached(MappedStatement ms, CacheKey key) {
+    return delegate.isCached(ms, key);
+  }
+
+  @Override
+  public void deferLoad(MappedStatement ms, MetaObject resultObject, String property, CacheKey key, Class<?> targetType) {
+    delegate.deferLoad(ms, resultObject, property, key, targetType);
+  }
+
+  @Override
+  public void clearLocalCache() {
+    delegate.clearLocalCache();
+  }
+
+  @Override
+  public void setExecutorWrapper(Executor executor) {
+    throw new UnsupportedOperationException("This method should not be called");
+  }
+
+  private MappedStatement newCountMappedStatement(MappedStatement ms) {
+    MappedStatement.Builder builder = new MappedStatement.Builder(ms.getConfiguration(), ms.getId() + "_COUNT", ms.getSqlSource(), ms.getSqlCommandType());
+    builder.resource(ms.getResource());
+    builder.fetchSize(ms.getFetchSize());
+    builder.statementType(ms.getStatementType());
+    builder.keyGenerator(ms.getKeyGenerator());
+    if (ms.getKeyProperties() != null && ms.getKeyProperties().length != 0) {
+      StringBuilder keyProperties = new StringBuilder();
+      for (String keyProperty : ms.getKeyProperties()) {
+        keyProperties.append(keyProperty).append(",");
+      }
+      keyProperties.delete(keyProperties.length() - 1, keyProperties.length());
+      builder.keyProperty(keyProperties.toString());
+    }
+    builder.timeout(ms.getTimeout());
+    builder.parameterMap(ms.getParameterMap());
+    List<ResultMap> resultMaps = new ArrayList<ResultMap>();
+    ResultMap resultMap = new ResultMap.Builder(ms.getConfiguration(), ms.getId(), Long.class, new ArrayList<ResultMapping>(0)).build();
+    resultMaps.add(resultMap);
+    builder.resultMaps(resultMaps);
+    builder.resultSetType(ms.getResultSetType());
+    builder.cache(ms.getCache());
+    builder.flushCacheRequired(ms.isFlushCacheRequired());
+    builder.useCache(ms.isUseCache());
+
+    return builder.build();
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/executor/dialect/DerbyDialect.java
+++ b/src/main/java/org/apache/ibatis/executor/dialect/DerbyDialect.java
@@ -1,0 +1,89 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor.dialect;
+
+import org.apache.ibatis.cache.CacheKey;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.PageRowBounds;
+import org.apache.ibatis.session.RowBounds;
+
+import java.util.List;
+
+/**
+ * support derby 10.6+
+ *
+ * @author liuzenghui
+ */
+public class DerbyDialect implements Dialect {
+
+  @Override
+  public boolean doCount(MappedStatement ms, Object parameterObject, RowBounds rowBounds) {
+    if(rowBounds instanceof PageRowBounds){
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public String getCountSql(MappedStatement ms, BoundSql boundSql, Object parameterObject, RowBounds rowBounds, CacheKey countKey) {
+    String sql = boundSql.getSql();
+    StringBuilder countBuilder = new StringBuilder(sql.length() + 40);
+    countBuilder.append("SELECT COUNT(0) FROM (");
+    countBuilder.append(sql);
+    countBuilder.append(") TEMP");
+    return countBuilder.toString();
+  }
+
+  @Override
+  public void afterCount(long count, Object parameterObject, RowBounds rowBounds) {
+    PageRowBounds pageRowBounds = (PageRowBounds)rowBounds;
+    pageRowBounds.setTotal(count);
+  }
+
+  @Override
+  public boolean doPage(MappedStatement ms, Object parameterObject, RowBounds rowBounds) {
+    return rowBounds != RowBounds.DEFAULT;
+  }
+
+  @Override
+  public Object processParameterObject(MappedStatement ms, Object parameterObject, BoundSql boundSql, CacheKey pageKey) {
+    return parameterObject;
+  }
+
+  @Override
+  public String getPageSql(MappedStatement ms, BoundSql boundSql, Object parameterObject, RowBounds rowBounds, CacheKey pageKey) {
+    String sql = boundSql.getSql();
+    StringBuilder sqlBuilder = new StringBuilder(sql.length() + 20);
+    sqlBuilder.append(sql);
+    if(rowBounds.getOffset() != 0){
+      sqlBuilder.append(" OFFSET ");
+      sqlBuilder.append(rowBounds.getOffset());
+      sqlBuilder.append(" ROWS ");
+    }
+    if(rowBounds.getLimit() != 0){
+      sqlBuilder.append(" FETCH NEXT ");
+      sqlBuilder.append(rowBounds.getLimit());
+      sqlBuilder.append(" ROWS ONLY");
+    }
+    return sqlBuilder.toString();
+  }
+
+  @Override
+  public <E> List<E> afterPage(List<E> pageList, Object parameterObject, RowBounds rowBounds) {
+    return pageList;
+  }
+}

--- a/src/main/java/org/apache/ibatis/executor/dialect/Dialect.java
+++ b/src/main/java/org/apache/ibatis/executor/dialect/Dialect.java
@@ -1,0 +1,44 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor.dialect;
+
+import org.apache.ibatis.cache.CacheKey;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.RowBounds;
+
+import java.util.List;
+
+/**
+ * @author liuzenghui
+ */
+public interface Dialect {
+
+  boolean doCount(MappedStatement ms, Object parameterObject, RowBounds rowBounds);
+
+  String getCountSql(MappedStatement ms, BoundSql boundSql, Object parameterObject, RowBounds rowBounds, CacheKey countKey);
+
+  void afterCount(long count, Object parameterObject, RowBounds rowBounds);
+
+  boolean doPage(MappedStatement ms, Object parameterObject, RowBounds rowBounds);
+
+  Object processParameterObject(MappedStatement ms, Object parameterObject, BoundSql boundSql, CacheKey pageKey);
+
+  String getPageSql(MappedStatement ms, BoundSql boundSql, Object parameterObject, RowBounds rowBounds, CacheKey pageKey);
+
+  <E> List<E> afterPage(List<E> pageList, Object parameterObject, RowBounds rowBounds);
+
+}

--- a/src/main/java/org/apache/ibatis/executor/dialect/HSQLDBDialect.java
+++ b/src/main/java/org/apache/ibatis/executor/dialect/HSQLDBDialect.java
@@ -1,0 +1,85 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor.dialect;
+
+import org.apache.ibatis.cache.CacheKey;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.PageRowBounds;
+import org.apache.ibatis.session.RowBounds;
+
+import java.util.List;
+
+/**
+ * @author liuzenghui
+ */
+public class HSQLDBDialect implements Dialect {
+
+  @Override
+  public boolean doCount(MappedStatement ms, Object parameterObject, RowBounds rowBounds) {
+    if(rowBounds instanceof PageRowBounds){
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public String getCountSql(MappedStatement ms, BoundSql boundSql, Object parameterObject, RowBounds rowBounds, CacheKey countKey) {
+    String sql = boundSql.getSql();
+    StringBuilder countBuilder = new StringBuilder(sql.length() + 40);
+    countBuilder.append("SELECT COUNT(0) FROM (");
+    countBuilder.append(sql);
+    countBuilder.append(") TEMP");
+    return countBuilder.toString();
+  }
+
+  @Override
+  public void afterCount(long count, Object parameterObject, RowBounds rowBounds) {
+    PageRowBounds pageRowBounds = (PageRowBounds)rowBounds;
+    pageRowBounds.setTotal(count);
+  }
+
+  @Override
+  public boolean doPage(MappedStatement ms, Object parameterObject, RowBounds rowBounds) {
+    return rowBounds != RowBounds.DEFAULT;
+  }
+
+  @Override
+  public Object processParameterObject(MappedStatement ms, Object parameterObject, BoundSql boundSql, CacheKey pageKey) {
+    return parameterObject;
+  }
+
+  @Override
+  public String getPageSql(MappedStatement ms, BoundSql boundSql, Object parameterObject, RowBounds rowBounds, CacheKey pageKey) {
+    String sql = boundSql.getSql();
+    StringBuilder sqlBuilder = new StringBuilder(sql.length() + 20);
+    sqlBuilder.append(sql);
+    if(rowBounds.getLimit() != 0){
+      sqlBuilder.append(" LIMIT ");
+      sqlBuilder.append(rowBounds.getLimit());
+    }
+    if(rowBounds.getOffset() != 0){
+      sqlBuilder.append(" OFFSET ");
+      sqlBuilder.append(rowBounds.getOffset());
+    }
+    return sqlBuilder.toString();
+  }
+
+  @Override
+  public <E> List<E> afterPage(List<E> pageList, Object parameterObject, RowBounds rowBounds) {
+    return pageList;
+  }
+}

--- a/src/main/java/org/apache/ibatis/executor/dialect/MySQLDialect.java
+++ b/src/main/java/org/apache/ibatis/executor/dialect/MySQLDialect.java
@@ -1,0 +1,85 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor.dialect;
+
+import org.apache.ibatis.cache.CacheKey;
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.PageRowBounds;
+import org.apache.ibatis.session.RowBounds;
+
+import java.util.List;
+
+/**
+ * @author liuzenghui
+ */
+public class MySQLDialect implements Dialect {
+
+  @Override
+  public boolean doCount(MappedStatement ms, Object parameterObject, RowBounds rowBounds) {
+    if(rowBounds instanceof PageRowBounds){
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public String getCountSql(MappedStatement ms, BoundSql boundSql, Object parameterObject, RowBounds rowBounds, CacheKey countKey) {
+    String sql = boundSql.getSql();
+    StringBuilder countBuilder = new StringBuilder(sql.length() + 40);
+    countBuilder.append("SELECT COUNT(0) FROM (");
+    countBuilder.append(sql);
+    countBuilder.append(") TEMP");
+    return countBuilder.toString();
+  }
+
+  @Override
+  public void afterCount(long count, Object parameterObject, RowBounds rowBounds) {
+    PageRowBounds pageRowBounds = (PageRowBounds)rowBounds;
+    pageRowBounds.setTotal(count);
+  }
+
+  @Override
+  public boolean doPage(MappedStatement ms, Object parameterObject, RowBounds rowBounds) {
+    return rowBounds != RowBounds.DEFAULT;
+  }
+
+  @Override
+  public Object processParameterObject(MappedStatement ms, Object parameterObject, BoundSql boundSql, CacheKey pageKey) {
+    return parameterObject;
+  }
+
+  @Override
+  public String getPageSql(MappedStatement ms, BoundSql boundSql, Object parameterObject, RowBounds rowBounds, CacheKey pageKey) {
+    String sql = boundSql.getSql();
+    StringBuilder sqlBuilder = new StringBuilder(sql.length() + 20);
+    sqlBuilder.append(sql);
+    sqlBuilder.append(" LIMIT ");
+    if(rowBounds.getOffset() == 0){
+      sqlBuilder.append(rowBounds.getLimit());
+    } else {
+      sqlBuilder.append(rowBounds.getOffset());
+      sqlBuilder.append(", ");
+      sqlBuilder.append(rowBounds.getLimit());
+    }
+    return sqlBuilder.toString();
+  }
+
+  @Override
+  public <E> List<E> afterPage(List<E> pageList, Object parameterObject, RowBounds rowBounds) {
+    return pageList;
+  }
+}

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -44,6 +44,11 @@ import org.apache.ibatis.executor.CachingExecutor;
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.executor.ReuseExecutor;
 import org.apache.ibatis.executor.SimpleExecutor;
+import org.apache.ibatis.executor.PagingExecutor;
+import org.apache.ibatis.executor.dialect.DerbyDialect;
+import org.apache.ibatis.executor.dialect.Dialect;
+import org.apache.ibatis.executor.dialect.HSQLDBDialect;
+import org.apache.ibatis.executor.dialect.MySQLDialect;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
 import org.apache.ibatis.executor.loader.ProxyFactory;
 import org.apache.ibatis.executor.loader.cglib.CglibProxyFactory;
@@ -108,6 +113,8 @@ public class Configuration {
   protected boolean callSettersOnNulls = false;
   protected boolean useActualParamName = true;
   protected boolean returnInstanceForEmptyRow = false;
+  protected boolean usePagingExcutor = false;
+  protected Dialect dialect;
 
   protected String logPrefix;
   protected Class <? extends Log> logImpl;
@@ -200,6 +207,10 @@ public class Configuration {
     typeAliasRegistry.registerAlias("CGLIB", CglibProxyFactory.class);
     typeAliasRegistry.registerAlias("JAVASSIST", JavassistProxyFactory.class);
 
+    typeAliasRegistry.registerAlias("Derby", DerbyDialect.class);
+    typeAliasRegistry.registerAlias("HSQLDB", HSQLDBDialect.class);
+    typeAliasRegistry.registerAlias("MySQL", MySQLDialect.class);
+
     languageRegistry.setDefaultDriverClass(XMLLanguageDriver.class);
     languageRegistry.register(RawLanguageDriver.class);
   }
@@ -256,6 +267,22 @@ public class Configuration {
 
   public void setReturnInstanceForEmptyRow(boolean returnEmptyInstance) {
     this.returnInstanceForEmptyRow = returnEmptyInstance;
+  }
+
+  public boolean isUsePagingExcutor() {
+    return usePagingExcutor;
+  }
+
+  public void setUsePagingExcutor(boolean usePagingExcutor) {
+    this.usePagingExcutor = usePagingExcutor;
+  }
+
+  public Dialect getDialect() {
+    return dialect;
+  }
+
+  public void setDialect(Dialect dialect) {
+    this.dialect = dialect;
   }
 
   public String getDatabaseId() {
@@ -564,6 +591,9 @@ public class Configuration {
     }
     if (cacheEnabled) {
       executor = new CachingExecutor(executor);
+    }
+    if (usePagingExcutor) {
+      executor = new PagingExecutor(executor, dialect);
     }
     executor = (Executor) interceptorChain.pluginAll(executor);
     return executor;

--- a/src/main/java/org/apache/ibatis/session/PageRowBounds.java
+++ b/src/main/java/org/apache/ibatis/session/PageRowBounds.java
@@ -1,0 +1,38 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.session;
+
+/**
+ * @author liuzenghui
+ */
+public class PageRowBounds extends RowBounds {
+  private Long total;
+
+  public PageRowBounds() {
+  }
+
+  public PageRowBounds(int offset, int limit) {
+    super(offset, limit);
+  }
+
+  public Long getTotal() {
+    return total;
+  }
+
+  public void setTotal(Long total) {
+    this.total = total;
+  }
+}

--- a/src/test/java/org/apache/ibatis/executor/PagingBatchExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/PagingBatchExecutorTest.java
@@ -1,0 +1,41 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor;
+
+import org.apache.ibatis.executor.dialect.DerbyDialect;
+import org.apache.ibatis.executor.dialect.Dialect;
+import org.apache.ibatis.transaction.Transaction;
+import org.junit.Test;
+
+public class PagingBatchExecutorTest extends BaseExecutorTest {
+  private Dialect dialect = new DerbyDialect();
+
+  public PagingBatchExecutorTest() {
+    super();
+    config.setUsePagingExcutor(true);
+    config.setDialect(dialect);
+  }
+
+  @Test
+  public void dummy() {
+  }
+
+  @Override
+  protected Executor createExecutor(Transaction transaction) {
+    return new PagingExecutor(new BatchExecutor(config, transaction), dialect);
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/executor/PagingCachingBatchExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/PagingCachingBatchExecutorTest.java
@@ -1,0 +1,41 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor;
+
+import org.apache.ibatis.executor.dialect.DerbyDialect;
+import org.apache.ibatis.executor.dialect.Dialect;
+import org.apache.ibatis.transaction.Transaction;
+import org.junit.Test;
+
+public class PagingCachingBatchExecutorTest extends BaseExecutorTest {
+  private Dialect dialect = new DerbyDialect();
+
+  public PagingCachingBatchExecutorTest() {
+    super();
+    config.setUsePagingExcutor(true);
+    config.setDialect(dialect);
+  }
+
+  @Test
+  public void dummy() {
+  }
+
+  @Override
+  protected Executor createExecutor(Transaction transaction) {
+    return new PagingExecutor(new CachingExecutor(new BatchExecutor(config, transaction)), dialect);
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/executor/PagingCachingReuseExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/PagingCachingReuseExecutorTest.java
@@ -1,0 +1,41 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor;
+
+import org.apache.ibatis.executor.dialect.DerbyDialect;
+import org.apache.ibatis.executor.dialect.Dialect;
+import org.apache.ibatis.transaction.Transaction;
+import org.junit.Test;
+
+public class PagingCachingReuseExecutorTest extends BaseExecutorTest {
+  private Dialect dialect = new DerbyDialect();
+
+  public PagingCachingReuseExecutorTest() {
+    super();
+    config.setUsePagingExcutor(true);
+    config.setDialect(dialect);
+  }
+
+  @Test
+  public void dummy() {
+  }
+
+  @Override
+  protected Executor createExecutor(Transaction transaction) {
+    return new PagingExecutor(new CachingExecutor(new ReuseExecutor(config, transaction)), dialect);
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/executor/PagingCachingSimpleExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/PagingCachingSimpleExecutorTest.java
@@ -1,0 +1,41 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor;
+
+import org.apache.ibatis.executor.dialect.DerbyDialect;
+import org.apache.ibatis.executor.dialect.Dialect;
+import org.apache.ibatis.transaction.Transaction;
+import org.junit.Test;
+
+public class PagingCachingSimpleExecutorTest extends BaseExecutorTest {
+  private Dialect dialect = new DerbyDialect();
+
+  public PagingCachingSimpleExecutorTest() {
+    super();
+    config.setUsePagingExcutor(true);
+    config.setDialect(dialect);
+  }
+
+  @Test
+  public void dummy() {
+  }
+
+  @Override
+  protected Executor createExecutor(Transaction transaction) {
+    return new PagingExecutor(new CachingExecutor(new SimpleExecutor(config,transaction)),dialect);
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/executor/PagingReuseExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/PagingReuseExecutorTest.java
@@ -1,0 +1,41 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor;
+
+import org.apache.ibatis.executor.dialect.DerbyDialect;
+import org.apache.ibatis.executor.dialect.Dialect;
+import org.apache.ibatis.transaction.Transaction;
+import org.junit.Test;
+
+public class PagingReuseExecutorTest extends BaseExecutorTest {
+  private Dialect dialect = new DerbyDialect();
+
+  public PagingReuseExecutorTest() {
+    super();
+    config.setUsePagingExcutor(true);
+    config.setDialect(dialect);
+  }
+
+  @Test
+  public void dummy() {
+  }
+
+  @Override
+  protected Executor createExecutor(Transaction transaction) {
+    return new PagingExecutor(new ReuseExecutor(config, transaction), dialect);
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/executor/PagingSimpleExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/PagingSimpleExecutorTest.java
@@ -1,0 +1,41 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor;
+
+import org.apache.ibatis.executor.dialect.DerbyDialect;
+import org.apache.ibatis.executor.dialect.Dialect;
+import org.apache.ibatis.transaction.Transaction;
+import org.junit.Test;
+
+public class PagingSimpleExecutorTest extends BaseExecutorTest {
+  private Dialect dialect = new DerbyDialect();
+
+  public PagingSimpleExecutorTest() {
+    super();
+    config.setUsePagingExcutor(true);
+    config.setDialect(dialect);
+  }
+
+  @Test
+  public void dummy() {
+  }
+
+  @Override
+  protected Executor createExecutor(Transaction transaction) {
+    return new PagingExecutor(new CachingExecutor(new SimpleExecutor(config,transaction)),dialect);
+  }
+
+}


### PR DESCRIPTION
The main source are:
- PagingExecutor
- Dialect

modify source:
- XMLConfigBuilder
- Configuration

others are three implementation class for Dialect:
- DerbyDialect
- HSQLDBDialect
- MySQLDialect

enhance RowBounds:
- PageRowBounds

six test for PagingExecutor:
- PagingBatchExecutorTest
- PagingCachingBatchExecutorTest
- PagingCachingReuseExecutorTest
- PagingCachingSimpleExecutorTest
- PagingReuseExecutorTest
- PagingSimpleExecutorTest

settings config:
```xml
<configuration>
    <settings>
        <setting name="usePagingExcutor" value="true"/>
        <setting name="dialect" value="MySQL"/>
    </settings>
</configuration>
```

I think this is a better way for mybatis to support paging.
It will make stronger mybatis.
Allows developers to more easily.