### PR TITLE
In BatchExecutor, close each statement right after it is executed.

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/BatchExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BatchExecutor.java
@@ -131,6 +131,7 @@ public class BatchExecutor extends BaseExecutor {
               keyGenerator.processAfter(this, ms, stmt, parameter);
             }
           }
+          closeStatement(stmt);
         } catch (BatchUpdateException e) {
           StringBuilder message = new StringBuilder();
           message.append(batchResult.getMappedStatement().getId())
@@ -149,9 +150,6 @@ public class BatchExecutor extends BaseExecutor {
       }
       return results;
     } finally {
-      for (Statement stmt : statementList) {
-        closeStatement(stmt);
-      }
       currentSql = null;
       statementList.clear();
       batchResultList.clear();

--- a/src/main/java/org/apache/ibatis/executor/BatchExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BatchExecutor.java
@@ -150,6 +150,9 @@ public class BatchExecutor extends BaseExecutor {
       }
       return results;
     } finally {
+      for (Statement stmt : statementList) {
+        closeStatement(stmt);
+      }
       currentSql = null;
       statementList.clear();
       batchResultList.clear();


### PR DESCRIPTION
fix for #1109 