### PR TITLE
补充第49行代码 sqlSessionFactory前面缺少的类型声明

### DIFF
--- a/src/site/zh/xdoc/getting-started.xml
+++ b/src/site/zh/xdoc/getting-started.xml
@@ -46,7 +46,7 @@
       <source><![CDATA[
 String resource = "org/mybatis/example/mybatis-config.xml";
 InputStream inputStream = Resources.getResourceAsStream(resource);
-sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream);]]></source>
+SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream);]]></source>
       <p>XML 配置文件（configuration XML）中包含了对 MyBatis 系统的核心设置，包含获取数据库连接实例的数据源（DataSource）和决定事务作用域和控制方式的事务管理器（TransactionManager）。XML 配置文件的详细内容后面再探讨，这里先给出一个简单的示例：</p>
       <source><![CDATA[<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE configuration


### PR DESCRIPTION
sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream);
改为
SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream);