### PR TITLE
Potential fix for #997

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -344,7 +344,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
     skipRows(rsw.getResultSet(), rowBounds);
     while (shouldProcessMoreRows(resultContext, rowBounds) && rsw.getResultSet().next()) {
       ResultMap discriminatedResultMap = resolveDiscriminatedResultMap(rsw.getResultSet(), resultMap, null);
-      Object rowValue = getRowValue(rsw, discriminatedResultMap);
+      Object rowValue = getRowValue(rsw, discriminatedResultMap, false);
       storeObject(resultHandler, resultContext, rowValue, parentMapping, rsw.getResultSet());
     }
   }
@@ -383,13 +383,13 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   // GET VALUE FROM ROW FOR SIMPLE RESULT MAP
   //
 
-  private Object getRowValue(ResultSetWrapper rsw, ResultMap resultMap) throws SQLException {
+  private Object getRowValue(ResultSetWrapper rsw, ResultMap resultMap, final boolean isNested) throws SQLException {
     final ResultLoaderMap lazyLoader = new ResultLoaderMap();
     Object rowValue = createResultObject(rsw, resultMap, lazyLoader, null);
     if (rowValue != null && !hasTypeHandlerForResultObject(rsw, resultMap.getType())) {
       final MetaObject metaObject = configuration.newMetaObject(rowValue);
       boolean foundValues = this.useConstructorMappings;
-      if (shouldApplyAutomaticMappings(resultMap, false)) {
+      if (shouldApplyAutomaticMappings(resultMap, isNested)) {
         foundValues = applyAutomaticMappings(rsw, resultMap, metaObject, null) || foundValues;
       }
       foundValues = applyPropertyMappings(rsw, resultMap, metaObject, lazyLoader, null) || foundValues;
@@ -627,7 +627,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
           value = getNestedQueryConstructorValue(rsw.getResultSet(), constructorMapping, columnPrefix);
         } else if (constructorMapping.getNestedResultMapId() != null) {
           final ResultMap resultMap = configuration.getResultMap(constructorMapping.getNestedResultMapId());
-          value = getRowValue(rsw, resultMap);
+          value = getRowValue(rsw, resultMap, true);
         } else {
           final TypeHandler<?> typeHandler = constructorMapping.getTypeHandler();
           value = typeHandler.getResult(rsw.getResultSet(), prependPrefix(column, columnPrefix));

--- a/src/test/java/org/apache/ibatis/BaseMapperTest.java
+++ b/src/test/java/org/apache/ibatis/BaseMapperTest.java
@@ -1,0 +1,60 @@
+/*
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.sql.Connection;
+
+public abstract class BaseMapperTest {
+  protected SqlSessionFactory sqlSessionFactory;
+  protected SqlSession sqlSession;
+
+  @Before
+  public final void setupSession() throws Exception {
+    // create a SqlSessionFactory
+    final Reader reader = asReader("./mybatis-config.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
+
+    // populate in-memory database
+    sqlSession = sqlSessionFactory.openSession();
+    final SqlSession session = sqlSession;
+    final Connection conn = session.getConnection();
+    final Reader dbReader = asReader("./CreateDB.sql");
+    final ScriptRunner runner = new ScriptRunner(conn);
+    runner.setLogWriter(null);
+    runner.runScript(dbReader);
+    dbReader.close();
+  }
+
+  @After
+  public final void tearDownSession() {
+    sqlSession.close();
+  }
+
+  private Reader asReader(final String resource) throws IOException {
+    return Resources.getUrlAsReader(getClass().getResource(resource).toString());
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/constructor_args_997/Child.java
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_args_997/Child.java
@@ -1,0 +1,70 @@
+/*
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.constructor_args_997;
+
+public class Child {
+  private final String id;
+  private final String name;
+  private final Parent parent;
+
+  public Child(String id, String name, Parent parent) {
+    System.out.println("CHILD: id = [" + id + "], name = [" + name + "], parent = [" + parent + "]");
+    this.id = id;
+    this.name = name;
+    this.parent = parent;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Parent getParent() {
+    return parent;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    Child child = (Child) o;
+
+    if (id != null ? !id.equals(child.id) : child.id != null) return false;
+    if (name != null ? !name.equals(child.name) : child.name != null) return false;
+    return parent != null ? parent.equals(child.parent) : child.parent == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = id != null ? id.hashCode() : 0;
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    result = 31 * result + (parent != null ? parent.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "Child{" +
+      "id='" + id + '\'' +
+      ", name='" + name + '\'' +
+      ", parent=" + parent +
+      '}';
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/constructor_args_997/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_args_997/CreateDB.sql
@@ -1,0 +1,44 @@
+--
+--    Copyright 2009-2017 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+DROP TABLE child_t
+IF EXISTS;
+
+DROP TABLE parent_t
+IF EXISTS;
+
+CREATE TABLE child_t (
+  id     VARCHAR(10),
+  name   VARCHAR(30),
+  family VARCHAR(10)
+);
+
+CREATE TABLE parent_t (
+  id     VARCHAR(10),
+  name   VARCHAR(30),
+  family VARCHAR(10)
+);
+
+CREATE VIEW child AS
+  SELECT
+    c.id,
+    c.name,
+    p.id   AS p_id,
+    p.name AS p_name
+  FROM child_t c LEFT JOIN parent_t p ON (c.family = p.family);
+
+INSERT INTO child_t VALUES ('C10', 'Child Name', 'FAM1');
+INSERT INTO parent_t VALUES ('P11', 'Parent Name', 'FAM1');

--- a/src/test/java/org/apache/ibatis/submitted/constructor_args_997/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_args_997/Mapper.java
@@ -1,0 +1,20 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.constructor_args_997;
+
+public interface Mapper {
+  Child findById(String id);
+}

--- a/src/test/java/org/apache/ibatis/submitted/constructor_args_997/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_args_997/Mapper.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8' ?>
+<!--
+
+       Copyright 2009-2017 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+  PUBLIC '-//mybatis.org//DTD Config 3.0//EN'
+  'http://mybatis.org/dtd/mybatis-3-mapper.dtd'>
+<mapper namespace="org.apache.ibatis.submitted.constructor_args_997.Mapper">
+  <resultMap id="ParentResultMap" type="org.apache.ibatis.submitted.constructor_args_997.Parent">
+    <constructor>
+      <arg column="p_id" javaType="java.lang.String" jdbcType="VARCHAR"/>
+      <arg column="p_name" javaType="java.lang.String" jdbcType="VARCHAR"/>
+    </constructor>
+  </resultMap>
+
+  <resultMap id="ChildResultMap" type="org.apache.ibatis.submitted.constructor_args_997.Child">
+    <constructor>
+      <idArg column="id" javaType="java.lang.String" jdbcType="VARCHAR"/>
+      <arg column="name" javaType="java.lang.String" jdbcType="VARCHAR"/>
+      <arg resultMap="ParentResultMap" javaType="org.apache.ibatis.submitted.constructor_args_997.Parent"/>
+    </constructor>
+  </resultMap>
+
+  <select id="findById" resultMap="ChildResultMap">
+    SELECT id, name, p_id, p_name
+    FROM Child
+    WHERE id = #{id,jdbcType=VARCHAR}
+  </select>
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/constructor_args_997/MapperTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_args_997/MapperTest.java
@@ -1,0 +1,29 @@
+/*
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.constructor_args_997;
+
+import org.apache.ibatis.BaseMapperTest;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MapperTest extends BaseMapperTest {
+  @Test
+  public void testFindById() {
+    final Mapper mapper = sqlSession.getMapper(Mapper.class);
+    Child expected = new Child("C10", "Child Name", new Parent("P11", "Parent Name"));
+    Assert.assertEquals(expected, mapper.findById("C10"));
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/constructor_args_997/Parent.java
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_args_997/Parent.java
@@ -1,0 +1,61 @@
+/*
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.constructor_args_997;
+
+public class Parent {
+  private final String id;
+  private final String name;
+
+  public Parent(String id, String name) {
+    System.out.println("PARENT: id = [" + id + "], name = [" + name + "]");
+    this.id = id;
+    this.name = name;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    Parent parent = (Parent) o;
+
+    if (id != null ? !id.equals(parent.id) : parent.id != null) return false;
+    return name != null ? name.equals(parent.name) : parent.name == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = id != null ? id.hashCode() : 0;
+    result = 31 * result + (name != null ? name.hashCode() : 0);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "Parent{" +
+      "id='" + id + '\'' +
+      ", name='" + name + '\'' +
+      '}';
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/constructor_args_997/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_args_997/mybatis-config.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2017 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+	<environments default="development">
+		<environment id="development">
+			<transactionManager type="JDBC">
+				<property name="" value="" />
+			</transactionManager>
+			<dataSource type="UNPOOLED">
+				<property name="driver" value="org.hsqldb.jdbcDriver" />
+				<property name="url" value="jdbc:hsqldb:mem:complex_type" />
+				<property name="username" value="sa" />
+			</dataSource>
+		</environment>
+	</environments>
+
+	<mappers>
+		<mapper resource="org/apache/ibatis/submitted/constructor_args_997/Mapper.xml" />
+	</mappers>
+
+</configuration>


### PR DESCRIPTION
I'll like to wait for at least @emacarron to review this as he introduces that check for a different issue.
I'm not quite comfortable relaying on automapping behaviors to control this.

Another possible fix is how we decide what has `setMethods` in `Reflector`.
I don't see why `final` fields are in there other than for the use case of *maybe* auto incremented db ids.
But that could be solved by adding an appropriate constructor.

#997 