### PR TITLE
Change property existing check logic on MapWrapper

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
+++ b/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
@@ -71,6 +71,9 @@ public class Jdbc3KeyGenerator implements KeyGenerator {
           if (!rs.next()) {
             break;
           }
+          if (parameter == null) {
+            continue;
+          }
           final MetaObject metaParam = configuration.newMetaObject(parameter);
           if (typeHandlers == null) {
             typeHandlers = getTypeHandlers(typeHandlerRegistry, metaParam, keyProperties, rsmd);

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
@@ -82,8 +82,9 @@ public class MapWrapper extends BaseWrapper {
         return metaValue.getSetterType(prop.getChildren());
       }
     } else {
-      if (map.get(name) != null) {
-        return map.get(name).getClass();
+      if (map.containsKey(name)) {
+        Object value = map.get(name);
+        return value != null ? value.getClass() : Object.class;
       } else {
         return Object.class;
       }
@@ -101,8 +102,9 @@ public class MapWrapper extends BaseWrapper {
         return metaValue.getGetterType(prop.getChildren());
       }
     } else {
-      if (map.get(name) != null) {
-        return map.get(name).getClass();
+      if (map.containsKey(name)) {
+        Object value = map.get(name);
+        return value != null ? value.getClass() : Object.class;
       } else {
         return Object.class;
       }

--- a/src/test/java/org/apache/ibatis/submitted/usesjava8/postgres_genkeys/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/usesjava8/postgres_genkeys/CreateDB.sql
@@ -1,0 +1,32 @@
+--
+--    Copyright 2009-2017 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+CREATE SCHEMA mbtest;
+
+CREATE TABLE mbtest.users (
+  user_id serial PRIMARY KEY,
+  name character varying(30)
+);
+
+INSERT INTO mbtest.users (name) values ('Jimmy');
+
+
+CREATE TABLE mbtest.sections (
+  section_id int PRIMARY KEY,
+  name character varying(30)
+);
+
+INSERT INTO mbtest.sections (section_id, name) values (1, 'Section 1');

--- a/src/test/java/org/apache/ibatis/submitted/usesjava8/postgres_genkeys/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/usesjava8/postgres_genkeys/Mapper.java
@@ -1,0 +1,31 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.usesjava8.postgres_genkeys;
+
+import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Update;
+
+public interface Mapper {
+  @Update("update mbtest.users set name = #{name} where user_id = #{userId}")
+  int updateUserById(@Param("userId") Integer userId, @Param("name") String name);
+
+  @Update("update mbtest.users set name = 'Dummy' where user_id = 1")
+  int updateUserByIdIsOne();
+
+  @Update("update mbtest.sections set name = #{name} where section_id = #{sectionId}")
+  int updateSectionById(@Param("sectionId") Integer sectionId, @Param("name") String name);
+}

--- a/src/test/java/org/apache/ibatis/submitted/usesjava8/postgres_genkeys/PostgresGeneratedKeysTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/usesjava8/postgres_genkeys/PostgresGeneratedKeysTest.java
@@ -1,0 +1,97 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.usesjava8.postgres_genkeys;
+
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import ru.yandex.qatools.embed.postgresql.EmbeddedPostgres;
+import ru.yandex.qatools.embed.postgresql.util.SocketUtil;
+
+import java.io.Reader;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class PostgresGeneratedKeysTest {
+
+  private static final EmbeddedPostgres postgres = new EmbeddedPostgres();
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // Launch PostgreSQL server. Download / unarchive if necessary.
+    String url = postgres.start(EmbeddedPostgres.cachedRuntimeConfig(Paths.get("target/postgres")), "localhost", SocketUtil.findFreePort(), "postgres_genkeys", "postgres", "root", Collections.emptyList());
+
+    Configuration configuration = new Configuration();
+    Environment environment = new Environment("development", new JdbcTransactionFactory(), new UnpooledDataSource(
+      "org.postgresql.Driver", url, null));
+    configuration.setEnvironment(environment);
+    configuration.setMapUnderscoreToCamelCase(true);
+    configuration.setUseGeneratedKeys(true);
+    configuration.addMapper(Mapper.class);
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+
+    try (SqlSession session = sqlSessionFactory.openSession();
+         Connection conn = session.getConnection();
+         Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/usesjava8/postgres_genkeys/CreateDB.sql")) {
+      ScriptRunner runner = new ScriptRunner(conn);
+      runner.setLogWriter(null);
+      runner.runScript(reader);
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    postgres.stop();
+  }
+
+  @Test
+  public void shouldDefaultKeyPropertyNotCauseExceptionWhenIdIsSerial() throws Exception {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      int result = mapper.updateUserById(1, "Ethan");
+      assertEquals(1, result);
+    }
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      int result = mapper.updateUserByIdIsOne();
+      assertEquals(1, result);
+    }
+  }
+
+  @Test
+  public void shouldDefaultKeyPropertyNotCauseExceptionWhenIdIsNotSerial() throws Exception {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      int result = mapper.updateSectionById(1, "IMF");
+      assertEquals(1, result);
+    }
+  }
+
+}


### PR DESCRIPTION
I've fixed 2 problems into gh-902 (This pr is workaround for #902 into some problem).

* If mapper method argument is empty, parameter is null. Therefor this case is skip a processing for bind a key value.

* If use multiple argument using `@Param`, the MyBatis convert to `ParamMap` (implements `Map` interface). The `ParamMap#get` method has check logic as follow:

```
@Override
public V get(Object key) {
  if (!super.containsKey(key)) {
    throw new BindingException("Parameter '" + key + "' not found. Available parameters are " + keySet());
  }
  return super.get(key);
}
```

Therefor... in current implementation, this error is occurred when check a parameter type and return type of setter/getter method. I think better that change to use `containsKey` method instead of `get(key) != null`.

Note: This solution cannot resolve errors for JavaBeans that not have key property .

What do you think for this solution ?
