### PR TITLE
PR showing resultMap Bug when SQL using "as" aliases for column names

### DIFF
--- a/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
@@ -19,6 +19,7 @@ import java.io.Reader;
 import java.sql.Connection;
 import java.util.List;
 
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.AutoMappingBehavior;
@@ -60,6 +61,36 @@ public class AutomappingTest {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = mapper.getUser(1);
       Assert.assertEquals("User1", user.getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldGetAUserWithoutAsAliases() {
+    sqlSessionFactory.getConfiguration().setAutoMappingBehavior(AutoMappingBehavior.NONE);
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.getUserPhoneNumberWithoutAs(1);
+      Assert.assertEquals("User1", user.getName());
+      Assert.assertNotNull(user.getPhone());
+      Assert.assertTrue("Phone number is not equals to 12345678901", ObjectUtils.equals(12345678901L, user.getPhone()));
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void shouldGetAUserWithAsAliases() {
+    sqlSessionFactory.getConfiguration().setAutoMappingBehavior(AutoMappingBehavior.NONE);
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.getUserPhoneNumberWithAs(1);
+      Assert.assertEquals("User1", user.getName());
+      Assert.assertNotNull(user.getPhone());
+      Assert.assertTrue("Phone number is not equals to 12345678901", ObjectUtils.equals(12345678901L, user.getPhone()));
     } finally {
       sqlSession.close();
     }

--- a/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.java
@@ -21,6 +21,10 @@ public interface Mapper {
 
   User getUser(Integer id);
 
+  User getUserPhoneNumberWithoutAs(Integer id);
+
+  User getUserPhoneNumberWithAs(Integer id);
+
   User getUserWithPhoneNumber(Integer id);
 
   User getUserWithPets_Inline(Integer id);

--- a/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.xml
@@ -29,6 +29,20 @@
 	<resultMap type="org.apache.ibatis.submitted.automapping.User" id="result" autoMapping="true">
 	</resultMap>
 
+	<select id="getUserPhoneNumberWithoutAs" resultMap="result2">
+		select id, name, phone_number from users where id = #{id}
+	</select>
+
+	<select id="getUserPhoneNumberWithAs" resultMap="result2">
+		select id, name, phone_number as phone from users where id = #{id}
+	</select>
+
+	<resultMap type="org.apache.ibatis.submitted.automapping.User" id="result2">
+		<id property="id" column="id"/>
+		<result property="name" column="name"/>
+		<result property="phone" column="phone_number"/>
+	</resultMap>
+
 	<select id="getUserWithPhoneNumber" resultMap="resultWithPhoneNumber">
 		select * from users where id = #{id}
 	</select>


### PR DESCRIPTION
This PR is intended to show a bug that was introduced with mybatis 3.4.3.

I've added a couple of tests in org.apache.ibatis.submitted.automapping.AutomappingTest (shouldGetAUserWithoutAsAliases and shouldGetAUserWithAsAliases) that show the issue. The tests are the same, but the second fails using a SQL statement that include an "as" alias.

This test would have worked with mybatis 3.4.2 and earlier.

I'm not 100% sure, but I _think_ the issue was introduced with https://github.com/mybatis/mybatis-3/pull/895.

Note: this PR is expected to fail the build because it includes tests that expose what is believed to be a bug (see #1101).