### PR TITLE
Unset default value of keyProperty.

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/Options.java
+++ b/src/main/java/org/apache/ibatis/annotations/Options.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/ibatis/annotations/Options.java
+++ b/src/main/java/org/apache/ibatis/annotations/Options.java
@@ -58,7 +58,7 @@ public @interface Options {
 
   boolean useGeneratedKeys() default false;
 
-  String keyProperty() default "id";
+  String keyProperty() default "";
 
   String keyColumn() default "";
   

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -300,7 +300,7 @@ public class MapperAnnotationBuilder {
       boolean useCache = isSelect;
 
       KeyGenerator keyGenerator;
-      String keyProperty = "id";
+      String keyProperty = null;
       String keyColumn = null;
       if (SqlCommandType.INSERT.equals(sqlCommandType) || SqlCommandType.UPDATE.equals(sqlCommandType)) {
         // first check for SelectKey annotation - that overrides everything else

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Current implementation sets "id" as the default value of `keyProperty`.
But having default value makes it difficult to report helpful errors from Jdbc3KeyGenerator (see #782 and #902).

As it is possible that there are solutions relying on this default value, the target is set to 3.5.0.