### PR TITLE
fix(#1156): illegal reflective access on java 9

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/Reflector.java
+++ b/src/main/java/org/apache/ibatis/reflection/Reflector.java
@@ -313,7 +313,6 @@ public class Reflector {
   private Method[] getClassMethods(Class<?> cls) {
     Map<String, Method> uniqueMethods = new HashMap<String, Method>();
     Class<?> currentClass = cls;
-    //there's no point of looking thought method of Object class and it causes illegal reflection access on Java 9
     while (currentClass != null && currentClass != Object.class) {
       addUniqueMethods(uniqueMethods, currentClass.getDeclaredMethods());
 

--- a/src/main/java/org/apache/ibatis/reflection/Reflector.java
+++ b/src/main/java/org/apache/ibatis/reflection/Reflector.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -313,7 +313,8 @@ public class Reflector {
   private Method[] getClassMethods(Class<?> cls) {
     Map<String, Method> uniqueMethods = new HashMap<String, Method>();
     Class<?> currentClass = cls;
-    while (currentClass != null) {
+    //there's no point of looking thought method of Object class and it causes illegal reflection access on Java 9
+    while (currentClass != null && currentClass != Object.class) {
       addUniqueMethods(uniqueMethods, currentClass.getDeclaredMethods());
 
       // we also need to look for interface methods -


### PR DESCRIPTION
Hi,

This pull request allow to workaround the java 9 illegal access warning generated by mybatis.

When mybatis search for existing methods on objects, it goes to the object hierarchy including the top java.lang.Object class.

As there is no point to go to the java.lang.Object class as it didn't contains any getter/setter, a trivial workaround is to skip this class.
I tested this approach and with this patch there is no more illegall access warning on Java 9.

Regards,

Loïc