### PR TITLE
Support trusty on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: java
 sudo: false
-dist: precise
 
 addons:
-  hosts:
-    - mybatisci
-  hostname: mybatisci
+  apt:
+    packages:
+      - openjdk-6-jdk
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk8
   - openjdk7
   - openjdk6
 


### PR DESCRIPTION
I suggest using the Ubuntu trusty on Travis CI.

See https://docs.travis-ci.com/user/reference/trusty/#JVM-(Clojure%2C-Groovy%2C-Java%2C-Scala)-images .

I've added openjdk8 instead of oraclejdk7.

