### PR TITLE
Add JSON support Feature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,6 +263,13 @@
       <version>1.4.4</version>
       <scope>test</scope>
     </dependency>
+    <!-- For json handler -->
+    <dependency>
+      <groupId>com.alibaba</groupId>
+      <artifactId>fastjson</artifactId>
+      <version>1.2.32</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -86,10 +86,7 @@ import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
 import org.apache.ibatis.transaction.Transaction;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.apache.ibatis.transaction.managed.ManagedTransactionFactory;
-import org.apache.ibatis.type.JdbcType;
-import org.apache.ibatis.type.TypeAliasRegistry;
-import org.apache.ibatis.type.TypeHandler;
-import org.apache.ibatis.type.TypeHandlerRegistry;
+import org.apache.ibatis.type.*;
 
 /**
  * @author Clinton Begin
@@ -131,6 +128,7 @@ public class Configuration {
   protected ProxyFactory proxyFactory = new JavassistProxyFactory(); // #224 Using internal Javassist instead of OGNL
 
   protected String databaseId;
+  protected String defaultJsonTypeHandler = "";
   /**
    * Configuration factory class.
    * Used to create Configuration for loading deserialized unread properties.
@@ -471,6 +469,42 @@ public class Configuration {
   public void setDefaultEnumTypeHandler(Class<? extends TypeHandler> typeHandler) {
     if (typeHandler != null) {
       getTypeHandlerRegistry().setDefaultEnumTypeHandler(typeHandler);
+    }
+  }
+
+  public String getDefaultJsonTypeHandler() {
+    return defaultJsonTypeHandler;
+  }
+
+  /**
+   * Set a default {@link JsonTypeHandler} class for Json type
+   * the default {@link JsonTypeHandler} is not set,
+   * user can extend the abstract class {@link BaseJsonTypeHandler} to implement it.
+   * @param jsonTypeHandler a JsonTypeHandler class for Json
+   * @since 3.4.5
+   */
+  public void setDefaultJsonTypeHandler(JsonTypeHandler jsonTypeHandler) {
+    if (jsonTypeHandler != null) {
+      this.defaultJsonTypeHandler = jsonTypeHandler.getClass().getName();
+      getTypeHandlerRegistry().setDefaultJsonTypeHandler(jsonTypeHandler);
+    }
+  }
+
+  /**
+   * Set a default {@link JsonTypeHandler} class for Json type
+   * the default {@link JsonTypeHandler} is not set,
+   * user can extend the abstract class {@link BaseJsonTypeHandler} to implement it.
+   * How to config defaultJsonTypeHandler ?
+   * 1. application.properties(Spring Boot Project): mybatis.configuration.defaultJsonTypeHandler=your_class_name
+   * 2. mybatis-config.xml(Spring Project): ?
+   * @param className a JsonTypeHandler implement class name.
+   * @since 3.4.5
+   */
+  public void setDefaultJsonTypeHandler(String className) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+    if (className!=null && className.length() > 0) {
+      JsonTypeHandler jsonTypeHandler = (JsonTypeHandler) Class.forName(className).newInstance();
+      this.defaultJsonTypeHandler = className;
+      getTypeHandlerRegistry().setDefaultJsonTypeHandler(jsonTypeHandler);
     }
   }
 

--- a/src/main/java/org/apache/ibatis/type/BaseJsonTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BaseJsonTypeHandler.java
@@ -1,0 +1,58 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.lang.reflect.Type;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ *
+ * @author tianhao
+ */
+public abstract class BaseJsonTypeHandler extends BaseTypeHandler<Object> implements JsonTypeHandler {
+
+    @Override
+    public abstract void setNonNullParameter(PreparedStatement ps, int i, Object parameter, JdbcType jdbcType)
+            throws SQLException;
+
+    @Override
+    public abstract Object getNullableResult(ResultSet rs, String columnName, String property, Object targetObject)
+            throws SQLException;
+
+    @Override
+    public abstract Object getNullableResult(ResultSet rs, String columnName, Type targetType) throws SQLException;
+
+    @Override
+    public Object getNullableResult(ResultSet rs, String columnName)
+            throws SQLException {
+        return rs.getObject(columnName);
+    }
+
+    @Override
+    public Object getNullableResult(ResultSet rs, int columnIndex)
+            throws SQLException {
+        return rs.getObject(columnIndex);
+    }
+
+    @Override
+    public Object getNullableResult(CallableStatement cs, int columnIndex)
+            throws SQLException {
+        return cs.getObject(columnIndex);
+    }
+}

--- a/src/main/java/org/apache/ibatis/type/JsonTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/JsonTypeHandler.java
@@ -30,6 +30,4 @@ public interface JsonTypeHandler extends TypeHandler<Object> {
     Object getNullableResult(ResultSet rs, String columnName, String property, Object targetObject) throws SQLException;
 
     Object getNullableResult(ResultSet rs, String columnName, Type targetType) throws SQLException;
-
-    void setNonNullParameter(PreparedStatement ps, int i, Object parameter, JdbcType jdbcType) throws SQLException;
 }

--- a/src/main/java/org/apache/ibatis/type/JsonTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/JsonTypeHandler.java
@@ -1,0 +1,35 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.session.Configuration;
+
+import java.lang.reflect.Type;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * @author tianhao
+ */
+public interface JsonTypeHandler extends TypeHandler<Object> {
+    Object getNullableResult(ResultSet rs, String columnName, String property, Object targetObject) throws SQLException;
+
+    Object getNullableResult(ResultSet rs, String columnName, Type targetType) throws SQLException;
+
+    void setNonNullParameter(PreparedStatement ps, int i, Object parameter, JdbcType jdbcType) throws SQLException;
+}

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -230,7 +230,7 @@ public final class TypeHandlerRegistry {
         handler = pickSoleHandler(jdbcHandlerMap);
       }
     }
-    // if handler is null and jdbcType is JSON or OTHER, use defaultJsonTypeHandler
+    // if handler is null and jdbcType is OTHER, use defaultJsonTypeHandler
     if (handler == null && jdbcType != null && JdbcType.OTHER.equals(jdbcType)){
       handler = defaultJsonTypeHandler;
     }

--- a/src/test/java/org/apache/ibatis/type/FastJsonTypeHandler.java
+++ b/src/test/java/org/apache/ibatis/type/FastJsonTypeHandler.java
@@ -17,7 +17,6 @@ package org.apache.ibatis.type;
 
 import com.alibaba.fastjson.JSON;
 import org.apache.ibatis.executor.result.ResultMapException;
-import org.apache.ibatis.reflection.MetaObject;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
@@ -34,7 +33,7 @@ import java.util.NoSuchElementException;
  */
 public class FastJsonTypeHandler extends BaseJsonTypeHandler {
 
-    private final Map<String, Type> fieldClassCache = new HashMap<String, Type>();
+    private final Map<String, Type> fieldTypeCache = new HashMap<String, Type>();
 
     @Override
     public void setNonNullParameter(PreparedStatement ps, int i, Object parameter, JdbcType jdbcType)
@@ -48,13 +47,13 @@ public class FastJsonTypeHandler extends BaseJsonTypeHandler {
         try {
             String jsonStr = rs.getString(columnName);
             String key = targetObject.getClass().getName() + ":" + columnName;
-            if (fieldClassCache.containsKey(key)) {
-                Type type = fieldClassCache.get(key);
+            if (fieldTypeCache.containsKey(key)) {
+                Type type = fieldTypeCache.get(key);
                 return JSON.parseObject(jsonStr, type);
             }
             Field field = getField(targetObject.getClass(), property);
             Type type = field.getGenericType();
-            fieldClassCache.put(key, type);
+            fieldTypeCache.put(key, type);
             return JSON.parseObject(jsonStr, type);
         } catch (Exception e) {
             throw new ResultMapException("Error attempting to get column '" + columnName +

--- a/src/test/java/org/apache/ibatis/type/FastJsonTypeHandler.java
+++ b/src/test/java/org/apache/ibatis/type/FastJsonTypeHandler.java
@@ -88,6 +88,6 @@ public class FastJsonTypeHandler extends BaseJsonTypeHandler {
                 }
             }
         }
-        throw new NoSuchElementException("No Field '"+ name + "' for Class "+ cls.getName());
+        throw new NoSuchFieldException("No Field '"+ name + "' for Class "+ cls.getName());
     }
 }

--- a/src/test/java/org/apache/ibatis/type/FastJsonTypeHandler.java
+++ b/src/test/java/org/apache/ibatis/type/FastJsonTypeHandler.java
@@ -1,0 +1,94 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import com.alibaba.fastjson.JSON;
+import org.apache.ibatis.executor.result.ResultMapException;
+import org.apache.ibatis.reflection.MetaObject;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Type;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * A Implement example of JsonTypeHandler
+ * @author tianhao
+ */
+public class FastJsonTypeHandler extends BaseJsonTypeHandler {
+
+    private final Map<String, Type> fieldClassCache = new HashMap<String, Type>();
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, Object parameter, JdbcType jdbcType)
+            throws SQLException {
+        ps.setString(i, JSON.toJSONString(parameter));
+    }
+
+    @Override
+    public Object getNullableResult(ResultSet rs, String columnName, String property, Object targetObject)
+            throws SQLException {
+        try {
+            String jsonStr = rs.getString(columnName);
+            String key = targetObject.getClass().getName() + ":" + columnName;
+            if (fieldClassCache.containsKey(key)) {
+                Type type = fieldClassCache.get(key);
+                return JSON.parseObject(jsonStr, type);
+            }
+            Field field = getField(targetObject.getClass(), property);
+            Type type = field.getGenericType();
+            fieldClassCache.put(key, type);
+            return JSON.parseObject(jsonStr, type);
+        } catch (Exception e) {
+            throw new ResultMapException("Error attempting to get column '" + columnName +
+                    "' from result set.  Cause: " + e, e);
+        }
+    }
+
+    @Override
+    public Object getNullableResult(ResultSet rs, String columnName, Type targetType) throws SQLException {
+        try {
+            String jsonStr = rs.getString(columnName);
+            return JSON.parseObject(jsonStr, targetType);
+        } catch (Exception e) {
+            throw new ResultMapException("Error attempting to get column '" + columnName +
+                    "' from result set.  Cause: " + e, e);
+        }
+    }
+
+    /*
+     * Find name field in cls and it's superClass,until found or encountered Object.class
+     */
+    private static Field getField(Class cls, String name) throws NoSuchFieldException {
+        try {
+            return cls.getDeclaredField(name);
+        } catch (NoSuchFieldException var6) {
+            Class current = cls;
+            while (cls != Object.class) {
+                try {
+                    return current.getDeclaredField(name);
+                } catch (NoSuchFieldException var5) {
+                    current = current.getSuperclass();
+                }
+            }
+        }
+        throw new NoSuchElementException("No Field '"+ name + "' for Class "+ cls.getName());
+    }
+}

--- a/src/test/java/org/apache/ibatis/type/JsonTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/JsonTypeHandlerTest.java
@@ -1,0 +1,214 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import com.alibaba.fastjson.JSON;
+import org.apache.ibatis.executor.result.ResultMapException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.sql.SQLException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class JsonTypeHandlerTest extends BaseTypeHandlerTest {
+
+  /*
+   * JsonEntity is json column
+   */
+  public static class JsonEntity{
+    private String name;
+    private Integer age;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public Integer getAge() {
+      return age;
+    }
+
+    public void setAge(Integer age) {
+      this.age = age;
+    }
+  }
+  public static class TableEntity{
+    Integer id;
+    JsonEntity jsonEntity;
+
+    public Integer getId() {
+      return id;
+    }
+
+    public void setId(Integer id) {
+      this.id = id;
+    }
+
+    public JsonEntity getJsonEntity() {
+      return jsonEntity;
+    }
+
+    public void setJsonEntity(JsonEntity jsonEntity) {
+      this.jsonEntity = jsonEntity;
+    }
+  }
+
+  private static JsonEntity jsonEntity = new JsonEntity();
+  private static String jsonString;
+  private static TableEntity tableEntity = new TableEntity();
+  private static final JsonTypeHandler JSON_TYPE_HANDLER = spy(new FastJsonTypeHandler());
+
+  static {
+    jsonEntity.setAge(10);
+    jsonEntity.setName("Jack");
+    jsonString = JSON.toJSONString(jsonEntity);
+    tableEntity.setId(1);
+    tableEntity.setJsonEntity(jsonEntity);
+  }
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    JSON_TYPE_HANDLER.setParameter(ps, 1, jsonEntity, null);
+    verify(ps).setString(1, jsonString);
+  }
+
+  @Test
+  public void shouldGetResultFromResultSetByNamePropertyObject() throws Exception{
+      when(rs.getString("column")).thenReturn(jsonString);
+      JsonEntity dbData = (JsonEntity) JSON_TYPE_HANDLER.getNullableResult(rs, "column", "jsonEntity", tableEntity);
+      assertEquals(jsonEntity.getAge(),dbData.getAge());
+      assertEquals(jsonEntity.getName(),dbData.getName());
+  }
+
+  @Test
+  public void shouldGetResultFromResultSetByNameType() throws Exception{
+      when(rs.getString("column")).thenReturn(jsonString);
+      JsonEntity dbData = (JsonEntity) JSON_TYPE_HANDLER.getNullableResult(rs, "column", JsonEntity.class);
+      assertEquals(jsonEntity.getAge(),dbData.getAge());
+      assertEquals(jsonEntity.getName(),dbData.getName());
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+      when(rs.getObject("column")).thenReturn(jsonString);
+      when(rs.wasNull()).thenReturn(false);
+      assertEquals(jsonString, JSON_TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    // Unnecessary
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getObject(1)).thenReturn(jsonString);
+    when(rs.wasNull()).thenReturn(false);
+    assertEquals(jsonString, JSON_TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    // Unnecessary
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getObject(1)).thenReturn("Hello");
+    when(cs.wasNull()).thenReturn(false);
+    assertEquals("Hello", JSON_TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    // Unnecessary
+  }
+
+  @Test
+  public void setParameterWithNullParameter() throws Exception {
+    JSON_TYPE_HANDLER.setParameter(ps, 0, null, JdbcType.OTHER);
+    verify(ps).setNull(0, JdbcType.OTHER.TYPE_CODE);
+  }
+
+  @Test
+  public void setParameterWithNullParameterThrowsException() throws SQLException {
+    doThrow(new SQLException("invalid column")).when(ps).setNull(1, JdbcType.OTHER.TYPE_CODE);
+    try {
+      JSON_TYPE_HANDLER.setParameter(ps, 1, null, JdbcType.OTHER);
+      Assert.fail("Should have thrown a TypeException");
+    } catch (Exception e) {
+      Assert.assertTrue("Expected TypedException", e instanceof TypeException);
+      Assert.assertTrue("Parameter index is in exception", e.getMessage().contains("parameter #1"));
+    }
+  }
+
+  @Test
+  public void setParameterWithNonNullParameterThrowsException() throws SQLException {
+    doThrow(new SQLException("invalid column")).when((FastJsonTypeHandler)JSON_TYPE_HANDLER).setNonNullParameter(ps, 1, jsonEntity, JdbcType.OTHER);
+    try {
+      JSON_TYPE_HANDLER.setParameter(ps, 1, jsonEntity, JdbcType.OTHER);
+      Assert.fail("Should have thrown a TypeException");
+    } catch (Exception e) {
+      Assert.assertTrue("Expected TypedException", e instanceof TypeException);
+      Assert.assertTrue("Parameter index is in exception", e.getMessage().contains("parameter #1"));
+    }
+  }
+
+  @Test
+  public void getResultWithResultSetAndColumnNameThrowsException() throws SQLException {
+    doThrow(new SQLException("invalid column")).when((FastJsonTypeHandler)JSON_TYPE_HANDLER).getNullableResult(rs, "foo");
+    try {
+      JSON_TYPE_HANDLER.getResult(rs, "foo");
+      Assert.fail("Should have thrown a ResultMapException");
+    } catch (Exception e) {
+      Assert.assertTrue("Expected ResultMapException", e instanceof ResultMapException);
+      Assert.assertTrue("column name is not in exception", e.getMessage().contains("column 'foo'"));
+    }
+  }
+
+  @Test
+  public void getResultWithResultSetAndColumnIndexThrowsException() throws SQLException {
+    doThrow(new SQLException("invalid column")).when((FastJsonTypeHandler)JSON_TYPE_HANDLER).getNullableResult(rs, 1);
+    try {
+      JSON_TYPE_HANDLER.getResult(rs, 1);
+      Assert.fail("Should have thrown a ResultMapException");
+    } catch (Exception e) {
+      Assert.assertTrue("Expected ResultMapException", e instanceof ResultMapException);
+      Assert.assertTrue("column index is not in exception", e.getMessage().contains("column #1"));
+    }
+  }
+
+  @Test
+  public void getResultWithCallableStatementAndColumnIndexThrowsException() throws SQLException {
+    doThrow(new SQLException("invalid column")).when((FastJsonTypeHandler)JSON_TYPE_HANDLER).getNullableResult(cs, 1);
+    try {
+      JSON_TYPE_HANDLER.getResult(cs, 1);
+      Assert.fail("Should have thrown a ResultMapException");
+    } catch (Exception e) {
+      Assert.assertTrue("Expected ResultMapException", e instanceof ResultMapException);
+      Assert.assertTrue("column index is not in exception", e.getMessage().contains("column #1"));
+    }
+  }
+
+}


### PR DESCRIPTION
Json support Demo: https://github.com/tianhao/mybatis-JsonTypeHandler

## target effect
1. If the user does not implement or does not configure the defaultJsonTypeHandler, there will be no ;
2. If the user is configured with defaultJsonTypeHandler: when not found typeHandler to deal read/write and jdbcType is JdbcType.OTHER, use the defaultJsonTypeHandler, Call the following special method.

--------
I want a typeHandler, it can deserialize json string to any target object property, the `getResult(ResultSet rs, String columnName)` method's parameters is not enough, because it need target type, and the target type incoming in runtime

So I define a interface:

```
public interface JsonTypeHandler extends TypeHandler<Object> {
    Object getNullableResult(ResultSet rs, String columnName, String property, Object targetObject) throws SQLException;
    Object getNullableResult(ResultSet rs, String columnName, Type targetType) throws SQLException;
}
```
And a implement with fastjson

```
public class FastJsonTypeHandler extends BaseJsonTypeHandler {

    private final Map<String, Type> fieldTypeCache = new HashMap<String, Type>();

    @Override
    public void setNonNullParameter(PreparedStatement ps, int i, Object parameter, JdbcType jdbcType)
            throws SQLException {
        ps.setString(i, JSON.toJSONString(parameter));
    }

    @Override
    public Object getNullableResult(ResultSet rs, String columnName, String property, Object targetObject)
            throws SQLException {
        try {
            String jsonStr = rs.getString(columnName);
            String key = targetObject.getClass().getName() + ":" + columnName;
            if (fieldTypeCache.containsKey(key)) {
                Type type = fieldTypeCache.get(key);
                return JSON.parseObject(jsonStr, type);
            }
            Field field = getField(targetObject.getClass(), property);
            Type type = field.getGenericType();
            fieldTypeCache.put(key, type);
            return JSON.parseObject(jsonStr, type);
        } catch (Exception e) {
            throw new ResultMapException("Error attempting to get column '" + columnName +
                    "' from result set.  Cause: " + e, e);
        }
    }

    @Override
    public Object getNullableResult(ResultSet rs, String columnName, Type targetType) throws SQLException {
        try {
            String jsonStr = rs.getString(columnName);
            return JSON.parseObject(jsonStr, targetType);
        } catch (Exception e) {
            throw new ResultMapException("Error attempting to get column '" + columnName +
                    "' from result set.  Cause: " + e, e);
        }
    }

    /*
     * Find name field in cls and it's superClass,until found or encountered Object.class
     */
    private static Field getField(Class cls, String name) throws NoSuchFieldException {
        try {
            return cls.getDeclaredField(name);
        } catch (NoSuchFieldException var6) {
            Class current = cls;
            while (cls != Object.class) {
                try {
                    return current.getDeclaredField(name);
                } catch (NoSuchFieldException var5) {
                    current = current.getSuperclass();
                }
            }
        }
        throw new NoSuchElementException("No Field '"+ name + "' for Class "+ cls.getName());
    }
}
```

# Modify the mybatis code to make it work 
## add option in Configuration.java
```
  protected String defaultJsonTypeHandler = "";

  public String getDefaultJsonTypeHandler() {
    return defaultJsonTypeHandler;
  }

  /**
   * Set a default {@link JsonTypeHandler} class for Json type
   * the default {@link JsonTypeHandler} is not set,
   * user can extend the abstract class {@link BaseJsonTypeHandler} to implement it.
   * @param jsonTypeHandler a JsonTypeHandler class for Json
   * @since 3.4.5
   */
  public void setDefaultJsonTypeHandler(JsonTypeHandler jsonTypeHandler) {
    if (jsonTypeHandler != null) {
      this.defaultJsonTypeHandler = jsonTypeHandler.getClass().getName();
      getTypeHandlerRegistry().setDefaultJsonTypeHandler(jsonTypeHandler);
    }
  }

  /**
   * Set a default {@link JsonTypeHandler} class for Json type
   * the default {@link JsonTypeHandler} is not set,
   * user can extend the abstract class {@link BaseJsonTypeHandler} to implement it.
   * How to config defaultJsonTypeHandler ?
   * 1. application.properties(Spring Boot Project): mybatis.configuration.defaultJsonTypeHandler=your_class_name
   * 2. mybatis-config.xml(Spring Project): ?
   * @param className a JsonTypeHandler implement class name.
   * @since 3.4.5
   */
  public void setDefaultJsonTypeHandler(String className) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
    if (className!=null && className.length() > 0) {
      JsonTypeHandler jsonTypeHandler = (JsonTypeHandler) Class.forName(className).newInstance();
      this.defaultJsonTypeHandler = className;
      getTypeHandlerRegistry().setDefaultJsonTypeHandler(jsonTypeHandler);
    }
  }
```

## add defaultJsonTypeHandler property in TypeHandlerRegistry
```
  private JsonTypeHandler defaultJsonTypeHandler = null;

  public void setDefaultJsonTypeHandler(JsonTypeHandler jsonTypeHandler) {
    if (jsonTypeHandler != null) {
      this.defaultJsonTypeHandler = jsonTypeHandler;
    }
  }
```


## change getTypeHandler method
     **if not found typeHandler and jdbcType is OTHER, use defaultJsonTypeHandler(may be is null if not configured), if defaultJsonTypeHandler is null, it will not change anything.**

```
  private <T> TypeHandler<T> getTypeHandler(Type type, JdbcType jdbcType) {
    Map<JdbcType, TypeHandler<?>> jdbcHandlerMap = getJdbcHandlerMap(type);
    TypeHandler<?> handler = null;
    if (jdbcHandlerMap != null) {
      handler = jdbcHandlerMap.get(jdbcType);
      if (handler == null) {
        handler = jdbcHandlerMap.get(null);
      }
      if (handler == null) {
        // #591
        handler = pickSoleHandler(jdbcHandlerMap);
      }
    }
    // if handler is null and jdbcType is OTHER, use defaultJsonTypeHandler
    if (handler == null && jdbcType != null && JdbcType.OTHER.equals(jdbcType)){
      handler = defaultJsonTypeHandler;
    }
    // type drives generics here
    return (TypeHandler<T>) handler;
  }
```

## change jsonTypeHandler#getResult method caller 

```
        // if typeHandler is JsonTypeHandler, call the json deserializer method
        // @since 3.4.5
        if (mapping.typeHandler instanceof JsonTypeHandler) {
          JsonTypeHandler jsonTypeHandler = (JsonTypeHandler) mapping.typeHandler;
          value = jsonTypeHandler.getNullableResult(rsw.getResultSet(), mapping.column, mapping.property, metaObject.getOriginalObject());
        } else {
          value = mapping.typeHandler.getResult(rsw.getResultSet(), mapping.column);
        }
```

```
      // if typeHandler is JsonTypeHandler, call the json deserializer method
      // @since 3.4.5
      if (typeHandler instanceof JsonTypeHandler) {
        JsonTypeHandler jsonTypeHandler = (JsonTypeHandler) typeHandler;
        return jsonTypeHandler.getNullableResult(rs, column, propertyMapping.getProperty(), metaResultObject.getOriginalObject());
      }
      return typeHandler.getResult(rs, column);
```

