### PR TITLE
Add notice in documents when  multi-row insert list and retrieve the auto-generated keys

### DIFF
--- a/src/site/es/xdoc/sqlmap-xml.xml
+++ b/src/site/es/xdoc/sqlmap-xml.xml
@@ -335,9 +335,12 @@ Por ejemplo, si la columna id de la tabla Author del ejemplo siguiente fuera aut
 
         <p>
           If your database also supports multi-row insert, you can pass a list or an array of <code>Author</code>s and retrieve the auto-generated keys.
+          <b> NOTA: cuando usted lote insertar datos y recuperar el auto genera llaves, clave en la <code>@Param ("list")</code> y <code>collection = "list"</code> debe ser una cadena <code>list</code>. Esto esta diseñado para solucionar el problema de que parametros la genera automaticamente la llave primaria debe rellenar cuando hay múltiples parámetros de tipo de recogida.</b>
         </p>
 
-        <source><![CDATA[<insert id="insertAuthor" useGeneratedKeys="true"
+        <source><![CDATA[List<Long> insert(@Param("list") List<Author> authors);
+
+        <insert id="insertAuthor" useGeneratedKeys="true"
     keyProperty="id">
   insert into Author (username, password, email, bio) values
   <foreach item="item" collection="list" separator=",">

--- a/src/site/ja/xdoc/sqlmap-xml.xml
+++ b/src/site/ja/xdoc/sqlmap-xml.xml
@@ -374,9 +374,12 @@ ps.setInt(1,id);]]></source>
 
         <p>
           複数行の一括挿入に対応したデータベースなら、 <code>Author</code> のリストまたは配列を引数として渡して自動生成された id の値を一括取得することも可能です。
+          <b>注意：ロットにデータを挿入するそして自動生成のキーのリストの時、<code>@Param("list")</code>と<code>collection="list"</code>中のキーでなければならない約束の文字列<code>list</code>。これは設計して、解決が集合タイプのパラメータの時、知らない自動生成のキー同埋戻しどのパラメータの問題。</b>
         </p>
 
-        <source><![CDATA[<insert id="insertAuthor" useGeneratedKeys="true"
+        <source><![CDATA[List<Long> insert(@Param("list") List<Author> authors);
+
+        <insert id="insertAuthor" useGeneratedKeys="true"
     keyProperty="id">
   insert into Author (username, password, email, bio) values
   <foreach item="item" collection="list" separator=",">

--- a/src/site/ko/xdoc/sqlmap-xml.xml
+++ b/src/site/ko/xdoc/sqlmap-xml.xml
@@ -320,9 +320,13 @@ ps.setInt(1,id);]]></source>
   values (#{username},#{password},#{email},#{bio})
 </insert>]]></source>
 
-        <p>사용하는 데이터베이스가 다중레코드 입력을 지원한다면, <code>Author</code>의 목록이나 배열을 전달할수 있고 자동생성키를 가져올 수 있다. </p>
+        <p>사용하는 데이터베이스가 다중레코드 입력을 지원한다면, <code>Author</code>의 목록이나 배열을 전달할수 있고 자동생성키를 가져올 수 있다.
+            <b>메모: 대량 산입 데이터 고 복귀 자동 생성 기본 키 목록 때，<code>@Param("list")</code>과<code>collection="list"</code>중 key 반드시 약속 문자열<code>list</code>。이 디자인 적 으로 해결 얼마나 개 집합 형식 매개 변수 때 모르는 자동 생성 곁쇠 이 되 묻음 까지 어느 인자 문제.</b>
+        </p>
 
-        <source><![CDATA[<insert id="insertAuthor" useGeneratedKeys="true"
+          <source><![CDATA[List<Long> insert(@Param("list") List<Author> authors);
+
+        <insert id="insertAuthor" useGeneratedKeys="true"
     keyProperty="id">
   insert into Author (username, password, email, bio) values
   <foreach item="item" collection="list" separator=",">

--- a/src/site/xdoc/sqlmap-xml.xml
+++ b/src/site/xdoc/sqlmap-xml.xml
@@ -399,9 +399,12 @@ ps.setInt(1,id);]]></source>
 
         <p>
           If your database also supports multi-row insert, you can pass a list or an array of <code>Author</code>s and retrieve the auto-generated keys.
+          <b> Note: when you batch insert data and retrieve the auto-generated keys, key in <code>@Param ("list")</code> and <code>collection = "list"</code> must be an agreed string <code>list</code>. This is designed to solve the problem of which parameters the auto generated primary key should backfill when there are multiple collection type parameters.</b>
         </p>
 
-        <source><![CDATA[<insert id="insertAuthor" useGeneratedKeys="true"
+        <source><![CDATA[List<Long> insert(@Param("list") List<Author> authors);
+
+        <insert id="insertAuthor" useGeneratedKeys="true"
     keyProperty="id">
   insert into Author (username, password, email, bio) values
   <foreach item="item" collection="list" separator=",">

--- a/src/site/zh/xdoc/sqlmap-xml.xml
+++ b/src/site/zh/xdoc/sqlmap-xml.xml
@@ -329,9 +329,12 @@ ps.setInt(1,id);]]></source>
 
         <p>
           如果你的数据库还支持多行插入, 你也可以传入一个<code>Author</code>s数组或集合，并返回自动生成的主键。
+          <b>注意：批量插入数据并且返回自动生成的主键列表的时候，<code>@Param("list")</code>和<code>collection="list"</code>中的key必须是约定的字符串<code>list</code>。这个是设计过的，以解决有多个集合类型参数的时候，不知道自动生成的主键该回填到哪个参数的问题。</b>
         </p>
 
-        <source><![CDATA[<insert id="insertAuthor" useGeneratedKeys="true"
+        <source><![CDATA[List<Long> insert(@Param("list") List<Author> authors);
+
+        <insert id="insertAuthor" useGeneratedKeys="true"
     keyProperty="id">
   insert into Author (username, password, email, bio) values
   <foreach item="item" collection="list" separator=",">


### PR DESCRIPTION
Fix #1113 
Add notice in documents when  multi-row insert list and and retrieve the auto-generated keys