### PR TITLE
Apply strategy pattern on TypeAliasRegistry

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -45,6 +45,8 @@ import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.LocalCacheScope;
 import org.apache.ibatis.transaction.TransactionFactory;
 import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeAliasRegistry.TypeAliasGenerator;
+import org.apache.ibatis.type.TypeAliasRegistry.TypeAliasesPackageScanResultFilter;
 import org.apache.ibatis.type.TypeHandler;
 
 /**
@@ -106,6 +108,8 @@ public class XMLConfigBuilder extends BaseBuilder {
       propertiesElement(root.evalNode("properties"));
       Properties settings = settingsAsProperties(root.evalNode("settings"));
       loadCustomVfs(settings);
+      // before calling typeAliasesElement()
+      loadCustomTypeAliasingStrategy(settings);
       typeAliasesElement(root.evalNode("typeAliases"));
       pluginElement(root.evalNode("plugins"));
       objectFactoryElement(root.evalNode("objectFactory"));
@@ -148,6 +152,21 @@ public class XMLConfigBuilder extends BaseBuilder {
           configuration.setVfsImpl(vfsImpl);
         }
       }
+    }
+  }
+  
+  @SuppressWarnings("unchecked")
+  private void loadCustomTypeAliasingStrategy(Properties props) throws ClassNotFoundException {
+    String filterClassName = props.getProperty("typeAliasesPackageScanResultFilter");
+    if (filterClassName != null) {
+      typeAliasRegistry.setTypeAliasesPackageScanResultFilter(
+    		  (Class<? extends TypeAliasesPackageScanResultFilter>) Resources.classForName(filterClassName));
+    }
+    
+    String generatorClassName = props.getProperty("typeAliasGenerator");
+    if (generatorClassName != null) {
+      typeAliasRegistry.setTypeAliasGenerator(
+    		  (Class<? extends TypeAliasGenerator>) Resources.classForName(generatorClassName));
     }
   }
 

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -88,6 +88,8 @@ import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.apache.ibatis.transaction.managed.ManagedTransactionFactory;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeAliasRegistry;
+import org.apache.ibatis.type.TypeAliasRegistry.TypeAliasGenerator;
+import org.apache.ibatis.type.TypeAliasRegistry.TypeAliasesPackageScanResultFilter;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
 
@@ -477,7 +479,19 @@ public class Configuration {
   public TypeAliasRegistry getTypeAliasRegistry() {
     return typeAliasRegistry;
   }
-
+  
+  public void setTypeAliasesPackageScanResultFilter(Class<? extends TypeAliasesPackageScanResultFilter> clazz) {
+    if (clazz != null) {
+      getTypeAliasRegistry().setTypeAliasesPackageScanResultFilter(clazz);
+    }
+  }
+  
+  public void setTypeAliasGenerator(Class<? extends TypeAliasGenerator> clazz) {
+    if (clazz != null) {
+      getTypeAliasRegistry().setTypeAliasGenerator(clazz);
+    }
+  }
+  
   /**
    * @since 3.2.2
    */

--- a/src/test/java/org/apache/ibatis/builder/CustomTypeAliasGenerator.java
+++ b/src/test/java/org/apache/ibatis/builder/CustomTypeAliasGenerator.java
@@ -1,0 +1,26 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder;
+
+import org.apache.ibatis.type.TypeAliasRegistry.TypeAliasGenerator;
+
+public class CustomTypeAliasGenerator implements TypeAliasGenerator {
+	@Override
+	public String aliasFor(Class<?> type) {
+		String name = type.getName();
+		return name.substring(name.lastIndexOf(".") + 1);
+	}
+}

--- a/src/test/java/org/apache/ibatis/builder/CustomTypeAliasesPackageScanResultFilter.java
+++ b/src/test/java/org/apache/ibatis/builder/CustomTypeAliasesPackageScanResultFilter.java
@@ -1,0 +1,27 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder;
+
+import java.lang.reflect.Modifier;
+
+import org.apache.ibatis.type.TypeAliasRegistry.TypeAliasesPackageScanResultFilter;
+
+public class CustomTypeAliasesPackageScanResultFilter implements TypeAliasesPackageScanResultFilter {
+	@Override
+	public boolean include(Class<?> type) {
+		return !type.isMemberClass() || Modifier.isStatic(type.getModifiers());
+	}
+}

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -53,12 +53,16 @@
     <setting name="vfsImpl" value="org.apache.ibatis.io.JBoss6VFS"/>
     <setting name="configurationFactory" value="java.lang.String"/>
     <setting name="defaultEnumTypeHandler" value="org.apache.ibatis.type.EnumOrdinalTypeHandler"/>
+    <setting name="typeAliasesPackageScanResultFilter" value="org.apache.ibatis.builder.CustomTypeAliasesPackageScanResultFilter"/>
+    <setting name="typeAliasGenerator" value="org.apache.ibatis.builder.CustomTypeAliasGenerator"/>
   </settings>
 
   <typeAliases>
     <typeAlias alias="BlogAuthor" type="org.apache.ibatis.domain.blog.Author"/>
     <typeAlias type="org.apache.ibatis.domain.blog.Blog"/>
     <typeAlias type="org.apache.ibatis.domain.blog.Post"/>
+    <typeAlias type="org.apache.ibatis.domain.dummy.Foo$Type"/>
+    <typeAlias type="org.apache.ibatis.domain.dummy.Bar$Type"/>
     <package name="org.apache.ibatis.domain.jpetstore"/>
   </typeAliases>
 

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -276,6 +276,27 @@ public class XmlConfigBuilderTest {
   }
 
   @Test
+  public void nestedTypeAliasing() {
+	  final String MAPPER_CONFIG = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+			  + "<!DOCTYPE configuration PUBLIC \"-//mybatis.org//DTD Config 3.0//EN\" \"http://mybatis.org/dtd/mybatis-3-config.dtd\">\n"
+			  + "<configuration>\n"
+			  + "  <settings>\n"
+			  + "    <setting name=\"typeAliasesPackageScanResultFilter\" value=\"org.apache.ibatis.builder.CustomTypeAliasesPackageScanResultFilter\"/>\n"
+			  + "    <setting name=\"typeAliasGenerator\" value=\"org.apache.ibatis.builder.CustomTypeAliasGenerator\"/>\n"
+			  + "  </settings>\n"
+              + "  <typeAliases>\n"
+              + "    <package name=\"org.apache.ibatis.domain.dummy\"/>\n"
+              + "  </typeAliases>\n"
+			  + "</configuration>\n";
+	  
+	  XMLConfigBuilder builder = new XMLConfigBuilder(new StringReader(MAPPER_CONFIG));
+	  Configuration config = builder.parse();
+	  
+	  assertThat(config.getTypeAliasRegistry().resolveAlias("foo$type")).isNotNull().isEqualTo(Foo.Type.class);
+	  assertThat(config.getTypeAliasRegistry().resolveAlias("bar$type")).isNotNull().isEqualTo(Bar.Type.class);
+  }
+
+  @Test
   public void unknownJavaTypeOnTypeHandler() {
     final String MAPPER_CONFIG = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
             + "<!DOCTYPE configuration PUBLIC \"-//mybatis.org//DTD Config 3.0//EN\" \"http://mybatis.org/dtd/mybatis-3-config.dtd\">\n"

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -35,6 +35,8 @@ import org.apache.ibatis.domain.blog.Author;
 import org.apache.ibatis.domain.blog.Blog;
 import org.apache.ibatis.domain.blog.mappers.BlogMapper;
 import org.apache.ibatis.domain.blog.mappers.NestedBlogMapper;
+import org.apache.ibatis.domain.dummy.Bar;
+import org.apache.ibatis.domain.dummy.Foo;
 import org.apache.ibatis.domain.jpetstore.Cart;
 import org.apache.ibatis.executor.loader.cglib.CglibProxyFactory;
 import org.apache.ibatis.executor.loader.javassist.JavassistProxyFactory;
@@ -197,6 +199,8 @@ public class XmlConfigBuilderTest {
       assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("blogauthor").equals(Author.class));
       assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("blog").equals(Blog.class));
       assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("cart").equals(Cart.class));
+      assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("foo$type").equals(Foo.Type.class));
+      assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("bar$type").equals(Bar.Type.class));
 
       assertThat(config.getTypeHandlerRegistry().getTypeHandler(Integer.class)).isInstanceOf(CustomIntegerTypeHandler.class);
       assertThat(config.getTypeHandlerRegistry().getTypeHandler(Long.class)).isInstanceOf(CustomLongTypeHandler.class);

--- a/src/test/java/org/apache/ibatis/domain/dummy/Bar.java
+++ b/src/test/java/org/apache/ibatis/domain/dummy/Bar.java
@@ -1,0 +1,33 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.domain.dummy;
+
+public class Bar {
+
+	private Type type;
+	
+	public Type getType() {
+		return type;
+	}
+
+	public void setType(Type type) {
+		this.type = type;
+	}
+
+	public enum Type {
+		C, D;
+	}
+}

--- a/src/test/java/org/apache/ibatis/domain/dummy/Foo.java
+++ b/src/test/java/org/apache/ibatis/domain/dummy/Foo.java
@@ -1,0 +1,33 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.domain.dummy;
+
+public class Foo {
+
+	private Type type;
+	
+	public Type getType() {
+		return type;
+	}
+
+	public void setType(Type type) {
+		this.type = type;
+	}
+
+	public enum Type {
+		A, B;
+	}
+}

--- a/src/test/java/org/apache/ibatis/type/TypeAliasRegistryTest.java
+++ b/src/test/java/org/apache/ibatis/type/TypeAliasRegistryTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 
 import org.apache.ibatis.builder.CustomTypeAliasGenerator;

--- a/src/test/java/org/apache/ibatis/type/TypeAliasRegistryTest.java
+++ b/src/test/java/org/apache/ibatis/type/TypeAliasRegistryTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,12 +15,19 @@
  */
 package org.apache.ibatis.type;
 
+import static com.googlecode.catchexception.apis.BDDCatchException.caughtException;
+import static com.googlecode.catchexception.apis.BDDCatchException.when;
+import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
-import org.junit.Test;
-
+import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
+
+import org.apache.ibatis.builder.CustomTypeAliasGenerator;
+import org.apache.ibatis.domain.dummy.Bar;
+import org.apache.ibatis.domain.dummy.Foo;
+import org.junit.Test;
 
 public class TypeAliasRegistryTest {
 
@@ -65,5 +72,40 @@ public class TypeAliasRegistryTest {
     typeAliasRegistry.registerAlias("foo", (Class<?>) null);
     typeAliasRegistry.registerAlias("foo", String.class);
   }
-
+  
+  @Test
+  public void shouldBeSimpleClassNameIfTypeAliasGeneratorIsNotSpecified() {
+    TypeAliasRegistry typeAliasRegistry = new TypeAliasRegistry();
+    
+    typeAliasRegistry.registerAlias(Foo.class);
+    typeAliasRegistry.registerAlias(Bar.class);
+    assertEquals(Foo.class, typeAliasRegistry.getTypeAliases().get("foo"));
+    assertEquals(Bar.class, typeAliasRegistry.getTypeAliases().get("bar"));
+    
+    typeAliasRegistry.registerAlias(Foo.Type.class);
+    assertEquals(Foo.Type.class, typeAliasRegistry.getTypeAliases().get("type"));
+    
+    when(typeAliasRegistry).registerAlias(Bar.Type.class);
+    
+    then(caughtException())
+    .isInstanceOf(TypeException.class)
+    .hasMessageContaining("The alias 'Type' is already mapped to the value");
+  }
+  
+  @Test
+  public void shouldBeAbleToRegisterDifferentNestedTypesHavingSameSimpleNameUsingCustomTypeAliasGenerator() {
+    TypeAliasRegistry typeAliasRegistry = new TypeAliasRegistry();
+    typeAliasRegistry.setTypeAliasGenerator(CustomTypeAliasGenerator.class);
+    
+    typeAliasRegistry.registerAlias(Foo.class);
+    typeAliasRegistry.registerAlias(Bar.class);
+    assertEquals(Foo.class, typeAliasRegistry.getTypeAliases().get("foo"));
+    assertEquals(Bar.class, typeAliasRegistry.getTypeAliases().get("bar"));
+    
+    typeAliasRegistry.registerAlias(Foo.Type.class);
+    typeAliasRegistry.registerAlias(Bar.Type.class);
+    assertNull(typeAliasRegistry.getTypeAliases().get("type"));
+    assertEquals(Foo.Type.class, typeAliasRegistry.getTypeAliases().get("foo$type"));
+    assertEquals(Bar.Type.class, typeAliasRegistry.getTypeAliases().get("bar$type"));
+  }
 }


### PR DESCRIPTION
I'am poor at English. You might see awkward expressions. 
And this is my first PR at public github! Please be generous.
Thanks in advance. :)

---

There're many nested enum types in my project like described in issue #6.
(every enum implements custom interface called `Coded`)

To solve this(nested enum type alias & handler registering), I had customized `SqlSessionFactoryBean` in some tricky way.
(before parsing mapper files, register type aliases/handlers for all sub types.)

And I used like below :
- In Java,
```java
package my.domain;

public class A {
   private B b;
   public enum B implements Coded<Integer> { 
      ONE(1), TWO(2); 
      @Override
      public Integer getCode() { ... }
   }
}
```
- In Mapper XML,
```xml
<resultMap type="A" ...>
    <result property="b" javaType="A$B" ... />
</resultMap>
```

Then I found good news lately. It was #859  #970 !

But, type alias problem was remained. I think both of the following ways seem to be somewhat exhausting.
- attaching `@Alias` annotation on every nested types
- fully specifying type name on every mapper (e.g. `my.domain.A$B`)

---

I think it would be nice, if..
- Support nested type aliasing automatically (no descriptive way)
- Support customizing an alias generating (`Class#getSimpleName` + other options)

So... That's what I want and what this branch contains : **customizable `TypeAliasRegistry`**