### PR TITLE
Improve test on MetaClass

### DIFF
--- a/src/test/java/org/apache/ibatis/reflection/MetaClassTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/MetaClassTest.java
@@ -65,6 +65,8 @@ public class MetaClassTest {
     assertTrue(meta.hasGetter("richType.richMap"));
     assertTrue(meta.hasGetter("richType.richList[0]"));
 
+    assertEquals("richType.richProperty", meta.findProperty("richType.richProperty", false));
+
     assertFalse(meta.hasGetter("[0]"));
   }
 


### PR DESCRIPTION
Hello,

I open this pull request to specify the lines [174-179](https://github.com/mybatis/mybatis-3/blob/master/src/main/java/org/apache/ibatis/reflection/MetaClass.java#L174) in the ```buildProperty(String, StringBuilder)``` method of ```org.apache.ibatis.reflection.MetaClass```.

```java
String propertyName = reflector.findPropertyName(prop.getName());
if (propertyName != null) {
    builder.append(propertyName);
    builder.append(".");
    MetaClass metaProp = metaClassForProperty(propertyName);
    metaProp.buildProperty(prop.getChildren(), builder);
}
```