### PR TITLE
Add the MergingBatchExecutor

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/MergingBatchExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/MergingBatchExecutor.java
@@ -1,0 +1,92 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor;
+
+import org.apache.ibatis.executor.statement.StatementHandler;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.RowBounds;
+import org.apache.ibatis.transaction.Transaction;
+
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The Batch Executor for merging an sql that created using same mapper method regardless of calling order.
+ *
+ * @author Kazuki Shimizu
+ * @version 3.4.2
+ */
+public class MergingBatchExecutor extends BatchExecutor {
+
+  private final Map<String, Statement> statementMap = new LinkedHashMap<String, Statement>();
+  private final Map<String, BatchResult> batchResultMap = new LinkedHashMap<String, BatchResult>();
+
+  public MergingBatchExecutor(Configuration configuration, Transaction transaction) {
+    super(configuration, transaction);
+  }
+
+  @Override
+  public int doUpdate(MappedStatement ms, Object parameterObject) throws SQLException {
+    final StatementHandler handler = configuration.newStatementHandler(this, ms, parameterObject, RowBounds.DEFAULT, null, null);
+    final String sql = handler.getBoundSql().getSql();
+    final String statementKey = sql.hashCode() + "_" + ms.hashCode();
+    final Statement stmt;
+    if (statementMap.containsKey(statementKey)) {
+      stmt = statementMap.get(statementKey);
+      applyTransactionTimeout(stmt);
+      handler.parameterize(stmt);
+      batchResultMap.get(statementKey).addParameterObject(parameterObject);
+    } else {
+      stmt = handler.prepare(getConnection(ms.getStatementLog()), transaction.getTimeout());
+      handler.parameterize(stmt);
+      statementMap.put(statementKey, stmt);
+      batchResultMap.put(statementKey, new BatchResult(ms, sql, parameterObject));
+    }
+    handler.batch(stmt);
+    return BATCH_UPDATE_RETURN_VALUE;
+  }
+
+  @Override
+  public List<BatchResult> doFlushStatements(boolean isRollback) throws SQLException {
+    try {
+      if (isRollback) {
+        return Collections.emptyList();
+      }
+      List<BatchResult> results = new ArrayList<BatchResult>();
+      int i = 0;
+      for (String statementKey : statementMap.keySet()) {
+        Statement stmt = statementMap.get(statementKey);
+        applyTransactionTimeout(stmt);
+        BatchResult batchResult = batchResultMap.get(statementKey);
+        executeBatch(stmt, batchResult, i, results);
+        results.add(batchResult);
+        i++;
+      }
+      return results;
+    } finally {
+      closeStatements(statementMap.values());
+      statementMap.clear();
+      batchResultMap.clear();
+    }
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -42,6 +42,7 @@ import org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory;
 import org.apache.ibatis.executor.BatchExecutor;
 import org.apache.ibatis.executor.CachingExecutor;
 import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.executor.MergingBatchExecutor;
 import org.apache.ibatis.executor.ReuseExecutor;
 import org.apache.ibatis.executor.SimpleExecutor;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
@@ -555,7 +556,9 @@ public class Configuration {
     executorType = executorType == null ? defaultExecutorType : executorType;
     executorType = executorType == null ? ExecutorType.SIMPLE : executorType;
     Executor executor;
-    if (ExecutorType.BATCH == executorType) {
+    if (ExecutorType.MERGING_BATCH == executorType) {
+      executor = new MergingBatchExecutor(this, transaction);
+    } else if (ExecutorType.BATCH == executorType) {
       executor = new BatchExecutor(this, transaction);
     } else if (ExecutorType.REUSE == executorType) {
       executor = new ReuseExecutor(this, transaction);

--- a/src/main/java/org/apache/ibatis/session/ExecutorType.java
+++ b/src/main/java/org/apache/ibatis/session/ExecutorType.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2016 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,9 +15,37 @@
  */
 package org.apache.ibatis.session;
 
+import org.apache.ibatis.executor.MergingBatchExecutor;
+
 /**
+ * Executor type.
+ *
+ * @see org.apache.ibatis.executor.Executor
  * @author Clinton Begin
+ * @author Kazuki Shimizu
+ *
  */
 public enum ExecutorType {
-  SIMPLE, REUSE, BATCH
+  /**
+   * Enable the simple executor.
+   * @see org.apache.ibatis.executor.SimpleExecutor
+   *
+   */
+  SIMPLE,
+  /**
+   * Enable the executor for reusing a prepared statement.
+   * @see org.apache.ibatis.executor.ReuseExecutor
+   */
+  REUSE,
+  /**
+   * Enable the batch executor. (valid only when consecutively calling the same mapper method)
+   * @see org.apache.ibatis.executor.BatchExecutor
+   */
+  BATCH,
+  /**
+   * Enable the batch executor for merging an SQL that created using same mapper method regardless of calling order.
+   * @see MergingBatchExecutor
+   * @since 3.4.2
+   */
+  MERGING_BATCH
 }

--- a/src/test/java/org/apache/ibatis/executor/MergingBatchExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/MergingBatchExecutorTest.java
@@ -1,0 +1,73 @@
+/**
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.executor;
+
+import org.apache.ibatis.domain.blog.Author;
+import org.apache.ibatis.domain.blog.Section;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.transaction.Transaction;
+import org.apache.ibatis.transaction.jdbc.JdbcTransaction;
+import org.junit.Test;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test cases for {@link MergingBatchExecutor}.
+ *
+ * @author Kazuki Shimizu
+ * @since 3.4.2
+ */
+public class MergingBatchExecutorTest extends BaseExecutorTest {
+
+  @Override
+  protected Executor createExecutor(Transaction transaction) {
+    return new MergingBatchExecutor(config, transaction);
+  }
+
+  @Test
+  public void testMerge() throws SQLException {
+    Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
+    try {
+      MappedStatement insertStatement = ExecutorTestHelper.prepareInsertAuthorMappedStatement(config);
+      MappedStatement insertStatement2 = ExecutorTestHelper.prepareInsertAuthorMappedStatementWithAutoKey(config);
+
+      executor.update(insertStatement, new Author(1099, "someone1", "******", "someone1@apache.org", null, Section.NEWS));
+
+      executor.update(insertStatement2, new Author(0, "someone3", "******", "someone1@apache.org", null, Section.NEWS));
+
+      executor.update(insertStatement, new Author(1100, "someone2", "******", "someone2@apache.org", null, Section.NEWS));
+
+      executor.update(insertStatement2, new Author(0, "someone4", "******", "someone1@apache.org", null, Section.NEWS));
+
+      List<BatchResult> results = executor.flushStatements();
+      assertEquals(2, results.size());
+      assertEquals("INSERT INTO author (id,username,password,email,bio,favourite_section) values(?,?,?,?,?,?)", results.get(0).getSql());
+      assertEquals(2, results.get(0).getUpdateCounts().length);
+      assertEquals(1, results.get(0).getUpdateCounts()[0]);
+      assertEquals(1, results.get(0).getUpdateCounts()[1]);
+      assertEquals("INSERT INTO author (username,password,email,bio,favourite_section) values(?,?,?,?,?)", results.get(1).getSql());
+      assertEquals(2, results.get(1).getUpdateCounts().length);
+      assertEquals(1, results.get(1).getUpdateCounts()[0]);
+      assertEquals(1, results.get(1).getUpdateCounts()[1]);
+    } finally {
+      executor.close(true);
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/batch_test/BatchTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_test/BatchTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2016 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class BatchTest
   }
 
   @Test
-  public void shouldGetAUserNoException() {
+  public void testOnBatch() {
     SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH,false);
     try {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
@@ -63,19 +63,31 @@ public class BatchTest
       user.setName("User2");
       mapper.insertUser(user);
       Assert.assertEquals("Dept1", mapper.getUser(2).getDept().getName());
-    }
-    catch (Exception e)
-    {
-      Assert.fail(e.getMessage());
-
-    }
-
-    finally {
-      sqlSession.commit();
+    } finally {
+      sqlSession.rollback();
       sqlSession.close();
     }
   }
 
+
+  @Test
+  public void testOnMergingBatch() {
+    SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.MERGING_BATCH,false);
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+
+      User user = mapper.getUser(1);
+
+      user.setId(20);
+      user.setName("User20");
+      mapper.insertUser(user);
+
+      Assert.assertEquals("User20", mapper.getUser(20).getName());
+    } finally {
+      sqlSession.rollback();
+      sqlSession.close();
+    }
+  }
 
 
 }


### PR DESCRIPTION
I've added new `Executor`(`ExecutorType.MERGING_BATCH`) for batch updating.
This executor is the Batch Executor for merging an sql that created using same mapper method **regardless of calling order**.

For example:

```java
public createAll(List<Account> accounts) {

    for (Account account : accounts) {
        accountMapper.insertProfile(account);
        accountMapper.insertCredential(account);
        accountMapper.insertPaymentMethod(account);
    }
    // ...
}
```

If you use this `Executor`, it create only three `Statement` of JDBC batch updating.
If you use the traditional `BatchExecutor`(`ExecutorType.BATCH`), it create many `Statement`( 3 statements * account list size).

What do you think this new `Executor` ?

## Related links

* https://github.com/mybatis/mybatis-3/issues/864