### PR TITLE
Support test that depends on mysql using wix-embedded-mysql

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: java
 sudo: false
 
-jdk:
-  - oraclejdk8
-  - oraclejdk7
-  - openjdk7
-  - openjdk6
+matrix:
+  include:
+    - sudo: required
+      jdk: oraclejdk8
+      script:
+        - sudo apt-get install libaio1
+        - ./mvnw test -Dmaven.surefire.excludeGroups= -B
+    - jdk: oraclejdk7
+    - jdk: openjdk7
+    - jdk: openjdk6
 
 before_install:
   - echo "MAVEN_OPTS='-Dlicense.skip=true'" > ~/.mavenrc
@@ -18,7 +23,8 @@ install:
   # Switch back to the original JDK to run the tests
   - jdk_switcher use ${TRAVIS_JDK_VERSION}
 
-script: ./mvnw test -Dmaven.surefire.excludeGroups= -B
+script:
+  - ./mvnw test -Dmaven.surefire.excludeGroups= -B
 
 after_success:
   - chmod -R 777 ./travis/after_success.sh

--- a/pom.xml
+++ b/pom.xml
@@ -264,6 +264,18 @@
       <version>2.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.wix</groupId>
+      <artifactId>wix-embedded-mysql</artifactId>
+      <version>2.2.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>mysql</groupId>
+      <artifactId>mysql-connector-java</artifactId>
+      <version>6.0.6</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/org/apache/ibatis/datasource/unpooled/UnpooledDataSourceTest.java
+++ b/src/test/java/org/apache/ibatis/datasource/unpooled/UnpooledDataSourceTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,15 +15,9 @@
  */
 package org.apache.ibatis.datasource.unpooled;
 
-import static org.junit.Assert.*;
+import static org.apache.ibatis.datasource.unpooled.UnpooledDataSourceTestSupport.countRegisteredDrivers;
+import static org.junit.Assert.assertEquals;
 
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.sql.Driver;
-import java.sql.DriverManager;
-import java.util.Enumeration;
-
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class UnpooledDataSourceTest {
@@ -38,32 +32,6 @@ public class UnpooledDataSourceTest {
     dataSource = new UnpooledDataSource("org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:multipledrivers", "sa", "");
     dataSource.getConnection();
     assertEquals(before, countRegisteredDrivers());
-  }
-
-  @Ignore("Requires MySQL server and a driver.")
-  @Test
-  public void shouldRegisterDynamicallyLoadedDriver() throws Exception {
-    int before = countRegisteredDrivers();
-    ClassLoader driverClassLoader = null;
-    UnpooledDataSource dataSource = null;
-    driverClassLoader = new URLClassLoader(new URL[] { new URL("jar:file:/PATH_TO/mysql-connector-java-5.1.25.jar!/") });
-    dataSource = new UnpooledDataSource(driverClassLoader, "com.mysql.jdbc.Driver", "jdbc:mysql://127.0.0.1/test", "root", "");
-    dataSource.getConnection();
-    assertEquals(before + 1, countRegisteredDrivers());
-    driverClassLoader = new URLClassLoader(new URL[] { new URL("jar:file:/PATH_TO/mysql-connector-java-5.1.25.jar!/") });
-    dataSource = new UnpooledDataSource(driverClassLoader, "com.mysql.jdbc.Driver", "jdbc:mysql://127.0.0.1/test", "root", "");
-    dataSource.getConnection();
-    assertEquals(before + 1, countRegisteredDrivers());
-  }
-
-  protected int countRegisteredDrivers() {
-    Enumeration<Driver> drivers = DriverManager.getDrivers();
-    int count = 0;
-    while (drivers.hasMoreElements()) {
-      drivers.nextElement();
-      count++;
-    }
-    return count;
   }
 
 }

--- a/src/test/java/org/apache/ibatis/datasource/unpooled/UnpooledDataSourceTestSupport.java
+++ b/src/test/java/org/apache/ibatis/datasource/unpooled/UnpooledDataSourceTestSupport.java
@@ -1,0 +1,34 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.datasource.unpooled;
+
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.util.Enumeration;
+
+public abstract class UnpooledDataSourceTestSupport {
+
+  public static int countRegisteredDrivers() {
+    Enumeration<Driver> drivers = DriverManager.getDrivers();
+    int count = 0;
+    while (drivers.hasMoreElements()) {
+      drivers.nextElement();
+      count++;
+    }
+    return count;
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/datasource/unpooled/usesjava8/UnpooledDataSourceMysqlTest.java
+++ b/src/test/java/org/apache/ibatis/datasource/unpooled/usesjava8/UnpooledDataSourceMysqlTest.java
@@ -1,0 +1,76 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.datasource.unpooled.usesjava8;
+
+import com.wix.mysql.EmbeddedMysql;
+import com.wix.mysql.config.MysqldConfig;
+import com.wix.mysql.distribution.Version;
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
+import org.apache.ibatis.test.EmbeddedMysqlTests;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.sql.Connection;
+
+import static org.apache.ibatis.datasource.unpooled.UnpooledDataSourceTestSupport.countRegisteredDrivers;
+import static org.junit.Assert.assertEquals;
+
+@Category(EmbeddedMysqlTests.class)
+public class UnpooledDataSourceMysqlTest {
+
+  private static EmbeddedMysql mysql;
+
+  @BeforeClass
+  public static void startMySql() throws IOException {
+    MysqldConfig config = MysqldConfig.aMysqldConfig(Version.v5_7_latest)
+      .withFreePort()
+      .build();
+    mysql = EmbeddedMysql.anEmbeddedMysql(config)
+      .addSchema("test")
+      .start();
+  }
+
+  @AfterClass
+  public static void stopMySql() {
+    if (mysql != null) {
+      mysql.stop();
+    }
+  }
+
+  @Test
+  public void shouldRegisterDynamicallyLoadedDriver() throws Exception {
+    final String url = String.format("jdbc:mysql://localhost:%d/test", mysql.getConfig().getPort());
+    final String username = mysql.getConfig().getUsername();
+    final String password = mysql.getConfig().getPassword();
+
+    int before = countRegisteredDrivers();
+    ClassLoader driverClassLoader = getClass().getClassLoader();
+
+    UnpooledDataSource dataSource = new UnpooledDataSource(driverClassLoader, "com.mysql.jdbc.Driver", url, username, password);
+    try (Connection con = dataSource.getConnection()) {
+      assertEquals(before + 1, countRegisteredDrivers());
+    }
+
+    dataSource = new UnpooledDataSource(driverClassLoader, "com.mysql.jdbc.Driver", url, username, password);
+    try (Connection con = dataSource.getConnection()) {
+      assertEquals(before + 1, countRegisteredDrivers());
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/jdbc/PooledDataSourceTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/PooledDataSourceTest.java
@@ -18,18 +18,13 @@ package org.apache.ibatis.jdbc;
 import static org.junit.Assert.*;
 
 import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.pooled.PooledDataSource;
 import org.hsqldb.jdbc.JDBCConnection;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class PooledDataSourceTest extends BaseDataTest {
@@ -91,58 +86,4 @@ public class PooledDataSourceTest extends BaseDataTest {
     c.close();
   }
 
-  @Ignore("See the comments")
-  @Test
-  public void shouldReconnectWhenServerKilledLeakedConnection() throws Exception {
-    // See #748
-    // Requirements:
-    // 1. MySQL JDBC driver dependency.
-    // 2. MySQL server instance with the following.
-    //  - CREATE DATABASE `test`;
-    //  - SET GLOBAL wait_timeout=3;
-    // 3. Tweak the connection info below.
-    final String URL = "jdbc:mysql://localhost:3306/test";
-    final String USERNAME = "admin";
-    final String PASSWORD = "";
-
-    PooledDataSource ds = new PooledDataSource();
-    ds.setDriver("com.mysql.jdbc.Driver");
-    ds.setUrl(URL);
-    ds.setUsername(USERNAME);
-    ds.setPassword(PASSWORD);
-    ds.setPoolMaximumActiveConnections(1);
-    ds.setPoolMaximumIdleConnections(1);
-    ds.setPoolTimeToWait(1000);
-    ds.setPoolMaximumCheckoutTime(2000);
-    ds.setPoolPingEnabled(true);
-    ds.setPoolPingQuery("select 1");
-    ds.setDefaultAutoCommit(true);
-    // MySQL wait_timeout * 1000 or less. (unit:ms)
-    ds.setPoolPingConnectionsNotUsedFor(1000);
-
-    Connection con = ds.getConnection();
-    exexuteQuery(con);
-    // Simulate connection leak by not closing.
-    // con.close();
-
-    // Wait for disconnected from mysql...
-    Thread.sleep(TimeUnit.SECONDS.toMillis(3));
-
-    con.close();
-
-    // Should return usable connection.
-    con = ds.getConnection();
-    exexuteQuery(con);
-    con.close();
-  }
-
-  private void exexuteQuery(Connection con) throws SQLException {
-    PreparedStatement st = con.prepareStatement("select 1");
-    ResultSet rs = st.executeQuery();
-    while (rs.next()) {
-      assertEquals(1, rs.getInt(1));
-    }
-    rs.close();
-    st.close();
-  }
 }

--- a/src/test/java/org/apache/ibatis/jdbc/usesjava8/PooledDataSourceMysqlTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/usesjava8/PooledDataSourceMysqlTest.java
@@ -1,0 +1,105 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.jdbc.usesjava8;
+
+import com.wix.mysql.EmbeddedMysql;
+import com.wix.mysql.config.MysqldConfig;
+import com.wix.mysql.distribution.Version;
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.datasource.pooled.PooledDataSource;
+import org.apache.ibatis.test.EmbeddedMysqlTests;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+@Category(EmbeddedMysqlTests.class)
+public class PooledDataSourceMysqlTest extends BaseDataTest {
+
+  private static EmbeddedMysql mysql;
+
+  @BeforeClass
+  public static void startMySql() throws IOException {
+    MysqldConfig config = MysqldConfig.aMysqldConfig(Version.v5_7_latest)
+      .withFreePort()
+      .withServerVariable("wait_timeout", 3)
+      .build();
+    mysql = EmbeddedMysql.anEmbeddedMysql(config)
+      .addSchema("test")
+      .start();
+  }
+
+  @AfterClass
+  public static void stopMySql() {
+    if (mysql != null) {
+      mysql.stop();
+    }
+  }
+
+  @Test
+  public void shouldReconnectWhenServerKilledLeakedConnection() throws Exception {
+    final String URL = String.format("jdbc:mysql://localhost:%d/test", mysql.getConfig().getPort());
+    final String USERNAME = mysql.getConfig().getUsername();
+    final String PASSWORD = mysql.getConfig().getPassword();
+
+    PooledDataSource ds = new PooledDataSource();
+    ds.setDriver("com.mysql.cj.jdbc.Driver");
+    ds.setUrl(URL);
+    ds.setUsername(USERNAME);
+    ds.setPassword(PASSWORD);
+    ds.setPoolMaximumActiveConnections(1);
+    ds.setPoolMaximumIdleConnections(1);
+    ds.setPoolTimeToWait(1000);
+    ds.setPoolMaximumCheckoutTime(2000);
+    ds.setPoolPingEnabled(true);
+    ds.setPoolPingQuery("select 1");
+    ds.setDefaultAutoCommit(true);
+    // MySQL wait_timeout * 1000 or less. (unit:ms)
+    ds.setPoolPingConnectionsNotUsedFor(1000);
+
+    try (Connection con = ds.getConnection()) {
+      executeQueryAndAssertion(con);
+      // Simulate connection leak by not closing.
+      // con.close();
+
+      // Wait for disconnected from mysql...
+      TimeUnit.SECONDS.sleep(3);
+    }
+
+    // Should return usable connection.
+    try(Connection con = ds.getConnection()) {
+      executeQueryAndAssertion(con);
+    }
+  }
+
+  private void executeQueryAndAssertion(Connection con) throws SQLException {
+    try(PreparedStatement st = con.prepareStatement("select 1");
+        ResultSet rs = st.executeQuery()) {
+      while (rs.next()) {
+        assertEquals(1, rs.getInt(1));
+      }
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/test/EmbeddedMysqlTests.java
+++ b/src/test/java/org/apache/ibatis/test/EmbeddedMysqlTests.java
@@ -1,0 +1,20 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.test;
+
+public interface EmbeddedMysqlTests extends SlowTests {
+}


### PR DESCRIPTION
Supported tests that depends on mysql similar to #1037 .

Notes:

- Add [`wix-embedded-mysql`](https://github.com/wix/wix-embedded-mysql)
- Support `sudo` for installing `libaio1` on travis ci `oraclejdk8` 
