### PR TITLE
singleton pattern should be thread safe in VFS

### DIFF
--- a/src/main/java/org/apache/ibatis/io/VFS.java
+++ b/src/main/java/org/apache/ibatis/io/VFS.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ public abstract class VFS {
   private static class VFSHolder {
     static final VFS INSTANCE = createVFS();
 
+    @SuppressWarnings("unchecked")
     static VFS createVFS() {
       // Try the user implementations first, then the built-ins
       List<Class<? extends VFS>> impls = new ArrayList<Class<? extends VFS>>();
@@ -80,12 +81,10 @@ public abstract class VFS {
     }
   }
 
-
   /**
    * Get the singleton {@link VFS} instance. If no {@link VFS} implementation can be found for the
    * current environment, then this method returns null.
    */
-  @SuppressWarnings("unchecked")
   public static VFS getInstance() {
     return VFSHolder.INSTANCE;
   }

--- a/src/main/java/org/apache/ibatis/io/VFS.java
+++ b/src/main/java/org/apache/ibatis/io/VFS.java
@@ -42,7 +42,7 @@ public abstract class VFS {
   public static final List<Class<? extends VFS>> USER_IMPLEMENTATIONS = new ArrayList<Class<? extends VFS>>();
 
   /** Singleton instance. */
-  private static VFS instance;
+  private static volatile VFS instance;
 
   /**
    * Get the singleton {@link VFS} instance. If no {@link VFS} implementation can be found for the
@@ -50,41 +50,50 @@ public abstract class VFS {
    */
   @SuppressWarnings("unchecked")
   public static VFS getInstance() {
-    if (instance != null) {
-      return instance;
-    }
 
-    // Try the user implementations first, then the built-ins
-    List<Class<? extends VFS>> impls = new ArrayList<Class<? extends VFS>>();
-    impls.addAll(USER_IMPLEMENTATIONS);
-    impls.addAll(Arrays.asList((Class<? extends VFS>[]) IMPLEMENTATIONS));
+    if (instance == null) {
+      synchronized (VFS.class){
+        if (instance == null){
 
-    // Try each implementation class until a valid one is found
-    VFS vfs = null;
-    for (int i = 0; vfs == null || !vfs.isValid(); i++) {
-      Class<? extends VFS> impl = impls.get(i);
-      try {
-        vfs = impl.newInstance();
-        if (vfs == null || !vfs.isValid()) {
-          if (log.isDebugEnabled()) {
-            log.debug("VFS implementation " + impl.getName() +
-              " is not valid in this environment.");
+          // Try the user implementations first, then the built-ins
+          List<Class<? extends VFS>> impls = new ArrayList<Class<? extends VFS>>();
+          impls.addAll(USER_IMPLEMENTATIONS);
+          impls.addAll(Arrays.asList((Class<? extends VFS>[]) IMPLEMENTATIONS));
+
+          // Try each implementation class until a valid one is found
+          VFS vfs = null;
+          for (int i = 0; vfs == null || !vfs.isValid(); i++) {
+            Class<? extends VFS> impl = impls.get(i);
+            try {
+              vfs = impl.newInstance();
+              if (vfs == null || !vfs.isValid()) {
+                if (log.isDebugEnabled()) {
+                  log.debug("VFS implementation " + impl.getName() +
+                      " is not valid in this environment.");
+                }
+              }
+            } catch (InstantiationException e) {
+              log.error("Failed to instantiate " + impl, e);
+              return null;
+            } catch (IllegalAccessException e) {
+              log.error("Failed to instantiate " + impl, e);
+              return null;
+            }
           }
+
+          if (log.isDebugEnabled()) {
+            log.debug("Using VFS adapter " + vfs.getClass().getName());
+          }
+          /*
+            Only one thread and one time to initialize
+            this singleton class.
+           */
+          VFS.instance = vfs;
         }
-      } catch (InstantiationException e) {
-        log.error("Failed to instantiate " + impl, e);
-        return null;
-      } catch (IllegalAccessException e) {
-        log.error("Failed to instantiate " + impl, e);
-        return null;
       }
     }
 
-    if (log.isDebugEnabled()) {
-      log.debug("Using VFS adapter " + vfs.getClass().getName());
-    }
-    VFS.instance = vfs;
-    return VFS.instance;
+    return instance;
   }
 
   /**

--- a/src/test/java/org/apache/ibatis/io/VFSTest.java
+++ b/src/test/java/org/apache/ibatis/io/VFSTest.java
@@ -1,14 +1,27 @@
+/**
+ *    Copyright 2009-2017 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.io;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Author: jasonleaster
- * Date  : 2017/7/30
- * Email : jasonleaster@gmail.com
- * Description:
- *    Unit test for VFS getInstance method in multi-thread environment
+ * Unit test for VFS getInstance method in multi-thread environment
+ * 
+ * @author: jasonleaster
  */
 public class VFSTest {
 
@@ -18,16 +31,15 @@ public class VFSTest {
     Assert.assertNotNull(vsf);
   }
 
-
   @Test
-  public void getInstanceShouldNotBeNullInMultiThreadEnv() throws InterruptedException{
+  public void getInstanceShouldNotBeNullInMultiThreadEnv() throws InterruptedException {
     final int threadCount = 3;
 
     Thread[] threads = new Thread[threadCount];
     InstanceGetterProcedure[] procedures = new InstanceGetterProcedure[threadCount];
 
     for (int i = 0; i < threads.length; i++) {
-      String threadName = "Thread##"+ i;
+      String threadName = "Thread##" + i;
 
       procedures[i] = new InstanceGetterProcedure();
       threads[i] = new Thread(procedures[i], threadName);
@@ -37,19 +49,17 @@ public class VFSTest {
       thread.start();
     }
 
-    for (Thread thread :threads)
-    {
+    for (Thread thread : threads) {
       thread.join();
     }
 
     // All caller got must be the same instance
-    for (int i = 0; i < threadCount- 1; i++){
-      Assert.assertEquals(procedures[i].instanceGot, procedures[i+1].instanceGot);
+    for (int i = 0; i < threadCount - 1; i++) {
+      Assert.assertEquals(procedures[i].instanceGot, procedures[i + 1].instanceGot);
     }
-
   }
 
-  private class InstanceGetterProcedure implements Runnable{
+  private class InstanceGetterProcedure implements Runnable {
 
     volatile VFS instanceGot;
 

--- a/src/test/java/org/apache/ibatis/io/VFSTest.java
+++ b/src/test/java/org/apache/ibatis/io/VFSTest.java
@@ -31,8 +31,10 @@ public class VFSTest {
 
       procedures[i] = new InstanceGetterProcedure();
       threads[i] = new Thread(procedures[i], threadName);
+    }
 
-      threads[i].start();
+    for (Thread thread : threads) {
+      thread.start();
     }
 
     for (Thread thread :threads)

--- a/src/test/java/org/apache/ibatis/io/VFSTest.java
+++ b/src/test/java/org/apache/ibatis/io/VFSTest.java
@@ -1,0 +1,59 @@
+package org.apache.ibatis.io;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Author: jasonleaster
+ * Date  : 2017/7/30
+ * Email : jasonleaster@gmail.com
+ * Description:
+ *    Unit test for VFS getInstance method in multi-thread environment
+ */
+public class VFSTest {
+
+  @Test
+  public void getInstanceShouldNotBeNull() throws Exception {
+    VFS vsf = VFS.getInstance();
+    Assert.assertNotNull(vsf);
+  }
+
+
+  @Test
+  public void getInstanceShouldNotBeNullInMultiThreadEnv() throws InterruptedException{
+    final int threadCount = 3;
+
+    Thread[] threads = new Thread[threadCount];
+    InstanceGetterProcedure[] procedures = new InstanceGetterProcedure[threadCount];
+
+    for (int i = 0; i < threads.length; i++) {
+      String threadName = "Thread##"+ i;
+
+      procedures[i] = new InstanceGetterProcedure();
+      threads[i] = new Thread(procedures[i], threadName);
+
+      threads[i].start();
+    }
+
+    for (Thread thread :threads)
+    {
+      thread.join();
+    }
+
+    // All caller got must be the same instance
+    for (int i = 0; i < threadCount- 1; i++){
+      Assert.assertEquals(procedures[i].instanceGot, procedures[i+1].instanceGot);
+    }
+
+  }
+
+  private class InstanceGetterProcedure implements Runnable{
+
+    volatile VFS instanceGot;
+
+    @Override
+    public void run() {
+      instanceGot = VFS.getInstance();
+    }
+  }
+}


### PR DESCRIPTION
I found that the implementation of singleton in `VFS`  may not be thread-safe.  In multi-thread environment, singleton should also ensure that there will be only one instance created for the caller.

I also add a unit test file for that to improve the correctness of the implementation, please check it.

 

