### PR TITLE
Drop support JDK 6 and 7 at build definitions

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.2.5/apache-maven-3.2.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.2/apache-maven-3.5.2-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.4.0/maven-wrapper-0.4.0.jar

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ jdk:
   - oraclejdk9
   - oraclejdk8
   - openjdk8
-  - openjdk7
 
 before_install:
   - echo "MAVEN_OPTS='-Dlicense.skip=true'" > ~/.mavenrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,11 @@
 language: java
 sudo: false
 
-addons:
-  apt:
-    packages:
-      - openjdk-6-jdk
-
 jdk:
   - oraclejdk9
   - oraclejdk8
   - openjdk8
   - openjdk7
-  - openjdk6
 
 before_install:
   - echo "MAVEN_OPTS='-Dlicense.skip=true'" > ~/.mavenrc

--- a/pom.xml
+++ b/pom.xml
@@ -380,32 +380,4 @@
     </testResources>
   </build>
 
-  <profiles>
-    <profile>
-      <id>java17</id>
-      <activation>
-        <jdk>1.7</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.testTarget>1.7</maven.compiler.testTarget>
-        <maven.compiler.testSource>1.7</maven.compiler.testSource>
-        <maven.compiler.testCompilerArgument />
-      </properties>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <testExcludes>
-                  <testExclude>**/usesjava8/**/*.java</testExclude>
-                </testExcludes>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>30</version>
+    <version>31-SNAPSHOT</version>
     <relativePath />
   </parent>
 
@@ -377,5 +377,14 @@
       </testResource>
     </testResources>
   </build>
+
+  <repositories>
+    <!-- Adding for mybatis-parent 31-SNAPSHOT -->
+    <repository>
+      <id>sonatype-oss-snapshots</id>
+      <name>Sonatype OSS Snapshots Repository</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -382,45 +382,6 @@
 
   <profiles>
     <profile>
-      <id>java16</id>
-      <activation>
-        <jdk>1.6</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.testTarget>1.6</maven.compiler.testTarget>
-        <maven.compiler.testSource>1.6</maven.compiler.testSource>
-        <maven.compiler.testCompilerArgument />
-      </properties>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <configuration>
-                <testExcludes>
-                  <testExclude>**/usesjava7/**/*.java</testExclude>
-                  <testExclude>**/usesjava8/**/*.java</testExclude>
-                </testExcludes>
-              </configuration>
-            </plugin>
-            <plugin>
-              <groupId>org.apache.felix</groupId>
-              <artifactId>maven-bundle-plugin</artifactId>
-              <version>2.5.4</version> <!-- For java 6, remain at older version -->
-            </plugin>
-          </plugins>
-        </pluginManagement>
-        <plugins>
-            <plugin>
-              <groupId>org.apache.felix</groupId>
-              <artifactId>maven-bundle-plugin</artifactId>
-              <version>2.5.4</version> <!-- For java 6, remain at older version -->
-            </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>java17</id>
       <activation>
         <jdk>1.7</jdk>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
     <dependency>
       <groupId>ognl</groupId>
       <artifactId>ognl</artifactId>
-      <version>3.1.16</version>
+      <version>3.1.16</version> <!-- Keep to use 3.1.x because 3.2.2+ occurred a RuntimeException on OgnlContext -->
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
@@ -181,11 +181,10 @@
       <version>1.2.17</version>
       <optional>true</optional>
     </dependency>
-    <!-- Don't upgrade to 2.4+ until mybatis switches to java 7 -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.3</version>
+      <version>2.5</version> <!-- 2.6+ occurred a compile error on Log4j2AbstractLoggerImpl (This compile error will resolve on other issue)  -->
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -197,7 +196,7 @@
     <dependency>
       <groupId>cglib</groupId>
       <artifactId>cglib</artifactId>
-      <version>3.2.5</version>
+      <version>3.2.6</version>
       <optional>true</optional>
     </dependency>
 
@@ -205,38 +204,37 @@
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <version>4.12.2</version>
+      <version>5.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
-      <version>2.3.5</version> <!-- Version 2.4.0 required jdk8 -->
+      <version>2.4.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.12.1.1</version>
+      <version>10.14.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.12.0</version>
+      <version>2.16.0</version>
       <scope>test</scope>
     </dependency>
-    <!-- Do not go to 2.x until we are on jdk7 -->
     <dependency>
-      <groupId>commons-dbcp</groupId>
-      <artifactId>commons-dbcp</artifactId>
-      <version>1.4</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-dbcp2</artifactId>
+      <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.transaction</groupId>
       <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-      <version>1.0.1.Final</version>
+      <version>1.1.1.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -249,25 +247,25 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>42.1.4.jre6</version>
+      <version>42.2.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <version>1.7.1</version> <!-- Stay on 1.7.1 to support Java 6 -->
+      <version>3.9.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>eu.codearte.catch-exception</groupId>
       <artifactId>catch-exception</artifactId>
-      <version>1.4.4</version>
+      <version>1.4.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>ru.yandex.qatools.embed</groupId>
       <artifactId>postgresql-embedded</artifactId>
-      <version>2.5</version>
+      <version>2.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -232,9 +232,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.spec.javax.transaction</groupId>
-      <artifactId>jboss-transaction-api_1.2_spec</artifactId>
-      <version>1.1.1.Final</version>
+      <groupId>javax.transaction</groupId>
+      <artifactId>javax.transaction-api</artifactId>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.mybatis</groupId>
     <artifactId>mybatis-parent</artifactId>
-    <version>29</version>
+    <version>30</version>
     <relativePath />
   </parent>
 
@@ -131,6 +131,8 @@
   </distributionManagement>
 
   <properties>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
     <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
     <maven.compiler.testSource>1.8</maven.compiler.testSource>
     <maven.compiler.testCompilerArgument>-parameters</maven.compiler.testCompilerArgument>
@@ -140,6 +142,10 @@
     <osgi.import>*;resolution:=optional</osgi.import>
     <osgi.dynamicImport>*</osgi.dynamicImport>
     <maven.surefire.excludeGroups>org.apache.ibatis.test.SlowTests</maven.surefire.excludeGroups>
+
+    <!-- Override: Animal Sniffer Signature -->
+    <signature.artifact>java17</signature.artifact>
+    <signature.version>1.0</signature.version>
   </properties>
 
   <dependencies>
@@ -345,12 +351,6 @@
             <exclude>org.apache.ibatis.javassist.*</exclude>
           </excludes>
         </configuration>
-      </plugin>
-      <!-- Patch until mybatis-parent 30 (jdk9 build support) -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.16</version>
       </plugin>
     </plugins>
 

--- a/pom.xml
+++ b/pom.xml
@@ -131,8 +131,8 @@
   </distributionManagement>
 
   <properties>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
     <maven.compiler.testSource>1.8</maven.compiler.testSource>
     <maven.compiler.testCompilerArgument>-parameters</maven.compiler.testCompilerArgument>
@@ -144,7 +144,7 @@
     <maven.surefire.excludeGroups>org.apache.ibatis.test.SlowTests</maven.surefire.excludeGroups>
 
     <!-- Override: Animal Sniffer Signature -->
-    <signature.artifact>java17</signature.artifact>
+    <signature.artifact>java18</signature.artifact>
     <signature.version>1.0</signature.version>
   </properties>
 

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-#    Copyright 2009-2017 the original author or authors.
+#    Copyright 2009-2018 the original author or authors.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -15,10 +15,4 @@
 #    limitations under the License.
 #
 
-if [ $TRAVIS_JDK_VERSION == "openjdk7" ]; then
-  # Java 1.7
-  ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pjava17 --settings ./travis/settings.xml
-else
-  # Java 1.8 and 9
-  ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V --settings ./travis/settings.xml
-fi
+./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V --settings ./travis/settings.xml

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -15,10 +15,7 @@
 #    limitations under the License.
 #
 
-if [ $TRAVIS_JDK_VERSION == "openjdk6" ]; then
-  # Java 1.6
-  ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pjava16 --settings ./travis/settings.xml
-elif [ $TRAVIS_JDK_VERSION == "openjdk7" ]; then
+if [ $TRAVIS_JDK_VERSION == "openjdk7" ]; then
   # Java 1.7
   ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Pjava17 --settings ./travis/settings.xml
 else


### PR DESCRIPTION
I've fixed #1207 .
Please review this.

Notes:

Following two artifacts could not upgrade to the latest version. Please see the xml's comment about reason. I will create new issues to fix it.

* log4j-core #1210 
* ognl #1211 

Thanks.
