### PR TITLE
Fixes #1143 - Change setCharacterStream to setClob

### DIFF
--- a/src/main/java/org/apache/ibatis/type/ClobTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ClobTypeHandler.java
@@ -31,7 +31,7 @@ public class ClobTypeHandler extends BaseTypeHandler<String> {
   public void setNonNullParameter(PreparedStatement ps, int i, String parameter, JdbcType jdbcType)
       throws SQLException {
     StringReader reader = new StringReader(parameter);
-    ps.setCharacterStream(i, reader, parameter.length());
+    ps.setClob(i, reader, parameter.length());
   }
 
   @Override


### PR DESCRIPTION
Oracle does not use the correct datatype if it is a clob and is inserted
as CharacterStream. This fixes ORA-01461.