### PR TITLE
Add interface that edit a parameter value

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/BaseBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/BaseBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.apache.ibatis.mapping.ParameterEditor;
 import org.apache.ibatis.mapping.ParameterMode;
 import org.apache.ibatis.mapping.ResultSetType;
 import org.apache.ibatis.session.Configuration;
@@ -148,4 +149,26 @@ public abstract class BaseBuilder {
   protected Class<?> resolveAlias(String alias) {
     return typeAliasRegistry.resolveAlias(alias);
   }
+
+  /**
+   * Resolve a editor for parameter value.
+   * @param alias alias for editor class
+   * @return a editor for parameter value
+   * @since 3.4.3
+   */
+  protected ParameterEditor<?> resolveParameterEditor(String alias) {
+    Class<?> type = resolveClass(alias);
+    if (type == null) {
+      return null;
+    }
+    if (!ParameterEditor.class.isAssignableFrom(type)) {
+      throw new BuilderException("Type " + type.getName() + " is not a valid ParameterEditor because it does not implement ParameterEditor interface");
+    }
+    try {
+      return (ParameterEditor<?>) type.newInstance();
+    } catch (Exception e) {
+      throw new BuilderException("Error creating instance. Cause: " + e, e);
+    }
+  }
+
 }

--- a/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.apache.ibatis.type.JdbcType;
  */
 public class SqlSourceBuilder extends BaseBuilder {
 
-  private static final String parameterProperties = "javaType,jdbcType,mode,numericScale,resultMap,typeHandler,jdbcTypeName";
+  private static final String parameterProperties = "javaType,jdbcType,mode,numericScale,resultMap,typeHandler,jdbcTypeName,editor";
 
   public SqlSourceBuilder(Configuration configuration) {
     super(configuration);
@@ -91,6 +91,7 @@ public class SqlSourceBuilder extends BaseBuilder {
       ParameterMapping.Builder builder = new ParameterMapping.Builder(configuration, property, propertyType);
       Class<?> javaType = propertyType;
       String typeHandlerAlias = null;
+      String editorAlias = null;
       for (Map.Entry<String, String> entry : propertiesMap.entrySet()) {
         String name = entry.getKey();
         String value = entry.getValue();
@@ -113,12 +114,17 @@ public class SqlSourceBuilder extends BaseBuilder {
           // Do Nothing
         } else if ("expression".equals(name)) {
           throw new BuilderException("Expression based parameters are not supported yet");
+        } else if ("editor".equals(name)) {
+          editorAlias = value;
         } else {
           throw new BuilderException("An invalid property '" + name + "' was found in mapping #{" + content + "}.  Valid properties are " + parameterProperties);
         }
       }
       if (typeHandlerAlias != null) {
         builder.typeHandler(resolveTypeHandler(javaType, typeHandlerAlias));
+      }
+      if (editorAlias != null) {
+        builder.editor(resolveParameterEditor(editorAlias));
       }
       return builder.build();
     }

--- a/src/main/java/org/apache/ibatis/mapping/ParameterEditor.java
+++ b/src/main/java/org/apache/ibatis/mapping/ParameterEditor.java
@@ -1,0 +1,34 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.mapping;
+
+/**
+ * The interface that edit a parameter value.
+ *
+ * @param <T> A type of parameter value
+ * @author Kazuki Shimizu
+ * @since 3.4.3
+ */
+public interface ParameterEditor<T> {
+
+  /**
+   * Edit a parameter value.
+   * @param value a parameter value
+   * @return a edited value
+   */
+  T edit(T value);
+
+}

--- a/src/main/java/org/apache/ibatis/mapping/ParameterMapping.java
+++ b/src/main/java/org/apache/ibatis/mapping/ParameterMapping.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ public class ParameterMapping {
   private String resultMapId;
   private String jdbcTypeName;
   private String expression;
+  private ParameterEditor<?> editor;
 
   private ParameterMapping() {
   }
@@ -96,6 +97,17 @@ public class ParameterMapping {
 
     public Builder expression(String expression) {
       parameterMapping.expression = expression;
+      return this;
+    }
+
+    /**
+     * Set a editor for parameter value.
+     * @param editor a editor for parameter value
+     * @return self
+     * @since 3.4.3
+     */
+    public Builder editor(ParameterEditor<?> editor) {
+      parameterMapping.editor = editor;
       return this;
     }
 
@@ -197,6 +209,15 @@ public class ParameterMapping {
    */
   public String getExpression() {
     return expression;
+  }
+
+  /**
+   * Used when edit a parameter value
+   * @return a {@link ParameterEditor} instance. (If it not specify, return null)
+   * @since 3.4.3
+   */
+  public ParameterEditor<?> getEditor() {
+    return editor;
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandler.java
+++ b/src/main/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.apache.ibatis.executor.ErrorContext;
 import org.apache.ibatis.executor.parameter.ParameterHandler;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.mapping.ParameterEditor;
 import org.apache.ibatis.mapping.ParameterMapping;
 import org.apache.ibatis.mapping.ParameterMode;
 import org.apache.ibatis.reflection.MetaObject;
@@ -77,6 +78,10 @@ public class DefaultParameterHandler implements ParameterHandler {
           } else {
             MetaObject metaObject = configuration.newMetaObject(parameterObject);
             value = metaObject.getValue(propertyName);
+          }
+          ParameterEditor editor = parameterMapping.getEditor();
+          if (editor != null) {
+            value = editor.edit(value);
           }
           TypeHandler typeHandler = parameterMapping.getTypeHandler();
           JdbcType jdbcType = parameterMapping.getJdbcType();

--- a/src/test/java/org/apache/ibatis/submitted/editor/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/editor/CreateDB.sql
@@ -1,0 +1,25 @@
+--
+--    Copyright 2009-2017 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(20),
+);
+
+insert into users (id, name) values(1, 'Jon%MyBatis');
+insert into users (id, name) values(2, 'Jon_MyBatis');

--- a/src/test/java/org/apache/ibatis/submitted/editor/LikeValueEditor.java
+++ b/src/test/java/org/apache/ibatis/submitted/editor/LikeValueEditor.java
@@ -1,0 +1,30 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.editor;
+
+import org.apache.ibatis.mapping.ParameterEditor;
+
+public class LikeValueEditor implements ParameterEditor<String> {
+
+  @Override
+  public String edit(String value) {
+    if (value == null) {
+      return null;
+    }
+    return value.replaceAll("%", "\\\\%").replaceAll("_", "\\\\_");
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/editor/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/editor/Mapper.java
@@ -1,0 +1,33 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.editor;
+
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+public interface Mapper {
+
+  @Select("SELECT id FROM users WHERE name LIKE ('%' || #{name} || '%') ESCAPE '\\'")
+  List<Integer> getUserIdsWithoutEditor(String name);
+
+  @Select("SELECT id FROM users WHERE name LIKE ('%' || #{name,editor=LikeValueEditor} || '%') ESCAPE '\\'")
+  List<Integer> getUserIdsUsingAlias(String name);
+
+  @Select("SELECT id FROM users WHERE name LIKE ('%' || #{name,editor=org.apache.ibatis.submitted.editor.LikeValueEditor} || '%') ESCAPE '\\'")
+  List<Integer> getUserIdsUsingFqcn(String name);
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/editor/ParameterEditorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/editor/ParameterEditorTest.java
@@ -1,0 +1,91 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.editor;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.hamcrest.core.Is;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.Reader;
+import java.sql.Connection;
+
+/**
+ * Tests for {@link org.apache.ibatis.mapping.ParameterEditor}.
+ * @author Kazuki Shimizu
+ * @since 3.4.3
+ */
+public class ParameterEditorTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // create a SqlSessionFactory
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/editor/mybatis-config.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
+
+    // populate in-memory database
+    SqlSession session = sqlSessionFactory.openSession();
+    Connection conn = session.getConnection();
+    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/editor/CreateDB.sql");
+    ScriptRunner runner = new ScriptRunner(conn);
+    runner.setLogWriter(null);
+    runner.runScript(reader);
+    reader.close();
+    session.close();
+  }
+
+  @Test
+  public void testWithoutEditor() {
+    SqlSession session = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = session.getMapper(Mapper.class);
+      Assert.assertThat(mapper.getUserIdsWithoutEditor("%").size(), Is.is(2));
+    } finally {
+      session.close();
+    }
+  }
+
+  @Test
+  public void testForAlias() {
+    SqlSession session = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = session.getMapper(Mapper.class);
+      Assert.assertThat(mapper.getUserIdsUsingAlias("%").size(), Is.is(1));
+    } finally {
+      session.close();
+    }
+  }
+
+  @Test
+  public void testForFqcn() {
+    SqlSession session = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = session.getMapper(Mapper.class);
+      Assert.assertThat(mapper.getUserIdsUsingFqcn("_").size(), Is.is(1));
+    } finally {
+      session.close();
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/editor/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/editor/mybatis-config.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2017 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+	<typeAliases>
+		<typeAlias type="org.apache.ibatis.submitted.editor.LikeValueEditor" />
+	</typeAliases>
+
+	<environments default="development">
+		<environment id="development">
+			<transactionManager type="JDBC">
+				<property name="" value="" />
+			</transactionManager>
+			<dataSource type="UNPOOLED">
+				<property name="driver" value="org.hsqldb.jdbcDriver" />
+				<property name="url" value="jdbc:hsqldb:mem:rounding" />
+				<property name="username" value="sa" />
+			</dataSource>
+		</environment>
+	</environments>
+
+	<mappers>
+		<mapper class="org.apache.ibatis.submitted.editor.Mapper" />
+	</mappers>
+
+</configuration>


### PR DESCRIPTION
I will propose to add a interface that edit a parameter value.
For example, I will use this interface for escaping a criteria value of like search as follow:

```java
public class LikeEscapeEditor implements ParameterEditor<String> {

  @Override
  public String edit(String value) {
    if (value == null) {
      return null;
    }
    return value.replaceAll("%", "\\\\%").replaceAll("_", "\\\\_");
  }

}
```

```java
@Select("SELECT id FROM users WHERE name LIKE ('%' || #{name,editor=LikeEscapeEditor} || '%') ESCAPE '\\'")
List<Integer> getUserIds(String name);
```

What do you think ?
