### PR TITLE
Merge typehandlers-jsr310 into the core.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,12 +157,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.mybatis</groupId>
-      <artifactId>mybatis-typehandlers-jsr310</artifactId>
-      <version>1.0.2</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <version>1.7.25</version>

--- a/src/main/java/org/apache/ibatis/reflection/Jdk.java
+++ b/src/main/java/org/apache/ibatis/reflection/Jdk.java
@@ -39,6 +39,19 @@ public class Jdk {
     parameterExists = available;
   }
 
+  public static final boolean dateAndTimeApiExists;
+
+  static {
+    boolean available = false;
+    try {
+      Resources.classForName("java.time.Clock");
+      available = true;
+    } catch (ClassNotFoundException e) {
+      // ignore
+    }
+    dateAndTimeApiExists = available;
+  }
+
   private Jdk() {
     super();
   }

--- a/src/main/java/org/apache/ibatis/type/InstantTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/InstantTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.time.Instant;
 import org.apache.ibatis.lang.UsesJava8;
 
 /**
+ * @since 3.4.5
  * @author Tomas Rohovsky
  */
 @UsesJava8

--- a/src/main/java/org/apache/ibatis/type/InstantTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/InstantTypeHandler.java
@@ -1,0 +1,62 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import org.apache.ibatis.lang.UsesJava8;
+
+/**
+ * @author Tomas Rohovsky
+ */
+@UsesJava8
+public class InstantTypeHandler extends BaseTypeHandler<Instant> {
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, Instant parameter, JdbcType jdbcType) throws SQLException {
+    ps.setTimestamp(i, Timestamp.from(parameter));
+  }
+
+  @Override
+  public Instant getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    Timestamp timestamp = rs.getTimestamp(columnName);
+    return getInstant(timestamp);
+  }
+
+  @Override
+  public Instant getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    Timestamp timestamp = rs.getTimestamp(columnIndex);
+    return getInstant(timestamp);
+  }
+
+  @Override
+  public Instant getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    Timestamp timestamp = cs.getTimestamp(columnIndex);
+    return getInstant(timestamp);
+  }
+
+  private static Instant getInstant(Timestamp timestamp) {
+    if (timestamp != null) {
+      return timestamp.toInstant();
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/apache/ibatis/type/JapaneseDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/JapaneseDateTypeHandler.java
@@ -1,0 +1,68 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.chrono.JapaneseDate;
+
+import org.apache.ibatis.lang.UsesJava8;
+
+/**
+ * Type Handler for {@link JapaneseDate}.
+ *
+ * @since 1.0.2
+ * @author Kazuki Shimizu
+ */
+@UsesJava8
+public class JapaneseDateTypeHandler extends BaseTypeHandler<JapaneseDate> {
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, JapaneseDate parameter, JdbcType jdbcType)
+          throws SQLException {
+    ps.setDate(i, Date.valueOf(LocalDate.ofEpochDay(parameter.toEpochDay())));
+  }
+
+  @Override
+  public JapaneseDate getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    Date date = rs.getDate(columnName);
+    return getJapaneseDate(date);
+  }
+
+  @Override
+  public JapaneseDate getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    Date date = rs.getDate(columnIndex);
+    return getJapaneseDate(date);
+  }
+
+  @Override
+  public JapaneseDate getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    Date date = cs.getDate(columnIndex);
+    return getJapaneseDate(date);
+  }
+
+  private static JapaneseDate getJapaneseDate(Date date) {
+    if (date != null) {
+      return JapaneseDate.from(date.toLocalDate());
+    }
+    return null;
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/type/JapaneseDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/JapaneseDateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.apache.ibatis.lang.UsesJava8;
 /**
  * Type Handler for {@link JapaneseDate}.
  *
- * @since 1.0.2
+ * @since 3.4.5
  * @author Kazuki Shimizu
  */
 @UsesJava8

--- a/src/main/java/org/apache/ibatis/type/Java8TypeHandlersRegistrar.java
+++ b/src/main/java/org/apache/ibatis/type/Java8TypeHandlersRegistrar.java
@@ -30,11 +30,13 @@ import java.time.chrono.JapaneseDate;
 
 import org.apache.ibatis.lang.UsesJava8;
 
+/**
+ * @since 3.4.5
+ */
 @UsesJava8
 public abstract class Java8TypeHandlersRegistrar {
 
   public static void registerDateAndTimeHandlers(TypeHandlerRegistry registry) {
-    // since 1.0.0
     registry.register(Instant.class, InstantTypeHandler.class);
     registry.register(LocalDateTime.class, LocalDateTimeTypeHandler.class);
     registry.register(LocalDate.class, LocalDateTypeHandler.class);
@@ -42,10 +44,8 @@ public abstract class Java8TypeHandlersRegistrar {
     registry.register(OffsetDateTime.class, OffsetDateTimeTypeHandler.class);
     registry.register(OffsetTime.class, OffsetTimeTypeHandler.class);
     registry.register(ZonedDateTime.class, ZonedDateTimeTypeHandler.class);
-    // since 1.0.1
     registry.register(Month.class, MonthTypeHandler.class);
     registry.register(Year.class, YearTypeHandler.class);
-    // since 1.0.2
     registry.register(YearMonth.class, YearMonthTypeHandler.class);
     registry.register(JapaneseDate.class, JapaneseDateTypeHandler.class);
   }

--- a/src/main/java/org/apache/ibatis/type/Java8TypeHandlersRegistrar.java
+++ b/src/main/java/org/apache/ibatis/type/Java8TypeHandlersRegistrar.java
@@ -1,0 +1,53 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.type;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.time.chrono.JapaneseDate;
+
+import org.apache.ibatis.lang.UsesJava8;
+
+@UsesJava8
+public abstract class Java8TypeHandlersRegistrar {
+
+  public static void registerDateAndTimeHandlers(TypeHandlerRegistry registry) {
+    // since 1.0.0
+    registry.register(Instant.class, InstantTypeHandler.class);
+    registry.register(LocalDateTime.class, LocalDateTimeTypeHandler.class);
+    registry.register(LocalDate.class, LocalDateTypeHandler.class);
+    registry.register(LocalTime.class, LocalTimeTypeHandler.class);
+    registry.register(OffsetDateTime.class, OffsetDateTimeTypeHandler.class);
+    registry.register(OffsetTime.class, OffsetTimeTypeHandler.class);
+    registry.register(ZonedDateTime.class, ZonedDateTimeTypeHandler.class);
+    // since 1.0.1
+    registry.register(Month.class, MonthTypeHandler.class);
+    registry.register(Year.class, YearTypeHandler.class);
+    // since 1.0.2
+    registry.register(YearMonth.class, YearMonthTypeHandler.class);
+    registry.register(JapaneseDate.class, JapaneseDateTypeHandler.class);
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/type/LocalDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalDateTimeTypeHandler.java
@@ -1,0 +1,63 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import org.apache.ibatis.lang.UsesJava8;
+
+/**
+ * @author Tomas Rohovsky
+ */
+@UsesJava8
+public class LocalDateTimeTypeHandler extends BaseTypeHandler<LocalDateTime> {
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, LocalDateTime parameter, JdbcType jdbcType)
+          throws SQLException {
+    ps.setTimestamp(i, Timestamp.valueOf(parameter));
+  }
+
+  @Override
+  public LocalDateTime getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    Timestamp timestamp = rs.getTimestamp(columnName);
+    return getLocalDateTime(timestamp);
+  }
+
+  @Override
+  public LocalDateTime getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    Timestamp timestamp = rs.getTimestamp(columnIndex);
+    return getLocalDateTime(timestamp);
+  }
+
+  @Override
+  public LocalDateTime getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    Timestamp timestamp = cs.getTimestamp(columnIndex);
+    return getLocalDateTime(timestamp);
+  }
+
+  private static LocalDateTime getLocalDateTime(Timestamp timestamp) {
+    if (timestamp != null) {
+      return timestamp.toLocalDateTime();
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/apache/ibatis/type/LocalDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.time.LocalDateTime;
 import org.apache.ibatis.lang.UsesJava8;
 
 /**
+ * @since 3.4.5
  * @author Tomas Rohovsky
  */
 @UsesJava8

--- a/src/main/java/org/apache/ibatis/type/LocalDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalDateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.time.LocalDate;
 import org.apache.ibatis.lang.UsesJava8;
 
 /**
+ * @since 3.4.5
  * @author Tomas Rohovsky
  */
 @UsesJava8

--- a/src/main/java/org/apache/ibatis/type/LocalDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalDateTypeHandler.java
@@ -1,0 +1,63 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.Date;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDate;
+
+import org.apache.ibatis.lang.UsesJava8;
+
+/**
+ * @author Tomas Rohovsky
+ */
+@UsesJava8
+public class LocalDateTypeHandler extends BaseTypeHandler<LocalDate> {
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, LocalDate parameter, JdbcType jdbcType)
+          throws SQLException {
+    ps.setDate(i, Date.valueOf(parameter));
+  }
+
+  @Override
+  public LocalDate getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    Date date = rs.getDate(columnName);
+    return getLocalDate(date);
+  }
+
+  @Override
+  public LocalDate getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    Date date = rs.getDate(columnIndex);
+    return getLocalDate(date);
+  }
+
+  @Override
+  public LocalDate getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    Date date = cs.getDate(columnIndex);
+    return getLocalDate(date);
+  }
+
+  private static LocalDate getLocalDate(Date date) {
+    if (date != null) {
+      return date.toLocalDate();
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/apache/ibatis/type/LocalTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.time.LocalTime;
 import org.apache.ibatis.lang.UsesJava8;
 
 /**
+ * @since 3.4.5
  * @author Tomas Rohovsky
  */
 @UsesJava8

--- a/src/main/java/org/apache/ibatis/type/LocalTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalTimeTypeHandler.java
@@ -1,0 +1,63 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.time.LocalTime;
+
+import org.apache.ibatis.lang.UsesJava8;
+
+/**
+ * @author Tomas Rohovsky
+ */
+@UsesJava8
+public class LocalTimeTypeHandler extends BaseTypeHandler<LocalTime> {
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, LocalTime parameter, JdbcType jdbcType)
+          throws SQLException {
+    ps.setTime(i, Time.valueOf(parameter));
+  }
+
+  @Override
+  public LocalTime getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    Time time = rs.getTime(columnName);
+    return getLocalTime(time);
+  }
+
+  @Override
+  public LocalTime getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    Time time = rs.getTime(columnIndex);
+    return getLocalTime(time);
+  }
+
+  @Override
+  public LocalTime getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    Time time = cs.getTime(columnIndex);
+    return getLocalTime(time);
+  }
+
+  private static LocalTime getLocalTime(Time time) {
+    if (time != null) {
+      return time.toLocalTime();
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/apache/ibatis/type/MonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/MonthTypeHandler.java
@@ -1,0 +1,57 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Month;
+
+import org.apache.ibatis.lang.UsesJava8;
+
+/**
+ *
+ * @since 1.0.1
+ * @author Björn Raupach
+ */
+@UsesJava8
+public class MonthTypeHandler extends BaseTypeHandler<Month> {
+    
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, Month month, JdbcType type) throws SQLException {
+        ps.setInt(i, month.getValue());
+    }
+
+    @Override
+    public Month getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int month = rs.getInt(columnName);
+        return month == 0 ? null : Month.of(month);
+    }
+
+    @Override
+    public Month getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int month = rs.getInt(columnIndex);
+        return month == 0 ? null : Month.of(month);
+    }
+
+    @Override
+    public Month getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int month = cs.getInt(columnIndex);
+        return month == 0 ? null : Month.of(month);
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/MonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/MonthTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.apache.ibatis.lang.UsesJava8;
 
 /**
  *
- * @since 1.0.1
+ * @since 3.4.5
  * @author Björn Raupach
  */
 @UsesJava8

--- a/src/main/java/org/apache/ibatis/type/OffsetDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/OffsetDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.time.ZoneId;
 import org.apache.ibatis.lang.UsesJava8;
 
 /**
+ * @since 3.4.5
  * @author Tomas Rohovsky
  */
 @UsesJava8

--- a/src/main/java/org/apache/ibatis/type/OffsetDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/OffsetDateTimeTypeHandler.java
@@ -1,0 +1,64 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+
+import org.apache.ibatis.lang.UsesJava8;
+
+/**
+ * @author Tomas Rohovsky
+ */
+@UsesJava8
+public class OffsetDateTimeTypeHandler extends BaseTypeHandler<OffsetDateTime> {
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, OffsetDateTime parameter, JdbcType jdbcType)
+          throws SQLException {
+    ps.setTimestamp(i, Timestamp.from(parameter.toInstant()));
+  }
+
+  @Override
+  public OffsetDateTime getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    Timestamp timestamp = rs.getTimestamp(columnName);
+    return getOffsetDateTime(timestamp);
+  }
+
+  @Override
+  public OffsetDateTime getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    Timestamp timestamp = rs.getTimestamp(columnIndex);
+    return getOffsetDateTime(timestamp);
+  }
+
+  @Override
+  public OffsetDateTime getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    Timestamp timestamp = cs.getTimestamp(columnIndex);
+    return getOffsetDateTime(timestamp);
+  }
+
+  private static OffsetDateTime getOffsetDateTime(Timestamp timestamp) {
+    if (timestamp != null) {
+      return OffsetDateTime.ofInstant(timestamp.toInstant(), ZoneId.systemDefault());
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/apache/ibatis/type/OffsetTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/OffsetTimeTypeHandler.java
@@ -1,0 +1,63 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.time.OffsetTime;
+
+import org.apache.ibatis.lang.UsesJava8;
+
+/**
+ * @author Tomas Rohovsky
+ */
+@UsesJava8
+public class OffsetTimeTypeHandler extends BaseTypeHandler<OffsetTime> {
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, OffsetTime parameter, JdbcType jdbcType)
+          throws SQLException {
+    ps.setTime(i, Time.valueOf(parameter.toLocalTime()));
+  }
+
+  @Override
+  public OffsetTime getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    Time time = rs.getTime(columnName);
+    return getOffsetTime(time);
+  }
+
+  @Override
+  public OffsetTime getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    Time time = rs.getTime(columnIndex);
+    return getOffsetTime(time);
+  }
+
+  @Override
+  public OffsetTime getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    Time time = cs.getTime(columnIndex);
+    return getOffsetTime(time);
+  }
+
+  private static OffsetTime getOffsetTime(Time time) {
+    if (time != null) {
+      return time.toLocalTime().atOffset(OffsetTime.now().getOffset());
+    }
+    return null;
+  }
+}

--- a/src/main/java/org/apache/ibatis/type/OffsetTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/OffsetTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.time.OffsetTime;
 import org.apache.ibatis.lang.UsesJava8;
 
 /**
+ * @since 3.4.5
  * @author Tomas Rohovsky
  */
 @UsesJava8

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.ibatis.io.ResolverUtil;
 import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.reflection.Jdk;
 
 /**
  * @author Clinton Begin
@@ -130,24 +131,8 @@ public final class TypeHandlerRegistry {
     register(java.sql.Timestamp.class, new SqlTimestampTypeHandler());
 
     // mybatis-typehandlers-jsr310
-    try {
-      // since 1.0.0
-      register("java.time.Instant", "org.apache.ibatis.type.InstantTypeHandler");
-      register("java.time.LocalDateTime", "org.apache.ibatis.type.LocalDateTimeTypeHandler");
-      register("java.time.LocalDate", "org.apache.ibatis.type.LocalDateTypeHandler");
-      register("java.time.LocalTime", "org.apache.ibatis.type.LocalTimeTypeHandler");
-      register("java.time.OffsetDateTime", "org.apache.ibatis.type.OffsetDateTimeTypeHandler");
-      register("java.time.OffsetTime", "org.apache.ibatis.type.OffsetTimeTypeHandler");
-      register("java.time.ZonedDateTime", "org.apache.ibatis.type.ZonedDateTimeTypeHandler");
-      // since 1.0.1
-      register("java.time.Month", "org.apache.ibatis.type.MonthTypeHandler");
-      register("java.time.Year", "org.apache.ibatis.type.YearTypeHandler");
-      // since 1.0.2
-      register("java.time.YearMonth", "org.apache.ibatis.type.YearMonthTypeHandler");
-      register("java.time.chrono.JapaneseDate", "org.apache.ibatis.type.JapaneseDateTypeHandler");
-
-    } catch (ClassNotFoundException e) {
-      // no JSR-310 handlers
+    if (Jdk.dateAndTimeApiExists) {
+      Java8TypeHandlersRegistrar.registerDateAndTimeHandlers(this);
     }
 
     // issue #273

--- a/src/main/java/org/apache/ibatis/type/YearMonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearMonthTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * {@link java.time.YearMonth#parse YearMonth.parse}. Therefore column values
  * are expected as strings. The format must be uuuu-MM. Example: "2016-08"
  *
- * @since 1.0.2
+ * @since 3.4.5
  * @author Björn Raupach
  */
 @UsesJava8

--- a/src/main/java/org/apache/ibatis/type/YearMonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearMonthTypeHandler.java
@@ -1,0 +1,62 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.YearMonth;
+
+import org.apache.ibatis.lang.UsesJava8;
+
+/**
+ * Type Handler for {@link java.time.YearMonth}
+ *
+ * YearMonthTypeHandler relies upon
+ * {@link java.time.YearMonth#parse YearMonth.parse}. Therefore column values
+ * are expected as strings. The format must be uuuu-MM. Example: "2016-08"
+ *
+ * @since 1.0.2
+ * @author Björn Raupach
+ */
+@UsesJava8
+public class YearMonthTypeHandler extends BaseTypeHandler<YearMonth> {
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, YearMonth yearMonth, JdbcType jt) throws SQLException {
+    ps.setString(i, yearMonth.toString());
+  }
+
+  @Override
+  public YearMonth getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    String value = rs.getString(columnName);
+    return value == null ? null : YearMonth.parse(value);
+  }
+
+  @Override
+  public YearMonth getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    String value = rs.getString(columnIndex);
+    return value == null ? null : YearMonth.parse(value);
+  }
+
+  @Override
+  public YearMonth getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    String value = cs.getString(columnIndex);
+    return value == null ? null : YearMonth.parse(value);
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/type/YearTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.time.Year;
 import org.apache.ibatis.lang.UsesJava8;
 
 /**
- * @since 1.0.1
+ * @since 3.4.5
  * @author Björn Raupach
  */
 @UsesJava8

--- a/src/main/java/org/apache/ibatis/type/YearTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearTypeHandler.java
@@ -1,0 +1,56 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Year;
+
+import org.apache.ibatis.lang.UsesJava8;
+
+/**
+ * @since 1.0.1
+ * @author Björn Raupach
+ */
+@UsesJava8
+public class YearTypeHandler extends BaseTypeHandler<Year> {
+    
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, Year year, JdbcType type) throws SQLException {
+        ps.setInt(i, year.getValue());
+    }
+
+    @Override
+    public Year getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        int year = rs.getInt(columnName);
+        return year == 0 ? null : Year.of(year);
+    }
+
+    @Override
+    public Year getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        int year = rs.getInt(columnIndex);
+        return year == 0 ? null : Year.of(year);
+    }
+
+    @Override
+    public Year getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        int year = cs.getInt(columnIndex);
+        return year == 0 ? null : Year.of(year);
+    }
+    
+}

--- a/src/main/java/org/apache/ibatis/type/ZonedDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ZonedDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.time.ZonedDateTime;
 import org.apache.ibatis.lang.UsesJava8;
 
 /**
+ * @since 3.4.5
  * @author Tomas Rohovsky
  */
 @UsesJava8

--- a/src/main/java/org/apache/ibatis/type/ZonedDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ZonedDateTimeTypeHandler.java
@@ -1,0 +1,64 @@
+/**
+ *    Copyright 2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+import org.apache.ibatis.lang.UsesJava8;
+
+/**
+ * @author Tomas Rohovsky
+ */
+@UsesJava8
+public class ZonedDateTimeTypeHandler extends BaseTypeHandler<ZonedDateTime> {
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, ZonedDateTime parameter, JdbcType jdbcType)
+          throws SQLException {
+    ps.setTimestamp(i, Timestamp.from(parameter.toInstant()));
+  }
+
+  @Override
+  public ZonedDateTime getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    Timestamp timestamp = rs.getTimestamp(columnName);
+    return getZonedDateTime(timestamp);
+  }
+
+  @Override
+  public ZonedDateTime getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    Timestamp timestamp = rs.getTimestamp(columnIndex);
+    return getZonedDateTime(timestamp);
+  }
+
+  @Override
+  public ZonedDateTime getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    Timestamp timestamp = cs.getTimestamp(columnIndex);
+    return getZonedDateTime(timestamp);
+  }
+
+  private static ZonedDateTime getZonedDateTime(Timestamp timestamp) {
+    if (timestamp != null) {
+      return ZonedDateTime.ofInstant(timestamp.toInstant(), ZoneId.systemDefault());
+    }
+    return null;
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/usesjava8/InstantTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/InstantTypeHandlerTest.java
@@ -1,0 +1,86 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type.usesjava8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+
+import org.apache.ibatis.type.BaseTypeHandlerTest;
+import org.apache.ibatis.type.InstantTypeHandler;
+import org.apache.ibatis.type.TypeHandler;
+import org.junit.Test;
+
+public class InstantTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<Instant> TYPE_HANDLER = new InstantTypeHandler();
+  private static final Instant INSTANT = Instant.now();
+  private static final Timestamp TIMESTAMP = Timestamp.from(INSTANT);
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+    verify(ps).setTimestamp(1, TIMESTAMP);
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getTimestamp("column")).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getTimestamp(1)).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getTimestamp(1)).thenReturn(null);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/usesjava8/JapaneseDateTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/JapaneseDateTypeHandlerTest.java
@@ -1,0 +1,88 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type.usesjava8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.chrono.JapaneseDate;
+
+import org.apache.ibatis.type.BaseTypeHandlerTest;
+import org.apache.ibatis.type.JapaneseDateTypeHandler;
+import org.apache.ibatis.type.TypeHandler;
+import org.junit.Test;
+
+public class JapaneseDateTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<JapaneseDate> TYPE_HANDLER = new JapaneseDateTypeHandler();
+  private static final JapaneseDate JAPANESE_DATE = JapaneseDate.now();
+  private static final Date DATE = Date.valueOf(LocalDate.ofEpochDay(JAPANESE_DATE.toEpochDay()));
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, JAPANESE_DATE, null);
+    verify(ps).setDate(1, DATE);
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getDate("column")).thenReturn(DATE);
+    assertEquals(JAPANESE_DATE, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getDate("column")).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getDate(1)).thenReturn(DATE);
+    assertEquals(JAPANESE_DATE, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getDate(1)).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getDate(1)).thenReturn(DATE);
+    assertEquals(JAPANESE_DATE, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getDate(1)).thenReturn(null);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/type/usesjava8/Jsr310TypeHandlerRegistryTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/Jsr310TypeHandlerRegistryTest.java
@@ -15,14 +15,35 @@
  */
 package org.apache.ibatis.type.usesjava8;
 
-import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.type.*;
-import org.hamcrest.core.IsInstanceOf;
+import static org.hamcrest.core.IsInstanceOf.*;
+import static org.junit.Assert.*;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZonedDateTime;
+import java.time.chrono.JapaneseDate;
+
+import org.apache.ibatis.type.InstantTypeHandler;
+import org.apache.ibatis.type.JapaneseDateTypeHandler;
+import org.apache.ibatis.type.LocalDateTimeTypeHandler;
+import org.apache.ibatis.type.LocalDateTypeHandler;
+import org.apache.ibatis.type.LocalTimeTypeHandler;
+import org.apache.ibatis.type.MonthTypeHandler;
+import org.apache.ibatis.type.OffsetDateTimeTypeHandler;
+import org.apache.ibatis.type.OffsetTimeTypeHandler;
+import org.apache.ibatis.type.TypeHandlerRegistry;
+import org.apache.ibatis.type.YearMonthTypeHandler;
+import org.apache.ibatis.type.YearTypeHandler;
+import org.apache.ibatis.type.ZonedDateTimeTypeHandler;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.*;
-import static org.hamcrest.core.IsInstanceOf.*;
 
 /**
  * Tests for auto-detect type handlers of mybatis-typehandlers-jsr310.
@@ -40,29 +61,24 @@ public class Jsr310TypeHandlerRegistryTest {
 
   @Test
   public void testFor_v1_0_0() throws ClassNotFoundException {
-    assertThat(getTypeHandler("java.time.Instant"), instanceOf(InstantTypeHandler.class));
-    assertThat(getTypeHandler("java.time.LocalDateTime"), instanceOf(LocalDateTimeTypeHandler.class));
-    assertThat(getTypeHandler("java.time.LocalDate"), instanceOf(LocalDateTypeHandler.class));
-    assertThat(getTypeHandler("java.time.LocalTime"), instanceOf(LocalTimeTypeHandler.class));
-    assertThat(getTypeHandler("java.time.OffsetDateTime"), instanceOf(OffsetDateTimeTypeHandler.class));
-    assertThat(getTypeHandler("java.time.OffsetTime"), instanceOf(OffsetTimeTypeHandler.class));
-    assertThat(getTypeHandler("java.time.ZonedDateTime"), instanceOf(ZonedDateTimeTypeHandler.class));
+    assertThat(typeHandlerRegistry.getTypeHandler(Instant.class), instanceOf(InstantTypeHandler.class));
+    assertThat(typeHandlerRegistry.getTypeHandler(LocalDateTime.class), instanceOf(LocalDateTimeTypeHandler.class));
+    assertThat(typeHandlerRegistry.getTypeHandler(LocalDate.class), instanceOf(LocalDateTypeHandler.class));
+    assertThat(typeHandlerRegistry.getTypeHandler(LocalTime.class), instanceOf(LocalTimeTypeHandler.class));
+    assertThat(typeHandlerRegistry.getTypeHandler(OffsetDateTime.class), instanceOf(OffsetDateTimeTypeHandler.class));
+    assertThat(typeHandlerRegistry.getTypeHandler(OffsetTime.class), instanceOf(OffsetTimeTypeHandler.class));
+    assertThat(typeHandlerRegistry.getTypeHandler(ZonedDateTime.class), instanceOf(ZonedDateTimeTypeHandler.class));
   }
 
   @Test
   public void testFor_v1_0_1() throws ClassNotFoundException {
-    assertThat(getTypeHandler("java.time.Month"), instanceOf(MonthTypeHandler.class));
-    assertThat(getTypeHandler("java.time.Year"), instanceOf(YearTypeHandler.class));
+    assertThat(typeHandlerRegistry.getTypeHandler(Month.class), instanceOf(MonthTypeHandler.class));
+    assertThat(typeHandlerRegistry.getTypeHandler(Year.class), instanceOf(YearTypeHandler.class));
   }
 
   @Test
   public void testFor_v1_0_2() throws ClassNotFoundException {
-    assertThat(getTypeHandler("java.time.YearMonth"), instanceOf(YearMonthTypeHandler.class));
-    assertThat(getTypeHandler("java.time.chrono.JapaneseDate"), instanceOf(JapaneseDateTypeHandler.class));
+    assertThat(typeHandlerRegistry.getTypeHandler(YearMonth.class), instanceOf(YearMonthTypeHandler.class));
+    assertThat(typeHandlerRegistry.getTypeHandler(JapaneseDate.class), instanceOf(JapaneseDateTypeHandler.class));
   }
-
-  private TypeHandler<?> getTypeHandler(String fqcn) throws ClassNotFoundException {
-    return typeHandlerRegistry.getTypeHandler(Resources.classForName(fqcn));
-  }
-
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/Jsr310TypeHandlerRegistryTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/Jsr310TypeHandlerRegistryTest.java
@@ -46,8 +46,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Tests for auto-detect type handlers of mybatis-typehandlers-jsr310.
- *
  * @author Kazuki Shimizu
  */
 public class Jsr310TypeHandlerRegistryTest {
@@ -60,7 +58,7 @@ public class Jsr310TypeHandlerRegistryTest {
   }
 
   @Test
-  public void testFor_v1_0_0() throws ClassNotFoundException {
+  public void shouldRegisterJsr310TypeHandlers() throws ClassNotFoundException {
     assertThat(typeHandlerRegistry.getTypeHandler(Instant.class), instanceOf(InstantTypeHandler.class));
     assertThat(typeHandlerRegistry.getTypeHandler(LocalDateTime.class), instanceOf(LocalDateTimeTypeHandler.class));
     assertThat(typeHandlerRegistry.getTypeHandler(LocalDate.class), instanceOf(LocalDateTypeHandler.class));
@@ -68,16 +66,8 @@ public class Jsr310TypeHandlerRegistryTest {
     assertThat(typeHandlerRegistry.getTypeHandler(OffsetDateTime.class), instanceOf(OffsetDateTimeTypeHandler.class));
     assertThat(typeHandlerRegistry.getTypeHandler(OffsetTime.class), instanceOf(OffsetTimeTypeHandler.class));
     assertThat(typeHandlerRegistry.getTypeHandler(ZonedDateTime.class), instanceOf(ZonedDateTimeTypeHandler.class));
-  }
-
-  @Test
-  public void testFor_v1_0_1() throws ClassNotFoundException {
     assertThat(typeHandlerRegistry.getTypeHandler(Month.class), instanceOf(MonthTypeHandler.class));
     assertThat(typeHandlerRegistry.getTypeHandler(Year.class), instanceOf(YearTypeHandler.class));
-  }
-
-  @Test
-  public void testFor_v1_0_2() throws ClassNotFoundException {
     assertThat(typeHandlerRegistry.getTypeHandler(YearMonth.class), instanceOf(YearMonthTypeHandler.class));
     assertThat(typeHandlerRegistry.getTypeHandler(JapaneseDate.class), instanceOf(JapaneseDateTypeHandler.class));
   }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/LocalDateTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/LocalDateTimeTypeHandlerTest.java
@@ -1,0 +1,86 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type.usesjava8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+
+import org.apache.ibatis.type.BaseTypeHandlerTest;
+import org.apache.ibatis.type.LocalDateTimeTypeHandler;
+import org.apache.ibatis.type.TypeHandler;
+import org.junit.Test;
+
+public class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<LocalDateTime> TYPE_HANDLER = new LocalDateTimeTypeHandler();
+  private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.now();
+  private static final Timestamp TIMESTAMP = Timestamp.valueOf(LOCAL_DATE_TIME);
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, LOCAL_DATE_TIME, null);
+    verify(ps).setTimestamp(1, TIMESTAMP);
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
+    assertEquals(LOCAL_DATE_TIME, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getTimestamp("column")).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
+    assertEquals(LOCAL_DATE_TIME, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getTimestamp(1)).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
+    assertEquals(LOCAL_DATE_TIME, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getTimestamp(1)).thenReturn(null);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/usesjava8/LocalDateTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/LocalDateTypeHandlerTest.java
@@ -1,0 +1,86 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type.usesjava8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Date;
+import java.time.LocalDate;
+
+import org.apache.ibatis.type.BaseTypeHandlerTest;
+import org.apache.ibatis.type.LocalDateTypeHandler;
+import org.apache.ibatis.type.TypeHandler;
+import org.junit.Test;
+
+public class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<LocalDate> TYPE_HANDLER = new LocalDateTypeHandler();
+  private static final LocalDate LOCAL_DATE = LocalDate.now();
+  private static final Date DATE = Date.valueOf(LOCAL_DATE);
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, LOCAL_DATE, null);
+    verify(ps).setDate(1, DATE);
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getDate("column")).thenReturn(DATE);
+    assertEquals(LOCAL_DATE, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getDate("column")).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getDate(1)).thenReturn(DATE);
+    assertEquals(LOCAL_DATE, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getDate(1)).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getDate(1)).thenReturn(DATE);
+    assertEquals(LOCAL_DATE, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getDate(1)).thenReturn(null);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/usesjava8/LocalTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/LocalTimeTypeHandlerTest.java
@@ -1,0 +1,87 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type.usesjava8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Time;
+import java.time.LocalTime;
+
+import org.apache.ibatis.type.BaseTypeHandlerTest;
+import org.apache.ibatis.type.LocalTimeTypeHandler;
+import org.apache.ibatis.type.TypeHandler;
+import org.junit.Test;
+
+public class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<LocalTime> TYPE_HANDLER = new LocalTimeTypeHandler();
+  // java.sql.Time doesn't contain millis, so set nano to 0
+  private static final LocalTime LOCAL_TIME = LocalTime.now().withNano(0);
+  private static final Time TIME = Time.valueOf(LOCAL_TIME);
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, LOCAL_TIME, null);
+    verify(ps).setTime(1, TIME);
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getTime("column")).thenReturn(TIME);
+    assertEquals(LOCAL_TIME, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getTime("column")).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getTime(1)).thenReturn(TIME);
+    assertEquals(LOCAL_TIME, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getTime(1)).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getTime(1)).thenReturn(TIME);
+    assertEquals(LOCAL_TIME, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getTime(1)).thenReturn(null);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/usesjava8/MonthTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/MonthTypeHandlerTest.java
@@ -1,0 +1,89 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type.usesjava8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Month;
+
+import org.apache.ibatis.type.BaseTypeHandlerTest;
+import org.apache.ibatis.type.MonthTypeHandler;
+import org.apache.ibatis.type.TypeHandler;
+import org.junit.Test;
+
+/**
+ * 
+ * @author Eduardo Macarron
+ */
+public class MonthTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<Month> TYPE_HANDLER = new MonthTypeHandler();
+  private static final Month INSTANT = Month.JANUARY;
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+    verify(ps).setInt(1, INSTANT.getValue());
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getInt("column")).thenReturn(INSTANT.getValue());
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getInt("column")).thenReturn(0);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getInt(1)).thenReturn(INSTANT.getValue());
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getInt(1)).thenReturn(0);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getInt(1)).thenReturn(INSTANT.getValue());
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getInt(1)).thenReturn(0);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/type/usesjava8/OffsetDateTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/OffsetDateTimeTypeHandlerTest.java
@@ -1,0 +1,86 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type.usesjava8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.time.OffsetDateTime;
+
+import org.apache.ibatis.type.BaseTypeHandlerTest;
+import org.apache.ibatis.type.OffsetDateTimeTypeHandler;
+import org.apache.ibatis.type.TypeHandler;
+import org.junit.Test;
+
+public class OffsetDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<OffsetDateTime> TYPE_HANDLER = new OffsetDateTimeTypeHandler();
+  private static final OffsetDateTime OFFSET_DATE_TIME = OffsetDateTime.now();
+  private static final Timestamp TIMESTAMP = Timestamp.from(OFFSET_DATE_TIME.toInstant());
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, OFFSET_DATE_TIME, null);
+    verify(ps).setTimestamp(1, TIMESTAMP);
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
+    assertEquals(OFFSET_DATE_TIME, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getTimestamp("column")).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
+    assertEquals(OFFSET_DATE_TIME, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getTimestamp(1)).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
+    assertEquals(OFFSET_DATE_TIME, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getTimestamp(1)).thenReturn(null);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/usesjava8/OffsetTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/OffsetTimeTypeHandlerTest.java
@@ -1,0 +1,87 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type.usesjava8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Time;
+import java.time.OffsetTime;
+
+import org.apache.ibatis.type.BaseTypeHandlerTest;
+import org.apache.ibatis.type.OffsetTimeTypeHandler;
+import org.apache.ibatis.type.TypeHandler;
+import org.junit.Test;
+
+public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<OffsetTime> TYPE_HANDLER = new OffsetTimeTypeHandler();
+  // java.sql.Time doesn't contain millis, so set nano to 0
+  private static final OffsetTime OFFSET_TIME = OffsetTime.now().withNano(0);
+  private static final Time TIME = Time.valueOf(OFFSET_TIME.toLocalTime());
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, OFFSET_TIME, null);
+    verify(ps).setTime(1, TIME);
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getTime("column")).thenReturn(TIME);
+    assertEquals(OFFSET_TIME, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getTime("column")).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getTime(1)).thenReturn(TIME);
+    assertEquals(OFFSET_TIME, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getTime(1)).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getTime(1)).thenReturn(TIME);
+    assertEquals(OFFSET_TIME, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getTime(1)).thenReturn(null);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/usesjava8/YearMonthTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/YearMonthTypeHandlerTest.java
@@ -1,0 +1,85 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type.usesjava8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.time.YearMonth;
+
+import org.apache.ibatis.type.BaseTypeHandlerTest;
+import org.apache.ibatis.type.TypeHandler;
+import org.apache.ibatis.type.YearMonthTypeHandler;
+import org.junit.Test;
+
+/**
+ * @author Björn Raupach
+ */
+public class YearMonthTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<YearMonth> TYPE_HANDLER = new YearMonthTypeHandler();
+  private static final YearMonth INSTANT = YearMonth.now();
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+    verify(ps).setString(1, INSTANT.toString());
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getString("column")).thenReturn(INSTANT.toString());
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getString(1)).thenReturn(INSTANT.toString());
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getString(1)).thenReturn(INSTANT.toString());
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/type/usesjava8/YearTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/YearTypeHandlerTest.java
@@ -1,0 +1,89 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type.usesjava8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Year;
+
+import org.apache.ibatis.type.BaseTypeHandlerTest;
+import org.apache.ibatis.type.TypeHandler;
+import org.apache.ibatis.type.YearTypeHandler;
+import org.junit.Test;
+
+/**
+ * 
+ * @author Eduardo Macarron
+ */
+public class YearTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<Year> TYPE_HANDLER = new YearTypeHandler();
+  private static final Year INSTANT = Year.now();
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, INSTANT, null);
+    verify(ps).setInt(1, INSTANT.getValue());
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getInt("column")).thenReturn(INSTANT.getValue());
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getInt("column")).thenReturn(0);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getInt(1)).thenReturn(INSTANT.getValue());
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getInt(1)).thenReturn(0);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getInt(1)).thenReturn(INSTANT.getValue());
+    assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getInt(1)).thenReturn(0);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/type/usesjava8/ZonedDateTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/ZonedDateTimeTypeHandlerTest.java
@@ -1,0 +1,87 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type.usesjava8;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Timestamp;
+import java.time.ZonedDateTime;
+
+import org.apache.ibatis.type.BaseTypeHandlerTest;
+import org.apache.ibatis.type.TypeHandler;
+import org.apache.ibatis.type.ZonedDateTimeTypeHandler;
+import org.junit.Test;
+
+public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<ZonedDateTime> TYPE_HANDLER = new ZonedDateTimeTypeHandler();
+  private static final ZonedDateTime ZONED_DATE_TIME = ZonedDateTime.now();
+  private static final Timestamp TIMESTAMP = Timestamp.from(ZONED_DATE_TIME.toInstant());
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, ZONED_DATE_TIME, null);
+    verify(ps).setTimestamp(1, TIMESTAMP);
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
+    assertEquals(ZONED_DATE_TIME, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getTimestamp("column")).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
+    assertEquals(ZONED_DATE_TIME, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getTimestamp(1)).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
+    assertEquals(ZONED_DATE_TIME, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getTimestamp(1)).thenReturn(null);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+
+}


### PR DESCRIPTION
[typehandlers-jsr310](https://github.com/mybatis/typehandlers-jsr310) are for standard Java types and they belong to the core in the first place.
We didn't know how to include them in the core without breaking Java 6 compatibility, but we do now.
So I propose to merge them into the core.
It might be a little bit confusing at first, but I cannot think of any serious issue caused by this change.

Any thoughts?

Cc-ing: @emacarron @hazendaz @kazuki43zoo @trohovsky @raupachz