### PR TITLE
Update to OGNL 3.1.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
     <dependency>
       <groupId>ognl</groupId>
       <artifactId>ognl</artifactId>
-      <version>3.1.12</version>
+      <version>3.1.14</version>
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>


### PR DESCRIPTION
fix gh-934

I've fixed report of versioneye.

See https://github.com/jkuhnert/ognl#release-notes---version-3114-3020.

The OGNL 3.2 has been released already, However version 3.2 is required Java 7. (Drop support Java 6)