### PR TITLE
[travis] Move onto trusty build, remove oraclejdk7 (obsolete), and add openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: java
 sudo: false
-dist: precise
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk8
   - openjdk7
   - openjdk6
 


### PR DESCRIPTION
...because oracle charges for releases of old jdks, new builds of travis-ci no longer support oraclejdk6 or oraclejdk7.  Thus, removing oraclejdk7 from our build and then adding newly supported openjdk8.  