### PR TITLE
avoid unexpected automapping 

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -477,7 +477,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
           }
         }
         final String property = metaObject.findProperty(propertyName, configuration.isMapUnderscoreToCamelCase());
-        if (property != null && metaObject.hasSetter(property)) {
+        if (property != null && metaObject.hasSetter(property) && !resultMap.getMappedProperties().contains(property)) {
           final Class<?> propertyType = metaObject.getSetterType(property);
           if (typeHandlerRegistry.hasTypeHandler(propertyType, rsw.getJdbcType(columnName))) {
             final TypeHandler<?> typeHandler = rsw.getTypeHandler(propertyType, columnName);

--- a/src/main/java/org/apache/ibatis/mapping/ResultMap.java
+++ b/src/main/java/org/apache/ibatis/mapping/ResultMap.java
@@ -35,6 +35,7 @@ public class ResultMap {
   private List<ResultMapping> constructorResultMappings;
   private List<ResultMapping> propertyResultMappings;
   private Set<String> mappedColumns;
+  private Set<String> mappedProperties;
   private Discriminator discriminator;
   private boolean hasNestedResultMaps;
   private boolean hasNestedQueries;
@@ -71,6 +72,7 @@ public class ResultMap {
         throw new IllegalArgumentException("ResultMaps must have an id");
       }
       resultMap.mappedColumns = new HashSet<String>();
+      resultMap.mappedProperties = new HashSet<String>();
       resultMap.idResultMappings = new ArrayList<ResultMapping>();
       resultMap.constructorResultMappings = new ArrayList<ResultMapping>();
       resultMap.propertyResultMappings = new ArrayList<ResultMapping>();
@@ -87,6 +89,10 @@ public class ResultMap {
               resultMap.mappedColumns.add(compositeColumn.toUpperCase(Locale.ENGLISH));
             }
           }
+        }
+        final String property = resultMapping.getProperty();
+        if(property != null) {
+          resultMap.mappedProperties.add(property);
         }
         if (resultMapping.getFlags().contains(ResultFlag.CONSTRUCTOR)) {
           resultMap.constructorResultMappings.add(resultMapping);
@@ -144,6 +150,10 @@ public class ResultMap {
 
   public Set<String> getMappedColumns() {
     return mappedColumns;
+  }
+
+  public Set<String> getMappedProperties() {
+    return mappedProperties;
   }
 
   public Discriminator getDiscriminator() {

--- a/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
@@ -65,6 +65,20 @@ public class AutomappingTest {
   }
 
   @Test
+  public void shouldGetAUserWhithPhoneNumber() {
+    sqlSessionFactory.getConfiguration().setAutoMappingBehavior(AutoMappingBehavior.NONE);
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.getUserWithPhoneNumber(1);
+      Assert.assertEquals("User1", user.getName());
+      Assert.assertEquals(new Long(12345678901L), user.getPhone());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
   public void shouldNotInheritAutoMappingInherited_InlineNestedResultMap() {
     sqlSessionFactory.getConfiguration().setAutoMappingBehavior(AutoMappingBehavior.NONE);
     SqlSession sqlSession = sqlSessionFactory.openSession();

--- a/src/test/java/org/apache/ibatis/submitted/automapping/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/CreateDB.sql
@@ -20,7 +20,9 @@ drop table books if exists;
 
 create table users (
   id int,
-  name varchar(20)
+  name varchar(20),
+  phone varchar(20),
+  phone_number bigint
 );
 
 create table books (
@@ -40,8 +42,9 @@ create table breeder (
   name varchar(20)
 );
 
-insert into users (id, name) values(1, 'User1');
-insert into users (id, name) values(2, 'User2');
+-- '+86 12345678901' can't be converted to a number
+insert into users (id, name, phone, phone_number) values(1, 'User1', '+86 12345678901', 12345678901);
+insert into users (id, name, phone, phone_number) values(2, 'User2', '+86 12345678902', 12345678902);
 
 insert into books (version, name) values(99, 'Learn Java');
 

--- a/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.java
@@ -21,6 +21,8 @@ public interface Mapper {
 
   User getUser(Integer id);
 
+  User getUserWithPhoneNumber(Integer id);
+
   User getUserWithPets_Inline(Integer id);
 
   User getUserWithPets_External(Integer id);

--- a/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.xml
@@ -23,10 +23,18 @@
 <mapper namespace="org.apache.ibatis.submitted.automapping.Mapper">
 
 	<select id="getUser" resultMap="result">
-		select * from users where id = #{id}
+		select id, name from users where id = #{id}
 	</select>
 
 	<resultMap type="org.apache.ibatis.submitted.automapping.User" id="result" autoMapping="true">
+	</resultMap>
+
+	<select id="getUserWithPhoneNumber" resultMap="resultWithPhoneNumber">
+		select * from users where id = #{id}
+	</select>
+
+	<resultMap type="org.apache.ibatis.submitted.automapping.User" id="resultWithPhoneNumber" autoMapping="true">
+		<result property="phone" column="phone_number"/>
 	</resultMap>
 
 	<sql id="selectUserPetBreeder">

--- a/src/test/java/org/apache/ibatis/submitted/automapping/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/User.java
@@ -21,6 +21,8 @@ public class User {
 
   private Integer id;
   private String name;
+  private Long phone; // phone number of Long type
+
   private List<Pet> pets;
 
   public Integer getId() {
@@ -37,6 +39,14 @@ public class User {
 
   public void setName(String name) {
     this.name = name;
+  }
+
+  public Long getPhone() {
+    return phone;
+  }
+
+  public void setPhone(Long phone) {
+    this.phone = phone;
   }
 
   public List<Pet> getPets() {


### PR DESCRIPTION
avoid unexpected automapping when a explicit mapped proerty has the same name as another column