### PR TITLE
Avoid unnecessary object creation when parsing XML tags.

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/factory/DefaultObjectFactory.java
+++ b/src/main/java/org/apache/ibatis/reflection/factory/DefaultObjectFactory.java
@@ -55,7 +55,7 @@ public class DefaultObjectFactory implements ObjectFactory, Serializable {
     // no props for default
   }
 
-  <T> T instantiateClass(Class<T> type, List<Class<?>> constructorArgTypes, List<Object> constructorArgs) {
+  private  <T> T instantiateClass(Class<T> type, List<Class<?>> constructorArgTypes, List<Object> constructorArgs) {
     try {
       Constructor<T> constructor;
       if (constructorArgTypes == null || constructorArgs == null) {

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -37,6 +37,7 @@ public class XMLScriptBuilder extends BaseBuilder {
   private final XNode context;
   private boolean isDynamic;
   private final Class<?> parameterType;
+  private final Map<String, NodeHandler> nodeHandlerMap = new HashMap<String, NodeHandler>();
 
   public XMLScriptBuilder(Configuration configuration, XNode context) {
     this(configuration, context, null);
@@ -46,6 +47,19 @@ public class XMLScriptBuilder extends BaseBuilder {
     super(configuration);
     this.context = context;
     this.parameterType = parameterType;
+  }
+
+
+  private void initNodeHandlerMap(){
+      nodeHandlerMap.put("trim", new TrimHandler());
+      nodeHandlerMap.put("where", new WhereHandler());
+      nodeHandlerMap.put("set", new SetHandler());
+      nodeHandlerMap.put("foreach", new ForEachHandler());
+      nodeHandlerMap.put("if", new IfHandler());
+      nodeHandlerMap.put("choose", new ChooseHandler());
+      nodeHandlerMap.put("when", new IfHandler());
+      nodeHandlerMap.put("otherwise", new OtherwiseHandler());
+      nodeHandlerMap.put("bind", new BindHandler());
   }
 
   public SqlSource parseScriptNode() {
@@ -88,17 +102,7 @@ public class XMLScriptBuilder extends BaseBuilder {
   }
 
   NodeHandler nodeHandlers(String nodeName) {
-    Map<String, NodeHandler> map = new HashMap<String, NodeHandler>();
-    map.put("trim", new TrimHandler());
-    map.put("where", new WhereHandler());
-    map.put("set", new SetHandler());
-    map.put("foreach", new ForEachHandler());
-    map.put("if", new IfHandler());
-    map.put("choose", new ChooseHandler());
-    map.put("when", new IfHandler());
-    map.put("otherwise", new OtherwiseHandler());
-    map.put("bind", new BindHandler());
-    return map.get(nodeName);
+    return nodeHandlerMap.get(nodeName);
   }
 
   private interface NodeHandler {

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -47,6 +47,7 @@ public class XMLScriptBuilder extends BaseBuilder {
     super(configuration);
     this.context = context;
     this.parameterType = parameterType;
+    initNodeHandlerMap();
   }
 
 

--- a/src/test/java/org/apache/ibatis/reflection/factory/DefaultObjectFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/factory/DefaultObjectFactoryTest.java
@@ -15,8 +15,18 @@
  */
 package org.apache.ibatis.reflection.factory;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import org.apache.ibatis.reflection.ReflectionException;
 import org.junit.Assert;
@@ -30,9 +40,9 @@ import org.junit.Test;
 public class DefaultObjectFactoryTest {
 
   @Test
-  public void instantiateClass() throws Exception {
+  public void createClass() throws Exception {
     DefaultObjectFactory defaultObjectFactory = new DefaultObjectFactory();
-    TestClass testClass = defaultObjectFactory.instantiateClass(TestClass.class,
+    TestClass testClass = defaultObjectFactory.create(TestClass.class,
         Arrays.<Class<?>>asList(String.class, Integer.class), Arrays.<Object>asList("foo", 0));
 
     Assert.assertEquals("myInteger didn't match expected", (Integer) 0, testClass.myInteger);
@@ -40,10 +50,10 @@ public class DefaultObjectFactoryTest {
   }
 
   @Test
-  public void instantiateClassThrowsProperErrorMsg() {
+  public void createClassThrowsProperErrorMsg() {
     DefaultObjectFactory defaultObjectFactory = new DefaultObjectFactory();
     try {
-      defaultObjectFactory.instantiateClass(TestClass.class, Collections.<Class<?>>singletonList(String.class), Collections.<Object>singletonList("foo"));
+      defaultObjectFactory.create(TestClass.class, Collections.<Class<?>>singletonList(String.class), Collections.<Object>singletonList("foo"));
       Assert.fail("Should have thrown ReflectionException");
     } catch (Exception e) {
       Assert.assertTrue("Should be ReflectionException", e instanceof ReflectionException);
@@ -52,4 +62,39 @@ public class DefaultObjectFactoryTest {
     }
   }
 
+  @Test
+  public void creatHashMap() throws  Exception{
+     DefaultObjectFactory defaultObjectFactory=new DefaultObjectFactory();
+     Map  map= defaultObjectFactory.create(Map.class,null,null);
+     Assert.assertTrue("Should be HashMap",map instanceof HashMap);
+  }
+
+  @Test
+  public void createArrayList() throws Exception {
+    DefaultObjectFactory defaultObjectFactory = new DefaultObjectFactory();
+    List list = defaultObjectFactory.create(List.class);
+    Assert.assertTrue(" list should be ArrayList", list instanceof ArrayList);
+
+    Collection collection = defaultObjectFactory.create(Collection.class);
+    Assert.assertTrue(" collection should be ArrayList", collection instanceof ArrayList);
+
+    Iterable iterable = defaultObjectFactory.create(Iterable.class);
+    Assert.assertTrue(" iterable should be ArrayList", iterable instanceof ArrayList);
+  }
+
+
+  @Test
+  public void createTreeSet() throws Exception {
+    DefaultObjectFactory defaultObjectFactory = new DefaultObjectFactory();
+    SortedSet sortedSet = defaultObjectFactory.create(SortedSet.class);
+    Assert.assertTrue(" sortedSet should be TreeSet", sortedSet instanceof TreeSet);
+  }
+
+
+  @Test
+  public void createHashSet() throws Exception {
+    DefaultObjectFactory defaultObjectFactory = new DefaultObjectFactory();
+    Set set = defaultObjectFactory.create(Set.class);
+    Assert.assertTrue(" set should be HashSet", set instanceof HashSet);
+  }
 }

--- a/src/test/java/org/apache/ibatis/reflection/factory/DefaultObjectFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/factory/DefaultObjectFactoryTest.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;


### PR DESCRIPTION
https://github.com/mybatis/mybatis-3/blob/master/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
These handlers are thread-safe, so they do not need to be created every time。
Using a global Map instead of local variables

#1148 