### PR TITLE
3.4.5 org.apache.ibatis.executor.resultset.DefaultResultSetHandler getNextResultSet cause stackoverflow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+sudo: false
+
 jdk:
   - oraclejdk8
   - oraclejdk7

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>24-SNAPSHOT</version>
+    <version>24</version>
   </parent>
 
   <artifactId>mybatis</artifactId>
@@ -126,7 +126,7 @@
   </distributionManagement>
 
   <properties>
-    <clirr.comparisonVersion>3.2.7</clirr.comparisonVersion>
+    <clirr.comparisonVersion>3.2.8</clirr.comparisonVersion>
     <findbugs.onlyAnalyze>org.apache.ibatis.*</findbugs.onlyAnalyze>
     <osgi.export>org.apache.ibatis.*;version=${project.version};-noimport:=true</osgi.export>
     <osgi.import>*;resolution:=optional</osgi.import>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -25,7 +24,7 @@
   </parent>
 
   <artifactId>mybatis</artifactId>
-  <version>3.3.0-SNAPSHOT</version>
+  <version>3.3.0</version>
   <packaging>jar</packaging>
 
   <name>mybatis</name>
@@ -108,7 +107,7 @@
     <url>http://github.com/mybatis/mybatis-3</url>
     <connection>scm:git:ssh://github.com/mybatis/mybatis-3.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/mybatis/mybatis-3.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>mybatis-3.3.0</tag>
   </scm>
   <issueManagement>
     <system>GitHub Issue Management</system>

--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <argLine>-Xmx1024m</argLine>
           <systemProperties>
             <property>
               <name>derby.stream.error.file</name>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
   <scm>
     <url>http://github.com/mybatis/mybatis-3</url>
     <connection>scm:git:ssh://github.com/mybatis/mybatis-3.git</connection>
-    <developerConnection>scm:git:git+ssh://git@github.com/mybatis/mybatis-3.git</developerConnection>
+    <developerConnection>scm:git:ssh://git@github.com/mybatis/mybatis-3.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
   <issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2009-2015 the original author or authors.
 
@@ -25,7 +25,7 @@
   </parent>
 
   <artifactId>mybatis</artifactId>
-  <version>3.3.1-SNAPSHOT</version>
+  <version>3.3.1</version>
   <packaging>jar</packaging>
 
   <name>mybatis</name>
@@ -108,7 +108,7 @@
     <url>http://github.com/mybatis/mybatis-3</url>
     <connection>scm:git:ssh://github.com/mybatis/mybatis-3.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/mybatis/mybatis-3.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>mybatis-3.3.1</tag>
   </scm>
   <issueManagement>
     <system>GitHub Issue Management</system>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
   </parent>
 
   <artifactId>mybatis</artifactId>
-  <version>3.3.1</version>
+  <version>3.3.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>mybatis</name>
@@ -108,7 +108,7 @@
     <url>http://github.com/mybatis/mybatis-3</url>
     <connection>scm:git:ssh://github.com/mybatis/mybatis-3.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/mybatis/mybatis-3.git</developerConnection>
-    <tag>mybatis-3.3.1</tag>
+    <tag>HEAD</tag>
   </scm>
   <issueManagement>
     <system>GitHub Issue Management</system>

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
   Copyright 2009-2015 the original author or authors.
 
@@ -20,16 +20,17 @@
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>24</version>
+    <version>26</version>
+    <relativePath />
   </parent>
 
   <artifactId>mybatis</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>mybatis</name>
   <description>
-    The MyBatis data mapper framework makes it easier to use a relational database with object-oriented
+    The MyBatis SQL mapper framework makes it easier to use a relational database with object-oriented
     applications. MyBatis couples objects with stored procedures or SQL statements using a XML descriptor or
     annotations. Simplicity is the biggest advantage of the MyBatis data mapper over object relational mapping
     tools.
@@ -107,7 +108,7 @@
     <url>http://github.com/mybatis/mybatis-3</url>
     <connection>scm:git:ssh://github.com/mybatis/mybatis-3.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/mybatis/mybatis-3.git</developerConnection>
-    <tag>mybatis-3.3.0</tag>
+    <tag>HEAD</tag>
   </scm>
   <issueManagement>
     <system>GitHub Issue Management</system>
@@ -119,13 +120,14 @@
   </ciManagement>
   <distributionManagement>
     <site>
-      <id>github</id>
-      <url>gitsite:git@github.com/mybatis/mybatis-3.git</url>
+      <id>gh-pages</id>
+      <name>Mybatis GitHub Pages</name>
+      <url>git:ssh://git@github.com/mybatis/mybatis-3.git?gh-pages#</url>
     </site>
   </distributionManagement>
 
   <properties>
-    <clirr.comparisonVersion>3.2.8</clirr.comparisonVersion>
+    <clirr.comparisonVersion>3.3.0</clirr.comparisonVersion>
     <findbugs.onlyAnalyze>org.apache.ibatis.*</findbugs.onlyAnalyze>
     <osgi.export>org.apache.ibatis.*;version=${project.version};-noimport:=true</osgi.export>
     <osgi.import>*;resolution:=optional</osgi.import>
@@ -136,8 +138,8 @@
     <dependency>
       <groupId>ognl</groupId>
       <artifactId>ognl</artifactId>
-      <version>3.0.11</version>
-      <scope>provided</scope>
+      <version>3.1.2</version>
+      <scope>compile</scope>
       <optional>true</optional>
       <exclusions>
          <exclusion>
@@ -146,24 +148,23 @@
          </exclusion>
       </exclusions>
     </dependency>
-    <!-- 3.19.0 causes significant failures in unit tests.  Review why... -->
     <dependency>
       <groupId>org.javassist</groupId>
       <artifactId>javassist</artifactId>
-      <version>3.18.2-GA</version>
-      <scope>provided</scope>
+      <version>3.20.0-GA</version>
+      <scope>compile</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.12</version>
+      <version>1.7.14</version>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.12</version>
+      <version>1.7.14</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -172,10 +173,11 @@
       <version>1.2.17</version>
       <optional>true</optional>
     </dependency>
+    <!-- Don't upgrade to 2.4+ until mybatis switches to java 7 -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.2</version>
+      <version>2.3</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -187,7 +189,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
-      <version>3.1</version>
+      <version>3.2.0</version>
       <optional>true</optional>
     </dependency>
 
@@ -201,13 +203,13 @@
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.2</version>
+      <version>2.3.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.11.1.1</version>
+      <version>10.12.1.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -216,6 +218,7 @@
       <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
+    <!-- Do not go to 2.x until we are on jdk7 -->
     <dependency>
       <groupId>commons-dbcp</groupId>
       <artifactId>commons-dbcp</artifactId>
@@ -255,7 +258,7 @@
               <name>derby.stream.error.file</name>
               <value>target/derby.log</value>
             </property>
-        </systemProperties>
+          </systemProperties>
         </configuration>
       </plugin>
       <plugin>
@@ -263,52 +266,36 @@
         <artifactId>maven-pdf-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>jarjar-maven-plugin</artifactId>
-        <configuration>
-          <input>{classes}</input>
-          <input>{test-classes}</input>
-          <includes>
-            <include>ognl:ognl</include>
-            <include>org.javassist:javassist</include>
-          </includes>
-          <rules>
-            <rule>
-              <pattern>ognl.**</pattern>
-              <result>org.apache.ibatis.ognl.@1</result>
-            </rule>
-            <rule>
-              <pattern>javassist.**</pattern>
-              <result>org.apache.ibatis.javassist.@1</result>
-            </rule>
-            <keep>
-              <pattern>org.apache.ibatis.**</pattern>
-            </keep>
-          </rules>
-          <overwrite>true</overwrite>
-        </configuration>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
-            <id>jarjar-classes</id>
-            <phase>process-test-classes</phase>
+            <phase>package</phase>
             <goals>
-              <goal>jarjar</goal>
+              <goal>shade</goal>
             </goals>
             <configuration>
-              <input>{classes}</input>
-            </configuration>
-          </execution>
-          <execution>
-            <id>jarjar-test-classes</id>
-            <phase>process-test-classes</phase>
-            <goals>
-              <goal>jarjar</goal>
-            </goals>
-            <configuration>
-              <input>{test-classes}</input>
-            </configuration>
-          </execution>
-        </executions>
+               <createDependencyReducedPom>false</createDependencyReducedPom>
+               <artifactSet>
+                 <includes>
+                   <include>org.mybatis:mybatis</include>
+                   <include>ognl:ognl</include>
+                   <include>org.javassist:javassist</include>
+                 </includes>
+               </artifactSet>
+               <relocations>
+                 <relocation>
+                   <pattern>ognl</pattern>
+                   <shadedPattern>org.apache.ibatis.ognl</shadedPattern>
+                 </relocation>
+                 <relocation>
+                   <pattern>javassist</pattern>
+                   <shadedPattern>org.apache.ibatis.javassist</shadedPattern>
+                 </relocation>
+               </relocations>
+             </configuration>
+           </execution>
+         </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -318,27 +305,14 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
         <configuration>
-          <instrumentation>
-            <ignores>
-              <ignore>org.apache.ibatis.ognl.*</ignore>
-              <ignore>org.apache.ibatis.javassist.*</ignore>
-            </ignores>
-            <excludes>
-              <exclude>org/apache/ibatis/ognl/**/*.class</exclude>
-              <exclude>org/apache/ibatis/javassist/**/*.class</exclude>
-            </excludes>
-          </instrumentation>
+          <excludes>
+            <exclude>org.apache.ibatis.ognl.*</exclude>
+            <exclude>org.apache.ibatis.javassist.*</exclude>
+          </excludes>
         </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
 

--- a/src/main/java/org/apache/ibatis/annotations/Many.java
+++ b/src/main/java/org/apache/ibatis/annotations/Many.java
@@ -30,10 +30,6 @@ import org.apache.ibatis.mapping.FetchType;
 public @interface Many {
   String select() default "";
 
-  String resultSet() default "";
-
-  String resultMap() default "";
-
   FetchType fetchType() default FetchType.DEFAULT;
 
 }

--- a/src/main/java/org/apache/ibatis/annotations/Options.java
+++ b/src/main/java/org/apache/ibatis/annotations/Options.java
@@ -46,4 +46,6 @@ public @interface Options {
   String keyProperty() default "id";
 
   String keyColumn() default "";
+  
+  String resultSets() default "";
 }

--- a/src/main/java/org/apache/ibatis/annotations/Options.java
+++ b/src/main/java/org/apache/ibatis/annotations/Options.java
@@ -46,6 +46,5 @@ public @interface Options {
   String keyProperty() default "id";
 
   String keyColumn() default "";
-  
-  String resultSets() default "";
+
 }

--- a/src/main/java/org/apache/ibatis/annotations/Select.java
+++ b/src/main/java/org/apache/ibatis/annotations/Select.java
@@ -27,5 +27,4 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface Select {
   String[] value();
-  String resultSets() default "";
 }

--- a/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
+++ b/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
@@ -128,11 +128,9 @@ public class MapperBuilderAssistant extends BaseBuilder {
       boolean readWrite,
       boolean blocking,
       Properties props) {
-    typeClass = valueOrDefault(typeClass, PerpetualCache.class);
-    evictionClass = valueOrDefault(evictionClass, LruCache.class);
     Cache cache = new CacheBuilder(currentNamespace)
-        .implementation(typeClass)
-        .addDecorator(evictionClass)
+        .implementation(valueOrDefault(typeClass, PerpetualCache.class))
+        .addDecorator(valueOrDefault(evictionClass, LruCache.class))
         .clearInterval(flushInterval)
         .size(size)
         .readWrite(readWrite)
@@ -146,8 +144,7 @@ public class MapperBuilderAssistant extends BaseBuilder {
 
   public ParameterMap addParameterMap(String id, Class<?> parameterClass, List<ParameterMapping> parameterMappings) {
     id = applyCurrentNamespace(id, false);
-    ParameterMap.Builder parameterMapBuilder = new ParameterMap.Builder(configuration, id, parameterClass, parameterMappings);
-    ParameterMap parameterMap = parameterMapBuilder.build();
+    ParameterMap parameterMap = new ParameterMap.Builder(configuration, id, parameterClass, parameterMappings).build();
     configuration.addParameterMap(parameterMap);
     return parameterMap;
   }
@@ -167,13 +164,13 @@ public class MapperBuilderAssistant extends BaseBuilder {
     Class<?> javaTypeClass = resolveParameterJavaType(parameterType, property, javaType, jdbcType);
     TypeHandler<?> typeHandlerInstance = resolveTypeHandler(javaTypeClass, typeHandler);
 
-    ParameterMapping.Builder builder = new ParameterMapping.Builder(configuration, property, javaTypeClass);
-    builder.jdbcType(jdbcType);
-    builder.resultMapId(resultMap);
-    builder.mode(parameterMode);
-    builder.numericScale(numericScale);
-    builder.typeHandler(typeHandlerInstance);
-    return builder.build();
+    return new ParameterMapping.Builder(configuration, property, javaTypeClass)
+        .jdbcType(jdbcType)
+        .resultMapId(resultMap)
+        .mode(parameterMode)
+        .numericScale(numericScale)
+        .typeHandler(typeHandlerInstance)
+        .build();
   }
 
   public ResultMap addResultMap(
@@ -186,7 +183,6 @@ public class MapperBuilderAssistant extends BaseBuilder {
     id = applyCurrentNamespace(id, false);
     extend = applyCurrentNamespace(extend, true);
 
-    ResultMap.Builder resultMapBuilder = new ResultMap.Builder(configuration, id, type, resultMappings, autoMapping);
     if (extend != null) {
       if (!configuration.hasResultMap(extend)) {
         throw new IncompleteElementException("Could not find a parent resultmap with id '" + extend + "'");
@@ -212,8 +208,9 @@ public class MapperBuilderAssistant extends BaseBuilder {
       }
       resultMappings.addAll(extendedResultMappings);
     }
-    resultMapBuilder.discriminator(discriminator);
-    ResultMap resultMap = resultMapBuilder.build();
+    ResultMap resultMap = new ResultMap.Builder(configuration, id, type, resultMappings, autoMapping)
+        .discriminator(discriminator)
+        .build();
     configuration.addResultMap(resultMap);
     return resultMap;
   }
@@ -246,8 +243,7 @@ public class MapperBuilderAssistant extends BaseBuilder {
       resultMap = applyCurrentNamespace(resultMap, true);
       namespaceDiscriminatorMap.put(e.getKey(), resultMap);
     }
-    Discriminator.Builder discriminatorBuilder = new Discriminator.Builder(configuration, resultMapping, namespaceDiscriminatorMap);
-    return discriminatorBuilder.build();
+    return new Discriminator.Builder(configuration, resultMapping, namespaceDiscriminatorMap).build();
   }
 
   public MappedStatement addMappedStatement(
@@ -279,22 +275,28 @@ public class MapperBuilderAssistant extends BaseBuilder {
     id = applyCurrentNamespace(id, false);
     boolean isSelect = sqlCommandType == SqlCommandType.SELECT;
 
-    MappedStatement.Builder statementBuilder = new MappedStatement.Builder(configuration, id, sqlSource, sqlCommandType);
-    statementBuilder.resource(resource);
-    statementBuilder.fetchSize(fetchSize);
-    statementBuilder.statementType(statementType);
-    statementBuilder.keyGenerator(keyGenerator);
-    statementBuilder.keyProperty(keyProperty);
-    statementBuilder.keyColumn(keyColumn);
-    statementBuilder.databaseId(databaseId);
-    statementBuilder.lang(lang);
-    statementBuilder.resultOrdered(resultOrdered);
-    statementBuilder.resulSets(resultSets);
-    setStatementTimeout(timeout, statementBuilder);
+    MappedStatement.Builder statementBuilder = new MappedStatement.Builder(configuration, id, sqlSource, sqlCommandType)
+        .resource(resource)
+        .fetchSize(fetchSize)
+        .timeout(timeout)
+        .statementType(statementType)
+        .keyGenerator(keyGenerator)
+        .keyProperty(keyProperty)
+        .keyColumn(keyColumn)
+        .databaseId(databaseId)
+        .lang(lang)
+        .resultOrdered(resultOrdered)
+        .resulSets(resultSets)
+        .resultMaps(getStatementResultMaps(resultMap, resultType, id))
+        .resultSetType(resultSetType)
+        .flushCacheRequired(valueOrDefault(flushCache, !isSelect))
+        .useCache(valueOrDefault(useCache, isSelect))
+        .cache(currentCache);
 
-    setStatementParameterMap(parameterMap, parameterType, statementBuilder);
-    setStatementResultMap(resultMap, resultType, resultSetType, statementBuilder);
-    setStatementCache(isSelect, flushCache, useCache, currentCache, statementBuilder);
+    ParameterMap statementParameterMap = getStatementParameterMap(parameterMap, parameterType, id);
+    if (statementParameterMap != null) {
+      statementBuilder.parameterMap(statementParameterMap);
+    }
 
     MappedStatement statement = statementBuilder.build();
     configuration.addMappedStatement(statement);
@@ -305,47 +307,33 @@ public class MapperBuilderAssistant extends BaseBuilder {
     return value == null ? defaultValue : value;
   }
 
-  private void setStatementCache(
-      boolean isSelect,
-      boolean flushCache,
-      boolean useCache,
-      Cache cache,
-      MappedStatement.Builder statementBuilder) {
-    flushCache = valueOrDefault(flushCache, !isSelect);
-    useCache = valueOrDefault(useCache, isSelect);
-    statementBuilder.flushCacheRequired(flushCache);
-    statementBuilder.useCache(useCache);
-    statementBuilder.cache(cache);
-  }
-
-  private void setStatementParameterMap(
-      String parameterMap,
+  private ParameterMap getStatementParameterMap(
+      String parameterMapName,
       Class<?> parameterTypeClass,
-      MappedStatement.Builder statementBuilder) {
-    parameterMap = applyCurrentNamespace(parameterMap, true);
-
-    if (parameterMap != null) {
+      String statementId) {
+    parameterMapName = applyCurrentNamespace(parameterMapName, true);
+    ParameterMap parameterMap = null;
+    if (parameterMapName != null) {
       try {
-        statementBuilder.parameterMap(configuration.getParameterMap(parameterMap));
+        parameterMap = configuration.getParameterMap(parameterMapName);
       } catch (IllegalArgumentException e) {
-        throw new IncompleteElementException("Could not find parameter map " + parameterMap, e);
+        throw new IncompleteElementException("Could not find parameter map " + parameterMapName, e);
       }
     } else if (parameterTypeClass != null) {
       List<ParameterMapping> parameterMappings = new ArrayList<ParameterMapping>();
-      ParameterMap.Builder inlineParameterMapBuilder = new ParameterMap.Builder(
+      parameterMap = new ParameterMap.Builder(
           configuration,
-          statementBuilder.id() + "-Inline",
+          statementId + "-Inline",
           parameterTypeClass,
-          parameterMappings);
-      statementBuilder.parameterMap(inlineParameterMapBuilder.build());
+          parameterMappings).build();
     }
+    return parameterMap;
   }
 
-  private void setStatementResultMap(
+  private List<ResultMap> getStatementResultMaps(
       String resultMap,
       Class<?> resultType,
-      ResultSetType resultSetType,
-      MappedStatement.Builder statementBuilder) {
+      String statementId) {
     resultMap = applyCurrentNamespace(resultMap, true);
 
     List<ResultMap> resultMaps = new ArrayList<ResultMap>();
@@ -359,24 +347,15 @@ public class MapperBuilderAssistant extends BaseBuilder {
         }
       }
     } else if (resultType != null) {
-      ResultMap.Builder inlineResultMapBuilder = new ResultMap.Builder(
+      ResultMap inlineResultMap = new ResultMap.Builder(
           configuration,
-          statementBuilder.id() + "-Inline",
+          statementId + "-Inline",
           resultType,
           new ArrayList<ResultMapping>(),
-          null);
-      resultMaps.add(inlineResultMapBuilder.build());
+          null).build();
+      resultMaps.add(inlineResultMap);
     }
-    statementBuilder.resultMaps(resultMaps);
-
-    statementBuilder.resultSetType(resultSetType);
-  }
-
-  private void setStatementTimeout(Integer timeout, MappedStatement.Builder statementBuilder) {
-    if (timeout == null) {
-      timeout = configuration.getDefaultStatementTimeout();
-    }
-    statementBuilder.timeout(timeout);
+    return resultMaps;
   }
 
   public ResultMapping buildResultMapping(
@@ -400,19 +379,19 @@ public class MapperBuilderAssistant extends BaseBuilder {
     if (composites.size() > 0) {
       column = null;
     }
-    ResultMapping.Builder builder = new ResultMapping.Builder(configuration, property, column, javaTypeClass);
-    builder.jdbcType(jdbcType);
-    builder.nestedQueryId(applyCurrentNamespace(nestedSelect, true));
-    builder.nestedResultMapId(applyCurrentNamespace(nestedResultMap, true));
-    builder.resultSet(resultSet);
-    builder.typeHandler(typeHandlerInstance);
-    builder.flags(flags == null ? new ArrayList<ResultFlag>() : flags);
-    builder.composites(composites);
-    builder.notNullColumns(parseMultipleColumnNames(notNullColumn));
-    builder.columnPrefix(columnPrefix);
-    builder.foreignColumn(foreignColumn);
-    builder.lazy(lazy);
-    return builder.build();
+    return new ResultMapping.Builder(configuration, property, column, javaTypeClass)
+        .jdbcType(jdbcType)
+        .nestedQueryId(applyCurrentNamespace(nestedSelect, true))
+        .nestedResultMapId(applyCurrentNamespace(nestedResultMap, true))
+        .resultSet(resultSet)
+        .typeHandler(typeHandlerInstance)
+        .flags(flags == null ? new ArrayList<ResultFlag>() : flags)
+        .composites(composites)
+        .notNullColumns(parseMultipleColumnNames(notNullColumn))
+        .columnPrefix(columnPrefix)
+        .foreignColumn(foreignColumn)
+        .lazy(lazy)
+        .build();
   }
 
   private Set<String> parseMultipleColumnNames(String columnName) {
@@ -438,8 +417,9 @@ public class MapperBuilderAssistant extends BaseBuilder {
       while (parser.hasMoreTokens()) {
         String property = parser.nextToken();
         String column = parser.nextToken();
-        ResultMapping.Builder complexBuilder = new ResultMapping.Builder(configuration, property, column, configuration.getTypeHandlerRegistry().getUnknownTypeHandler());
-        composites.add(complexBuilder.build());
+        ResultMapping complexResultMapping = new ResultMapping.Builder(
+            configuration, property, column, configuration.getTypeHandlerRegistry().getUnknownTypeHandler()).build();
+        composites.add(complexResultMapping);
       }
     }
     return composites;

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -339,7 +339,7 @@ public class MapperAnnotationBuilder {
           null,
           languageDriver,
           // ResultSets
-          select != null ? nullOrEmpty(options.resultSets()) : null);
+          options != null ? nullOrEmpty(options.resultSets()) : null);
     }
   }
   

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -196,6 +196,10 @@ public class MapperAnnotationBuilder {
   }
 
   private String generateResultMapName(Method method) {
+    Results results = method.getAnnotation(Results.class);
+    if (results != null && !results.id().isEmpty()) {
+      return type.getName() + "." + results.id();
+    }
     StringBuilder suffix = new StringBuilder();
     for (Class<?> c : method.getParameterTypes()) {
       suffix.append("-");

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -314,7 +314,6 @@ public class MapperAnnotationBuilder {
         resultMapId = parseResultMap(method);
       }
 
-      final Select select = method.getAnnotation(Select.class);
       assistant.addMappedStatement(
           mappedStatementId,
           sqlSource,
@@ -339,7 +338,7 @@ public class MapperAnnotationBuilder {
           null,
           languageDriver,
           // ResultSets
-          options != null ? nullOrEmpty(options.resultSets()) : null);
+          null);
     }
   }
   

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -499,12 +499,12 @@ public class MapperAnnotationBuilder {
           result.javaType() == void.class ? null : result.javaType(),
           result.jdbcType() == JdbcType.UNDEFINED ? null : result.jdbcType(),
           hasNestedSelect(result) ? nestedSelectId(result) : null,
-          hasNestedResultMap(result) ? nestedResultMap(result) : null,
+          null,
           null,
           null,
           result.typeHandler() == UnknownTypeHandler.class ? null : result.typeHandler(),
           flags,
-          hasNestedResultSet(result) ? nestedResultSet(result) : null,
+          null,
           null,
           isLazy(result));
       resultMappings.add(resultMapping);
@@ -522,18 +522,6 @@ public class MapperAnnotationBuilder {
     return nestedSelect;
   }
 
-  private String nestedResultSet(Result result) {
-    return result.many().resultSet();
-  }
-
-  private String nestedResultMap(Result result) {
-    String nestedResultMap = result.many().resultMap();
-    if (!nestedResultMap.contains(".")) {
-      nestedResultMap = type.getName() + "." + nestedResultMap;
-    }
-    return nestedResultMap;
-  }
-
   private boolean isLazy(Result result) {
     boolean isLazy = configuration.isLazyLoadingEnabled();
     if (result.one().select().length() > 0 && FetchType.DEFAULT != result.one().fetchType()) {
@@ -549,14 +537,6 @@ public class MapperAnnotationBuilder {
       throw new BuilderException("Cannot use both @One and @Many annotations in the same @Result");
     }
     return result.one().select().length() > 0 || result.many().select().length() > 0;  
-  }
-
-  private boolean hasNestedResultSet(Result result) {
-    return result.many().resultSet().length() > 0;
-  }
-
-  private boolean hasNestedResultMap(Result result) {
-    return result.many().resultMap().length() > 0;
   }
 
   private void applyConstructorArgs(Arg[] args, Class<?> resultType, List<ResultMapping> resultMappings) {

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -339,7 +339,7 @@ public class MapperAnnotationBuilder {
           null,
           languageDriver,
           // ResultSets
-          select != null ? nullOrEmpty(select.resultSets()) : null);
+          select != null ? nullOrEmpty(options.resultSets()) : null);
     }
   }
   

--- a/src/main/java/org/apache/ibatis/cache/Cache.java
+++ b/src/main/java/org/apache/ibatis/cache/Cache.java
@@ -59,10 +59,18 @@ public interface Cache {
   Object getObject(Object key);
 
   /**
-   * Optional. It is not called by the core.
+   * As of 3.3.0 this method is only called during a rollback 
+   * for any previous value that was missing in the cache.
+   * This lets any blocking cache to release the lock that 
+   * may have previously put on the key.
+   * A blocking cache puts a lock when a value is null 
+   * and releases it when the value is back again.
+   * This way other threads will wait for the value to be 
+   * available instead of hitting the database.
+   *
    * 
    * @param key The key
-   * @return The object that was removed
+   * @return Not used
    */
   Object removeObject(Object key);
 

--- a/src/main/java/org/apache/ibatis/cache/decorators/BlockingCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/BlockingCache.java
@@ -27,7 +27,7 @@ import org.apache.ibatis.cache.CacheException;
 /**
  * Simple blocking decorator 
  * 
- * Sipmle and inefficient version of EhCache's BlockingCache decorator.
+ * Simple and inefficient version of EhCache's BlockingCache decorator.
  * It sets a lock over a cache key when the element is not found in cache.
  * This way, other threads will wait until this element is filled instead of hitting the database.
  * 
@@ -76,7 +76,9 @@ public class BlockingCache implements Cache {
 
   @Override
   public Object removeObject(Object key) {
-    return delegate.removeObject(key);
+    // despite of its name, this method is called only to release locks
+    releaseLock(key);
+    return null;
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/cache/decorators/TransactionalCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/TransactionalCache.java
@@ -22,6 +22,8 @@ import java.util.Set;
 import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apache.ibatis.cache.Cache;
+import org.apache.ibatis.logging.Log;
+import org.apache.ibatis.logging.LogFactory;
 
 /**
  * The 2nd level cache transactional buffer.
@@ -35,6 +37,8 @@ import org.apache.ibatis.cache.Cache;
  * @author Eduardo Macarron
  */
 public class TransactionalCache implements Cache {
+
+  private static final Log log = LogFactory.getLog(TransactionalCache.class);
 
   private Cache delegate;
   private boolean clearOnCommit;
@@ -126,7 +130,12 @@ public class TransactionalCache implements Cache {
 
   private void unlockMissedEntries() {
     for (Object entry : entriesMissedInCache) {
-      delegate.putObject(entry, null);
+      try {
+        delegate.removeObject(entry);
+      } catch (Exception e) {
+        log.warn("Unexpected exception while notifiying a rollback to the cache adapter."
+            + "Consider upgrading your cache adapter to the latest version.  Cause: " + e);
+      }
     }
   }
 

--- a/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
+++ b/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
@@ -19,14 +19,14 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import org.apache.ibatis.executor.Executor;
 import org.apache.ibatis.executor.ExecutorException;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
 
@@ -42,12 +42,10 @@ public class Jdbc3KeyGenerator implements KeyGenerator {
 
   @Override
   public void processAfter(Executor executor, MappedStatement ms, Statement stmt, Object parameter) {
-    List<Object> parameters = new ArrayList<Object>();
-    parameters.add(parameter);
-    processBatch(ms, stmt, parameters);
+    processBatch(ms, stmt, getParameters(parameter));
   }
 
-  public void processBatch(MappedStatement ms, Statement stmt, List<Object> parameters) {
+  public void processBatch(MappedStatement ms, Statement stmt, Collection<Object> parameters) {
     ResultSet rs = null;
     try {
       rs = stmt.getGeneratedKeys();
@@ -64,7 +62,7 @@ public class Jdbc3KeyGenerator implements KeyGenerator {
           }
           final MetaObject metaParam = configuration.newMetaObject(parameter);
           if (typeHandlers == null) {
-            typeHandlers = getTypeHandlers(typeHandlerRegistry, metaParam, keyProperties);
+            typeHandlers = getTypeHandlers(typeHandlerRegistry, metaParam, keyProperties, rsmd);
           }
           populateKeys(rs, metaParam, keyProperties, typeHandlers);
         }
@@ -82,12 +80,33 @@ public class Jdbc3KeyGenerator implements KeyGenerator {
     }
   }
 
-  private TypeHandler<?>[] getTypeHandlers(TypeHandlerRegistry typeHandlerRegistry, MetaObject metaParam, String[] keyProperties) {
+  private Collection<Object> getParameters(Object parameter) {
+    Collection<Object> parameters = null;
+    if (parameter instanceof Collection) {
+      parameters = (Collection) parameter;
+    } else if (parameter instanceof Map) {
+      Map parameterMap = (Map) parameter;
+      if (parameterMap.containsKey("collection")) {
+        parameters = (Collection) parameterMap.get("collection");
+      } else if (parameterMap.containsKey("list")) {
+        parameters = (List) parameterMap.get("list");
+      } else if (parameterMap.containsKey("array")) {
+        parameters = Arrays.asList((Object[]) parameterMap.get("array"));
+      }
+    }
+    if (parameters == null) {
+      parameters = new ArrayList<Object>();
+      parameters.add(parameter);
+    }
+    return parameters;
+  }
+
+  private TypeHandler<?>[] getTypeHandlers(TypeHandlerRegistry typeHandlerRegistry, MetaObject metaParam, String[] keyProperties, ResultSetMetaData rsmd) throws SQLException {
     TypeHandler<?>[] typeHandlers = new TypeHandler<?>[keyProperties.length];
     for (int i = 0; i < keyProperties.length; i++) {
       if (metaParam.hasSetter(keyProperties[i])) {
         Class<?> keyPropertyType = metaParam.getSetterType(keyProperties[i]);
-        TypeHandler<?> th = typeHandlerRegistry.getTypeHandler(keyPropertyType);
+        TypeHandler<?> th = typeHandlerRegistry.getTypeHandler(keyPropertyType, JdbcType.forCode(rsmd.getColumnType(i + 1)));
         typeHandlers[i] = th;
       }
     }

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -127,6 +127,9 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   }
 
   private void handleRefCursorOutputParameter(ResultSet rs, ParameterMapping parameterMapping, MetaObject metaParam) throws SQLException {
+    if (rs == null) {
+      return;
+    }
     try {
       final String resultMapId = parameterMapping.getResultMapId();
       final ResultMap resultMap = configuration.getResultMap(resultMapId);

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -86,11 +86,27 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   private final Map<String, ResultMapping> nextResultMaps = new HashMap<String, ResultMapping>();
   private final Map<CacheKey, List<PendingRelation>> pendingRelations = new HashMap<CacheKey, List<PendingRelation>>();
 
+  // Cached Automappings
+  private final Map<String, List<UnMappedColumAutoMapping>> autoMappingsCache = new HashMap<String, List<UnMappedColumAutoMapping>>();
+  
   private static class PendingRelation {
     public MetaObject metaObject;
     public ResultMapping propertyMapping;
   }
 
+  private static class UnMappedColumAutoMapping {    
+    private final String column;   
+    private final String property;    
+    private final TypeHandler<?> typeHandler;
+    private final boolean primitive;
+    public UnMappedColumAutoMapping(String column, String property, TypeHandler<?> typeHandler, boolean primitive) {
+      this.column = column;
+      this.property = property;
+      this.typeHandler = typeHandler;
+      this.primitive = primitive;
+    }
+  }  
+  
   public DefaultResultSetHandler(Executor executor, MappedStatement mappedStatement, ParameterHandler parameterHandler, ResultHandler<?> resultHandler, BoundSql boundSql,
       RowBounds rowBounds) {
     this.executor = executor;
@@ -416,33 +432,49 @@ public class DefaultResultSetHandler implements ResultSetHandler {
     }
   }
 
-  private boolean applyAutomaticMappings(ResultSetWrapper rsw, ResultMap resultMap, MetaObject metaObject, String columnPrefix) throws SQLException {
-    final List<String> unmappedColumnNames = rsw.getUnmappedColumnNames(resultMap, columnPrefix);
-    boolean foundValues = false;
-    for (String columnName : unmappedColumnNames) {
-      String propertyName = columnName;
-      if (columnPrefix != null && !columnPrefix.isEmpty()) {
-        // When columnPrefix is specified,
-        // ignore columns without the prefix.
-        if (columnName.toUpperCase(Locale.ENGLISH).startsWith(columnPrefix)) {
-          propertyName = columnName.substring(columnPrefix.length());
-        } else {
-          continue;
+  private List<UnMappedColumAutoMapping> createAutomaticMappings(ResultSetWrapper rsw, ResultMap resultMap, MetaObject metaObject, String columnPrefix) throws SQLException {
+    final String mapKey = getMapKey(resultMap, columnPrefix);
+    List<UnMappedColumAutoMapping> autoMapping = autoMappingsCache.get(mapKey);
+    if (autoMapping == null) {
+      autoMapping = new ArrayList<UnMappedColumAutoMapping>();
+      final List<String> unmappedColumnNames = rsw.getUnmappedColumnNames(resultMap, columnPrefix);
+      for (String columnName : unmappedColumnNames) {
+        String propertyName = columnName;
+        if (columnPrefix != null && !columnPrefix.isEmpty()) {
+          // When columnPrefix is specified,
+          // ignore columns without the prefix.
+          if (columnName.toUpperCase(Locale.ENGLISH).startsWith(columnPrefix)) {
+            propertyName = columnName.substring(columnPrefix.length());
+          } else {
+            continue;
+          }
+        }
+        final String property = metaObject.findProperty(propertyName, configuration.isMapUnderscoreToCamelCase());
+        if (property != null && metaObject.hasSetter(property)) {
+          final Class<?> propertyType = metaObject.getSetterType(property);
+          if (typeHandlerRegistry.hasTypeHandler(propertyType)) {
+            final TypeHandler<?> typeHandler = rsw.getTypeHandler(propertyType, columnName);
+            autoMapping.add(new UnMappedColumAutoMapping(columnName, property, typeHandler, propertyType.isPrimitive()));
+          }
         }
       }
-      final String property = metaObject.findProperty(propertyName, configuration.isMapUnderscoreToCamelCase());
-      if (property != null && metaObject.hasSetter(property)) {
-        final Class<?> propertyType = metaObject.getSetterType(property);
-        if (typeHandlerRegistry.hasTypeHandler(propertyType)) {
-          final TypeHandler<?> typeHandler = rsw.getTypeHandler(propertyType, columnName);
-          final Object value = typeHandler.getResult(rsw.getResultSet(), columnName);
-          // issue #377, call setter on nulls
-          if (value != null || configuration.isCallSettersOnNulls()) {
-            if (value != null || !propertyType.isPrimitive()) {
-              metaObject.setValue(property, value);
-            }
-            foundValues = true;
+      autoMappingsCache.put(mapKey, autoMapping);
+    }
+    return autoMapping;
+  }
+  
+  private boolean applyAutomaticMappings(ResultSetWrapper rsw, ResultMap resultMap, MetaObject metaObject, String columnPrefix) throws SQLException {
+    List<UnMappedColumAutoMapping> autoMapping = createAutomaticMappings(rsw, resultMap, metaObject, columnPrefix);
+    boolean foundValues = false;
+    if (autoMapping.size() > 0) {
+      for (UnMappedColumAutoMapping mapping : autoMapping) {
+        final Object value = mapping.typeHandler.getResult(rsw.getResultSet(), mapping.column);
+        // issue #377, call setter on nulls
+        if (value != null || configuration.isCallSettersOnNulls()) {
+          if (value != null || !mapping.primitive) {
+            metaObject.setValue(mapping.property, value);
           }
+          foundValues = true;
         }
       }
     }
@@ -1015,6 +1047,10 @@ public class DefaultResultSetHandler implements ResultSetHandler {
       return propertyValue;
     }
     return null;
-  }
+  }  
 
+  private String getMapKey(ResultMap resultMap, String columnPrefix) {
+    return resultMap.getId() + ":" + columnPrefix;
+  }
+  
 }

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -60,6 +60,7 @@ import org.apache.ibatis.type.TypeHandlerRegistry;
 /**
  * @author Clinton Begin
  * @author Eduardo Macarron
+ * @author Iwao AVE!
  */
 public class DefaultResultSetHandler implements ResultSetHandler {
 
@@ -78,7 +79,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
 
   // nested resultmaps
   private final Map<CacheKey, Object> nestedResultObjects = new HashMap<CacheKey, Object>();
-  private final Map<CacheKey, Object> ancestorObjects = new HashMap<CacheKey, Object>();
+  private final Map<String, Object> ancestorObjects = new HashMap<String, Object>();
   private final Map<String, String> ancestorColumnPrefix = new HashMap<String, String>();
 
   // multiple resultsets
@@ -755,9 +756,9 @@ public class DefaultResultSetHandler implements ResultSetHandler {
           nestedResultObjects.clear();
           storeObject(resultHandler, resultContext, rowValue, parentMapping, rsw.getResultSet());
         }
-        rowValue = getRowValue(rsw, discriminatedResultMap, rowKey, rowKey, null, partialObject);
+        rowValue = getRowValue(rsw, discriminatedResultMap, rowKey, null, partialObject);
       } else {
-        rowValue = getRowValue(rsw, discriminatedResultMap, rowKey, rowKey, null, partialObject);
+        rowValue = getRowValue(rsw, discriminatedResultMap, rowKey, null, partialObject);
         if (partialObject == null) {
           storeObject(resultHandler, resultContext, rowValue, parentMapping, rsw.getResultSet());
         }
@@ -772,14 +773,14 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   // GET VALUE FROM ROW FOR NESTED RESULT MAP
   //
 
-  private Object getRowValue(ResultSetWrapper rsw, ResultMap resultMap, CacheKey combinedKey, CacheKey absoluteKey, String columnPrefix, Object partialObject) throws SQLException {
+  private Object getRowValue(ResultSetWrapper rsw, ResultMap resultMap, CacheKey combinedKey, String columnPrefix, Object partialObject) throws SQLException {
     final String resultMapId = resultMap.getId();
     Object resultObject = partialObject;
     if (resultObject != null) {
       final MetaObject metaObject = configuration.newMetaObject(resultObject);
-      putAncestor(absoluteKey, resultObject, resultMapId, columnPrefix);
+      putAncestor(resultObject, resultMapId, columnPrefix);
       applyNestedResultMappings(rsw, resultMap, metaObject, columnPrefix, combinedKey, false);
-      ancestorObjects.remove(absoluteKey);
+      ancestorObjects.remove(resultMapId);
     } else {
       final ResultLoaderMap lazyLoader = new ResultLoaderMap();
       resultObject = createResultObject(rsw, resultMap, lazyLoader, columnPrefix);
@@ -790,9 +791,9 @@ public class DefaultResultSetHandler implements ResultSetHandler {
           foundValues = applyAutomaticMappings(rsw, resultMap, metaObject, columnPrefix) || foundValues;
         }
         foundValues = applyPropertyMappings(rsw, resultMap, metaObject, lazyLoader, columnPrefix) || foundValues;
-        putAncestor(absoluteKey, resultObject, resultMapId, columnPrefix);
+        putAncestor(resultObject, resultMapId, columnPrefix);
         foundValues = applyNestedResultMappings(rsw, resultMap, metaObject, columnPrefix, combinedKey, true) || foundValues;
-        ancestorObjects.remove(absoluteKey);
+        ancestorObjects.remove(resultMapId);
         foundValues = lazyLoader.size() > 0 || foundValues;
         resultObject = foundValues ? resultObject : null;
       }
@@ -803,11 +804,11 @@ public class DefaultResultSetHandler implements ResultSetHandler {
     return resultObject;
   }
 
-  private void putAncestor(CacheKey rowKey, Object resultObject, String resultMapId, String columnPrefix) {
+  private void putAncestor(Object resultObject, String resultMapId, String columnPrefix) {
     if (!ancestorColumnPrefix.containsKey(resultMapId)) {
       ancestorColumnPrefix.put(resultMapId, columnPrefix);
     }
-    ancestorObjects.put(rowKey, resultObject);
+    ancestorObjects.put(resultMapId, resultObject);
   }
 
   //
@@ -822,24 +823,19 @@ public class DefaultResultSetHandler implements ResultSetHandler {
         try {
           final String columnPrefix = getColumnPrefix(parentPrefix, resultMapping);
           final ResultMap nestedResultMap = getNestedResultMap(rsw.getResultSet(), nestedResultMapId, columnPrefix);
-          CacheKey rowKey = null;
-          Object ancestorObject = null;
-          if (ancestorColumnPrefix.containsKey(nestedResultMapId)) {
-            rowKey = createRowKey(nestedResultMap, rsw, ancestorColumnPrefix.get(nestedResultMapId));
-            ancestorObject = ancestorObjects.get(rowKey);
-          }
+          Object ancestorObject = ancestorObjects.get(nestedResultMapId);
           if (ancestorObject != null) {
             if (newObject) {
               linkObjects(metaObject, resultMapping, ancestorObject); // issue #385
             }
           } else {
-            rowKey = createRowKey(nestedResultMap, rsw, columnPrefix);
+            final CacheKey rowKey = createRowKey(nestedResultMap, rsw, columnPrefix);
             final CacheKey combinedKey = combineKeys(rowKey, parentRowKey);
             Object rowValue = nestedResultObjects.get(combinedKey);
             boolean knownValue = (rowValue != null);
             instantiateCollectionPropertyIfAppropriate(resultMapping, metaObject); // mandatory            
             if (anyNotNullColumnHasValue(resultMapping, columnPrefix, rsw.getResultSet())) {
-              rowValue = getRowValue(rsw, nestedResultMap, combinedKey, rowKey, columnPrefix, rowValue);
+              rowValue = getRowValue(rsw, nestedResultMap, combinedKey, columnPrefix, rowValue);
               if (rowValue != null && !knownValue) {
                 linkObjects(metaObject, resultMapping, rowValue);
                 foundValues = true;
@@ -903,6 +899,9 @@ public class DefaultResultSetHandler implements ResultSetHandler {
     } else {
       createRowKeyForMappedProperties(resultMap, rsw, cacheKey, resultMappings, columnPrefix);
     }
+    if (cacheKey.getUpdateCount() < 2) {
+      return CacheKey.NULL_CACHE_KEY;
+    }    
     return cacheKey;
   }
 

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -433,7 +433,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   }
 
   private List<UnMappedColumAutoMapping> createAutomaticMappings(ResultSetWrapper rsw, ResultMap resultMap, MetaObject metaObject, String columnPrefix) throws SQLException {
-    final String mapKey = getMapKey(resultMap, columnPrefix);
+    final String mapKey = resultMap.getId() + ":" + columnPrefix;
     List<UnMappedColumAutoMapping> autoMapping = autoMappingsCache.get(mapKey);
     if (autoMapping == null) {
       autoMapping = new ArrayList<UnMappedColumAutoMapping>();
@@ -1048,9 +1048,5 @@ public class DefaultResultSetHandler implements ResultSetHandler {
     }
     return null;
   }  
-
-  private String getMapKey(ResultMap resultMap, String columnPrefix) {
-    return resultMap.getId() + ":" + columnPrefix;
-  }
   
 }

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -394,7 +394,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
             && (value != null || (configuration.isCallSettersOnNulls() && !metaObject.getSetterType(property).isPrimitive()))) {
           metaObject.setValue(property, value);
         }
-        if (value != null || value == DEFERED) {
+        if (property != null && (value != null || value == DEFERED)) {
           foundValues = true;
         }
       }

--- a/src/main/java/org/apache/ibatis/executor/statement/BaseStatementHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/statement/BaseStatementHandler.java
@@ -102,10 +102,12 @@ public abstract class BaseStatementHandler implements StatementHandler {
 
   protected void setStatementTimeout(Statement stmt) throws SQLException {
     Integer timeout = mappedStatement.getTimeout();
-    Integer defaultTimeout = configuration.getDefaultStatementTimeout();
     if (timeout != null) {
       stmt.setQueryTimeout(timeout);
-    } else if (defaultTimeout != null) {
+      return;
+    }
+    Integer defaultTimeout = configuration.getDefaultStatementTimeout();
+    if (defaultTimeout != null) {
       stmt.setQueryTimeout(defaultTimeout);
     }
   }

--- a/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
@@ -59,6 +59,7 @@ public abstract class BaseJdbcLogger {
 
   static {
     SET_METHODS.add("setString");
+    SET_METHODS.add("setNString");
     SET_METHODS.add("setInt");
     SET_METHODS.add("setByte");
     SET_METHODS.add("setShort");
@@ -76,7 +77,9 @@ public abstract class BaseJdbcLogger {
     SET_METHODS.add("setBoolean");
     SET_METHODS.add("setBytes");
     SET_METHODS.add("setCharacterStream");
+    SET_METHODS.add("setNCharacterStream");
     SET_METHODS.add("setClob");
+    SET_METHODS.add("setNClob");
     SET_METHODS.add("setObject");
     SET_METHODS.add("setNull");
 

--- a/src/main/java/org/apache/ibatis/mapping/BoundSql.java
+++ b/src/main/java/org/apache/ibatis/mapping/BoundSql.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.reflection.property.PropertyTokenizer;
 import org.apache.ibatis.session.Configuration;
 
 /**
@@ -62,7 +63,9 @@ public class BoundSql {
   }
 
   public boolean hasAdditionalParameter(String name) {
-    return metaParameters.hasGetter(name);
+    PropertyTokenizer prop = new PropertyTokenizer(name);
+    String indexedName = prop.getIndexedName();
+    return additionalParameters.containsKey(indexedName);
   }
 
   public void setAdditionalParameter(String name, Object value) {

--- a/src/main/java/org/apache/ibatis/mapping/MappedStatement.java
+++ b/src/main/java/org/apache/ibatis/mapping/MappedStatement.java
@@ -71,7 +71,6 @@ public final class MappedStatement {
       mappedStatement.statementType = StatementType.PREPARED;
       mappedStatement.parameterMap = new ParameterMap.Builder(configuration, "defaultParameterMap", null, new ArrayList<ParameterMapping>()).build();
       mappedStatement.resultMaps = new ArrayList<ResultMap>();
-      mappedStatement.timeout = configuration.getDefaultStatementTimeout();
       mappedStatement.sqlCommandType = sqlCommandType;
       mappedStatement.keyGenerator = configuration.isUseGeneratedKeys() && SqlCommandType.INSERT.equals(sqlCommandType) ? new Jdbc3KeyGenerator() : new NoKeyGenerator();
       String logId = id;

--- a/src/main/java/org/apache/ibatis/parsing/GenericTokenParser.java
+++ b/src/main/java/org/apache/ibatis/parsing/GenericTokenParser.java
@@ -31,26 +31,42 @@ public class GenericTokenParser {
   }
 
   public String parse(String text) {
-    StringBuilder builder = new StringBuilder();
+    final StringBuilder builder = new StringBuilder();
+    final StringBuilder expression = new StringBuilder();
     if (text != null && text.length() > 0) {
       char[] src = text.toCharArray();
       int offset = 0;
+      // search open token
       int start = text.indexOf(openToken, offset);
       while (start > -1) {
         if (start > 0 && src[start - 1] == '\\') {
-          // the variable is escaped. remove the backslash.
+          // this open token is escaped. remove the backslash and continue.
           builder.append(src, offset, start - offset - 1).append(openToken);
           offset = start + openToken.length();
         } else {
-          int end = text.indexOf(closeToken, start);
+          // found open token. let's search close token.
+          expression.setLength(0);
+          builder.append(src, offset, start - offset);
+          offset = start + openToken.length();
+          int end = text.indexOf(closeToken, offset);
+          while (end > -1) {
+            if (end > offset && src[end - 1] == '\\') {
+              // this close token is escaped. remove the backslash and continue.
+              expression.append(src, offset, end - offset - 1).append(closeToken);
+              offset = end + closeToken.length();
+              end = text.indexOf(closeToken, offset);
+            } else {
+              expression.append(src, offset, end - offset);
+              offset = end + closeToken.length();
+              break;
+            }
+          }
           if (end == -1) {
-            builder.append(src, offset, src.length - offset);
+            // close token was not found.
+            builder.append(src, start, src.length - start);
             offset = src.length;
           } else {
-            builder.append(src, offset, start - offset);
-            offset = start + openToken.length();
-            String content = new String(src, offset, end - offset);
-            builder.append(handler.handleToken(content));
+            builder.append(handler.handleToken(expression.toString()));
             offset = end + closeToken.length();
           }
         }
@@ -62,5 +78,4 @@ public class GenericTokenParser {
     }
     return builder.toString();
   }
-
 }

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -53,6 +53,7 @@ import org.apache.ibatis.executor.resultset.DefaultResultSetHandler;
 import org.apache.ibatis.executor.resultset.ResultSetHandler;
 import org.apache.ibatis.executor.statement.RoutingStatementHandler;
 import org.apache.ibatis.executor.statement.StatementHandler;
+import org.apache.ibatis.io.VFS;
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.logging.LogFactory;
 import org.apache.ibatis.logging.commons.JakartaCommonsLoggingImpl;
@@ -108,6 +109,7 @@ public class Configuration {
 
   protected String logPrefix;
   protected Class <? extends Log> logImpl;
+  protected Class <? extends VFS> vfsImpl;
   protected LocalCacheScope localCacheScope = LocalCacheScope.SESSION;
   protected JdbcType jdbcTypeForNull = JdbcType.OTHER;
   protected Set<String> lazyLoadTriggerMethods = new HashSet<String>(Arrays.asList(new String[] { "equals", "clone", "hashCode", "toString" }));
@@ -216,6 +218,18 @@ public class Configuration {
     if (logImpl != null) {
       this.logImpl = (Class<? extends Log>) logImpl;
       LogFactory.useCustomLogging(this.logImpl);
+    }
+  }
+
+  public Class<? extends VFS> getVfsImpl() {
+    return this.vfsImpl;
+  }
+
+  @SuppressWarnings("unchecked")
+  public void setVfsImpl(Class<?> vfsImpl) {
+    if (vfsImpl != null) {
+      this.vfsImpl = (Class<? extends VFS>) vfsImpl;
+      VFS.addImplClass(this.vfsImpl);
     }
   }
 

--- a/src/main/java/org/apache/ibatis/type/NStringTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/NStringTypeHandler.java
@@ -28,28 +28,25 @@ public class NStringTypeHandler extends BaseTypeHandler<String> {
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, String parameter, JdbcType jdbcType)
       throws SQLException {
-//    ps.setNString(i, ((String) parameter));
-    ps.setString(i, parameter);
+    ps.setNString(i, parameter);
   }
 
   @Override
   public String getNullableResult(ResultSet rs, String columnName)
       throws SQLException {
-//    return rs.getNString(columnName);
-    return rs.getString(columnName);
+    return rs.getNString(columnName);
   }
 
   @Override
   public String getNullableResult(ResultSet rs, int columnIndex)
       throws SQLException {
-    return rs.getString(columnIndex);
+    return rs.getNString(columnIndex);
   }
 
   @Override
   public String getNullableResult(CallableStatement cs, int columnIndex)
       throws SQLException {
-//    return cs.getNString(columnIndex);
-    return cs.getString(columnIndex);
+    return cs.getNString(columnIndex);
   }
 
 }

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.ibatis.io.ResolverUtil;
+import org.apache.ibatis.io.Resources;
 
 /**
  * @author Clinton Begin
@@ -119,6 +120,19 @@ public final class TypeHandlerRegistry {
     register(java.sql.Date.class, new SqlDateTypeHandler());
     register(java.sql.Time.class, new SqlTimeTypeHandler());
     register(java.sql.Timestamp.class, new SqlTimestampTypeHandler());
+
+    // mybatis-typehandlers-jsr310
+    try {
+      register("java.time.Instant", "org.apache.ibatis.type.InstantTypeHandler");
+      register("java.time.LocalDateTime", "org.apache.ibatis.type.LocalDateTimeTypeHandler");
+      register("java.time.LocalDate", "org.apache.ibatis.type.LocalDateTypeHandler");
+      register("java.time.LocalTime", "org.apache.ibatis.type.LocalTimeTypeHandler");
+      register("java.time.OffsetDateTime", "org.apache.ibatis.type.OffsetDateTimeTypeHandler");
+      register("java.time.OffsetTime", "org.apache.ibatis.type.OffsetTimeTypeHandler");
+      register("java.time.ZonedDateTime", "org.apache.ibatis.type.ZonedDateTimeTypeHandler");
+    } catch (ClassNotFoundException e) {
+      // no JSR-310 handlers
+    }
 
     // issue #273
     register(Character.class, new CharacterTypeHandler());
@@ -284,6 +298,10 @@ public final class TypeHandlerRegistry {
   }
 
   // java type + handler type
+
+  public void register(String javaTypeClassName, String typeHandlerClassName) throws ClassNotFoundException {
+    register(Resources.classForName(javaTypeClassName), Resources.classForName(typeHandlerClassName));
+  }
 
   public void register(Class<?> javaTypeClass, Class<?> typeHandlerClass) {
     register(javaTypeClass, getInstance(javaTypeClass, typeHandlerClass));

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -45,6 +45,7 @@
     <setting name="callSettersOnNulls" value="true"/>
     <setting name="logPrefix" value="mybatis_"/>
     <setting name="logImpl" value="SLF4J"/>
+    <setting name="vfsImpl" value="org.apache.ibatis.io.JBoss6VFS"/>
     <setting name="configurationFactory" value="java.lang.String"/>
   </settings>
 

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.apache.ibatis.builder.xml.XMLConfigBuilder;
 import org.apache.ibatis.executor.loader.cglib.CglibProxyFactory;
 import org.apache.ibatis.executor.loader.javassist.JavassistProxyFactory;
+import org.apache.ibatis.io.JBoss6VFS;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.logging.slf4j.Slf4jImpl;
 import org.apache.ibatis.scripting.defaults.RawLanguageDriver;
@@ -164,6 +165,7 @@ public class XmlConfigBuilderTest {
       assertThat(config.isCallSettersOnNulls(), is(true));
       assertThat(config.getLogPrefix(), is("mybatis_"));
       assertThat(config.getLogImpl().getName(), is(Slf4jImpl.class.getName()));
+      assertThat(config.getVfsImpl().getName(), is(JBoss6VFS.class.getName()));
       assertThat(config.getConfigurationFactory().getName(), is(String.class.getName()));
 
     }

--- a/src/test/java/org/apache/ibatis/builder/xml/dynamic/DynamicSqlSourceTest.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/dynamic/DynamicSqlSourceTest.java
@@ -318,6 +318,17 @@ public class DynamicSqlSourceTest extends BaseDataTest {
   }
 
   @Test
+  public void shouldHandleOgnlExpression() throws Exception {
+    final HashMap<String, String> parameterObject = new HashMap<String, String>() {{
+      put("name", "Steve");
+    }};
+    final String expected = "Expression test: 3 / yes.";
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("Expression test: ${name.indexOf('v')} / ${name in {'Bob', 'Steve'\\} ? 'yes' : 'no'}."));
+    BoundSql boundSql = source.getBoundSql(parameterObject);
+    assertEquals(expected, boundSql.getSql());
+  }
+
+  @Test
   public void shouldSkipForEachWhenCollectionIsEmpty() throws Exception {
     final HashMap<String, Integer[]> parameterObject = new HashMap<String, Integer[]>() {{
         put("array", new Integer[] {});

--- a/src/test/java/org/apache/ibatis/executor/ExecutorTestHelper.java
+++ b/src/test/java/org/apache/ibatis/executor/ExecutorTestHelper.java
@@ -197,7 +197,7 @@ public class ExecutorTestHelper {
               }
             }).build());
           }
-        }).fetchSize(1000).build();
+        }).fetchSize(1000).timeout(2000).build();
   }
 
   public static MappedStatement prepareSelectOneAuthorMappedStatementWithConstructorResults(final Configuration config) {

--- a/src/test/java/org/apache/ibatis/mapping/BoundSqlTest.java
+++ b/src/test/java/org/apache/ibatis/mapping/BoundSqlTest.java
@@ -1,0 +1,59 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.mapping;
+
+import static org.junit.Assert.*;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ibatis.session.Configuration;
+import org.junit.Test;
+
+public class BoundSqlTest {
+
+  @Test
+  public void testHasAdditionalParameter() throws Exception {
+    List<ParameterMapping> params = Collections.emptyList();
+    BoundSql boundSql = new BoundSql(new Configuration(), "some sql", params, new Object());
+
+    Map<String, String> map = new HashMap<String, String>();
+    map.put("key1", "value1");
+    boundSql.setAdditionalParameter("map", map);
+
+    Person bean = new Person();
+    bean.id = 1;
+    boundSql.setAdditionalParameter("person", bean);
+
+    assertFalse(boundSql.hasAdditionalParameter("pet"));
+    assertFalse(boundSql.hasAdditionalParameter("pet.name"));
+
+    assertTrue(boundSql.hasAdditionalParameter("map"));
+    assertTrue(boundSql.hasAdditionalParameter("map.key1"));
+    assertTrue("should return true even if the child property does not exists.", boundSql.hasAdditionalParameter("map.key2"));
+
+    assertTrue(boundSql.hasAdditionalParameter("person"));
+    assertTrue(boundSql.hasAdditionalParameter("person.id"));
+    assertTrue("should return true even if the child property does not exists.", boundSql.hasAdditionalParameter("person.name"));
+  }
+
+  public static class Person {
+    public Integer id;
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/parsing/GenericTokenParserTest.java
+++ b/src/test/java/org/apache/ibatis/parsing/GenericTokenParserTest.java
@@ -42,6 +42,7 @@ public class GenericTokenParserTest {
         put("first_name", "James");
         put("initial", "T");
         put("last_name", "Kirk");
+        put("var{with}brace", "Hiya");
         put("", "");
       }
     }));
@@ -61,6 +62,9 @@ public class GenericTokenParserTest {
 
     assertEquals("{$$something}JamesTKirk", parser.parse("{$$something}${first_name}${initial}${last_name}"));
     assertEquals("${", parser.parse("${"));
+    assertEquals("${\\}", parser.parse("${\\}"));
+    assertEquals("Hiya", parser.parse("${var{with\\}brace}"));
+    assertEquals("", parser.parse("${}"));
     assertEquals("}", parser.parse("}"));
     assertEquals("Hello ${ this is a test.", parser.parse("Hello ${ this is a test."));
     assertEquals("Hello } this is a test.", parser.parse("Hello } this is a test."));

--- a/src/test/java/org/apache/ibatis/submitted/emptycollection/Dao.java
+++ b/src/test/java/org/apache/ibatis/submitted/emptycollection/Dao.java
@@ -1,0 +1,24 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.emptycollection;
+
+import java.util.List;
+
+interface Dao {
+    List<TodoLists> selectWithEmptyList();
+    List<TodoLists> selectWithNonEmptyList();
+    List<TodoLists> selectWithNonEmptyList_noCollectionId();
+}

--- a/src/test/java/org/apache/ibatis/submitted/emptycollection/Dao.xml
+++ b/src/test/java/org/apache/ibatis/submitted/emptycollection/Dao.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.emptycollection.Dao">
+    <select id="selectWithEmptyList" resultMap="selectList">
+        select 1 id, null "order", null description from (VALUES ('dummy')) dummy(dummy)
+    </select>
+
+    <select id="selectWithNonEmptyList" resultMap="selectList">
+        select 1 id, 1 "order", 'a description' description from (VALUES ('dummy')) dummy(dummy)
+        union all select 1 id, 2 "order", 'a 2nd description' description from (VALUES ('dummy')) dummy(dummy)
+        union all select 2 id, 1 "order", 'a description' description from (VALUES ('dummy')) dummy(dummy)
+    </select>
+
+    <select id="selectWithNonEmptyList_noCollectionId" resultMap="selectList_noCollectionId">
+        select 1 id, 1 "order", 'a description' description from (VALUES ('dummy')) dummy(dummy)
+        union all select 1 id, 2 "order", 'a 2nd description' description from (VALUES ('dummy')) dummy(dummy)
+        union all select 2 id, 1 "order", 'a description' description from (VALUES ('dummy')) dummy(dummy)
+    </select>
+
+
+    <resultMap id="selectList" type="org.apache.ibatis.submitted.emptycollection.TodoLists">
+        <id column="id" property="id" />
+        <collection property="todoItems" ofType="org.apache.ibatis.submitted.emptycollection.TodoItem" javaType="list">
+            <id column="id" />
+            <id column="order" property="order" />
+            <result column="description" property="description"/>
+        </collection>
+    </resultMap>
+
+    <resultMap id="selectList_noCollectionId" type="org.apache.ibatis.submitted.emptycollection.TodoLists">
+        <id column="id" property="id" />
+        <collection property="todoItems" ofType="org.apache.ibatis.submitted.emptycollection.TodoItem" javaType="list">
+            <id column="order" property="order" />
+            <result column="description" property="description"/>
+        </collection>
+    </resultMap>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/emptycollection/DaoTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/emptycollection/DaoTest.java
@@ -1,0 +1,93 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.emptycollection;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.util.List;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DaoTest {
+    private Dao dao;
+    private SqlSession sqlSession;
+    
+    @Before
+    public void setUp() throws Exception {
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/emptycollection/mybatis-config.xml");
+        SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
+
+        sqlSession = sqlSessionFactory.openSession();
+        Connection conn = sqlSession.getConnection();
+        ScriptRunner runner = new ScriptRunner(conn);
+        runner.setLogWriter(null);
+        dao = sqlSession.getMapper(Dao.class);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        sqlSession.close();
+    }
+
+    @Test
+    public void testWithEmptyList() throws Exception {
+        final List<TodoLists> actual = dao.selectWithEmptyList();
+        Assert.assertEquals(1, actual.size());
+        final List<TodoItem> todoItems = actual.get(0).getTodoItems();
+        Assert.assertEquals("expect " + todoItems + " to be empty", 0, todoItems.size());        
+    }
+
+    @Test
+    public void testWithNonEmptyList() throws Exception {
+        final List<TodoLists> actual = dao.selectWithNonEmptyList();
+        checkNonEmptyList(actual);
+    }
+
+    @Test
+    public void testWithNonEmptyList_noCollectionId() throws Exception {
+        final List<TodoLists> actual = dao.selectWithNonEmptyList_noCollectionId();
+
+        checkNonEmptyList(actual);
+    }
+
+    private void checkNonEmptyList(final List<TodoLists> actual) {
+//        Assert.assertEquals("[List(1)=[a description(1), a 2nd description(2)], List(2)=[a description(1)]]", actual.toString());
+        Assert.assertEquals(2, actual.size());
+
+        Assert.assertEquals(2, actual.get(0).getTodoItems().size());
+        Assert.assertEquals(1, actual.get(0).getTodoItems().get(0).getOrder());
+        Assert.assertEquals("a description", actual.get(0).getTodoItems().get(0).getDescription().trim());
+        Assert.assertEquals(2, actual.get(0).getTodoItems().get(1).getOrder());
+        Assert.assertEquals("a 2nd description", actual.get(0).getTodoItems().get(1).getDescription().trim());
+
+        Assert.assertEquals(1, actual.get(1).getTodoItems().size());
+        Assert.assertEquals(1, actual.get(1).getTodoItems().get(0).getOrder());
+        Assert.assertEquals("a description", actual.get(0).getTodoItems().get(0).getDescription().trim());
+        
+        // We should have gotten three item objects. The first item from the first list and the first item from
+        // the second list have identical properties, but they should be distinct objects
+        Assert.assertNotSame(actual.get(0).getTodoItems().get(0), actual.get(1).getTodoItems().get(0));
+    }
+}

--- a/src/test/java/org/apache/ibatis/submitted/emptycollection/TodoItem.java
+++ b/src/test/java/org/apache/ibatis/submitted/emptycollection/TodoItem.java
@@ -1,0 +1,44 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.emptycollection;
+
+public class TodoItem {
+
+  @Override
+  public String toString() {
+    return "TodoItem [order=" + order + ", description=" + description + "]";
+  }
+
+  private int order;
+  private String description;
+
+  public int getOrder() {
+    return order;
+  }
+
+  public void setOrder(int order) {
+    this.order = order;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/emptycollection/TodoLists.java
+++ b/src/test/java/org/apache/ibatis/submitted/emptycollection/TodoLists.java
@@ -1,0 +1,47 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.emptycollection;
+
+import java.util.List;
+
+public class TodoLists {
+  
+  @Override
+  public String toString() {
+    return "TodoLists [id=" + id + ", todoItems=" + todoItems + "]";
+  }
+
+  private int id;
+
+  private List<TodoItem> todoItems;
+  
+  public int getId() {
+    return id;
+  }
+
+  public void setId(int id) {
+    this.id = id;
+  }
+
+  public List<TodoItem> getTodoItems() {
+    return todoItems;
+  }
+
+  public void setTodoItems(List<TodoItem> todoItems) {
+    this.todoItems = todoItems;
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/emptycollection/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/emptycollection/mybatis-config.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value="" />
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="org.hsqldb.jdbcDriver" />
+                <property name="url" value="jdbc:hsqldb:mem:emptycollection" />
+                <property name="username" value="sa" />
+            </dataSource>
+        </environment>
+    </environments>
+    <mappers>
+        <mapper resource="org/apache/ibatis/submitted/emptycollection/Dao.xml" />
+    </mappers>
+</configuration>

--- a/src/test/java/org/apache/ibatis/submitted/foreach/ForEachTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/foreach/ForEachTest.java
@@ -18,8 +18,10 @@ package org.apache.ibatis.submitted.foreach;
 import java.io.Reader;
 import java.sql.Connection;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
@@ -27,11 +29,16 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class ForEachTest {
 
   private static SqlSessionFactory sqlSessionFactory;
+
+  @Rule
+  public ExpectedException ex = ExpectedException.none();
 
   @BeforeClass
   public static void setUp() throws Exception {
@@ -119,6 +126,20 @@ public class ForEachTest {
       users.add(null);
       String name = mapper.selectWithNullItemCheck(users);
       Assert.assertEquals("User3", name);
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldReportMissingPropertyName() {
+    ex.expect(PersistenceException.class);
+    ex.expectMessage("There is no getter for property named 'idd' in 'class org.apache.ibatis.submitted.foreach.User'");
+
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      mapper.typoInItemProperty(Arrays.asList(new User()));
     } finally {
       sqlSession.close();
     }

--- a/src/test/java/org/apache/ibatis/submitted/foreach/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/foreach/Mapper.java
@@ -27,4 +27,5 @@ public interface Mapper {
 
   String selectWithNullItemCheck(List<User> users);
 
+  int typoInItemProperty(List<User> users);
 }

--- a/src/test/java/org/apache/ibatis/submitted/foreach/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/foreach/Mapper.xml
@@ -62,4 +62,11 @@
       </where>
   </select>
 
+  <insert id="typoInItemProperty">
+    insert into users (id, name) values
+    <foreach item="item" collection="list" separator=",">
+        (#{item.idd}, #{item.name})
+    </foreach>
+  </insert>
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/keygen/Country.java
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/Country.java
@@ -1,0 +1,63 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.keygen;
+
+/**
+ * @author liuzh
+ */
+public class Country {
+  private Integer id;
+  private String countryname;
+  private String countrycode;
+
+  public Country() {
+  }
+
+  public Country(String countryname, String countrycode) {
+    this.countryname = countryname;
+    this.countrycode = countrycode;
+  }
+
+  public Country(Integer id, String countryname, String countrycode) {
+    this.id = id;
+    this.countryname = countryname;
+    this.countrycode = countrycode;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getCountryname() {
+    return countryname;
+  }
+
+  public void setCountryname(String countryname) {
+    this.countryname = countryname;
+  }
+
+  public String getCountrycode() {
+    return countrycode;
+  }
+
+  public void setCountrycode(String countrycode) {
+    this.countrycode = countrycode;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/keygen/CountryMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/CountryMapper.java
@@ -1,0 +1,24 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.keygen;
+
+import java.util.List;
+
+public interface CountryMapper {
+
+  int insertList(List<Country> countries);
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/keygen/CountryMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/CountryMapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+       Copyright 2009-2012 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.submitted.keygen.CountryMapper" >
+  <insert id="insertList" parameterType="org.apache.ibatis.submitted.keygen.Country" useGeneratedKeys="true" keyProperty="id">
+      insert into country (countryname,countrycode)
+      values
+      <foreach collection="list" separator="," item="country">
+          (#{country.countryname},#{country.countrycode})
+      </foreach>
+  </insert>
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/keygen/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/CreateDB.sql
@@ -1,0 +1,23 @@
+--
+--    Copyright 2009-2016 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+DROP TABLE country IF EXISTS;
+
+CREATE TABLE country (
+  Id int IDENTITY,
+  countryname varchar(255) DEFAULT NULL,
+  countrycode varchar(255) DEFAULT NULL,
+);

--- a/src/test/java/org/apache/ibatis/submitted/keygen/Jdbc3KeyGeneratorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/Jdbc3KeyGeneratorTest.java
@@ -1,0 +1,76 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.keygen;
+
+import static org.junit.Assert.*;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author liuzh
+ */
+public class Jdbc3KeyGeneratorTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/keygen/MapperConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
+
+    // populate in-memory database
+    SqlSession session = sqlSessionFactory.openSession();
+    Connection conn = session.getConnection();
+    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/keygen/CreateDB.sql");
+    ScriptRunner runner = new ScriptRunner(conn);
+    runner.setLogWriter(null);
+    runner.runScript(reader);
+    reader.close();
+    session.close();
+  }
+
+  @Test
+  public void shouldInsertListAndRetrieveId() throws Exception {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+      List<Country> countries = new ArrayList<Country>();
+      countries.add(new Country("China", "CN"));
+      countries.add(new Country("United Kiongdom", "GB"));
+      countries.add(new Country("United States of America", "US"));
+      mapper.insertList(countries);
+      for (Country country : countries) {
+        assertNotNull(country.getId());
+      }
+    } finally {
+      sqlSession.rollback();
+      sqlSession.close();
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/keygen/MapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/MapperConfig.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+       Copyright 2009-2012 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+
+	<environments default="development">
+		<environment id="development">
+			<transactionManager type="JDBC">
+				<property name="" value="" />
+			</transactionManager>
+			<dataSource type="UNPOOLED">
+				<property name="driver" value="org.hsqldb.jdbcDriver" />
+				<property name="url" value="jdbc:hsqldb:mem:keygen" />
+				<property name="username" value="sa" />
+			</dataSource>
+		</environment>
+	</environments>
+
+	<mappers>
+		<mapper resource="org/apache/ibatis/submitted/keygen/CountryMapper.xml" />
+	</mappers>
+</configuration>

--- a/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/Mapper.java
@@ -26,9 +26,9 @@ public interface Mapper {
 
   List<OrderDetail> getOrderDetailsWithHeaders();
 
-  @Select(value = "{ call GetOrderDetailsAndHeaders() }", resultSets="orderDetailResultSet,orderHeaderResultSet")
+  @Select(value = "{ call GetOrderDetailsAndHeaders() }")
   @ResultMap("orderDetailResultMap")
-  @Options(statementType= StatementType.CALLABLE)
+  @Options(statementType= StatementType.CALLABLE, resultSets="orderDetailResultSet,orderHeaderResultSet")
   List<OrderDetail> getOrderDetailsWithHeadersAnnotationBased();
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/Mapper.java
@@ -15,20 +15,10 @@
  */
 package org.apache.ibatis.submitted.multipleresultsetswithassociation;
 
-import org.apache.ibatis.annotations.Options;
-import org.apache.ibatis.annotations.ResultMap;
-import org.apache.ibatis.annotations.Select;
-import org.apache.ibatis.mapping.StatementType;
-
 import java.util.List;
 
 public interface Mapper {
 
   List<OrderDetail> getOrderDetailsWithHeaders();
-
-  @Select(value = "{ call GetOrderDetailsAndHeaders() }")
-  @ResultMap("orderDetailResultMap")
-  @Options(statementType= StatementType.CALLABLE, resultSets="orderDetailResultSet,orderHeaderResultSet")
-  List<OrderDetail> getOrderDetailsWithHeadersAnnotationBased();
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/MultipleResultSetTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/MultipleResultSetTest.java
@@ -92,26 +92,4 @@ public class MultipleResultSetTest {
     }
   }
 
-  @Test
-  public void shouldGetOrderDetailsEachHavingAnOrderHeaderAnnotationBased() throws IOException {
-    SqlSession sqlSession = sqlSessionFactory.openSession();
-    try {
-      Mapper mapper = sqlSession.getMapper(Mapper.class);
-      List<OrderDetail> orderDetails = mapper.getOrderDetailsWithHeadersAnnotationBased();
-
-      // There are six order detail records in the database
-      // As long as the data does not change this should be successful
-      Assert.assertEquals(6, orderDetails.size());
-
-      // Each order detail should have a corresponding OrderHeader
-      // Only 2 of 6 orderDetails have orderHeaders
-      for(OrderDetail orderDetail : orderDetails){
-          Assert.assertNotNull(orderDetail.getOrderHeader());
-      }
-
-    } finally {
-      sqlSession.close();
-    }
-  }
-
 }

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Mapper.java
@@ -20,4 +20,5 @@ import java.util.List;
 public interface Mapper {
   List<Person> getPersons();
   List<Person> getPersonsWithItemsOrdered();
+  List<PersonItemPair> getPersonItemPairs();
 }

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Mapper.xml
@@ -40,4 +40,23 @@
 		where p.id = i.owner
 		order by i.name
 	</select>
+
+	<select id="getPersonItemPairs" resultMap="personItemPairResult">
+		select p.id as person_id, p.name as person_name, i.id as item_id, i.name as item_name
+		from persons p, items i
+		where p.id = i.owner
+		order by p.id, i.id
+	</select>
+
+	<resultMap id="personItemPairResult" type="org.apache.ibatis.submitted.nestedresulthandler.PersonItemPair">
+		<association property="person" javaType="org.apache.ibatis.submitted.nestedresulthandler.Person">
+			<id property="id" column="person_id" />
+			<result property="name" column="person_name"/>
+		</association>
+		<association property="item" javaType="org.apache.ibatis.submitted.nestedresulthandler.Item">
+			<id property="id" column="item_id"/>
+			<result property="name" column="item_name"/>
+		</association>
+	</resultMap>
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/NestedResultHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/NestedResultHandlerTest.java
@@ -150,4 +150,24 @@ public class NestedResultHandlerTest {
     }
   }
 
+  @Test //reopen issue 39? (not a bug?)
+  public void testGetPersonItemPairs(){
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try{
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<PersonItemPair> pairs = mapper.getPersonItemPairs();
+
+      Assert.assertNotNull( pairs );
+//      System.out.println( new StringBuilder().append("selected pairs: ").append(pairs) );
+
+      Assert.assertEquals(5, pairs.size() );
+      Assert.assertNotNull(pairs.get(0).getPerson());
+      Assert.assertEquals(pairs.get(0).getPerson().getId(), Integer.valueOf(1));
+      Assert.assertNotNull(pairs.get(0).getItem());
+      Assert.assertEquals( pairs.get(0).getItem().getId(), Integer.valueOf(1));
+    } finally{
+      sqlSession.close();
+    }
+  }
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Person.java
@@ -22,7 +22,19 @@ import java.util.List;
 public class Person {
   private Integer id;
   private String name;
-  private List<Item> items=new ArrayList<Item>(); 
+  private List<Item> items=new ArrayList<Item>();
+
+  public String toString(){
+    return new StringBuilder()
+            .append("Person(")
+            .append(id)
+            .append(", ")
+            .append(name)
+            .append(", ")
+            .append(items)
+            .append(" )")
+            .toString();
+  }
 
   public Integer getId() {
     return id;

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/PersonItemPair.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/PersonItemPair.java
@@ -15,33 +15,36 @@
  */
 package org.apache.ibatis.submitted.nestedresulthandler;
 
-public class Item {
-  private Integer id;
-  private String name;
+/**
+ * Created by eyal on 12/9/2015.
+ */
+public class PersonItemPair {
+    private Person  person;
+    private Item item;
 
-  public String toString(){
-    return new StringBuilder()
-            .append("Item(")
-            .append(id)
-            .append(", ")
-            .append(name)
-            .append(" )")
-            .toString();
-  }
+    public String toString(){
+        return new StringBuilder()
+                .append("PersonItemPair(")
+                .append(person)
+                .append(", ")
+                .append(item)
+                .append(" )")
+                .toString();
+    }
 
-  public Integer getId() {
-    return id;
-  }
+    public Person getPerson() {
+        return person;
+    }
 
-  public void setId(Integer id) {
-    this.id = id;
-  }
+    public void setPerson(Person person) {
+        this.person = person;
+    }
 
-  public String getName() {
-    return name;
-  }
+    public Item getItem() {
+        return item;
+    }
 
-  public void setName(String name) {
-    this.name = name;
-  }
+    public void setItem(Item item) {
+        this.item = item;
+    }
 }

--- a/src/test/java/org/apache/ibatis/submitted/results_id/AnotherMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/AnotherMapper.java
@@ -13,22 +13,20 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.annotations;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+package org.apache.ibatis.submitted.results_id;
 
-/**
- * @author Clinton Begin
- */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-public @interface Results {
-  /**
-   * The name of the result map.
-   */
-  String id() default "";
-  Result[] value() default {};
+import java.util.List;
+
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+
+public interface AnotherMapper {
+
+  @ResultMap("org.apache.ibatis.submitted.results_id.Mapper.userResult")
+  @Select("select * from users order by uid")
+  List<User> getUsers();
+
+  User getUser(Integer id);
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/results_id/AnotherMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/AnotherMapper.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+       Copyright 2009-2015 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.results_id.AnotherMapper">
+	<select id="getUser" resultMap="org.apache.ibatis.submitted.results_id.Mapper.userResult">
+		select * from users where uid = #{id}
+	</select>
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/results_id/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/CreateDB.sql
@@ -1,0 +1,25 @@
+--
+--    Copyright 2009-2015 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  uid int,
+  name varchar(20)
+);
+
+insert into users (uid, name) values(1, 'User1');
+insert into users (uid, name) values(2, 'User2');

--- a/src/test/java/org/apache/ibatis/submitted/results_id/IdConflictMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/IdConflictMapper.java
@@ -13,22 +13,15 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.annotations;
+package org.apache.ibatis.submitted.results_id;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Select;
 
-/**
- * @author Clinton Begin
- */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-public @interface Results {
-  /**
-   * The name of the result map.
-   */
-  String id() default "";
-  Result[] value() default {};
+public interface IdConflictMapper {
+
+  @Results(id = "userResult", value = { @Result(id = true, column = "uid", property = "id") })
+  @Select("select * from users where uid = #{id}")
+  User getUserById(Integer id);
 }

--- a/src/test/java/org/apache/ibatis/submitted/results_id/IdConflictMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/IdConflictMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+       Copyright 2009-2015 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.results_id.IdConflictMapper">
+	<resultMap type="org.apache.ibatis.submitted.results_id.User"
+		id="userResult">
+		<id property="id" column="uid" />
+	</resultMap>
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/results_id/IdConflictTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/IdConflictTest.java
@@ -1,0 +1,38 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.results_id;
+
+import org.apache.ibatis.session.Configuration;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class IdConflictTest {
+
+  @Rule
+  public ExpectedException ex = ExpectedException.none();
+
+  @Test
+  public void shouldFailOnDuplicatedId() throws Exception {
+    ex.expect(RuntimeException.class);
+    ex.expectMessage("Result Maps collection already contains value for org.apache.ibatis.submitted.results_id.IdConflictMapper.userResult");
+
+    Configuration configuration = new Configuration();
+    configuration.addMapper(IdConflictMapper.class);
+    configuration.getMappedStatements();
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/results_id/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/Mapper.java
@@ -1,0 +1,49 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.results_id;
+
+import org.apache.ibatis.annotations.Arg;
+import org.apache.ibatis.annotations.ConstructorArgs;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Select;
+
+public interface Mapper {
+
+  @Results(id = "userResult", value = {
+    @Result(id = true, column = "uid", property = "id"),
+    @Result(column = "name", property = "name")
+  })
+  @Select("select * from users where uid = #{id}")
+  User getUserById(Integer id);
+
+  @ResultMap("userResult")
+  @Select("select * from users where name = #{name}")
+  User getUserByName(String name);
+
+  @Results(id = "userResultConstructor")
+  @ConstructorArgs({
+    @Arg(id = true, column = "uid", javaType = Integer.class),
+    @Arg(column = "name", javaType = String.class)
+  })
+  @Select("select * from users where uid = #{id}")
+  User getUserByIdConstructor(Integer id);
+
+  @ResultMap("userResultConstructor")
+  @Select("select * from users where name = #{name}")
+  User getUserByNameConstructor(String name);
+}

--- a/src/test/java/org/apache/ibatis/submitted/results_id/ResultsIdTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/ResultsIdTest.java
@@ -1,0 +1,108 @@
+/**
+ *    Copyright 2009-2015 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.results_id;
+
+import static org.junit.Assert.*;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.util.List;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ResultsIdTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/results_id/mybatis-config.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
+
+    // populate in-memory database
+    SqlSession session = sqlSessionFactory.openSession();
+    Connection conn = session.getConnection();
+    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/results_id/CreateDB.sql");
+    ScriptRunner runner = new ScriptRunner(conn);
+    runner.setLogWriter(null);
+    runner.runScript(reader);
+    reader.close();
+    session.close();
+  }
+
+  @Test
+  public void testNamingResults() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.getUserByName("User2");
+      assertEquals(Integer.valueOf(2), user.getId());
+      assertEquals("User2", user.getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void testResultsOnlyForNaming() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.getUserByNameConstructor("User2");
+      assertEquals(Integer.valueOf(2), user.getId());
+      assertEquals("User2", user.getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void testReuseNamedResultsFromAnotherMapper() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      AnotherMapper mapper = sqlSession.getMapper(AnotherMapper.class);
+      List<User> users = mapper.getUsers();
+      assertEquals(2, users.size());
+      assertEquals(Integer.valueOf(1), users.get(0).getId());
+      assertEquals("User1", users.get(0).getName());
+      assertEquals(Integer.valueOf(2), users.get(1).getId());
+      assertEquals("User2", users.get(1).getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void testReuseNamedResultsFromXmlMapper() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      AnotherMapper mapper = sqlSession.getMapper(AnotherMapper.class);
+      User user = mapper.getUser(1);
+      assertEquals(Integer.valueOf(1), user.getId());
+      assertEquals("User1", user.getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/results_id/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/User.java
@@ -13,22 +13,36 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.annotations;
+package org.apache.ibatis.submitted.results_id;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+public class User {
 
-/**
- * @author Clinton Begin
- */
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
-public @interface Results {
-  /**
-   * The name of the result map.
-   */
-  String id() default "";
-  Result[] value() default {};
+  private Integer id;
+  private String name;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public User() {
+    super();
+  }
+
+  public User(Integer id, String name) {
+    super();
+    this.id = id;
+    this.name = name;
+  }
 }

--- a/src/test/java/org/apache/ibatis/submitted/results_id/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/mybatis-config.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+       Copyright 2009-2015 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+	<environments default="development">
+		<environment id="development">
+			<transactionManager type="JDBC">
+				<property name="" value="" />
+			</transactionManager>
+			<dataSource type="UNPOOLED">
+				<property name="driver" value="org.hsqldb.jdbcDriver" />
+				<property name="url" value="jdbc:hsqldb:mem:resultsid" />
+				<property name="username" value="sa" />
+			</dataSource>
+		</environment>
+	</environments>
+
+	<mappers>
+		<mapper class="org.apache.ibatis.submitted.results_id.Mapper" />
+		<mapper class="org.apache.ibatis.submitted.results_id.AnotherMapper" />
+	</mappers>
+
+</configuration>

--- a/src/test/java/org/apache/ibatis/submitted/sptests/SPMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/sptests/SPMapper.java
@@ -18,7 +18,6 @@ package org.apache.ibatis.submitted.sptests;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.ibatis.annotations.Many;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Result;
@@ -47,15 +46,6 @@ public interface SPMapper {
   List<Name> getNamesAndItemsLinked();
   
   List<Name> getNamesAndItemsLinkedById(int id);
-
-  @Select("{call sptest.getnamesanditemsbyid(#{id,jdbcType=INTEGER,mode=IN})}")
-  @Results({
-    @Result(property = "firstName", column = "FIRST_NAME"),
-    @Result(property = "lastName", column = "LAST_NAME"),
-    @Result(property = "items", many = @Many(resultMap = "itemResult", resultSet = "items"))
-  })
-  @Options(resultSets = "names,items", statementType = StatementType.CALLABLE)
-  List<Name> getNamesAndItemsLinkedByIdAnnotationBased(@Param("id") int id);
 
   Object echoDate(Map<String, Object> parameter);  // issue #145
   

--- a/src/test/java/org/apache/ibatis/submitted/sptests/SPTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sptests/SPTest.java
@@ -858,18 +858,4 @@ public class SPTest {
     }
   }
 
-  @Test
-  public void testGetNamesAndItemsLinkedWithNoMatchingInfoAnnotationBased() throws SQLException {
-    SqlSession sqlSession = sqlSessionFactory.openSession();
-    try {
-      SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
-
-      List<Name> names = spMapper.getNamesAndItemsLinkedByIdAnnotationBased(0);
-      assertEquals(1, names.size());
-      assertEquals(2, names.get(0).getItems().size());
-    } finally {
-      sqlSession.close();
-    }
-  }
-
 }


### PR DESCRIPTION
In mybatis 3.4.5, class org.apache.ibatis.executor.resultset.DefaultResultSetHandler method getNextResultSet  changed from 
if (!((!stmt.getMoreResults()) && (stmt.getUpdateCount() == -1))) {
          ResultSet rs = stmt.getResultSet();
          return rs != null ? new ResultSetWrapper(rs, configuration) : null;
        }
to
if (!((!stmt.getMoreResults()) && (stmt.getUpdateCount() == -1))) {
          ResultSet rs = stmt.getResultSet();
          if (rs == null) {
            return getNextResultSet(stmt);  // !! this cause stackoverflow exception
          } else {
            return new ResultSetWrapper(rs, configuration);
          }
        }
When i use 3.4.5, i encounter a stackoverflow exception, i guess it maybe a bug?