### PR TITLE
Permit to call static function for ProviderSqlSource

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
@@ -16,6 +16,7 @@
 package org.apache.ibatis.builder.annotation;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
@@ -108,7 +108,9 @@ public class ProviderSqlSource implements SqlSource {
     try {
       int bindParameterCount = providerMethodParameterTypes.length - (providerContext == null ? 0 : 1);
       String sql;
-      if (providerMethodParameterTypes.length == 0) {
+      if (Modifier.isStatic(providerMethod.getModifiers())) {
+        sql = (String) providerMethod.invoke(null);
+      } else if (providerMethodParameterTypes.length == 0) {
         sql = (String) providerMethod.invoke(providerType.newInstance());
       } else if (bindParameterCount == 0) {
         sql = (String) providerMethod.invoke(providerType.newInstance(), providerContext);


### PR DESCRIPTION
The goal of this pullrequest is to permit the call of static functions form the ProviderSqlSource rather than instanciate a bean before calling the function.

I have just added the test to know if the function is a static function or not and invoke the function without an instance if the function is static.