### PR TITLE
[bugfix] Remove invalid marked transient on cacheKey as reported by sonarlint

### DIFF
--- a/src/main/java/org/apache/ibatis/cache/CacheKey.java
+++ b/src/main/java/org/apache/ibatis/cache/CacheKey.java
@@ -37,7 +37,8 @@ public class CacheKey implements Cloneable, Serializable {
   private int hashcode;
   private long checksum;
   private int count;
-  private transient List<Object> updateList;
+  // 8/21/2017 - Sonarlint flags this as needing to be marked transient.  While true if content is not serializable, this is not always true and thus should not be marked transient.
+  private List<Object> updateList;
 
   public CacheKey() {
     this.hashcode = DEFAULT_HASHCODE;

--- a/src/test/java/org/apache/ibatis/cache/CacheKeyTest.java
+++ b/src/test/java/org/apache/ibatis/cache/CacheKeyTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2017 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/cache/CacheKeyTest.java
+++ b/src/test/java/org/apache/ibatis/cache/CacheKeyTest.java
@@ -16,8 +16,16 @@
 package org.apache.ibatis.cache;
 
 import static org.junit.Assert.*;
+
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.NotSerializableException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Date;
 
 public class CacheKeyTest {
@@ -80,4 +88,31 @@ public class CacheKeyTest {
     assertTrue(key1.equals(key2));
   }
 
+  @Test (expected = NotSerializableException.class)
+  public void serializationExceptionTest() throws ClassNotFoundException, IOException {
+    CacheKey cacheKey = new CacheKey();
+    cacheKey.update(new Object());
+    canSerialize(cacheKey);
+  }
+
+  @Test
+  public void serializationTest() throws ClassNotFoundException, IOException {
+    CacheKey cacheKey = new CacheKey();
+    cacheKey.update("serializable");
+    canSerialize(cacheKey);
+  }
+
+  private void canSerialize(final CacheKey object) throws ClassNotFoundException, IOException {
+      FileOutputStream fout = new FileOutputStream("target/address.ser");
+      ObjectOutputStream output = new ObjectOutputStream(fout);
+      output.writeObject(object);
+      output.close();
+
+      FileInputStream fin = new FileInputStream("target/address.ser");
+      ObjectInputStream input = new ObjectInputStream(fin);
+      CacheKey cacheKey = (CacheKey) input.readObject();
+      input.close();
+
+      Assert.assertEquals(1, cacheKey.getUpdateCount());
+  }
 }


### PR DESCRIPTION
Test cases written around this to avoid this serious flaw in the future,
configured origin of scanning asking for transient to be added, added
comment about when this would actually fail serialization, and wrote
test for that as well.