### PR TITLE
change the setDefaultExecutorType

### DIFF
--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -393,7 +393,7 @@ public class Configuration {
   }
 
   public void setDefaultExecutorType(ExecutorType defaultExecutorType) {
-    this.defaultExecutorType = defaultExecutorType;
+    this.defaultExecutorType = defaultExecutorType == null ? ExecutorType.SIMPLE : defaultExecutorType;
   }
 
   public boolean isCacheEnabled() {
@@ -566,7 +566,6 @@ public class Configuration {
 
   public Executor newExecutor(Transaction transaction, ExecutorType executorType) {
     executorType = executorType == null ? defaultExecutorType : executorType;
-    executorType = executorType == null ? ExecutorType.SIMPLE : executorType;
     Executor executor;
     if (ExecutorType.BATCH == executorType) {
       executor = new BatchExecutor(this, transaction);


### PR DESCRIPTION
change the setter of the defaultExecutorType to ensure defaultExecutorType must not be null, so the subsequent code can use it direct no worry about npe