### PR TITLE
Polish to avoid creating unused character array on GenericTokenParser

### DIFF
--- a/src/main/java/org/apache/ibatis/parsing/GenericTokenParser.java
+++ b/src/main/java/org/apache/ibatis/parsing/GenericTokenParser.java
@@ -34,13 +34,13 @@ public class GenericTokenParser {
     if (text == null || text.isEmpty()) {
       return "";
     }
-    char[] src = text.toCharArray();
-    int offset = 0;
     // search open token
-    int start = text.indexOf(openToken, offset);
+    int start = text.indexOf(openToken, 0);
     if (start == -1) {
       return text;
     }
+    char[] src = text.toCharArray();
+    int offset = 0;
     final StringBuilder builder = new StringBuilder();
     StringBuilder expression = null;
     while (start > -1) {


### PR DESCRIPTION
In current implementation, there is case that create unused character array.
I think better that convert to character array when open token found.

Please review.