### PR TITLE
suggest to handler the IOException

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -166,6 +166,11 @@ public class MapperAnnotationBuilder {
       try {
         inputStream = Resources.getResourceAsStream(type.getClassLoader(), xmlResource);
       } catch (IOException e) {
+        // start from: 2017/01/03 5pm --hankChan
+        // in my case, it's may cause an error when the classLoader can not resolver the existed XML files.
+        // maybe it is benefit to handle the IOException to remind the coder.
+        e.printStackTrace();
+        // end
         // ignore, resource is not required
       }
       if (inputStream != null) {


### PR DESCRIPTION
Suggest to handler the IOException on MapperAnnotationBuilder#loadXmlResource().
In my case, there is existed Mapper.xml files, but it is failure resolve the XML. 
On the end, I got the error like "Mapped Statements collection does not contain value for....."