### PR TITLE
Delegating to the ClobReaderTypeHandler on ClobTypeHandler and NClobTypeHandler

### DIFF
--- a/src/main/java/org/apache/ibatis/type/NClobTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/NClobTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,58 +15,27 @@
  */
 package org.apache.ibatis.type;
 
-import java.io.StringReader;
-import java.sql.CallableStatement;
-import java.sql.Clob;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.io.Reader;
 
 /**
  * @author Clinton Begin
+ * @author Kazuki Shimizu
+ * @see ClobTypeHandler
  */
-public class NClobTypeHandler extends BaseTypeHandler<String> {
+public class NClobTypeHandler extends ClobTypeHandler {
 
-  @Override
-  public void setNonNullParameter(PreparedStatement ps, int i, String parameter, JdbcType jdbcType)
-      throws SQLException {
-    StringReader reader = new StringReader(parameter);
-    ps.setCharacterStream(i, reader, parameter.length());
+  /**
+   * @since 3.5.0
+   */
+  public NClobTypeHandler() {
+    super();
   }
 
-  @Override
-  public String getNullableResult(ResultSet rs, String columnName)
-      throws SQLException {
-    String value = "";
-    Clob clob = rs.getClob(columnName);
-    if (clob != null) {
-      int size = (int) clob.length();
-      value = clob.getSubString(1, size);
-    }
-    return value;
+  /**
+   * @since 3.5.0
+   */
+  public NClobTypeHandler(BaseTypeHandler<Reader> clobReaderTypeHandler) {
+    super(clobReaderTypeHandler);
   }
 
-  @Override
-  public String getNullableResult(ResultSet rs, int columnIndex)
-      throws SQLException {
-    String value = "";
-    Clob clob = rs.getClob(columnIndex);
-    if (clob != null) {
-      int size = (int) clob.length();
-      value = clob.getSubString(1, size);
-    }
-    return value;
-  }
-
-  @Override
-  public String getNullableResult(CallableStatement cs, int columnIndex)
-      throws SQLException {
-    String value = "";
-    Clob clob = cs.getClob(columnIndex);
-    if (clob != null) {
-      int size = (int) clob.length();
-      value = clob.getSubString(1, size);
-    }
-    return value;
-  }
 }

--- a/src/test/java/org/apache/ibatis/type/NClobTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/NClobTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
-import java.io.Reader;
+import java.io.StringReader;
 import java.sql.Clob;
 
 import static org.junit.Assert.assertEquals;
@@ -38,7 +38,7 @@ public class NClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldSetParameter() throws Exception {
     TYPE_HANDLER.setParameter(ps, 1, "Hello", null);
-    verify(ps).setCharacterStream(Mockito.eq(1), Mockito.any(Reader.class), Mockito.eq(5));
+    verify(ps).setClob(Mockito.eq(1), Mockito.any(StringReader.class));
   }
 
   @Override
@@ -46,8 +46,7 @@ public class NClobTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getClob("column")).thenReturn(clob);
     when(rs.wasNull()).thenReturn(false);
-    when(clob.length()).thenReturn(3l);
-    when(clob.getSubString(1, 3)).thenReturn("Hello");
+    when(clob.getCharacterStream()).thenReturn(new StringReader("Hello"));
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, "column"));
   }
 
@@ -64,8 +63,7 @@ public class NClobTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getClob(1)).thenReturn(clob);
     when(rs.wasNull()).thenReturn(false);
-    when(clob.length()).thenReturn(3l);
-    when(clob.getSubString(1, 3)).thenReturn("Hello");
+    when(clob.getCharacterStream()).thenReturn(new StringReader("Hello"));
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, 1));
   }
 
@@ -82,9 +80,8 @@ public class NClobTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getClob(1)).thenReturn(clob);
     when(cs.wasNull()).thenReturn(false);
-    when(clob.length()).thenReturn(3l);
-    when(clob.getSubString(1, 3)).thenReturn("Hello");
-    assertEquals("Hello", TYPE_HANDLER.getResult(cs, 1));
+    when(clob.getCharacterStream()).thenReturn(new StringReader("Hello"));
+    assertEquals("Hello", new NClobTypeHandler(new ClobReaderTypeHandler()).getResult(cs, 1));
   }
 
   @Override


### PR DESCRIPTION
I've tried to fix gh-1143 gh-1205.

This PR's approach is that uses APIs that added at the JDBC 4.0 using the `ClobReaderTypeHandler`. These methods don't conscious a CLob's length.

**Note:**

I don's know that whether this code works fine on all JDBC Drivers. I afraid that exists a JDBC Driver that does not support these methods.

@harawata @Cavva79 @jicheol-ryu
WDYT for this fix?
 