### PR TITLE
Fix a logic error

### DIFF
--- a/src/main/java/org/apache/ibatis/scripting/LanguageDriverRegistry.java
+++ b/src/main/java/org/apache/ibatis/scripting/LanguageDriverRegistry.java
@@ -48,7 +48,7 @@ public class LanguageDriverRegistry {
     }
     LanguageDriver driver = LANGUAGE_DRIVER_MAP.get(instance.getClass());
     if (driver == null) {
-      LANGUAGE_DRIVER_MAP.put(instance.getClass(), driver);
+      LANGUAGE_DRIVER_MAP.put(instance.getClass(), instance);
     }
   }
   


### PR DESCRIPTION
In the function `public void register(LanguageDriver instance)`, when the local variable `driver == null`, we should put the "instance" object
in the "LANGUAGE_DRIVER_MAP", **NOT** the "driver" object.