### PR TITLE
When resolving constructor args, @Param should precede actual name ev…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: java
 sudo: false
 dist: precise
 
+addons:
+  hosts:
+    - mybatisci
+  hostname: mybatisci
+
 jdk:
   - oraclejdk8
   - oraclejdk7

--- a/src/main/java/org/apache/ibatis/mapping/ResultMap.java
+++ b/src/main/java/org/apache/ibatis/mapping/ResultMap.java
@@ -185,24 +185,29 @@ public class ResultMap {
     }
 
     private List<String> getArgNames(Constructor<?> constructor) {
-      if (resultMap.configuration.isUseActualParamName() && Jdk.parameterExists) {
-        return ParamNameUtil.getParamNames(constructor);
-      } else {
-        List<String> paramNames = new ArrayList<String>();
-        final Annotation[][] paramAnnotations = constructor.getParameterAnnotations();
-        int paramCount = paramAnnotations.length;
-        for (int paramIndex = 0; paramIndex < paramCount; paramIndex++) {
-          String name = null;
-          for (Annotation annotation : paramAnnotations[paramIndex]) {
-            if (annotation instanceof Param) {
-              name = ((Param) annotation).value();
-              break;
-            }
+      List<String> paramNames = new ArrayList<String>();
+      List<String> actualParamNames = null;
+      final Annotation[][] paramAnnotations = constructor.getParameterAnnotations();
+      int paramCount = paramAnnotations.length;
+      for (int paramIndex = 0; paramIndex < paramCount; paramIndex++) {
+        String name = null;
+        for (Annotation annotation : paramAnnotations[paramIndex]) {
+          if (annotation instanceof Param) {
+            name = ((Param) annotation).value();
+            break;
           }
-          paramNames.add(name != null ? name : "arg" + paramIndex);
         }
-        return paramNames;
+        if (name == null && resultMap.configuration.isUseActualParamName() && Jdk.parameterExists) {
+          if (actualParamNames == null) {
+            actualParamNames = ParamNameUtil.getParamNames(constructor);
+          }
+          if (actualParamNames.size() > paramIndex) {
+            name = actualParamNames.get(paramIndex);
+          }
+        }
+        paramNames.add(name != null ? name : "arg" + paramIndex);
       }
+      return paramNames;
     }
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/named_constructor_args/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/named_constructor_args/User.java
@@ -28,10 +28,10 @@ public class User {
     this.id = Integer.valueOf(id);
   }
 
-  public User(Integer userId, String name) {
+  public User(Integer userId, @Param("name") String userName) {
     super();
     this.id = userId;
-    this.name = name;
+    this.name = userName;
   }
 
   public User(@Param("id") int id, @Param("name") String name, @Param("team") String team) {


### PR DESCRIPTION
…en when useActualParamName is enabled.

I realized I made a bug when fixing #721 .
If the name is specified with `@Param`, it should be used regardless of `useActualParamName` setting.