### PR TITLE
A new type handler for SQLXML data type.

### DIFF
--- a/src/main/java/org/apache/ibatis/type/SqlxmlTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/SqlxmlTypeHandler.java
@@ -1,0 +1,57 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLXML;
+
+public class SqlxmlTypeHandler extends BaseTypeHandler<String> {
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, String parameter, JdbcType jdbcType)
+      throws SQLException {
+    SQLXML sqlxml = ps.getConnection().createSQLXML();
+    sqlxml.setString(parameter);
+    ps.setSQLXML(i, sqlxml);
+    sqlxml.free();
+  }
+
+  @Override
+  public String getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    return sqlxmlToString(rs.getSQLXML(columnName));
+  }
+
+  @Override
+  public String getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    return sqlxmlToString(rs.getSQLXML(columnIndex));
+  }
+
+  @Override
+  public String getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    return sqlxmlToString(cs.getSQLXML(columnIndex));
+  }
+
+  protected String sqlxmlToString(SQLXML sqlxml) throws SQLException {
+    String result = sqlxml.getString();
+    sqlxml.free();
+    return result;
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -145,6 +145,8 @@ public final class TypeHandlerRegistry {
     register(java.sql.Time.class, new SqlTimeTypeHandler());
     register(java.sql.Timestamp.class, new SqlTimestampTypeHandler());
 
+    register(String.class, JdbcType.SQLXML, new SqlxmlTypeHandler());
+
     // mybatis-typehandlers-jsr310
     if (Jdk.dateAndTimeApiExists) {
       this.register(Instant.class, InstantTypeHandler.class);

--- a/src/test/java/org/apache/ibatis/type/SqlxmlTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/SqlxmlTypeHandlerTest.java
@@ -1,0 +1,131 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.type;
+
+import static org.junit.Assert.*;
+
+import java.io.Reader;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.util.Collections;
+
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.test.EmbeddedPostgresqlTests;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import ru.yandex.qatools.embed.postgresql.EmbeddedPostgres;
+import ru.yandex.qatools.embed.postgresql.util.SocketUtil;
+
+@Category(EmbeddedPostgresqlTests.class)
+public class SqlxmlTypeHandlerTest {
+  private static final EmbeddedPostgres postgres = new EmbeddedPostgres();
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // Launch PostgreSQL server. Download / unarchive if necessary.
+    String url = postgres.start(
+        EmbeddedPostgres.cachedRuntimeConfig(Paths.get(System.getProperty("java.io.tmpdir"), "pgembed")), "localhost",
+        SocketUtil.findFreePort(), "postgres_sqlxml", "postgres", "root", Collections.emptyList());
+
+    Configuration configuration = new Configuration();
+    Environment environment = new Environment("development", new JdbcTransactionFactory(), new UnpooledDataSource(
+        "org.postgresql.Driver", url, null));
+    configuration.setEnvironment(environment);
+    configuration.setUseGeneratedKeys(true);
+    configuration.addMapper(Mapper.class);
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+
+    try (SqlSession session = sqlSessionFactory.openSession();
+        Connection conn = session.getConnection();
+        Reader reader = Resources
+            .getResourceAsReader("org/apache/ibatis/type/SqlxmlTypeHandlerTest.sql")) {
+      ScriptRunner runner = new ScriptRunner(conn);
+      runner.setLogWriter(null);
+      runner.runScript(reader);
+    }
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    postgres.stop();
+  }
+
+  @Test
+  public void shouldRetrieveXml() throws Exception {
+    SqlSession session = sqlSessionFactory.openSession();
+    try {
+      Mapper mapper = session.getMapper(Mapper.class);
+      String content = mapper.select(1);
+      assertEquals("<title>XML data</title>",
+          content);
+    } finally {
+      session.close();
+    }
+  }
+
+  @Test
+  public void shouldInsertXml() throws Exception {
+    final Integer id = 100;
+    final String content = "<books><book><title>Save XML</title></book><book><title>Get XML</title></book></books>";
+    // Insert
+    {
+      SqlSession session = sqlSessionFactory.openSession();
+      try {
+        Mapper mapper = session.getMapper(Mapper.class);
+        mapper.insert(id, content);
+        session.commit();
+      } finally {
+        session.close();
+      }
+    }
+    // Select to verify
+    {
+      SqlSession session = sqlSessionFactory.openSession();
+      try {
+        Mapper mapper = session.getMapper(Mapper.class);
+        String result = mapper.select(id);
+        assertEquals(content, result);
+      } finally {
+        session.close();
+      }
+    }
+  }
+
+  interface Mapper {
+    @Select("select content from mbtest.test_sqlxml where id = #{id}")
+    String select(Integer id);
+
+    @Insert("insert into mbtest.test_sqlxml (id, content) values (#{id}, #{content,jdbcType=SQLXML})")
+    void insert(@Param("id") Integer id, @Param("content") String content);
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/SqlxmlTypeHandlerTest.sql
+++ b/src/test/java/org/apache/ibatis/type/SqlxmlTypeHandlerTest.sql
@@ -1,0 +1,25 @@
+--
+--    Copyright 2009-2018 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+CREATE SCHEMA mbtest;
+
+CREATE TABLE mbtest.test_sqlxml (
+  id serial PRIMARY KEY,
+  content XML
+);
+
+INSERT INTO mbtest.test_sqlxml (id, content)
+VALUES (1, '<title>XML data</title>');


### PR DESCRIPTION
It seems to be working with...

- Oracle 11g (`XMLTYPE` column)
- PostgreSQL 10 (`XML` column)
- MS SQL Server 2017 Express (`XML` column / mssql-jdbc driver)
