### PR TITLE
Adding cache for in-parameter to avoid handle in-parameter repeatedly, at the same time, we want to add more flexibility on parsing parameter mapping 

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
@@ -41,12 +41,12 @@ public class SqlSourceBuilder extends BaseBuilder {
 
   public SqlSource parse(String originalSql, Class<?> parameterType, Map<String, Object> additionalParameters) {
     ParameterMappingTokenHandler handler = new ParameterMappingTokenHandler(configuration, parameterType, additionalParameters);
-    GenericTokenParser parser = new GenericTokenParser("#{", "}", handler);
+    GenericTokenParser parser = new GenericTokenParser("#{", "}", configuration.newTokenHandler(handler));
     String sql = parser.parse(originalSql);
     return new StaticSqlSource(configuration, sql, handler.getParameterMappings());
   }
 
-  private static class ParameterMappingTokenHandler extends BaseBuilder implements TokenHandler {
+  public static class ParameterMappingTokenHandler extends BaseBuilder implements TokenHandler {
 
     private List<ParameterMapping> parameterMappings = new ArrayList<ParameterMapping>();
     private Class<?> parameterType;

--- a/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
@@ -1,10 +1,17 @@
 /**
- * Copyright 2009-2016 the original author or authors. Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions and limitations under the
- * License.
+ *    Copyright 2009-2016 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  */
 package org.apache.ibatis.executor;
 
@@ -42,364 +49,348 @@ import org.apache.ibatis.type.TypeHandlerRegistry;
  */
 public abstract class BaseExecutor implements Executor {
 
-    private static final Log log = LogFactory.getLog(BaseExecutor.class);
+  private static final Log log = LogFactory.getLog(BaseExecutor.class);
 
-    protected Transaction transaction;
-    protected Executor wrapper;
+  protected Transaction transaction;
+  protected Executor wrapper;
 
-    protected ConcurrentLinkedQueue<DeferredLoad> deferredLoads;
-    protected PerpetualCache localCache;
-    protected PerpetualCache localOutputParameterCache;
-    protected Configuration configuration;
+  protected ConcurrentLinkedQueue<DeferredLoad> deferredLoads;
+  protected PerpetualCache localCache;
+  protected PerpetualCache localOutputParameterCache;
+  protected Configuration configuration;
 
-    protected int queryStack;
-    private boolean closed;
+  protected int queryStack;
+  private boolean closed;
 
-    protected BaseExecutor(Configuration configuration, Transaction transaction) {
-        this.transaction = transaction;
-        this.deferredLoads = new ConcurrentLinkedQueue<DeferredLoad>();
-        this.localCache = new PerpetualCache("LocalCache");
-        this.localOutputParameterCache = new PerpetualCache("LocalOutputParameterCache");
-        this.closed = false;
-        this.configuration = configuration;
-        this.wrapper = this;
+  protected BaseExecutor(Configuration configuration, Transaction transaction) {
+    this.transaction = transaction;
+    this.deferredLoads = new ConcurrentLinkedQueue<DeferredLoad>();
+    this.localCache = new PerpetualCache("LocalCache");
+    this.localOutputParameterCache = new PerpetualCache("LocalOutputParameterCache");
+    this.closed = false;
+    this.configuration = configuration;
+    this.wrapper = this;
+  }
+
+  @Override
+  public Transaction getTransaction() {
+    if (closed) {
+      throw new ExecutorException("Executor was closed.");
     }
+    return transaction;
+  }
 
-    @Override
-    public Transaction getTransaction() {
-        if (closed) {
-            throw new ExecutorException("Executor was closed.");
+  @Override
+  public void close(boolean forceRollback) {
+    try {
+      try {
+        rollback(forceRollback);
+      } finally {
+        if (transaction != null) {
+          transaction.close();
         }
-        return transaction;
+      }
+    } catch (SQLException e) {
+      // Ignore.  There's nothing that can be done at this point.
+      log.warn("Unexpected exception on closing transaction.  Cause: " + e);
+    } finally {
+      transaction = null;
+      deferredLoads = null;
+      localCache = null;
+      localOutputParameterCache = null;
+      closed = true;
     }
+  }
 
-    @Override
-    public void close(boolean forceRollback) {
-        try {
-            try {
-                rollback(forceRollback);
-            }
-            finally {
-                if (transaction != null) {
-                    transaction.close();
-                }
-            }
-        }
-        catch (SQLException e) {
-            // Ignore. There's nothing that can be done at this point.
-            log.warn("Unexpected exception on closing transaction.  Cause: " + e);
-        }
-        finally {
-            transaction = null;
-            deferredLoads = null;
-            localCache = null;
-            localOutputParameterCache = null;
-            closed = true;
-        }
+  @Override
+  public boolean isClosed() {
+    return closed;
+  }
+
+  @Override
+  public int update(MappedStatement ms, Object parameter) throws SQLException {
+    ErrorContext.instance().resource(ms.getResource()).activity("executing an update").object(ms.getId());
+    if (closed) {
+      throw new ExecutorException("Executor was closed.");
     }
+    clearLocalCache();
+    return doUpdate(ms, parameter);
+  }
 
-    @Override
-    public boolean isClosed() {
-        return closed;
+  @Override
+  public List<BatchResult> flushStatements() throws SQLException {
+    return flushStatements(false);
+  }
+
+  public List<BatchResult> flushStatements(boolean isRollBack) throws SQLException {
+    if (closed) {
+      throw new ExecutorException("Executor was closed.");
     }
+    return doFlushStatements(isRollBack);
+  }
 
-    @Override
-    public int update(MappedStatement ms, Object parameter) throws SQLException {
-        ErrorContext.instance().resource(ms.getResource()).activity("executing an update").object(ms.getId());
-        if (closed) {
-            throw new ExecutorException("Executor was closed.");
-        }
+  @Override
+  public <E> List<E> query(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler) throws SQLException {
+    BoundSql boundSql = ms.getBoundSql(parameter);
+    CacheKey key = createCacheKey(ms, parameter, rowBounds, boundSql);
+    return query(ms, parameter, rowBounds, resultHandler, key, boundSql);
+ }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <E> List<E> query(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, CacheKey key, BoundSql boundSql) throws SQLException {
+    ErrorContext.instance().resource(ms.getResource()).activity("executing a query").object(ms.getId());
+    if (closed) {
+      throw new ExecutorException("Executor was closed.");
+    }
+    if (queryStack == 0 && ms.isFlushCacheRequired()) {
+      clearLocalCache();
+    }
+    List<E> list;
+    try {
+      queryStack++;
+      list = resultHandler == null ? (List<E>) localCache.getObject(key) : null;
+      if (list != null) {
+        handleLocallyCachedOutputParameters(ms, key, parameter, boundSql);
+      } else {
+        list = queryFromDatabase(ms, parameter, rowBounds, resultHandler, key, boundSql);
+      }
+    } finally {
+      queryStack--;
+    }
+    if (queryStack == 0) {
+      for (DeferredLoad deferredLoad : deferredLoads) {
+        deferredLoad.load();
+      }
+      // issue #601
+      deferredLoads.clear();
+      if (configuration.getLocalCacheScope() == LocalCacheScope.STATEMENT) {
+        // issue #482
         clearLocalCache();
-        return doUpdate(ms, parameter);
+      }
     }
+    return list;
+  }
 
-    @Override
-    public List<BatchResult> flushStatements() throws SQLException {
-        return flushStatements(false);
+  @Override
+  public <E> Cursor<E> queryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds) throws SQLException {
+    BoundSql boundSql = ms.getBoundSql(parameter);
+    return doQueryCursor(ms, parameter, rowBounds, boundSql);
+  }
+
+  @Override
+  public void deferLoad(MappedStatement ms, MetaObject resultObject, String property, CacheKey key, Class<?> targetType) {
+    if (closed) {
+      throw new ExecutorException("Executor was closed.");
     }
-
-    public List<BatchResult> flushStatements(boolean isRollBack) throws SQLException {
-        if (closed) {
-            throw new ExecutorException("Executor was closed.");
-        }
-        return doFlushStatements(isRollBack);
+    DeferredLoad deferredLoad = new DeferredLoad(resultObject, property, key, localCache, configuration, targetType);
+    if (deferredLoad.canLoad()) {
+      deferredLoad.load();
+    } else {
+      deferredLoads.add(new DeferredLoad(resultObject, property, key, localCache, configuration, targetType));
     }
+  }
 
-    @Override
-    public <E> List<E> query(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler)
-            throws SQLException {
-        BoundSql boundSql = ms.getBoundSql(parameter);
-        CacheKey key = createCacheKey(ms, parameter, rowBounds, boundSql);
-        return query(ms, parameter, rowBounds, resultHandler, key, boundSql);
+  @Override
+  public CacheKey createCacheKey(MappedStatement ms, Object parameterObject, RowBounds rowBounds, BoundSql boundSql) {
+    if (closed) {
+      throw new ExecutorException("Executor was closed.");
     }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public <E> List<E> query(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler,
-            CacheKey key, BoundSql boundSql) throws SQLException {
-        ErrorContext.instance().resource(ms.getResource()).activity("executing a query").object(ms.getId());
-        if (closed) {
-            throw new ExecutorException("Executor was closed.");
-        }
-        if (queryStack == 0 && ms.isFlushCacheRequired()) {
-            clearLocalCache();
-        }
-        List<E> list;
-        try {
-            queryStack++;
-            list = resultHandler == null ? (List<E>) localCache.getObject(key) : null;
-            if (list != null) {
-                handleLocallyCachedOutputParameters(ms, key, parameter, boundSql);
+    CacheKey cacheKey = new CacheKey();
+    cacheKey.update(ms.getId());
+    cacheKey.update(rowBounds.getOffset());
+    cacheKey.update(rowBounds.getLimit());
+    cacheKey.update(boundSql.getSql());
+    List<ParameterMapping> parameterMappings = boundSql.getParameterMappings();
+    TypeHandlerRegistry typeHandlerRegistry = ms.getConfiguration().getTypeHandlerRegistry();
+    // mimic DefaultParameterHandler logic
+    int inParamIndex = 0;
+    boolean inParameterValueUnset = boundSql.isInParameterValueUnset();
+    for (ParameterMapping parameterMapping : parameterMappings) {
+      if (parameterMapping.getMode() != ParameterMode.OUT) {
+        Object value = null;
+        if (inParameterValueUnset) {
+            String propertyName = parameterMapping.getProperty();
+            if (boundSql.hasAdditionalParameter(propertyName)) {
+                value = boundSql.getAdditionalParameter(propertyName);
+            } else if (parameterObject == null) {
+                value = null;
+            } else if (typeHandlerRegistry.hasTypeHandler(parameterObject.getClass())) {
+                value = parameterObject;
+            } else {
+                MetaObject metaObject = configuration.newMetaObject(parameterObject);
+                value = metaObject.getValue(propertyName);
             }
-            else {
-                list = queryFromDatabase(ms, parameter, rowBounds, resultHandler, key, boundSql);
-            }
+            boundSql.addInParameterValue(value);
+        }else{
+            value = boundSql.getInParameterValue(inParamIndex++);
         }
-        finally {
-            queryStack--;
-        }
-        if (queryStack == 0) {
-            for (DeferredLoad deferredLoad : deferredLoads) {
-                deferredLoad.load();
-            }
-            // issue #601
-            deferredLoads.clear();
-            if (configuration.getLocalCacheScope() == LocalCacheScope.STATEMENT) {
-                // issue #482
-                clearLocalCache();
-            }
-        }
-        return list;
+        cacheKey.update(value);
+      }
     }
-
-    @Override
-    public <E> Cursor<E> queryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds) throws SQLException {
-        BoundSql boundSql = ms.getBoundSql(parameter);
-        return doQueryCursor(ms, parameter, rowBounds, boundSql);
+    if (configuration.getEnvironment() != null) {
+      // issue #176
+      cacheKey.update(configuration.getEnvironment().getId());
     }
+    return cacheKey;
+  }
 
-    @Override
-    public void deferLoad(MappedStatement ms, MetaObject resultObject, String property, CacheKey key,
-            Class<?> targetType) {
-        if (closed) {
-            throw new ExecutorException("Executor was closed.");
-        }
-        DeferredLoad deferredLoad =
-                new DeferredLoad(resultObject, property, key, localCache, configuration, targetType);
-        if (deferredLoad.canLoad()) {
-            deferredLoad.load();
-        }
-        else {
-            deferredLoads.add(new DeferredLoad(resultObject, property, key, localCache, configuration, targetType));
-        }
+  @Override
+  public boolean isCached(MappedStatement ms, CacheKey key) {
+    return localCache.getObject(key) != null;
+  }
+
+  @Override
+  public void commit(boolean required) throws SQLException {
+    if (closed) {
+      throw new ExecutorException("Cannot commit, transaction is already closed");
     }
-
-    @Override
-    public CacheKey createCacheKey(MappedStatement ms, Object parameterObject, RowBounds rowBounds, BoundSql boundSql) {
-        if (closed) {
-            throw new ExecutorException("Executor was closed.");
-        }
-        CacheKey cacheKey = new CacheKey();
-        cacheKey.update(ms.getId());
-        cacheKey.update(rowBounds.getOffset());
-        cacheKey.update(rowBounds.getLimit());
-        cacheKey.update(boundSql.getSql());
-        List<ParameterMapping> parameterMappings = boundSql.getParameterMappings();
-        TypeHandlerRegistry typeHandlerRegistry = ms.getConfiguration().getTypeHandlerRegistry();
-        // mimic DefaultParameterHandler logic
-        int inParamIndex = 0;
-        boolean inParameterValueUnset = boundSql.isInParameterValueUnset();
-        for (ParameterMapping parameterMapping : parameterMappings) {
-            if (parameterMapping.getMode() != ParameterMode.OUT) {
-                Object value = null;
-                if (inParameterValueUnset) {
-                    String propertyName = parameterMapping.getProperty();
-                    if (boundSql.hasAdditionalParameter(propertyName)) {
-                        value = boundSql.getAdditionalParameter(propertyName);
-                    }
-                    else if (parameterObject == null) {
-                        value = null;
-                    }
-                    else if (typeHandlerRegistry.hasTypeHandler(parameterObject.getClass())) {
-                        value = parameterObject;
-                    }
-                    else {
-                        MetaObject metaObject = configuration.newMetaObject(parameterObject);
-                        value = metaObject.getValue(propertyName);
-                    }
-                    boundSql.addInParameterValue(value);
-                }
-                else {
-                    value = boundSql.getInParameterValues(inParamIndex++);
-                }
-                cacheKey.update(value);
-            }
-        }
-
-        if (configuration.getEnvironment() != null) {
-            // issue #176
-            cacheKey.update(configuration.getEnvironment().getId());
-        }
-        return cacheKey;
+    clearLocalCache();
+    flushStatements();
+    if (required) {
+      transaction.commit();
     }
+  }
 
-    @Override
-    public boolean isCached(MappedStatement ms, CacheKey key) {
-        return localCache.getObject(key) != null;
-    }
-
-    @Override
-    public void commit(boolean required) throws SQLException {
-        if (closed) {
-            throw new ExecutorException("Cannot commit, transaction is already closed");
-        }
+  @Override
+  public void rollback(boolean required) throws SQLException {
+    if (!closed) {
+      try {
         clearLocalCache();
-        flushStatements();
+        flushStatements(true);
+      } finally {
         if (required) {
-            transaction.commit();
+          transaction.rollback();
         }
+      }
+    }
+  }
+
+  @Override
+  public void clearLocalCache() {
+    if (!closed) {
+      localCache.clear();
+      localOutputParameterCache.clear();
+    }
+  }
+
+  protected abstract int doUpdate(MappedStatement ms, Object parameter)
+      throws SQLException;
+
+  protected abstract List<BatchResult> doFlushStatements(boolean isRollback)
+      throws SQLException;
+
+  protected abstract <E> List<E> doQuery(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql)
+      throws SQLException;
+
+  protected abstract <E> Cursor<E> doQueryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds, BoundSql boundSql)
+      throws SQLException;
+
+  protected void closeStatement(Statement statement) {
+    if (statement != null) {
+      try {
+        statement.close();
+      } catch (SQLException e) {
+        // ignore
+      }
+    }
+  }
+
+  /**
+   * Apply a transaction timeout.
+   * @param statement a current statement
+   * @throws SQLException if a database access error occurs, this method is called on a closed <code>Statement</code>
+   * @since 3.4.0
+   * @see StatementUtil#applyTransactionTimeout(Statement, Integer, Integer)
+   */
+  protected void applyTransactionTimeout(Statement statement) throws SQLException {
+    StatementUtil.applyTransactionTimeout(statement, statement.getQueryTimeout(), transaction.getTimeout());
+  }
+
+  private void handleLocallyCachedOutputParameters(MappedStatement ms, CacheKey key, Object parameter, BoundSql boundSql) {
+    if (ms.getStatementType() == StatementType.CALLABLE) {
+      final Object cachedParameter = localOutputParameterCache.getObject(key);
+      if (cachedParameter != null && parameter != null) {
+        final MetaObject metaCachedParameter = configuration.newMetaObject(cachedParameter);
+        final MetaObject metaParameter = configuration.newMetaObject(parameter);
+        for (ParameterMapping parameterMapping : boundSql.getParameterMappings()) {
+          if (parameterMapping.getMode() != ParameterMode.IN) {
+            final String parameterName = parameterMapping.getProperty();
+            final Object cachedValue = metaCachedParameter.getValue(parameterName);
+            metaParameter.setValue(parameterName, cachedValue);
+          }
+        }
+      }
+    }
+  }
+
+  private <E> List<E> queryFromDatabase(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, CacheKey key, BoundSql boundSql) throws SQLException {
+    List<E> list;
+    localCache.putObject(key, EXECUTION_PLACEHOLDER);
+    try {
+      list = doQuery(ms, parameter, rowBounds, resultHandler, boundSql);
+    } finally {
+      localCache.removeObject(key);
+    }
+    localCache.putObject(key, list);
+    if (ms.getStatementType() == StatementType.CALLABLE) {
+      localOutputParameterCache.putObject(key, parameter);
+    }
+    return list;
+  }
+
+  protected Connection getConnection(Log statementLog) throws SQLException {
+    Connection connection = transaction.getConnection();
+    if (statementLog.isDebugEnabled()) {
+      return ConnectionLogger.newInstance(connection, statementLog, queryStack);
+    } else {
+      return connection;
+    }
+  }
+
+  @Override
+  public void setExecutorWrapper(Executor wrapper) {
+    this.wrapper = wrapper;
+  }
+  
+  private static class DeferredLoad {
+
+    private final MetaObject resultObject;
+    private final String property;
+    private final Class<?> targetType;
+    private final CacheKey key;
+    private final PerpetualCache localCache;
+    private final ObjectFactory objectFactory;
+    private final ResultExtractor resultExtractor;
+
+    // issue #781
+    public DeferredLoad(MetaObject resultObject,
+                        String property,
+                        CacheKey key,
+                        PerpetualCache localCache,
+                        Configuration configuration,
+                        Class<?> targetType) {
+      this.resultObject = resultObject;
+      this.property = property;
+      this.key = key;
+      this.localCache = localCache;
+      this.objectFactory = configuration.getObjectFactory();
+      this.resultExtractor = new ResultExtractor(configuration, objectFactory);
+      this.targetType = targetType;
     }
 
-    @Override
-    public void rollback(boolean required) throws SQLException {
-        if (!closed) {
-            try {
-                clearLocalCache();
-                flushStatements(true);
-            }
-            finally {
-                if (required) {
-                    transaction.rollback();
-                }
-            }
-        }
+    public boolean canLoad() {
+      return localCache.getObject(key) != null && localCache.getObject(key) != EXECUTION_PLACEHOLDER;
     }
 
-    @Override
-    public void clearLocalCache() {
-        if (!closed) {
-            localCache.clear();
-            localOutputParameterCache.clear();
-        }
+    public void load() {
+      @SuppressWarnings( "unchecked" )
+      // we suppose we get back a List
+      List<Object> list = (List<Object>) localCache.getObject(key);
+      Object value = resultExtractor.extractObjectFromList(list, targetType);
+      resultObject.setValue(property, value);
     }
 
-    protected abstract int doUpdate(MappedStatement ms, Object parameter) throws SQLException;
-
-    protected abstract List<BatchResult> doFlushStatements(boolean isRollback) throws SQLException;
-
-    protected abstract <E> List<E> doQuery(MappedStatement ms, Object parameter, RowBounds rowBounds,
-            ResultHandler resultHandler, BoundSql boundSql) throws SQLException;
-
-    protected abstract <E> Cursor<E> doQueryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds,
-            BoundSql boundSql) throws SQLException;
-
-    protected void closeStatement(Statement statement) {
-        if (statement != null) {
-            try {
-                statement.close();
-            }
-            catch (SQLException e) {
-                // ignore
-            }
-        }
-    }
-
-    /**
-     * Apply a transaction timeout.
-     * 
-     * @param statement a current statement
-     * @throws SQLException if a database access error occurs, this method is called on a closed <code>Statement</code>
-     * @since 3.4.0
-     * @see StatementUtil#applyTransactionTimeout(Statement, Integer, Integer)
-     */
-    protected void applyTransactionTimeout(Statement statement) throws SQLException {
-        StatementUtil.applyTransactionTimeout(statement, statement.getQueryTimeout(), transaction.getTimeout());
-    }
-
-    private void handleLocallyCachedOutputParameters(MappedStatement ms, CacheKey key, Object parameter,
-            BoundSql boundSql) {
-        if (ms.getStatementType() == StatementType.CALLABLE) {
-            final Object cachedParameter = localOutputParameterCache.getObject(key);
-            if (cachedParameter != null && parameter != null) {
-                final MetaObject metaCachedParameter = configuration.newMetaObject(cachedParameter);
-                final MetaObject metaParameter = configuration.newMetaObject(parameter);
-                for (ParameterMapping parameterMapping : boundSql.getParameterMappings()) {
-                    if (parameterMapping.getMode() != ParameterMode.IN) {
-                        final String parameterName = parameterMapping.getProperty();
-                        final Object cachedValue = metaCachedParameter.getValue(parameterName);
-                        metaParameter.setValue(parameterName, cachedValue);
-                    }
-                }
-            }
-        }
-    }
-
-    private <E> List<E> queryFromDatabase(MappedStatement ms, Object parameter, RowBounds rowBounds,
-            ResultHandler resultHandler, CacheKey key, BoundSql boundSql) throws SQLException {
-        List<E> list;
-        localCache.putObject(key, EXECUTION_PLACEHOLDER);
-        try {
-            list = doQuery(ms, parameter, rowBounds, resultHandler, boundSql);
-        }
-        finally {
-            localCache.removeObject(key);
-        }
-        localCache.putObject(key, list);
-        if (ms.getStatementType() == StatementType.CALLABLE) {
-            localOutputParameterCache.putObject(key, parameter);
-        }
-        return list;
-    }
-
-    protected Connection getConnection(Log statementLog) throws SQLException {
-        Connection connection = transaction.getConnection();
-        if (statementLog.isDebugEnabled()) {
-            return ConnectionLogger.newInstance(connection, statementLog, queryStack);
-        }
-        else {
-            return connection;
-        }
-    }
-
-    @Override
-    public void setExecutorWrapper(Executor wrapper) {
-        this.wrapper = wrapper;
-    }
-
-    private static class DeferredLoad {
-
-        private final MetaObject resultObject;
-        private final String property;
-        private final Class<?> targetType;
-        private final CacheKey key;
-        private final PerpetualCache localCache;
-        private final ObjectFactory objectFactory;
-        private final ResultExtractor resultExtractor;
-
-        // issue #781
-        public DeferredLoad(MetaObject resultObject, String property, CacheKey key, PerpetualCache localCache,
-                Configuration configuration, Class<?> targetType) {
-            this.resultObject = resultObject;
-            this.property = property;
-            this.key = key;
-            this.localCache = localCache;
-            this.objectFactory = configuration.getObjectFactory();
-            this.resultExtractor = new ResultExtractor(configuration, objectFactory);
-            this.targetType = targetType;
-        }
-
-        public boolean canLoad() {
-            return localCache.getObject(key) != null && localCache.getObject(key) != EXECUTION_PLACEHOLDER;
-        }
-
-        public void load() {
-            @SuppressWarnings("unchecked")
-            // we suppose we get back a List
-            List<Object> list = (List<Object>) localCache.getObject(key);
-            Object value = resultExtractor.extractObjectFromList(list, targetType);
-            resultObject.setValue(property, value);
-        }
-
-    }
+  }
 
 }

--- a/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
@@ -1,17 +1,10 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Copyright 2009-2016 the original author or authors. Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and limitations under the
+ * License.
  */
 package org.apache.ibatis.executor;
 
@@ -49,341 +42,364 @@ import org.apache.ibatis.type.TypeHandlerRegistry;
  */
 public abstract class BaseExecutor implements Executor {
 
-  private static final Log log = LogFactory.getLog(BaseExecutor.class);
+    private static final Log log = LogFactory.getLog(BaseExecutor.class);
 
-  protected Transaction transaction;
-  protected Executor wrapper;
+    protected Transaction transaction;
+    protected Executor wrapper;
 
-  protected ConcurrentLinkedQueue<DeferredLoad> deferredLoads;
-  protected PerpetualCache localCache;
-  protected PerpetualCache localOutputParameterCache;
-  protected Configuration configuration;
+    protected ConcurrentLinkedQueue<DeferredLoad> deferredLoads;
+    protected PerpetualCache localCache;
+    protected PerpetualCache localOutputParameterCache;
+    protected Configuration configuration;
 
-  protected int queryStack;
-  private boolean closed;
+    protected int queryStack;
+    private boolean closed;
 
-  protected BaseExecutor(Configuration configuration, Transaction transaction) {
-    this.transaction = transaction;
-    this.deferredLoads = new ConcurrentLinkedQueue<DeferredLoad>();
-    this.localCache = new PerpetualCache("LocalCache");
-    this.localOutputParameterCache = new PerpetualCache("LocalOutputParameterCache");
-    this.closed = false;
-    this.configuration = configuration;
-    this.wrapper = this;
-  }
-
-  @Override
-  public Transaction getTransaction() {
-    if (closed) {
-      throw new ExecutorException("Executor was closed.");
+    protected BaseExecutor(Configuration configuration, Transaction transaction) {
+        this.transaction = transaction;
+        this.deferredLoads = new ConcurrentLinkedQueue<DeferredLoad>();
+        this.localCache = new PerpetualCache("LocalCache");
+        this.localOutputParameterCache = new PerpetualCache("LocalOutputParameterCache");
+        this.closed = false;
+        this.configuration = configuration;
+        this.wrapper = this;
     }
-    return transaction;
-  }
 
-  @Override
-  public void close(boolean forceRollback) {
-    try {
-      try {
-        rollback(forceRollback);
-      } finally {
-        if (transaction != null) {
-          transaction.close();
+    @Override
+    public Transaction getTransaction() {
+        if (closed) {
+            throw new ExecutorException("Executor was closed.");
         }
-      }
-    } catch (SQLException e) {
-      // Ignore.  There's nothing that can be done at this point.
-      log.warn("Unexpected exception on closing transaction.  Cause: " + e);
-    } finally {
-      transaction = null;
-      deferredLoads = null;
-      localCache = null;
-      localOutputParameterCache = null;
-      closed = true;
+        return transaction;
     }
-  }
 
-  @Override
-  public boolean isClosed() {
-    return closed;
-  }
-
-  @Override
-  public int update(MappedStatement ms, Object parameter) throws SQLException {
-    ErrorContext.instance().resource(ms.getResource()).activity("executing an update").object(ms.getId());
-    if (closed) {
-      throw new ExecutorException("Executor was closed.");
-    }
-    clearLocalCache();
-    return doUpdate(ms, parameter);
-  }
-
-  @Override
-  public List<BatchResult> flushStatements() throws SQLException {
-    return flushStatements(false);
-  }
-
-  public List<BatchResult> flushStatements(boolean isRollBack) throws SQLException {
-    if (closed) {
-      throw new ExecutorException("Executor was closed.");
-    }
-    return doFlushStatements(isRollBack);
-  }
-
-  @Override
-  public <E> List<E> query(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler) throws SQLException {
-    BoundSql boundSql = ms.getBoundSql(parameter);
-    CacheKey key = createCacheKey(ms, parameter, rowBounds, boundSql);
-    return query(ms, parameter, rowBounds, resultHandler, key, boundSql);
- }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public <E> List<E> query(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, CacheKey key, BoundSql boundSql) throws SQLException {
-    ErrorContext.instance().resource(ms.getResource()).activity("executing a query").object(ms.getId());
-    if (closed) {
-      throw new ExecutorException("Executor was closed.");
-    }
-    if (queryStack == 0 && ms.isFlushCacheRequired()) {
-      clearLocalCache();
-    }
-    List<E> list;
-    try {
-      queryStack++;
-      list = resultHandler == null ? (List<E>) localCache.getObject(key) : null;
-      if (list != null) {
-        handleLocallyCachedOutputParameters(ms, key, parameter, boundSql);
-      } else {
-        list = queryFromDatabase(ms, parameter, rowBounds, resultHandler, key, boundSql);
-      }
-    } finally {
-      queryStack--;
-    }
-    if (queryStack == 0) {
-      for (DeferredLoad deferredLoad : deferredLoads) {
-        deferredLoad.load();
-      }
-      // issue #601
-      deferredLoads.clear();
-      if (configuration.getLocalCacheScope() == LocalCacheScope.STATEMENT) {
-        // issue #482
-        clearLocalCache();
-      }
-    }
-    return list;
-  }
-
-  @Override
-  public <E> Cursor<E> queryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds) throws SQLException {
-    BoundSql boundSql = ms.getBoundSql(parameter);
-    return doQueryCursor(ms, parameter, rowBounds, boundSql);
-  }
-
-  @Override
-  public void deferLoad(MappedStatement ms, MetaObject resultObject, String property, CacheKey key, Class<?> targetType) {
-    if (closed) {
-      throw new ExecutorException("Executor was closed.");
-    }
-    DeferredLoad deferredLoad = new DeferredLoad(resultObject, property, key, localCache, configuration, targetType);
-    if (deferredLoad.canLoad()) {
-      deferredLoad.load();
-    } else {
-      deferredLoads.add(new DeferredLoad(resultObject, property, key, localCache, configuration, targetType));
-    }
-  }
-
-  @Override
-  public CacheKey createCacheKey(MappedStatement ms, Object parameterObject, RowBounds rowBounds, BoundSql boundSql) {
-    if (closed) {
-      throw new ExecutorException("Executor was closed.");
-    }
-    CacheKey cacheKey = new CacheKey();
-    cacheKey.update(ms.getId());
-    cacheKey.update(rowBounds.getOffset());
-    cacheKey.update(rowBounds.getLimit());
-    cacheKey.update(boundSql.getSql());
-    List<ParameterMapping> parameterMappings = boundSql.getParameterMappings();
-    TypeHandlerRegistry typeHandlerRegistry = ms.getConfiguration().getTypeHandlerRegistry();
-    // mimic DefaultParameterHandler logic
-    for (ParameterMapping parameterMapping : parameterMappings) {
-      if (parameterMapping.getMode() != ParameterMode.OUT) {
-        Object value;
-        String propertyName = parameterMapping.getProperty();
-        if (boundSql.hasAdditionalParameter(propertyName)) {
-          value = boundSql.getAdditionalParameter(propertyName);
-        } else if (parameterObject == null) {
-          value = null;
-        } else if (typeHandlerRegistry.hasTypeHandler(parameterObject.getClass())) {
-          value = parameterObject;
-        } else {
-          MetaObject metaObject = configuration.newMetaObject(parameterObject);
-          value = metaObject.getValue(propertyName);
+    @Override
+    public void close(boolean forceRollback) {
+        try {
+            try {
+                rollback(forceRollback);
+            }
+            finally {
+                if (transaction != null) {
+                    transaction.close();
+                }
+            }
         }
-        cacheKey.update(value);
-      }
+        catch (SQLException e) {
+            // Ignore. There's nothing that can be done at this point.
+            log.warn("Unexpected exception on closing transaction.  Cause: " + e);
+        }
+        finally {
+            transaction = null;
+            deferredLoads = null;
+            localCache = null;
+            localOutputParameterCache = null;
+            closed = true;
+        }
     }
-    if (configuration.getEnvironment() != null) {
-      // issue #176
-      cacheKey.update(configuration.getEnvironment().getId());
-    }
-    return cacheKey;
-  }
 
-  @Override
-  public boolean isCached(MappedStatement ms, CacheKey key) {
-    return localCache.getObject(key) != null;
-  }
-
-  @Override
-  public void commit(boolean required) throws SQLException {
-    if (closed) {
-      throw new ExecutorException("Cannot commit, transaction is already closed");
+    @Override
+    public boolean isClosed() {
+        return closed;
     }
-    clearLocalCache();
-    flushStatements();
-    if (required) {
-      transaction.commit();
-    }
-  }
 
-  @Override
-  public void rollback(boolean required) throws SQLException {
-    if (!closed) {
-      try {
+    @Override
+    public int update(MappedStatement ms, Object parameter) throws SQLException {
+        ErrorContext.instance().resource(ms.getResource()).activity("executing an update").object(ms.getId());
+        if (closed) {
+            throw new ExecutorException("Executor was closed.");
+        }
         clearLocalCache();
-        flushStatements(true);
-      } finally {
+        return doUpdate(ms, parameter);
+    }
+
+    @Override
+    public List<BatchResult> flushStatements() throws SQLException {
+        return flushStatements(false);
+    }
+
+    public List<BatchResult> flushStatements(boolean isRollBack) throws SQLException {
+        if (closed) {
+            throw new ExecutorException("Executor was closed.");
+        }
+        return doFlushStatements(isRollBack);
+    }
+
+    @Override
+    public <E> List<E> query(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler)
+            throws SQLException {
+        BoundSql boundSql = ms.getBoundSql(parameter);
+        CacheKey key = createCacheKey(ms, parameter, rowBounds, boundSql);
+        return query(ms, parameter, rowBounds, resultHandler, key, boundSql);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <E> List<E> query(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler,
+            CacheKey key, BoundSql boundSql) throws SQLException {
+        ErrorContext.instance().resource(ms.getResource()).activity("executing a query").object(ms.getId());
+        if (closed) {
+            throw new ExecutorException("Executor was closed.");
+        }
+        if (queryStack == 0 && ms.isFlushCacheRequired()) {
+            clearLocalCache();
+        }
+        List<E> list;
+        try {
+            queryStack++;
+            list = resultHandler == null ? (List<E>) localCache.getObject(key) : null;
+            if (list != null) {
+                handleLocallyCachedOutputParameters(ms, key, parameter, boundSql);
+            }
+            else {
+                list = queryFromDatabase(ms, parameter, rowBounds, resultHandler, key, boundSql);
+            }
+        }
+        finally {
+            queryStack--;
+        }
+        if (queryStack == 0) {
+            for (DeferredLoad deferredLoad : deferredLoads) {
+                deferredLoad.load();
+            }
+            // issue #601
+            deferredLoads.clear();
+            if (configuration.getLocalCacheScope() == LocalCacheScope.STATEMENT) {
+                // issue #482
+                clearLocalCache();
+            }
+        }
+        return list;
+    }
+
+    @Override
+    public <E> Cursor<E> queryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds) throws SQLException {
+        BoundSql boundSql = ms.getBoundSql(parameter);
+        return doQueryCursor(ms, parameter, rowBounds, boundSql);
+    }
+
+    @Override
+    public void deferLoad(MappedStatement ms, MetaObject resultObject, String property, CacheKey key,
+            Class<?> targetType) {
+        if (closed) {
+            throw new ExecutorException("Executor was closed.");
+        }
+        DeferredLoad deferredLoad =
+                new DeferredLoad(resultObject, property, key, localCache, configuration, targetType);
+        if (deferredLoad.canLoad()) {
+            deferredLoad.load();
+        }
+        else {
+            deferredLoads.add(new DeferredLoad(resultObject, property, key, localCache, configuration, targetType));
+        }
+    }
+
+    @Override
+    public CacheKey createCacheKey(MappedStatement ms, Object parameterObject, RowBounds rowBounds, BoundSql boundSql) {
+        if (closed) {
+            throw new ExecutorException("Executor was closed.");
+        }
+        CacheKey cacheKey = new CacheKey();
+        cacheKey.update(ms.getId());
+        cacheKey.update(rowBounds.getOffset());
+        cacheKey.update(rowBounds.getLimit());
+        cacheKey.update(boundSql.getSql());
+        List<ParameterMapping> parameterMappings = boundSql.getParameterMappings();
+        TypeHandlerRegistry typeHandlerRegistry = ms.getConfiguration().getTypeHandlerRegistry();
+        // mimic DefaultParameterHandler logic
+        int inParamIndex = 0;
+        boolean inParameterValueUnset = boundSql.isInParameterValueUnset();
+        for (ParameterMapping parameterMapping : parameterMappings) {
+            if (parameterMapping.getMode() != ParameterMode.OUT) {
+                Object value = null;
+                if (inParameterValueUnset) {
+                    String propertyName = parameterMapping.getProperty();
+                    if (boundSql.hasAdditionalParameter(propertyName)) {
+                        value = boundSql.getAdditionalParameter(propertyName);
+                    }
+                    else if (parameterObject == null) {
+                        value = null;
+                    }
+                    else if (typeHandlerRegistry.hasTypeHandler(parameterObject.getClass())) {
+                        value = parameterObject;
+                    }
+                    else {
+                        MetaObject metaObject = configuration.newMetaObject(parameterObject);
+                        value = metaObject.getValue(propertyName);
+                    }
+                    boundSql.addInParameterValue(value);
+                }
+                else {
+                    value = boundSql.getInParameterValues(inParamIndex++);
+                }
+                cacheKey.update(value);
+            }
+        }
+
+        if (configuration.getEnvironment() != null) {
+            // issue #176
+            cacheKey.update(configuration.getEnvironment().getId());
+        }
+        return cacheKey;
+    }
+
+    @Override
+    public boolean isCached(MappedStatement ms, CacheKey key) {
+        return localCache.getObject(key) != null;
+    }
+
+    @Override
+    public void commit(boolean required) throws SQLException {
+        if (closed) {
+            throw new ExecutorException("Cannot commit, transaction is already closed");
+        }
+        clearLocalCache();
+        flushStatements();
         if (required) {
-          transaction.rollback();
+            transaction.commit();
         }
-      }
     }
-  }
 
-  @Override
-  public void clearLocalCache() {
-    if (!closed) {
-      localCache.clear();
-      localOutputParameterCache.clear();
-    }
-  }
-
-  protected abstract int doUpdate(MappedStatement ms, Object parameter)
-      throws SQLException;
-
-  protected abstract List<BatchResult> doFlushStatements(boolean isRollback)
-      throws SQLException;
-
-  protected abstract <E> List<E> doQuery(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql)
-      throws SQLException;
-
-  protected abstract <E> Cursor<E> doQueryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds, BoundSql boundSql)
-      throws SQLException;
-
-  protected void closeStatement(Statement statement) {
-    if (statement != null) {
-      try {
-        statement.close();
-      } catch (SQLException e) {
-        // ignore
-      }
-    }
-  }
-
-  /**
-   * Apply a transaction timeout.
-   * @param statement a current statement
-   * @throws SQLException if a database access error occurs, this method is called on a closed <code>Statement</code>
-   * @since 3.4.0
-   * @see StatementUtil#applyTransactionTimeout(Statement, Integer, Integer)
-   */
-  protected void applyTransactionTimeout(Statement statement) throws SQLException {
-    StatementUtil.applyTransactionTimeout(statement, statement.getQueryTimeout(), transaction.getTimeout());
-  }
-
-  private void handleLocallyCachedOutputParameters(MappedStatement ms, CacheKey key, Object parameter, BoundSql boundSql) {
-    if (ms.getStatementType() == StatementType.CALLABLE) {
-      final Object cachedParameter = localOutputParameterCache.getObject(key);
-      if (cachedParameter != null && parameter != null) {
-        final MetaObject metaCachedParameter = configuration.newMetaObject(cachedParameter);
-        final MetaObject metaParameter = configuration.newMetaObject(parameter);
-        for (ParameterMapping parameterMapping : boundSql.getParameterMappings()) {
-          if (parameterMapping.getMode() != ParameterMode.IN) {
-            final String parameterName = parameterMapping.getProperty();
-            final Object cachedValue = metaCachedParameter.getValue(parameterName);
-            metaParameter.setValue(parameterName, cachedValue);
-          }
+    @Override
+    public void rollback(boolean required) throws SQLException {
+        if (!closed) {
+            try {
+                clearLocalCache();
+                flushStatements(true);
+            }
+            finally {
+                if (required) {
+                    transaction.rollback();
+                }
+            }
         }
-      }
-    }
-  }
-
-  private <E> List<E> queryFromDatabase(MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, CacheKey key, BoundSql boundSql) throws SQLException {
-    List<E> list;
-    localCache.putObject(key, EXECUTION_PLACEHOLDER);
-    try {
-      list = doQuery(ms, parameter, rowBounds, resultHandler, boundSql);
-    } finally {
-      localCache.removeObject(key);
-    }
-    localCache.putObject(key, list);
-    if (ms.getStatementType() == StatementType.CALLABLE) {
-      localOutputParameterCache.putObject(key, parameter);
-    }
-    return list;
-  }
-
-  protected Connection getConnection(Log statementLog) throws SQLException {
-    Connection connection = transaction.getConnection();
-    if (statementLog.isDebugEnabled()) {
-      return ConnectionLogger.newInstance(connection, statementLog, queryStack);
-    } else {
-      return connection;
-    }
-  }
-
-  @Override
-  public void setExecutorWrapper(Executor wrapper) {
-    this.wrapper = wrapper;
-  }
-  
-  private static class DeferredLoad {
-
-    private final MetaObject resultObject;
-    private final String property;
-    private final Class<?> targetType;
-    private final CacheKey key;
-    private final PerpetualCache localCache;
-    private final ObjectFactory objectFactory;
-    private final ResultExtractor resultExtractor;
-
-    // issue #781
-    public DeferredLoad(MetaObject resultObject,
-                        String property,
-                        CacheKey key,
-                        PerpetualCache localCache,
-                        Configuration configuration,
-                        Class<?> targetType) {
-      this.resultObject = resultObject;
-      this.property = property;
-      this.key = key;
-      this.localCache = localCache;
-      this.objectFactory = configuration.getObjectFactory();
-      this.resultExtractor = new ResultExtractor(configuration, objectFactory);
-      this.targetType = targetType;
     }
 
-    public boolean canLoad() {
-      return localCache.getObject(key) != null && localCache.getObject(key) != EXECUTION_PLACEHOLDER;
+    @Override
+    public void clearLocalCache() {
+        if (!closed) {
+            localCache.clear();
+            localOutputParameterCache.clear();
+        }
     }
 
-    public void load() {
-      @SuppressWarnings( "unchecked" )
-      // we suppose we get back a List
-      List<Object> list = (List<Object>) localCache.getObject(key);
-      Object value = resultExtractor.extractObjectFromList(list, targetType);
-      resultObject.setValue(property, value);
+    protected abstract int doUpdate(MappedStatement ms, Object parameter) throws SQLException;
+
+    protected abstract List<BatchResult> doFlushStatements(boolean isRollback) throws SQLException;
+
+    protected abstract <E> List<E> doQuery(MappedStatement ms, Object parameter, RowBounds rowBounds,
+            ResultHandler resultHandler, BoundSql boundSql) throws SQLException;
+
+    protected abstract <E> Cursor<E> doQueryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds,
+            BoundSql boundSql) throws SQLException;
+
+    protected void closeStatement(Statement statement) {
+        if (statement != null) {
+            try {
+                statement.close();
+            }
+            catch (SQLException e) {
+                // ignore
+            }
+        }
     }
 
-  }
+    /**
+     * Apply a transaction timeout.
+     * 
+     * @param statement a current statement
+     * @throws SQLException if a database access error occurs, this method is called on a closed <code>Statement</code>
+     * @since 3.4.0
+     * @see StatementUtil#applyTransactionTimeout(Statement, Integer, Integer)
+     */
+    protected void applyTransactionTimeout(Statement statement) throws SQLException {
+        StatementUtil.applyTransactionTimeout(statement, statement.getQueryTimeout(), transaction.getTimeout());
+    }
+
+    private void handleLocallyCachedOutputParameters(MappedStatement ms, CacheKey key, Object parameter,
+            BoundSql boundSql) {
+        if (ms.getStatementType() == StatementType.CALLABLE) {
+            final Object cachedParameter = localOutputParameterCache.getObject(key);
+            if (cachedParameter != null && parameter != null) {
+                final MetaObject metaCachedParameter = configuration.newMetaObject(cachedParameter);
+                final MetaObject metaParameter = configuration.newMetaObject(parameter);
+                for (ParameterMapping parameterMapping : boundSql.getParameterMappings()) {
+                    if (parameterMapping.getMode() != ParameterMode.IN) {
+                        final String parameterName = parameterMapping.getProperty();
+                        final Object cachedValue = metaCachedParameter.getValue(parameterName);
+                        metaParameter.setValue(parameterName, cachedValue);
+                    }
+                }
+            }
+        }
+    }
+
+    private <E> List<E> queryFromDatabase(MappedStatement ms, Object parameter, RowBounds rowBounds,
+            ResultHandler resultHandler, CacheKey key, BoundSql boundSql) throws SQLException {
+        List<E> list;
+        localCache.putObject(key, EXECUTION_PLACEHOLDER);
+        try {
+            list = doQuery(ms, parameter, rowBounds, resultHandler, boundSql);
+        }
+        finally {
+            localCache.removeObject(key);
+        }
+        localCache.putObject(key, list);
+        if (ms.getStatementType() == StatementType.CALLABLE) {
+            localOutputParameterCache.putObject(key, parameter);
+        }
+        return list;
+    }
+
+    protected Connection getConnection(Log statementLog) throws SQLException {
+        Connection connection = transaction.getConnection();
+        if (statementLog.isDebugEnabled()) {
+            return ConnectionLogger.newInstance(connection, statementLog, queryStack);
+        }
+        else {
+            return connection;
+        }
+    }
+
+    @Override
+    public void setExecutorWrapper(Executor wrapper) {
+        this.wrapper = wrapper;
+    }
+
+    private static class DeferredLoad {
+
+        private final MetaObject resultObject;
+        private final String property;
+        private final Class<?> targetType;
+        private final CacheKey key;
+        private final PerpetualCache localCache;
+        private final ObjectFactory objectFactory;
+        private final ResultExtractor resultExtractor;
+
+        // issue #781
+        public DeferredLoad(MetaObject resultObject, String property, CacheKey key, PerpetualCache localCache,
+                Configuration configuration, Class<?> targetType) {
+            this.resultObject = resultObject;
+            this.property = property;
+            this.key = key;
+            this.localCache = localCache;
+            this.objectFactory = configuration.getObjectFactory();
+            this.resultExtractor = new ResultExtractor(configuration, objectFactory);
+            this.targetType = targetType;
+        }
+
+        public boolean canLoad() {
+            return localCache.getObject(key) != null && localCache.getObject(key) != EXECUTION_PLACEHOLDER;
+        }
+
+        public void load() {
+            @SuppressWarnings("unchecked")
+            // we suppose we get back a List
+            List<Object> list = (List<Object>) localCache.getObject(key);
+            Object value = resultExtractor.extractObjectFromList(list, targetType);
+            resultObject.setValue(property, value);
+        }
+
+    }
 
 }

--- a/src/main/java/org/apache/ibatis/mapping/BoundSql.java
+++ b/src/main/java/org/apache/ibatis/mapping/BoundSql.java
@@ -1,21 +1,16 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Copyright 2009-2017 the original author or authors. Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and limitations under the
+ * License.
  */
 package org.apache.ibatis.mapping;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -24,53 +19,67 @@ import org.apache.ibatis.reflection.property.PropertyTokenizer;
 import org.apache.ibatis.session.Configuration;
 
 /**
- * An actual SQL String got from an {@link SqlSource} after having processed any dynamic content.
- * The SQL may have SQL placeholders "?" and an list (ordered) of an parameter mappings 
- * with the additional information for each parameter (at least the property name of the input object to read 
- * the value from). 
- * </br>
+ * An actual SQL String got from an {@link SqlSource} after having processed any dynamic content. The SQL may have SQL
+ * placeholders "?" and an list (ordered) of an parameter mappings with the additional information for each parameter
+ * (at least the property name of the input object to read the value from). </br>
  * Can also have additional parameters that are created by the dynamic language (for loops, bind...).
  *
  * @author Clinton Begin
  */
 public class BoundSql {
 
-  private final String sql;
-  private final List<ParameterMapping> parameterMappings;
-  private final Object parameterObject;
-  private final Map<String, Object> additionalParameters;
-  private final MetaObject metaParameters;
+    private final String sql;
+    private final List<ParameterMapping> parameterMappings;
+    private final Object parameterObject;
+    private final Map<String, Object> additionalParameters;
+    private final MetaObject metaParameters;
+    private final List<Object> inParameterValues;
 
-  public BoundSql(Configuration configuration, String sql, List<ParameterMapping> parameterMappings, Object parameterObject) {
-    this.sql = sql;
-    this.parameterMappings = parameterMappings;
-    this.parameterObject = parameterObject;
-    this.additionalParameters = new HashMap<String, Object>();
-    this.metaParameters = configuration.newMetaObject(additionalParameters);
-  }
+    public BoundSql(Configuration configuration, String sql, List<ParameterMapping> parameterMappings,
+            Object parameterObject) {
+        this.sql = sql;
+        this.parameterMappings = parameterMappings;
+        this.parameterObject = parameterObject;
+        this.additionalParameters = new HashMap<String, Object>();
+        this.metaParameters = configuration.newMetaObject(additionalParameters);
+        this.inParameterValues = new ArrayList<Object>(parameterMappings != null ? parameterMappings.size() : 0);
 
-  public String getSql() {
-    return sql;
-  }
+    }
 
-  public List<ParameterMapping> getParameterMappings() {
-    return parameterMappings;
-  }
+    public void addInParameterValue(Object value) {
+        inParameterValues.add(value);
+    }
 
-  public Object getParameterObject() {
-    return parameterObject;
-  }
+    public Object getInParameterValues(int paramterIndex) {
+        return inParameterValues.get(paramterIndex);
+    }
 
-  public boolean hasAdditionalParameter(String name) {
-    String paramName = new PropertyTokenizer(name).getName();
-    return additionalParameters.containsKey(paramName);
-  }
+    public boolean isInParameterValueUnset() {
+        return inParameterValues != null && inParameterValues.isEmpty();
+    }
 
-  public void setAdditionalParameter(String name, Object value) {
-    metaParameters.setValue(name, value);
-  }
+    public String getSql() {
+        return sql;
+    }
 
-  public Object getAdditionalParameter(String name) {
-    return metaParameters.getValue(name);
-  }
+    public List<ParameterMapping> getParameterMappings() {
+        return parameterMappings;
+    }
+
+    public Object getParameterObject() {
+        return parameterObject;
+    }
+
+    public boolean hasAdditionalParameter(String name) {
+        String paramName = new PropertyTokenizer(name).getName();
+        return additionalParameters.containsKey(paramName);
+    }
+
+    public void setAdditionalParameter(String name, Object value) {
+        metaParameters.setValue(name, value);
+    }
+
+    public Object getAdditionalParameter(String name) {
+        return metaParameters.getValue(name);
+    }
 }

--- a/src/main/java/org/apache/ibatis/mapping/BoundSql.java
+++ b/src/main/java/org/apache/ibatis/mapping/BoundSql.java
@@ -1,16 +1,22 @@
 /**
- * Copyright 2009-2017 the original author or authors. Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions and limitations under the
- * License.
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  */
 package org.apache.ibatis.mapping;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -19,67 +25,67 @@ import org.apache.ibatis.reflection.property.PropertyTokenizer;
 import org.apache.ibatis.session.Configuration;
 
 /**
- * An actual SQL String got from an {@link SqlSource} after having processed any dynamic content. The SQL may have SQL
- * placeholders "?" and an list (ordered) of an parameter mappings with the additional information for each parameter
- * (at least the property name of the input object to read the value from). </br>
+ * An actual SQL String got from an {@link SqlSource} after having processed any dynamic content.
+ * The SQL may have SQL placeholders "?" and an list (ordered) of an parameter mappings 
+ * with the additional information for each parameter (at least the property name of the input object to read 
+ * the value from). 
+ * </br>
  * Can also have additional parameters that are created by the dynamic language (for loops, bind...).
  *
  * @author Clinton Begin
  */
 public class BoundSql {
 
-    private final String sql;
-    private final List<ParameterMapping> parameterMappings;
-    private final Object parameterObject;
-    private final Map<String, Object> additionalParameters;
-    private final MetaObject metaParameters;
-    private final List<Object> inParameterValues;
+  private final String sql;
+  private final List<ParameterMapping> parameterMappings;
+  private final Object parameterObject;
+  private final Map<String, Object> additionalParameters;
+  private final MetaObject metaParameters;
+  private final List<Object> inParameterValues;
 
-    public BoundSql(Configuration configuration, String sql, List<ParameterMapping> parameterMappings,
-            Object parameterObject) {
-        this.sql = sql;
-        this.parameterMappings = parameterMappings;
-        this.parameterObject = parameterObject;
-        this.additionalParameters = new HashMap<String, Object>();
-        this.metaParameters = configuration.newMetaObject(additionalParameters);
-        this.inParameterValues = new ArrayList<Object>(parameterMappings != null ? parameterMappings.size() : 0);
+  public BoundSql(Configuration configuration, String sql, List<ParameterMapping> parameterMappings, Object parameterObject) {
+    this.sql = sql;
+    this.parameterMappings = parameterMappings;
+    this.parameterObject = parameterObject;
+    this.additionalParameters = new HashMap<String, Object>();
+    this.metaParameters = configuration.newMetaObject(additionalParameters);
+    this.inParameterValues = new ArrayList<Object>(parameterMappings != null ? parameterMappings.size() : 0);
+  }
+  
+  public void addInParameterValue(Object value) {
+      inParameterValues.add(value);
+  }
 
-    }
+  public Object getInParameterValue(int paramterIndex) {
+      return inParameterValues.get(paramterIndex);
+  }
 
-    public void addInParameterValue(Object value) {
-        inParameterValues.add(value);
-    }
+  public boolean isInParameterValueUnset() {
+      return inParameterValues != null && inParameterValues.isEmpty();
+  }
 
-    public Object getInParameterValues(int paramterIndex) {
-        return inParameterValues.get(paramterIndex);
-    }
+  public String getSql() {
+    return sql;
+  }
 
-    public boolean isInParameterValueUnset() {
-        return inParameterValues != null && inParameterValues.isEmpty();
-    }
+  public List<ParameterMapping> getParameterMappings() {
+    return parameterMappings;
+  }
 
-    public String getSql() {
-        return sql;
-    }
+  public Object getParameterObject() {
+    return parameterObject;
+  }
 
-    public List<ParameterMapping> getParameterMappings() {
-        return parameterMappings;
-    }
+  public boolean hasAdditionalParameter(String name) {
+    String paramName = new PropertyTokenizer(name).getName();
+    return additionalParameters.containsKey(paramName);
+  }
 
-    public Object getParameterObject() {
-        return parameterObject;
-    }
+  public void setAdditionalParameter(String name, Object value) {
+    metaParameters.setValue(name, value);
+  }
 
-    public boolean hasAdditionalParameter(String name) {
-        String paramName = new PropertyTokenizer(name).getName();
-        return additionalParameters.containsKey(paramName);
-    }
-
-    public void setAdditionalParameter(String name, Object value) {
-        metaParameters.setValue(name, value);
-    }
-
-    public Object getAdditionalParameter(String name) {
-        return metaParameters.getValue(name);
-    }
+  public Object getAdditionalParameter(String name) {
+    return metaParameters.getValue(name);
+  }
 }

--- a/src/main/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandler.java
+++ b/src/main/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandler.java
@@ -1,10 +1,17 @@
 /**
- * Copyright 2009-2017 the original author or authors. Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License. You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions and limitations under the
- * License.
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  */
 package org.apache.ibatis.scripting.defaults;
 
@@ -31,77 +38,68 @@ import org.apache.ibatis.type.TypeHandlerRegistry;
  */
 public class DefaultParameterHandler implements ParameterHandler {
 
-    private final TypeHandlerRegistry typeHandlerRegistry;
+  private final TypeHandlerRegistry typeHandlerRegistry;
 
-    private final MappedStatement mappedStatement;
-    private final Object parameterObject;
-    private final BoundSql boundSql;
-    private final Configuration configuration;
+  private final MappedStatement mappedStatement;
+  private final Object parameterObject;
+  private final BoundSql boundSql;
+  private final Configuration configuration;
 
-    public DefaultParameterHandler(MappedStatement mappedStatement, Object parameterObject, BoundSql boundSql) {
-        this.mappedStatement = mappedStatement;
-        this.configuration = mappedStatement.getConfiguration();
-        this.typeHandlerRegistry = mappedStatement.getConfiguration().getTypeHandlerRegistry();
-        this.parameterObject = parameterObject;
-        this.boundSql = boundSql;
-    }
+  public DefaultParameterHandler(MappedStatement mappedStatement, Object parameterObject, BoundSql boundSql) {
+    this.mappedStatement = mappedStatement;
+    this.configuration = mappedStatement.getConfiguration();
+    this.typeHandlerRegistry = mappedStatement.getConfiguration().getTypeHandlerRegistry();
+    this.parameterObject = parameterObject;
+    this.boundSql = boundSql;
+  }
 
-    @Override
-    public Object getParameterObject() {
-        return parameterObject;
-    }
+  @Override
+  public Object getParameterObject() {
+    return parameterObject;
+  }
 
-    @Override
-    public void setParameters(PreparedStatement ps) {
-        ErrorContext.instance().activity("setting parameters").object(mappedStatement.getParameterMap().getId());
-        List<ParameterMapping> parameterMappings = boundSql.getParameterMappings();
-        if (parameterMappings != null) {
-            int inParamIndex = 0;
-            boolean inParameterValueUnset = boundSql.isInParameterValueUnset();
-            for (int i = 0; i < parameterMappings.size(); i++) {
-                ParameterMapping parameterMapping = parameterMappings.get(i);
-                if (parameterMapping.getMode() != ParameterMode.OUT) {
-                    Object value = null;
-                    if (inParameterValueUnset) {
-                        String propertyName = parameterMapping.getProperty();
-                        if (boundSql.hasAdditionalParameter(propertyName)) { // issue #448 ask first for additional
-                                                                             // params
-                            value = boundSql.getAdditionalParameter(propertyName);
-                        }
-                        else if (parameterObject == null) {
-                            value = null;
-                        }
-                        else if (typeHandlerRegistry.hasTypeHandler(parameterObject.getClass())) {
-                            value = parameterObject;
-                        }
-                        else {
-                            MetaObject metaObject = configuration.newMetaObject(parameterObject);
-                            value = metaObject.getValue(propertyName);
-                        }
-                        boundSql.addInParameterValue(value);
-                    }
-                    else {
-                        value = boundSql.getInParameterValues(inParamIndex++);
-                    }
-                    TypeHandler typeHandler = parameterMapping.getTypeHandler();
-                    JdbcType jdbcType = parameterMapping.getJdbcType();
-                    if (value == null && jdbcType == null) {
-                        jdbcType = configuration.getJdbcTypeForNull();
-                    }
-                    try {
-                        typeHandler.setParameter(ps, i + 1, value, jdbcType);
-                    }
-                    catch (TypeException e) {
-                        throw new TypeException(
-                                "Could not set parameters for mapping: " + parameterMapping + ". Cause: " + e, e);
-                    }
-                    catch (SQLException e) {
-                        throw new TypeException(
-                                "Could not set parameters for mapping: " + parameterMapping + ". Cause: " + e, e);
-                    }
-                }
-            }
+  @Override
+  public void setParameters(PreparedStatement ps) {
+    ErrorContext.instance().activity("setting parameters").object(mappedStatement.getParameterMap().getId());
+    List<ParameterMapping> parameterMappings = boundSql.getParameterMappings();
+    if (parameterMappings != null) {
+      boolean inParameterValueUnset = boundSql.isInParameterValueUnset();
+      int inParamIndex = 0;
+      for (int i = 0; i < parameterMappings.size(); i++) {
+        ParameterMapping parameterMapping = parameterMappings.get(i);
+        if (parameterMapping.getMode() != ParameterMode.OUT) {
+          Object value = null;
+          if (inParameterValueUnset) {
+              String propertyName = parameterMapping.getProperty();
+              if (boundSql.hasAdditionalParameter(propertyName)) { // issue #448 ask first for additional params
+                value = boundSql.getAdditionalParameter(propertyName);
+              } else if (parameterObject == null) {
+                value = null;
+              } else if (typeHandlerRegistry.hasTypeHandler(parameterObject.getClass())) {
+                value = parameterObject;
+              } else {
+                MetaObject metaObject = configuration.newMetaObject(parameterObject);
+                value = metaObject.getValue(propertyName);
+              }
+              boundSql.addInParameterValue(value);
+          }else{
+              value = boundSql.getInParameterValue(inParamIndex++);
+          }
+          TypeHandler typeHandler = parameterMapping.getTypeHandler();
+          JdbcType jdbcType = parameterMapping.getJdbcType();
+          if (value == null && jdbcType == null) {
+            jdbcType = configuration.getJdbcTypeForNull();
+          }
+          try {
+            typeHandler.setParameter(ps, i + 1, value, jdbcType);
+          } catch (TypeException e) {
+            throw new TypeException("Could not set parameters for mapping: " + parameterMapping + ". Cause: " + e, e);
+          } catch (SQLException e) {
+            throw new TypeException("Could not set parameters for mapping: " + parameterMapping + ". Cause: " + e, e);
+          }
         }
+      }
     }
+  }
 
 }

--- a/src/main/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandler.java
+++ b/src/main/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandler.java
@@ -1,17 +1,10 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Copyright 2009-2017 the original author or authors. Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and limitations under the
+ * License.
  */
 package org.apache.ibatis.scripting.defaults;
 
@@ -38,61 +31,77 @@ import org.apache.ibatis.type.TypeHandlerRegistry;
  */
 public class DefaultParameterHandler implements ParameterHandler {
 
-  private final TypeHandlerRegistry typeHandlerRegistry;
+    private final TypeHandlerRegistry typeHandlerRegistry;
 
-  private final MappedStatement mappedStatement;
-  private final Object parameterObject;
-  private final BoundSql boundSql;
-  private final Configuration configuration;
+    private final MappedStatement mappedStatement;
+    private final Object parameterObject;
+    private final BoundSql boundSql;
+    private final Configuration configuration;
 
-  public DefaultParameterHandler(MappedStatement mappedStatement, Object parameterObject, BoundSql boundSql) {
-    this.mappedStatement = mappedStatement;
-    this.configuration = mappedStatement.getConfiguration();
-    this.typeHandlerRegistry = mappedStatement.getConfiguration().getTypeHandlerRegistry();
-    this.parameterObject = parameterObject;
-    this.boundSql = boundSql;
-  }
-
-  @Override
-  public Object getParameterObject() {
-    return parameterObject;
-  }
-
-  @Override
-  public void setParameters(PreparedStatement ps) {
-    ErrorContext.instance().activity("setting parameters").object(mappedStatement.getParameterMap().getId());
-    List<ParameterMapping> parameterMappings = boundSql.getParameterMappings();
-    if (parameterMappings != null) {
-      for (int i = 0; i < parameterMappings.size(); i++) {
-        ParameterMapping parameterMapping = parameterMappings.get(i);
-        if (parameterMapping.getMode() != ParameterMode.OUT) {
-          Object value;
-          String propertyName = parameterMapping.getProperty();
-          if (boundSql.hasAdditionalParameter(propertyName)) { // issue #448 ask first for additional params
-            value = boundSql.getAdditionalParameter(propertyName);
-          } else if (parameterObject == null) {
-            value = null;
-          } else if (typeHandlerRegistry.hasTypeHandler(parameterObject.getClass())) {
-            value = parameterObject;
-          } else {
-            MetaObject metaObject = configuration.newMetaObject(parameterObject);
-            value = metaObject.getValue(propertyName);
-          }
-          TypeHandler typeHandler = parameterMapping.getTypeHandler();
-          JdbcType jdbcType = parameterMapping.getJdbcType();
-          if (value == null && jdbcType == null) {
-            jdbcType = configuration.getJdbcTypeForNull();
-          }
-          try {
-            typeHandler.setParameter(ps, i + 1, value, jdbcType);
-          } catch (TypeException e) {
-            throw new TypeException("Could not set parameters for mapping: " + parameterMapping + ". Cause: " + e, e);
-          } catch (SQLException e) {
-            throw new TypeException("Could not set parameters for mapping: " + parameterMapping + ". Cause: " + e, e);
-          }
-        }
-      }
+    public DefaultParameterHandler(MappedStatement mappedStatement, Object parameterObject, BoundSql boundSql) {
+        this.mappedStatement = mappedStatement;
+        this.configuration = mappedStatement.getConfiguration();
+        this.typeHandlerRegistry = mappedStatement.getConfiguration().getTypeHandlerRegistry();
+        this.parameterObject = parameterObject;
+        this.boundSql = boundSql;
     }
-  }
+
+    @Override
+    public Object getParameterObject() {
+        return parameterObject;
+    }
+
+    @Override
+    public void setParameters(PreparedStatement ps) {
+        ErrorContext.instance().activity("setting parameters").object(mappedStatement.getParameterMap().getId());
+        List<ParameterMapping> parameterMappings = boundSql.getParameterMappings();
+        if (parameterMappings != null) {
+            int inParamIndex = 0;
+            boolean inParameterValueUnset = boundSql.isInParameterValueUnset();
+            for (int i = 0; i < parameterMappings.size(); i++) {
+                ParameterMapping parameterMapping = parameterMappings.get(i);
+                if (parameterMapping.getMode() != ParameterMode.OUT) {
+                    Object value = null;
+                    if (inParameterValueUnset) {
+                        String propertyName = parameterMapping.getProperty();
+                        if (boundSql.hasAdditionalParameter(propertyName)) { // issue #448 ask first for additional
+                                                                             // params
+                            value = boundSql.getAdditionalParameter(propertyName);
+                        }
+                        else if (parameterObject == null) {
+                            value = null;
+                        }
+                        else if (typeHandlerRegistry.hasTypeHandler(parameterObject.getClass())) {
+                            value = parameterObject;
+                        }
+                        else {
+                            MetaObject metaObject = configuration.newMetaObject(parameterObject);
+                            value = metaObject.getValue(propertyName);
+                        }
+                        boundSql.addInParameterValue(value);
+                    }
+                    else {
+                        value = boundSql.getInParameterValues(inParamIndex++);
+                    }
+                    TypeHandler typeHandler = parameterMapping.getTypeHandler();
+                    JdbcType jdbcType = parameterMapping.getJdbcType();
+                    if (value == null && jdbcType == null) {
+                        jdbcType = configuration.getJdbcTypeForNull();
+                    }
+                    try {
+                        typeHandler.setParameter(ps, i + 1, value, jdbcType);
+                    }
+                    catch (TypeException e) {
+                        throw new TypeException(
+                                "Could not set parameters for mapping: " + parameterMapping + ". Cause: " + e, e);
+                    }
+                    catch (SQLException e) {
+                        throw new TypeException(
+                                "Could not set parameters for mapping: " + parameterMapping + ". Cause: " + e, e);
+                    }
+                }
+            }
+        }
+    }
 
 }

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -69,6 +69,7 @@ import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.mapping.ParameterMap;
 import org.apache.ibatis.mapping.ResultMap;
 import org.apache.ibatis.mapping.VendorDatabaseIdProvider;
+import org.apache.ibatis.parsing.TokenHandler;
 import org.apache.ibatis.parsing.XNode;
 import org.apache.ibatis.plugin.Interceptor;
 import org.apache.ibatis.plugin.InterceptorChain;
@@ -546,6 +547,10 @@ public class Configuration {
     parameterHandler = (ParameterHandler) interceptorChain.pluginAll(parameterHandler);
     return parameterHandler;
   }
+  
+  public TokenHandler newTokenHandler(TokenHandler orginTokenHandler) {
+      return (TokenHandler) interceptorChain.pluginAll(orginTokenHandler);
+    }
 
   public ResultSetHandler newResultSetHandler(Executor executor, MappedStatement mappedStatement, RowBounds rowBounds, ParameterHandler parameterHandler,
       ResultHandler resultHandler, BoundSql boundSql) {

--- a/src/main/java/org/apache/ibatis/type/JdbcType.java
+++ b/src/main/java/org/apache/ibatis/type/JdbcType.java
@@ -43,6 +43,7 @@ public enum JdbcType {
   LONGVARCHAR(Types.LONGVARCHAR),
   DATE(Types.DATE),
   TIME(Types.TIME),
+  DATETIME(94),//such as date for oracle or datetime for mysql
   TIMESTAMP(Types.TIMESTAMP),
   BINARY(Types.BINARY),
   VARBINARY(Types.VARBINARY),

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -128,6 +128,7 @@ public final class TypeHandlerRegistry {
     register(JdbcType.TIMESTAMP, new DateTypeHandler());
     register(JdbcType.DATE, new DateOnlyTypeHandler());
     register(JdbcType.TIME, new TimeOnlyTypeHandler());
+    register(JdbcType.DATETIME, new DateTypeHandler());//default datetime handler
 
     register(java.sql.Date.class, new SqlDateTypeHandler());
     register(java.sql.Time.class, new SqlTimeTypeHandler());

--- a/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/CreateDB.sql
@@ -1,0 +1,25 @@
+--
+--    Copyright 2009-2016 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(20),
+  birthday date
+);
+
+insert into users (id, name, birthday) values(1, 'Inactive', '2017-01-01');

--- a/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/Mapper.java
@@ -1,0 +1,25 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.plugin.tokenhandler;
+
+import java.util.Date;
+import java.util.List;
+
+public interface Mapper {
+
+  List<User> getUsers(Date start);
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/Mapper.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2016 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.plugin.tokenhandler.Mapper">
+
+	<resultMap type="org.apache.ibatis.submitted.plugin.tokenhandler.User"
+		id="userResult">
+		<result property="id" column="id" />
+		<result property="name" column="name" />
+		<result property="birthday" column="birthday" />
+	</resultMap>
+
+	<select id="getUsers" resultMap="userResult">
+    <![CDATA[
+		select * from users
+    where birthday >=#{start}
+     ]]>
+	</select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/OracleDateHandler.java
+++ b/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/OracleDateHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Focus Technology, Co., Ltd. All rights reserved.
+ */
+/**
+ * 
+ */
+package org.apache.ibatis.submitted.plugin.tokenhandler;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import org.apache.ibatis.type.DateTypeHandler;
+import org.apache.ibatis.type.JdbcType;
+
+/**
+ * OracleDateHandler.java
+ *
+ * @author chuyifan
+ */
+/**
+ * @author chuyifan
+ */
+public class OracleDateHandler extends DateTypeHandler {
+    private static final String FORMAT = "yyyy-MM-dd hh:mm:ss";
+    private static ThreadLocal<SimpleDateFormat> format = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            return new SimpleDateFormat(FORMAT);
+        }
+    };
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, Date parameter, JdbcType jdbcType)
+            throws SQLException {
+        ps.setString(i, format.get().format(parameter));
+        // ps.setTimestamp(i, new Timestamp((parameter).getTime()));
+    }
+}

--- a/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/OracleParameterMappingTokenHandlerInterceptor.java
+++ b/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/OracleParameterMappingTokenHandlerInterceptor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Focus Technology, Co., Ltd. All rights reserved.
+ */
+/**
+ * 
+ */
+package org.apache.ibatis.submitted.plugin.tokenhandler;
+
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.ibatis.builder.SqlSourceBuilder.ParameterMappingTokenHandler;
+import org.apache.ibatis.mapping.ParameterMapping;
+import org.apache.ibatis.parsing.TokenHandler;
+import org.apache.ibatis.plugin.Interceptor;
+import org.apache.ibatis.plugin.Intercepts;
+import org.apache.ibatis.plugin.Invocation;
+import org.apache.ibatis.plugin.Plugin;
+import org.apache.ibatis.plugin.Signature;
+import org.apache.ibatis.type.JdbcType;
+
+/**
+ * FocusDateTypeHandler.java
+ *
+ * @author chuyifan
+ */
+/**
+ * @author chuyifan
+ */
+@Intercepts({@Signature(type = TokenHandler.class, method = "handleToken", args = {String.class})})
+public class OracleParameterMappingTokenHandlerInterceptor implements Interceptor {
+
+    @Override
+    public Object intercept(Invocation invocation) throws Throwable {
+        Object orignResult = invocation.proceed();
+        ParameterMappingTokenHandler parameterMappingHandler = (ParameterMappingTokenHandler) invocation.getTarget();
+        List<ParameterMapping> parameterMapping = parameterMappingHandler.getParameterMappings();
+        if (JdbcType.DATETIME.equals(parameterMapping.get(parameterMapping.size() - 1).getJdbcType())) {
+            return "to_date(?,'yyyy-mm-dd hh24:mi:ss')";
+        }
+        return orignResult;
+    }
+
+    @Override
+    public Object plugin(Object target) {
+        if (target instanceof ParameterMappingTokenHandler) {
+            return Plugin.wrap(target, this);
+        }
+        return target;
+    }
+
+    @Override
+    public void setProperties(Properties properties) {
+
+    }
+}

--- a/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/TokenHandlerInterceptorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/TokenHandlerInterceptorTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2009-2017 the original author or authors. Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and limitations under the
+ * License.
+ */
+package org.apache.ibatis.submitted.plugin.tokenhandler;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TokenHandlerInterceptorTest {
+
+    private static SqlSessionFactory sqlSessionFactory;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // create a SqlSessionFactory
+        Reader reader =
+                Resources.getResourceAsReader("org/apache/ibatis/submitted/plugin/tokenhandler/mybatis-config.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
+        sqlSessionFactory.getConfiguration().addMapper(Mapper.class);
+
+        // populate in-memory database
+        SqlSession session = sqlSessionFactory.openSession();
+        Connection conn = session.getConnection();
+        reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/plugin/tokenhandler/CreateDB.sql");
+        ScriptRunner runner = new ScriptRunner(conn);
+        runner.setLogWriter(null);
+        runner.runScript(reader);
+        conn.close();
+        reader.close();
+        session.close();
+    }
+
+    @Test
+    public void shouldGetAUser() {
+        SqlSession sqlSession = sqlSessionFactory.openSession();
+        Date curDate = new Date();
+        try {
+            Mapper mapper = sqlSession.getMapper(Mapper.class);
+            List<User> users = mapper.getUsers(curDate);
+            Assert.assertTrue(users == null || users.isEmpty());
+        }
+        finally {
+            sqlSession.close();
+        }
+    }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/User.java
@@ -1,0 +1,51 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.plugin.tokenhandler;
+
+import java.util.Date;
+
+public class User {
+
+  private Integer id;
+  private String name;
+  private Date birthday;
+
+
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+public Date getBirthday() {
+    return birthday;
+}
+
+public void setBirthday(Date birthday) {
+    this.birthday = birthday;
+}
+}

--- a/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/plugin/tokenhandler/mybatis-config.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2016 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+ <typeHandlers>
+    <typeHandler javaType="java.util.Date" jdbcType="DATETIME" handler="org.apache.ibatis.submitted.plugin.tokenhandler.OracleDateHandler"/>
+ </typeHandlers>
+  <plugins>
+        <plugin interceptor="org.apache.ibatis.submitted.plugin.tokenhandler.OracleParameterMappingTokenHandlerInterceptor">
+        </plugin>
+  </plugins>
+
+	<environments default="development">
+		<environment id="development">
+			<transactionManager type="JDBC">
+				<property name="" value="" />
+			</transactionManager>
+			<dataSource type="UNPOOLED">
+				<property name="driver" value="org.hsqldb.jdbcDriver" />
+				<property name="url" value="jdbc:hsqldb:mem:typehandlerinjection" />
+				<property name="username" value="sa" />
+			</dataSource>
+		</environment>
+	</environments>
+
+</configuration>


### PR DESCRIPTION
I want to add cache for in-parameter to avoid getting in-parameter repeatedly. Now there are at least twp places to handle the in-paramter. It is unnecessary to handle them repeatedly.