### PR TITLE
Support enum that implements multiple interfaces

### DIFF
--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -238,10 +238,11 @@ public final class TypeHandlerRegistry {
   private Map<JdbcType, TypeHandler<?>> getJdbcHandlerMapForEnumInterfaces(Class<?> clazz) {
     for (Class<?> iface : clazz.getInterfaces()) {
       Map<JdbcType, TypeHandler<?>> jdbcHandlerMap = TYPE_HANDLER_MAP.get(iface);
+      if (jdbcHandlerMap == null) {
+        jdbcHandlerMap = getJdbcHandlerMapForEnumInterfaces(iface);
+      }
       if (jdbcHandlerMap != null) {
         return jdbcHandlerMap;
-      } else {
-        return getJdbcHandlerMapForEnumInterfaces(iface);
       }
     }
     return null;

--- a/src/test/java/org/apache/ibatis/type/TypeHandlerRegistryTest.java
+++ b/src/test/java/org/apache/ibatis/type/TypeHandlerRegistryTest.java
@@ -159,8 +159,18 @@ public class TypeHandlerRegistryTest {
 
   interface SomeInterface {
   }
+  interface ExtendingSomeInterface extends SomeInterface {
+  }
+  interface NoTypeHandlerInterface {
+  }
 
   enum SomeEnum implements SomeInterface {
+  }
+  enum ExtendingSomeEnum implements ExtendingSomeInterface {
+  }
+  enum ImplementingMultiInterfaceSomeEnum implements NoTypeHandlerInterface, ExtendingSomeInterface {
+  }
+  enum NoTypeHandlerInterfaceEnum implements NoTypeHandlerInterface {
   }
 
   class SomeClass implements SomeInterface {
@@ -190,6 +200,10 @@ public class TypeHandlerRegistryTest {
   public void demoTypeHandlerForSuperInterface() {
     typeHandlerRegistry.register(SomeInterfaceTypeHandler.class);
     assertNull("Registering interface works only for enums.", typeHandlerRegistry.getTypeHandler(SomeClass.class));
+    assertSame("When type handler for interface is not exist, apply default enum type handler.",
+      EnumTypeHandler.class, typeHandlerRegistry.getTypeHandler(NoTypeHandlerInterfaceEnum.class).getClass());
     assertSame(SomeInterfaceTypeHandler.class, typeHandlerRegistry.getTypeHandler(SomeEnum.class).getClass());
+    assertSame(SomeInterfaceTypeHandler.class, typeHandlerRegistry.getTypeHandler(ExtendingSomeEnum.class).getClass());
+    assertSame(SomeInterfaceTypeHandler.class, typeHandlerRegistry.getTypeHandler(ImplementingMultiInterfaceSomeEnum.class).getClass());
   }
 }


### PR DESCRIPTION
See gh-947

In current implementation, there is case that can not detect a type handler related with interface when enum implements multiple interface. I've fixed this behavior.

**Note:**
And I've added asserts as follow:

* not found a type handler for interface
* found a type handler at super interface

@harawata Please review this.
