### PR TITLE
Enhanced ProviderSqlSource to support dynamic sqlSource.

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/DeleteProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/DeleteProvider.java
@@ -31,4 +31,10 @@ public @interface DeleteProvider {
   Class<?> type();
 
   String method();
+
+  /**
+   * Cache the generated SqlSource, avoiding every rebuild.
+   * @since 3.4.6
+   */
+  boolean cacheSqlSource() default false;
 }

--- a/src/main/java/org/apache/ibatis/annotations/InsertProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/InsertProvider.java
@@ -31,4 +31,10 @@ public @interface InsertProvider {
   Class<?> type();
 
   String method();
+
+  /**
+   * Cache the generated SqlSource, avoiding every rebuild.
+   * @since 3.4.6
+   */
+  boolean cacheSqlSource() default false;
 }

--- a/src/main/java/org/apache/ibatis/annotations/SelectProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/SelectProvider.java
@@ -31,4 +31,10 @@ public @interface SelectProvider {
   Class<?> type();
 
   String method();
+
+  /**
+   * Cache the generated SqlSource, avoiding every rebuild.
+   * @since 3.4.6
+   */
+  boolean cacheSqlSource() default false;
 }

--- a/src/main/java/org/apache/ibatis/annotations/UpdateProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/UpdateProvider.java
@@ -31,4 +31,10 @@ public @interface UpdateProvider {
   Class<?> type();
 
   String method();
+
+  /**
+   * Cache the generated SqlSource, avoiding every rebuild.
+   * @since 3.4.6
+   */
+  boolean cacheSqlSource() default false;
 }

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -465,7 +465,7 @@ public class MapperAnnotationBuilder {
         return buildSqlSourceFromStrings(strings, parameterType, languageDriver);
       } else if (sqlProviderAnnotationType != null) {
         Annotation sqlProviderAnnotation = method.getAnnotation(sqlProviderAnnotationType);
-        return new ProviderSqlSource(assistant.getConfiguration(), sqlProviderAnnotation, type, method);
+        return new ProviderSqlSource(assistant.getConfiguration(), sqlProviderAnnotation, type, method, languageDriver);
       }
       return null;
     } catch (Exception e) {

--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
@@ -16,15 +16,15 @@
 package org.apache.ibatis.builder.annotation;
 
 import java.lang.reflect.Method;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.ibatis.builder.BuilderException;
-import org.apache.ibatis.builder.SqlSourceBuilder;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.parsing.PropertyParser;
 import org.apache.ibatis.reflection.ParamNameResolver;
+import org.apache.ibatis.scripting.LanguageDriver;
+import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
 import org.apache.ibatis.session.Configuration;
 
 /**
@@ -34,13 +34,15 @@ import org.apache.ibatis.session.Configuration;
 public class ProviderSqlSource implements SqlSource {
 
   private final Configuration configuration;
-  private final SqlSourceBuilder sqlSourceParser;
   private final Class<?> providerType;
+  private final LanguageDriver languageDriver;
+  private final boolean cacheSqlSource;
   private Method providerMethod;
   private String[] providerMethodArgumentNames;
   private Class<?>[] providerMethodParameterTypes;
   private ProviderContext providerContext;
   private Integer providerContextIndex;
+  private SqlSource sqlSource;
 
   /**
    * @deprecated Please use the {@link #ProviderSqlSource(Configuration, Object, Class, Method)} instead of this.
@@ -54,11 +56,24 @@ public class ProviderSqlSource implements SqlSource {
    * @since 3.4.5
    */
   public ProviderSqlSource(Configuration configuration, Object provider, Class<?> mapperType, Method mapperMethod) {
+    this(configuration, provider, mapperType, mapperMethod, configuration.getDefaultScriptingLanguageInstance());
+  }
+
+  /**
+   * @since 3.4.6
+   */
+  public ProviderSqlSource(Configuration configuration, Object provider, Class<?> mapperType, Method mapperMethod, LanguageDriver languageDriver) {
     String providerMethodName;
     try {
       this.configuration = configuration;
-      this.sqlSourceParser = new SqlSourceBuilder(configuration);
+      //Compatible with velocity and freemarker LanguageDriver
+      if(languageDriver instanceof XMLLanguageDriver){
+        this.languageDriver = languageDriver;
+      } else {
+        this.languageDriver = new XMLLanguageDriver();
+      }
       this.providerType = (Class<?>) provider.getClass().getMethod("type").invoke(provider);
+      this.cacheSqlSource = (Boolean) provider.getClass().getMethod("cacheSqlSource").invoke(provider);
       providerMethodName = (String) provider.getClass().getMethod("method").invoke(provider);
 
       for (Method m : this.providerType.getMethods()) {
@@ -100,7 +115,15 @@ public class ProviderSqlSource implements SqlSource {
 
   @Override
   public BoundSql getBoundSql(Object parameterObject) {
-    SqlSource sqlSource = createSqlSource(parameterObject);
+    SqlSource sqlSource;
+    if (this.sqlSource != null) {
+      sqlSource = this.sqlSource;
+    } else {
+      sqlSource = createSqlSource(parameterObject);
+      if(this.cacheSqlSource){
+        this.sqlSource = sqlSource;
+      }
+    }
     return sqlSource.getBoundSql(parameterObject);
   }
 
@@ -127,7 +150,7 @@ public class ProviderSqlSource implements SqlSource {
                 + " using a specifying parameterObject. In this case, please specify a 'java.util.Map' object.");
       }
       Class<?> parameterType = parameterObject == null ? Object.class : parameterObject.getClass();
-      return sqlSourceParser.parse(replacePlaceholder(sql), parameterType, new HashMap<String, Object>());
+      return languageDriver.createSqlSource(configuration, sql, parameterType);
     } catch (BuilderException e) {
       throw e;
     } catch (Exception e) {

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/BaseMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/BaseMapper.java
@@ -15,8 +15,12 @@
  */
 package org.apache.ibatis.submitted.sqlprovider;
 
+import org.apache.ibatis.annotations.Lang;
 import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.annotations.UpdateProvider;
+import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -54,6 +58,16 @@ public interface BaseMapper<T> {
   @SelectProvider(type= OurSqlBuilder.class, method= "buildSelectByIdAndNameMultipleParamAndProviderContext")
   List<T> selectActiveByIdAndName(Integer id, String name);
 
+  @Lang(XMLLanguageDriver.class)
+  @InsertProvider(type = OurSqlBuilder.class, method = "buildInsertSelective", cacheSqlSource = true)
+  void insertSelective(T entity);
+
+  @UpdateProvider(type= OurSqlBuilder.class, method= "buildUpdateSelective", cacheSqlSource = true)
+  void updateSelective(T entity);
+
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildGetByEntityQuery", cacheSqlSource = true)
+  List<T> getByEntity(T entity);
+
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
   @interface ContainsLogicalDelete {
@@ -64,6 +78,12 @@ public interface BaseMapper<T> {
   @Target(ElementType.TYPE)
   @interface Meta {
     String tableName();
+  }
+
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.FIELD)
+  @interface Column {
+    String value() default "";
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/OurSqlBuilder.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/OurSqlBuilder.java
@@ -19,6 +19,11 @@ import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.builder.annotation.ProviderContext;
 import org.apache.ibatis.jdbc.SQL;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -211,6 +216,109 @@ public class OurSqlBuilder {
         WHERE("logical_delete = false");
       }
     }}.toString();
+  }
+
+  private Class getEntityClass(ProviderContext providerContext){
+    Method mapperMethod = providerContext.getMapperMethod();
+    Class<?> declaringClass = mapperMethod.getDeclaringClass();
+    Class<?> mapperClass = providerContext.getMapperType();
+
+    Type[] types = mapperClass.getGenericInterfaces();
+    for (Type type : types) {
+      if (type instanceof ParameterizedType) {
+        ParameterizedType t = (ParameterizedType) type;
+        if (t.getRawType() == declaringClass || mapperClass.isAssignableFrom((Class<?>) t.getRawType())) {
+          Class<?> returnType = (Class<?>) t.getActualTypeArguments()[0];
+          return returnType;
+        }
+      }
+    }
+    throw new RuntimeException("The interface ["
+        + mapperClass.getCanonicalName() + "] must specify a generic type.");
+  }
+
+  private Map<String, String> getColumnMap(ProviderContext context){
+    Class entityClass = getEntityClass(context);
+    Field[] fields = entityClass.getDeclaredFields();
+    Map<String, String> columnMap = new LinkedHashMap<String, String>();
+    for (Field field : fields) {
+      BaseMapper.Column column = field.getAnnotation(BaseMapper.Column.class);
+      if(column != null){
+        String columnName = column.value();
+        if(columnName == null || columnName.length() == 0){
+          columnName = field.getName();
+        }
+        columnMap.put(columnName, field.getName());
+      }
+    }
+    if(columnMap.size() == 0){
+      throw new RuntimeException("There is no field in the class ["
+          + entityClass.getCanonicalName() + "] that specifies the @BaseMapper.Column annotation.");
+    }
+    return columnMap;
+  }
+
+  public String buildInsertSelective(ProviderContext context) {
+    final String tableName = context.getMapperType().getAnnotation(BaseMapper.Meta.class).tableName();
+    Map<String, String> columnMap = getColumnMap(context);
+    StringBuffer sqlBuffer = new StringBuffer();
+    sqlBuffer.append("<script>");
+    sqlBuffer.append("insert into ");
+    sqlBuffer.append(tableName);
+    sqlBuffer.append("<trim prefix=\"(\" suffix=\")\" suffixOverrides=\",\">");
+    for (Map.Entry<String, String> entry : columnMap.entrySet()) {
+      sqlBuffer.append("<if test=\"").append(entry.getValue()).append(" != null\">");
+      sqlBuffer.append(entry.getKey()).append(",");
+      sqlBuffer.append("</if>");
+    }
+    sqlBuffer.append("</trim>");
+    sqlBuffer.append("<trim prefix=\"VALUES (\" suffix=\")\" suffixOverrides=\",\">");
+    for (String field : columnMap.values()) {
+      sqlBuffer.append("<if test=\"").append(field).append(" != null\">");
+      sqlBuffer.append("#{").append(field).append("} ,");
+      sqlBuffer.append("</if>");
+    }
+    sqlBuffer.append("</trim>");
+    sqlBuffer.append("</script>");
+    return sqlBuffer.toString();
+  }
+
+  public String buildUpdateSelective(ProviderContext context) {
+    final String tableName = context.getMapperType().getAnnotation(BaseMapper.Meta.class).tableName();
+    Map<String, String> columnMap = getColumnMap(context);
+    StringBuffer sqlBuffer = new StringBuffer();
+    sqlBuffer.append("<script>");
+    sqlBuffer.append("update ");
+    sqlBuffer.append(tableName);
+    sqlBuffer.append("<set>");
+    for (Map.Entry<String, String> entry : columnMap.entrySet()) {
+      sqlBuffer.append("<if test=\"").append(entry.getValue()).append(" != null\">");
+      sqlBuffer.append(entry.getKey()).append(" = #{").append(entry.getValue()).append("} ,");
+      sqlBuffer.append("</if>");
+    }
+    sqlBuffer.append("</set>");
+    //For simplicity, there is no @Id annotation here, using default id directly
+    sqlBuffer.append("where id = #{id}");
+    sqlBuffer.append("</script>");
+    return sqlBuffer.toString();
+  }
+
+  public String buildGetByEntityQuery(ProviderContext context) {
+    final String tableName = context.getMapperType().getAnnotation(BaseMapper.Meta.class).tableName();
+    Map<String, String> columnMap = getColumnMap(context);
+    StringBuffer sqlBuffer = new StringBuffer();
+    sqlBuffer.append("<script>");
+    sqlBuffer.append("select * from ");
+    sqlBuffer.append(tableName);
+    sqlBuffer.append("<where>");
+    for (Map.Entry<String, String> entry : columnMap.entrySet()) {
+      sqlBuffer.append("<if test=\"").append(entry.getValue()).append(" != null\">");
+      sqlBuffer.append("and ").append(entry.getKey()).append(" = #{").append(entry.getValue()).append("}");
+      sqlBuffer.append("</if>");
+    }
+    sqlBuffer.append("</where>");
+    sqlBuffer.append("</script>");
+    return sqlBuffer.toString();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
@@ -508,4 +508,63 @@ public class SqlProviderTest {
     }
   }
 
+  @Test
+  public void shouldInsertUserSelective() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = new User();
+      user.setId(999);
+      mapper.insertSelective(user);
+
+      User loadedUser = mapper.getUser(999);
+      assertEquals(null, loadedUser.getName());
+
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+
+  @Test
+  public void shouldUpdateUserSelective() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = new User();
+      user.setId(999);
+      user.setName("MyBatis");
+      mapper.insert(user);
+
+      user.setName(null);
+      mapper.updateSelective(user);
+
+      User loadedUser = mapper.getUser(999);
+      assertEquals("MyBatis", loadedUser.getName());
+
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+  @Test
+  public void mapperGetByEntity() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User query = new User();
+      query.setName("User4");
+      assertEquals(1, mapper.getByEntity(query).size());
+      query = new User();
+      query.setId(1);
+      assertEquals(1, mapper.getByEntity(query).size());
+      query = new User();
+      query.setId(1);
+      query.setName("User4");
+      assertEquals(0, mapper.getByEntity(query).size());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/User.java
@@ -16,8 +16,9 @@
 package org.apache.ibatis.submitted.sqlprovider;
 
 public class User {
-
+  @BaseMapper.Column
   private Integer id;
+  @BaseMapper.Column
   private String name;
 
   public Integer getId() {


### PR DESCRIPTION
## Major changes:

1. Process the SQL with the languageDriver, sql statement that supports the `<script>` pattern.
2. The `XXXProvider` annotation adds the `cacheSqlSource` property to avoid duplicate calculations.

## A more powerful general-purpose Dao.
Test cases demonstrate a simple usage, with reference to the basic principles, and can achieve a powerful general-purpose Dao.

## Test

### Test method 1
```java
@Lang(XMLLanguageDriver.class)
@InsertProvider(type = OurSqlBuilder.class, method = "buildInsertSelective", cacheSqlSource = true)
void insertSelective(T entity);
```

This method dynamically generates the following SQL script:
```xml
<script>
    insert into users
    <trim prefix="(" suffix=")" suffixOverrides=",">
        <if test="id != null">id,</if>
        <if test="name != null">name,</if>
    </trim>

    <trim prefix="VALUES (" suffix=")" suffixOverrides=",">
        <if test="id != null">#{id} ,</if>
        <if test="name != null">#{name} ,</if>
    </trim>
</script>
```

The executed SQL is as follows:
```
DEBUG [main] - ==>  Preparing: insert into users ( id ) VALUES ( ? ) 
DEBUG [main] - ==> Parameters: 999(Integer)
DEBUG [main] - <==    Updates: 1
DEBUG [main] - ==>  Preparing: select * from users where id = ? 
DEBUG [main] - ==> Parameters: 999(Integer)
TRACE [main] - <==    Columns: ID, NAME, LOGICAL_DELETE
TRACE [main] - <==        Row: 999, null, FALSE
DEBUG [main] - <==      Total: 1
```

### Test method 2

```java
@Lang(XMLLanguageDriver.class)
@UpdateProvider(type= OurSqlBuilder.class, method= "buildUpdateSelective", cacheSqlSource = true)
void updateSelective(T entity);
```

This method dynamically generates the following SQL script:
```xml
<script>
    update users
    <set>
        <if test="id != null">id = #{id} ,</if>
        <if test="name != null">name = #{name} ,</if>
    </set>
    <!-- For simplicity, there is no @Id annotation here, using default id directly -->
    where id = #{id}
</script>
```

The executed SQL is as follows:

```
DEBUG [main] - ==>  Preparing: update users SET id = ? where id = ? 
DEBUG [main] - ==> Parameters: 999(Integer), 999(Integer)
DEBUG [main] - <==    Updates: 1
```

### Test method 3

```java
@Lang(XMLLanguageDriver.class)
@SelectProvider(type = OurSqlBuilder.class, method = "buildGetByEntityQuery", cacheSqlSource = true)
List<T> getByEntity(T entity);
```

This method dynamically generates the following SQL script:

```xml
<script>
    select * from users
    <where>
        <if test="id != null">and id = #{id} </if>
        <if test="name != null">and name = #{name} </if>
    </where>
</script>
```

The executed SQL is as follows:

```
DEBUG [main] - ==>  Preparing: select * from users WHERE name = ? 
DEBUG [main] - ==> Parameters: User4(String)
TRACE [main] - <==    Columns: ID, NAME, LOGICAL_DELETE
TRACE [main] - <==        Row: 4, User4, TRUE
DEBUG [main] - <==      Total: 1
DEBUG [main] - ==>  Preparing: select * from users WHERE id = ? 
DEBUG [main] - ==> Parameters: 1(Integer)
TRACE [main] - <==    Columns: ID, NAME, LOGICAL_DELETE
TRACE [main] - <==        Row: 1, User1, FALSE
DEBUG [main] - <==      Total: 1
DEBUG [main] - ==>  Preparing: select * from users WHERE id = ?and name = ? 
DEBUG [main] - ==> Parameters: 1(Integer), User4(String)
DEBUG [main] - <==      Total: 0
```