### PR TITLE
Add registrar interface for TypeHandler

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.LocalCacheScope;
 import org.apache.ibatis.transaction.TransactionFactory;
 import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeHandlerRegistrar;
 
 /**
  * @author Clinton Begin
@@ -331,6 +332,10 @@ public class XMLConfigBuilder extends BaseBuilder {
         if ("package".equals(child.getName())) {
           String typeHandlerPackage = child.getStringAttribute("name");
           typeHandlerRegistry.register(typeHandlerPackage);
+        } else if ("registrar".equals(child.getName())) {
+          String type = child.getStringAttribute("type");
+          TypeHandlerRegistrar registrar = (TypeHandlerRegistrar) resolveClass(type).newInstance();
+          registrar.registerTypeHandlers(typeHandlerRegistry);
         } else {
           String javaTypeName = child.getStringAttribute("javaType");
           String jdbcTypeName = child.getStringAttribute("jdbcType");

--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-config.dtd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-config.dtd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2017 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ type CDATA #REQUIRED
 alias CDATA #IMPLIED
 >
 
-<!ELEMENT typeHandlers (typeHandler*,package*)>
+<!ELEMENT typeHandlers (typeHandler*,package*,registrar*)>
 
 <!ELEMENT typeHandler EMPTY>
 <!ATTLIST typeHandler
@@ -114,4 +114,9 @@ class CDATA #IMPLIED
 <!ELEMENT package EMPTY>
 <!ATTLIST package
 name CDATA #REQUIRED
+>
+
+<!ELEMENT registrar EMPTY>
+<!ATTLIST registrar
+type CDATA #REQUIRED
 >

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistrar.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistrar.java
@@ -1,0 +1,33 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+/**
+ * Registrar for {@link TypeHandler}.
+ *
+ * @author Kazuki Shimizu
+ * @since 3.4.3
+ */
+public interface TypeHandlerRegistrar {
+
+  /**
+   * register any {@link TypeHandler}.
+   *
+   * @param registry registry for {@link TypeHandler}
+   */
+  void registerTypeHandlers(TypeHandlerRegistry registry);
+
+}

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2017 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/builder/CustomTypeHandlerRegistrar.java
+++ b/src/test/java/org/apache/ibatis/builder/CustomTypeHandlerRegistrar.java
@@ -1,0 +1,34 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder;
+
+import org.apache.ibatis.type.ObjectTypeHandler;
+import org.apache.ibatis.type.TypeHandlerRegistrar;
+import org.apache.ibatis.type.TypeHandlerRegistry;
+
+public class CustomTypeHandlerRegistrar implements TypeHandlerRegistrar {
+  @Override
+  public void registerTypeHandlers(TypeHandlerRegistry registry) {
+    registry.register(MyClass.class, MyClassTypeHandler.class);
+  }
+
+  static class MyClass {
+  }
+
+  public static class MyClassTypeHandler extends ObjectTypeHandler {
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2017 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@
     <typeHandler javaType="String" jdbcType="VARCHAR" handler="org.apache.ibatis.builder.CustomStringTypeHandler"/>
     <typeHandler handler="org.apache.ibatis.builder.CustomLongTypeHandler"/>
     <package name="org.apache.ibatis.builder.typehandler"/>
+    <registrar type="org.apache.ibatis.builder.CustomTypeHandlerRegistrar"/>
   </typeHandlers>
 
   <objectFactory type="org.apache.ibatis.builder.ExampleObjectFactory">

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -197,6 +197,7 @@ public class XmlConfigBuilderTest {
       assertThat(config.getTypeHandlerRegistry().getTypeHandler(Long.class), is(instanceOf(CustomLongTypeHandler.class)));
       assertThat(config.getTypeHandlerRegistry().getTypeHandler(String.class), is(instanceOf(CustomStringTypeHandler.class)));
       assertThat(config.getTypeHandlerRegistry().getTypeHandler(String.class, JdbcType.VARCHAR), is(instanceOf(CustomStringTypeHandler.class)));
+      assertThat(config.getTypeHandlerRegistry().getTypeHandler(CustomTypeHandlerRegistrar.MyClass.class), is(instanceOf(CustomTypeHandlerRegistrar.MyClassTypeHandler.class)));
 
       ExampleObjectFactory objectFactory = (ExampleObjectFactory)config.getObjectFactory();
       assertThat(objectFactory.getProperties().size(), is(1));


### PR DESCRIPTION
I've added the `TypeHandlerRegistrar` interface to register a custom `TypeHandler`.
It can be shared registration code by multiple project by supporting this interface.

For example, I think this interface can use to share registration code for https://github.com/mybatis/typehandlers-threeten-extra.

```java
public class TreetenExtraTypeHandlerRegistrar implements TypeHandlerRegistrar {
    public void registerTypeHandlers(TypeHandlerRegistry registry) {
        // omit
    }
}
```

```xml
<typeHandlers>
    <registrar type="org.apache.ibatis.type.TreetenExtraTypeHandlerRegistrar"/>
</typeHandlers>
```

And I want to support auto-configuration on mybatis-spring-boot using this interface.

What do you think ?

### Related Issues

* mybatis/typehandlers-jsr310#31
* mybatis/typehandlers-threeten-extra#1