### PR TITLE
Clarify how the <cache /> tag interacts with the Java API.

### DIFF
--- a/src/site/es/xdoc/java-api.xml
+++ b/src/site/es/xdoc/java-api.xml
@@ -334,7 +334,7 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td><code>Class</code></td>
         <td><code>&lt;cacheRef&gt;</code></td>
         <td>
-          Referencia una cache de otro namespace. Atributos: <code>value</code> and <code>name</code>.
+          Referencia una cache de otro namespace. Note that caches declared in an XML mapper file are considered a separate namespace, even if they share the same FQCN. Atributos: <code>value</code> and <code>name</code>.
           If you use this annotation, you should be specified either <code>value</code> or <code>name</code> attribute.
           For the <code>value</code> attribute specify a java type indicating the namespace(the namespace name become a FQCN of specified java type),
           and for the <code>name</code> attribute(this attribute is available since 3.4.2) specify a name indicating the namespace.

--- a/src/site/es/xdoc/sqlmap-xml.xml
+++ b/src/site/es/xdoc/sqlmap-xml.xml
@@ -1659,6 +1659,13 @@ SELECT * FROM POST WHERE BLOG_ID = #{id}]]></source>
           <li>La caché puede tratarse como una cache de tipo lectura/escritura, lo cual significa que los objetos obtenidos no se comparten y pueden modificarse con seguridad por el llamante sin interferir en otras potenciales modificaciones realizadas por otros llamantes o hilos.</li>
         </ul>
 
+        <p>
+          <span class="label important">NOTE</span> The cache will only apply to statements declared in the mapping file
+          where the cache tag is located. If you are using the Java API in conjunction with the XML mapping files, then
+          statements declared in the companion interface will not be cached by default. You will need to refer to the
+          cache region using the @CacheNamespaceRef annotation.
+        </p>
+
         <p>Todas estas propiedades son modificables mediante atributos del elemento cache. Por ejemplo:
         </p>
 

--- a/src/site/ja/xdoc/java-api.xml
+++ b/src/site/ja/xdoc/java-api.xml
@@ -335,7 +335,7 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td><code>Class</code></td>
         <td><code>&lt;cacheRef&gt;</code></td>
         <td>
-          別のネームスペースに対して定義されているキャッシュの設定を参照します。 属性: <code>value</code>, <code>name</code>
+          別のネームスペースに対して定義されているキャッシュの設定を参照します。XML マッパーで宣言されているキャッシュは、namespace に同一 FQCN が指定されていても独立したキャッシュとして扱われます。属性: <code>value</code>, <code>name</code>
           このアノテーションを使用する場合は、<code>value</code>または<code>name</code>属性のどちらかを指定する必要があります。
           <code>value</code>属性にはネームスペースを示すJava型(ネームスペース名は指定したJava型のFQCNになる)を、
           <code>name</code>属性(この属性は3.4.2以降で利用可能)にはネームスペースを示す名前を指定します。

--- a/src/site/ja/xdoc/sqlmap-xml.xml
+++ b/src/site/ja/xdoc/sqlmap-xml.xml
@@ -1877,6 +1877,10 @@ SELECT * FROM POST WHERE BLOG_ID = #{id}]]></source>
         </ul>
 
         <p>
+          <span class="label important">重要</span> 対応する Java マッパーのステートメントをキャッシュの適用対象に含めるためには <code>@CacheNamespaceRef</code> アノテーションで XML マッパーのネームスペースを指定する必要があります。
+        </p>
+
+        <p>
           これらのプロパティは cache 要素の属性で変更することができます。
         </p>
 

--- a/src/site/ko/xdoc/java-api.xml
+++ b/src/site/ko/xdoc/java-api.xml
@@ -431,7 +431,7 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td><code>Class</code></td>
         <td><code>&lt;cacheRef&gt;</code></td>
         <td>
-          다른 명명공간의 캐시에 대한 참조 사용가능한 속성들 : <code>value</code>, <code>name</code>.
+          다른 명명공간의 캐시에 대한 참조 Note that caches declared in an XML mapper file are considered a separate namespace, even if they share the same FQCN. 사용가능한 속성들 : <code>value</code>, <code>name</code>.
           이 annotation 을 사용하려면 <code>value</code> 또는 <code>name</code> 속성을 지정해야 한다.
           <code>value</code> 속성은 namespace(namespace 이름은 지정된 java type 의 FQCN 이 된다) 를 나타내는 java type 을 지정한다,
           그리고 <code>name</code> 속성(이 속성은 3.4.2 부터 사용가능하다) 은 namespace 를 나타내는 이름을 지정한다.

--- a/src/site/ko/xdoc/sqlmap-xml.xml
+++ b/src/site/ko/xdoc/sqlmap-xml.xml
@@ -1600,6 +1600,13 @@ public class User {
           <li>캐시는 읽기/쓰기 캐시처럼 처리될 것이다. 이것은 가져올 객체는 공유되지 않고 호출자에 의해 안전하게 변경된다는 것을 의미한다.</li>
         </ul>
 
+        <p>
+          <span class="label important">NOTE</span> The cache will only apply to statements declared in the mapping file
+          where the cache tag is located. If you are using the Java API in conjunction with the XML mapping files, then
+          statements declared in the companion interface will not be cached by default. You will need to refer to the
+          cache region using the @CacheNamespaceRef annotation.
+        </p>
+
         <p>모든 프로퍼티는 cache 엘리먼트의 속성을 통해 변경가능하다. 
 		예를들면</p>
 

--- a/src/site/xdoc/java-api.xml
+++ b/src/site/xdoc/java-api.xml
@@ -344,7 +344,8 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td><code>Class</code></td>
         <td><code>&lt;cacheRef&gt;</code></td>
         <td>
-          References the cache of another namespace to use. Attributes: <code>value</code> and <code>name</code>.
+          References the cache of another namespace to use. Note that caches declared in an XML mapper file are considered
+          a separate namespace, even if they share the same FQCN. Attributes: <code>value</code> and <code>name</code>.
           If you use this annotation, you should be specified either <code>value</code> or <code>name</code> attribute.
           For the <code>value</code> attribute specify a java type indicating the namespace(the namespace name become a FQCN of specified java type),
           and for the <code>name</code> attribute(this attribute is available since 3.4.2) specify a name indicating the namespace.

--- a/src/site/xdoc/sqlmap-xml.xml
+++ b/src/site/xdoc/sqlmap-xml.xml
@@ -2013,7 +2013,7 @@ SELECT * FROM POST WHERE BLOG_ID = #{id}]]></source>
         </p>
 
         <p>          
-          By default, just local sessión caching is enabled that is used solely to cache data for the duration of a sessión.
+          By default, just local session caching is enabled that is used solely to cache data for the duration of a session.
           To enable a global second level of caching you simply need to add one line to your SQL Mapping file:
         </p>
 
@@ -2036,6 +2036,13 @@ SELECT * FROM POST WHERE BLOG_ID = #{id}]]></source>
             other callers or threads.
           </li>
         </ul>
+
+        <p>
+          <span class="label important">NOTE</span> The cache will only apply to statements declared in the mapping file
+          where the cache tag is located. If you are using the Java API in conjunction with the XML mapping files, then
+          statements declared in the companion interface will not be cached by default. You will need to refer to the
+          cache region using the @CacheNamespaceRef annotation.
+        </p>
 
         <p>
           All of these properties are modifiable through the attributes of the cache element. For example:

--- a/src/site/zh/xdoc/java-api.xml
+++ b/src/site/zh/xdoc/java-api.xml
@@ -541,7 +541,7 @@ flushInterval,size,readWrite,blocking 和 properties。
         <td><code>类</code></td>
         <td><code>&lt;cacheRef&gt;</code></td>
         <td>
-          参照另外一个命名空间的缓存来使用。属性:value, name。
+          参照另外一个命名空间的缓存来使用。Note that caches declared in an XML mapper file are considered a separate namespace, even if they share the same FQCN. 属性:value, name。
           If you use this annotation, you should be specified either <code>value</code> or <code>name</code> attribute.
           For the <code>value</code> attribute specify a java type indicating the namespace(the namespace name become a FQCN of specified java type),
           and for the <code>name</code> attribute(this attribute is available since 3.4.2) specify a name indicating the namespace.

--- a/src/site/zh/xdoc/sqlmap-xml.xml
+++ b/src/site/zh/xdoc/sqlmap-xml.xml
@@ -1770,6 +1770,13 @@ MyBatis 包含一个非常强大的查询缓存特性,它可以非常方便地�
         </ul>
 
         <p>
+          <span class="label important">NOTE</span> The cache will only apply to statements declared in the mapping file
+          where the cache tag is located. If you are using the Java API in conjunction with the XML mapping files, then
+          statements declared in the companion interface will not be cached by default. You will need to refer to the
+          cache region using the @CacheNamespaceRef annotation.
+        </p>
+
+        <p>
 所有的这些属性都可以通过缓存元素的属性来修改。比如:
         </p>
 

--- a/src/site/zh/xdoc/sqlmap-xml.xml
+++ b/src/site/zh/xdoc/sqlmap-xml.xml
@@ -756,7 +756,7 @@ ResultMap 就是 MyBatis 对这个问题的答案。
           <li>
             <code>collection</code> – 一个复杂类型的集合
             <ul>
-              <li>嵌套结果映射 – 集合可以指定为一个 <code>resultMap</code> 元素，或者引用一个
+              <li>嵌套结果映射 – 集合可以指定为一个 <code>resultMap</code> 元素，或者引用一个</li>
             </ul>
           </li>
           <li>


### PR DESCRIPTION
#1157 Improve the documentation around <cache /> and @Cachenamespace to clarify that Java interfaces do not automatically pick up mapper cache regions. 