### PR TITLE
Deprecated Log4J 1.x #1223

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,12 +163,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.32</version>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>1.2.17</version>
@@ -285,6 +279,12 @@
       <artifactId>mssql-jdbc</artifactId>
       <version>9.4.0.jre8</version>
       <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.2.9</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/apache/ibatis/logging/LogFactory.java
+++ b/src/main/java/org/apache/ibatis/logging/LogFactory.java
@@ -67,6 +67,10 @@ public final class LogFactory {
     setImplementation(org.apache.ibatis.logging.commons.JakartaCommonsLoggingImpl.class);
   }
 
+  /**
+   * @deprecated Since 3.5.9 - See https://github.com/mybatis/mybatis-3/issues/1223. This method will remove future.
+   */
+  @Deprecated
   public static synchronized void useLog4JLogging() {
     setImplementation(org.apache.ibatis.logging.log4j.Log4jImpl.class);
   }

--- a/src/main/java/org/apache/ibatis/logging/log4j/Log4jImpl.java
+++ b/src/main/java/org/apache/ibatis/logging/log4j/Log4jImpl.java
@@ -21,7 +21,9 @@ import org.apache.log4j.Logger;
 
 /**
  * @author Eduardo Macarron
+ * @deprecated Since 3.5.9 - See https://github.com/mybatis/mybatis-3/issues/1223. This class will remove future.
  */
+@Deprecated
 public class Log4jImpl implements Log {
 
   private static final String FQCN = Log4jImpl.class.getName();

--- a/src/main/java/org/apache/ibatis/logging/log4j/package-info.java
+++ b/src/main/java/org/apache/ibatis/logging/log4j/package-info.java
@@ -15,5 +15,6 @@
  */
 /**
  * logger using Log4J feature.
+ * @deprecated Since 3.5.9 - See https://github.com/mybatis/mybatis-3/issues/1223. This package will remove future.
  */
 package org.apache.ibatis.logging.log4j;

--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -482,7 +482,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 Permite especificar qué implementación de logging utilizar. Si no está informado la impelmentación se descubrirá automaticamente.
               </td>
               <td>
-                SLF4J | LOG4J | LOG4J2 | JDK_LOGGING | COMMONS_LOGGING | STDOUT_LOGGING | NO_LOGGING
+                SLF4J | LOG4J(deprecated since 3.5.9) | LOG4J2 | JDK_LOGGING | COMMONS_LOGGING | STDOUT_LOGGING | NO_LOGGING
               </td>
               <td>
                 No informado

--- a/src/site/es/xdoc/logging.xml
+++ b/src/site/es/xdoc/logging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@
           Log4j 2
         </li>
         <li>
-          Log4j
+          Log4j (deprecated since 3.5.9)
         </li>
         <li>
           JDK logging
@@ -51,27 +51,30 @@
       </p>
       <p>Muchos entornos vienen con Commons Logging incluido como pare del classpath del servidor (por ejemplo Tomcat y WebSphere). Es importante conocer que en esos entorno, MyBatis usará JCL como implementación de logging. En un entorno como WebSphere esto significa que tu configuración de log4j será ignorada dado que WebSphere proporciona su propia implementación de JCL. Esto puede ser muy frustrante porque parece que MyBatis está ignorando tu configuración de logging (en realidad, MyBatis está ignorando tu configuración de log4j porque está usando JCL en dicho entorno). Si tu aplicación se ejecuta en un entorno que lleva JCL incluido pero quieres usar un método distinto de logging puedes añadir un setting a tu fichero mybatis-config.xml:
       </p>
-      <source><![CDATA[<configuration>
+<source><![CDATA[
+<configuration>
   <settings>
     ...
     <setting name="logImpl" value="LOG4J"/>
     ...
   </settings>
-</configuration>]]>
-      </source>
+</configuration>
+]]></source>
       <p>Los valores válidos son: SLF4J, LOG4J, LOG4J2, JDK_LOGGING, COMMONS_LOGGING, STDOUT_LOGGING, NO_LOGGING o
       un nombre de clase plenamente cualificado que implemente <code>org.apache.ibatis.logging.Log</code> y reciba
       un string como parametro de constructor.
       </p>
       <p>Tambien puedes seleccionar el método de logging llamando a uno de los siguientes métodos:
       </p>
-      <source><![CDATA[org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
+<source><![CDATA[
+org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
 org.apache.ibatis.logging.LogFactory.useLog4JLogging();
 org.apache.ibatis.logging.LogFactory.useLog4J2Logging();
 org.apache.ibatis.logging.LogFactory.useJdkLogging();
 org.apache.ibatis.logging.LogFactory.useCommonsLogging();
-org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
-      <p>Si eliges llamar a alguno de estos métodos, deberías hacerlo antes de llamar a ningún otro método de MyBatis. Además, estos métodos solo establecerán la implementación de log indicada si dicha implementación está disponible en el classpath. Por ejemplo, si intentas seleccionar log4j y log4j no está disponible en el classpath, MyBatis ignorará la petición y usará su algoritmo normal de descubrimiento de implementaciones de logging.
+org.apache.ibatis.logging.LogFactory.useStdOutLogging();
+]]></source>
+      <p>Si eliges llamar a alguno de estos métodos, deberías hacerlo antes de llamar a ningún otro método de MyBatis. Además, estos métodos solo establecerán la implementación de log indicada si dicha implementación está disponible en el classpath. Por ejemplo, si intentas seleccionar log4j2 y log4j2 no está disponible en el classpath, MyBatis ignorará la petición y usará su algoritmo normal de descubrimiento de implementaciones de logging.
       </p>
       <p>Los temas específicos de JCL, Log4j y el Java Logging API quedan fuera del alcance de este documento. Sin embargo la configuración de ejemplo que se proporciona más abajo te ayudará a comenzar. Si quieres conocer más sobre estos frameworks, puedes obtener más información en las siguientes ubicaciones:
       </p>
@@ -91,50 +94,90 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
       </ul>
       <subsection name="Configuración">
         <p>Para ver el log de las sentencias debes activar el log en un paquete, el nombre plenamente cualificado de una clase, un namespace o un nombre plenamente cualificado de un mapped statement.</p>
-        <p>Nuevamente, cómo hagas esto es dependiente de la implementación de logging que se esté usando. Mostraremos cómo hacerlo con Log4j. Configurar los servicios de logging es simplemente cuestión de añadir uno o varios ficheros de configuración (por ejemplo log4j.properties) y a veces un nuevo JAR (por ejemplo log4j.jar). El ejemplo siguiente configura todos los servicios de logging para que usen log4j como proveedor. Sólo son dos pasos:
+        <p>Nuevamente, cómo hagas esto es dependiente de la implementación de logging que se esté usando. Mostraremos cómo hacerlo con SLF4J(Logback). Configurar los servicios de logging es simplemente cuestión de añadir uno o varios ficheros de configuración (por ejemplo <code>logback.xml</code>) y a veces un nuevo JAR. El ejemplo siguiente configura todos los servicios de logging para que usen SLF4J(Logback) como proveedor. Sólo son dos pasos:
         </p>
-        <h4>Paso 1: Añade el fichero Log4j JAR
+        <h4>Paso 1: Añade el fichero SLF4J + Logback JAR
         </h4>
-        <p>Dado que usamos Log4j, necesitaremos asegurarnos que el fichero JAR está disponible para nuestra aplicación. Para usar Log4j, necesitas añadir el fichero JAR al classpath de tu aplicación. Puedes descargar Log4j desde la URL indicada más arriba.
+        <p>Dado que usamos SLF4J(Logback), necesitaremos asegurarnos que el fichero JAR está disponible para nuestra aplicación. Para usar SLF4J(Logback), necesitas añadir el fichero JAR al classpath de tu aplicación.
         </p>
-        <p>En aplicaciones Web o de empresa debes añadir tu fichero log4j.java a tu directorio WEB-INF/lib, y en una aplicación standalone simplemente añádela al parámetro –classpath de la JVM.
+        <p>En aplicaciones Web o de empresa debes añadir tu fichero <code>logback-classic.jar</code>
+          ,<code>logback-core.jar</code> and <code>slf4j-api.jar</code> a tu directorio <code>WEB-INF/lib</code>, y en una aplicación standalone simplemente añádela al parámetro <code>–classpath</code> de la JVM.
         </p>
+        <p>If you use the maven, you can download jar files by adding following settings on your <code>pom.xml</code>.
+        </p>
+<source><![CDATA[
+<dependency>
+  <groupId>ch.qos.logback</groupId>
+  <artifactId>logback-classic</artifactId>
+  <version>1.x.x</version>
+</dependency>
+]]></source>
+
         <h4>
-          Paso 2: Configurar Log4j
+          Paso 2: Configurar Logback
         </h4>
-        <p>Configurar Log4j es sencillo. Supongamos que quieres habilitar el log para este mapper:</p>
-        <source><![CDATA[package org.mybatis.example;
+        <p>Configurar Logback es sencillo. Supongamos que quieres habilitar el log para este mapper:</p>
+<source><![CDATA[
+package org.mybatis.example;
 public interface BlogMapper {
   @Select("SELECT * FROM blog WHERE id = #{id}")
   Blog selectBlog(int id);
-}]]></source>
-        <p>Crea un fichero con nombre <code>log4j.properties</code>
+}
+]]></source>
+        <p>Crea un fichero con nombre <code>logback.xml</code>
         como el que se muestra a continuación y colocalo en tu classpath:
         </p>
-        <source><![CDATA[# Global logging configuration
-log4j.rootLogger=ERROR, stdout
-# MyBatis logging configuration...
-log4j.logger.org.mybatis.example.BlogMapper=TRACE
-# Console output...
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
-        <p>El fichero anterior hará que log4j reporte información detallada para <code>org.mybatis.example.BlogMapper</code> e información de errores para el resto de las clases de tu aplicación.</p>
+
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
+
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%5level [%thread] - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.mybatis.example.BlogMapper">
+    <level value="trace"/>
+  </logger>
+  <root level="error">
+    <appender-ref ref="stdout"/>
+  </root>
+
+</configuration>
+]]></source>
+
+        <p>El fichero anterior hará que SLF4J(Logback) reporte información detallada para <code>org.mybatis.example.BlogMapper</code> e información de errores para el resto de las clases de tu aplicación.</p>
         <p>Si quieres activar un nivel más fino de logging puedes activar el logging para statements específicos en lugar de para todo un mapper. La siguiente línea activa el logging sólo para el statement <code>selectBlog</code>:</p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper.selectBlog">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>Si por el contrario quieres activar el log para un grupo de mappers debes añadir un logger para el paquete raiz donde residen tus mappers:</p>
 
-        <source>log4j.logger.org.mybatis.example=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>Hay consultas que pueden devolver una gran cantidad de datos. En esos casos puedes querer ver las sentencias SQL pero no los datos. Para conseguirlo las sentencias se loguean con nivel DEBUG (FINE en JDK) y los resultados con TRACE (FINER en JDK), por tanto si quieres ver la sentencia pero no el resultado establece el nivel a DEBUG</p>
 
-        <source>log4j.logger.org.mybatis.example=DEBUG</source>
+<source><![CDATA[
+<logger name="org.mybatis.example">
+  <level value="debug"/>
+</logger>
+]]></source>
 
         <p>Y si estás usando ficheros XML como este?</p>
 
-      <source><![CDATA[<?xml version="1.0" encoding="UTF-8" ?>
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
@@ -142,21 +185,114 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
   <select id="selectBlog" resultType="Blog">
     select * from Blog where id = #{id}
   </select>
-</mapper>]]></source>
+</mapper>
+]]></source>
 
         <p>En tal caso puedes activar el logging de todo el fichero añadiendo un logger para el namespace como se muestra a continuación:</p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>O para un statement específico:</p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper.selectBlog">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>Sí, como ya te habrás dado cuenta, no hay ninguna diferencia entre configurar el logging para un mapper o para un fichero XML.</p>
 
-        <p><span class="label important">NOTA</span> Si usas SLF4J o Log4j 2 MyBatis le llamará usando MYBATIS como marker.</p>
+        <p><span class="label important">NOTA</span> Si usas SLF4J o Log4j 2 MyBatis le llamará usando <code>MYBATIS</code> como marker.</p>
 
-        <p>El resto de la configuración sirve para configurar los appenders, lo cual queda fuera del ámbito de este documento. Sin embargo, puedes encontrar más información en el site de Log4j (la url está más arriba). O, puedes simplemente experimentar para ver los efectos que consigues con las distintas opciones de configuración.</p>
+        <p>El resto de la configuración sirve para configurar los appenders, lo cual queda fuera del ámbito de este documento. Sin embargo, puedes encontrar más información en el site de <a href="https://logback.qos.ch/">Logback</a>. O, puedes simplemente experimentar para ver los efectos que consigues con las distintas opciones de configuración.</p>
+
+        <p></p>
+        <h4>
+          Configuration example for Log4j 2
+        </h4>
+
+        <p><code>pom.xml</code></p>
+
+<source><![CDATA[
+<dependency>
+  <groupId>org.apache.logging.log4j</groupId>
+  <artifactId>log4j-core</artifactId>
+  <version>2.x.x</version>
+</dependency>
+]]></source>
+
+        <p><code>log4j2.xml</code></p>
+
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration xmlns="http://logging.apache.org/log4j/2.0/config">
+
+  <Appenders>
+    <Console name="stdout" target="SYSTEM_OUT">
+      <PatternLayout pattern="%5level [%t] - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="org.mybatis.example.BlogMapper" level="trace"/>
+    <Root level="error" >
+      <AppenderRef ref="stdout"/>
+    </Root>
+  </Loggers>
+
+</Configuration>
+]]></source>
+
+        <p></p>
+        <h4>
+          Configuration example for Log4j
+        </h4>
+
+        <p><code>pom.xml</code></p>
+
+<source><![CDATA[
+<dependency>
+  <groupId>log4j</groupId>
+  <artifactId>log4j</artifactId>
+  <version>1.2.17</version>
+</dependency>
+]]></source>
+
+        <p><code>log4j.properties</code></p>
+
+<source><![CDATA[
+log4j.rootLogger=ERROR, stdout
+
+log4j.logger.org.mybatis.example.BlogMapper=TRACE
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n
+]]></source>
+
+
+        <p></p>
+        <h4>
+          Configuration example for JDK logging
+        </h4>
+
+        <p><code>logging.properties</code></p>
+
+<source><![CDATA[
+handlers=java.util.logging.ConsoleHandler
+.level=SEVERE
+
+org.mybatis.example.BlogMapper=FINER
+
+java.util.logging.ConsoleHandler.level=ALL
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tT.%1$tL %4$s %3$s - %5$s%6$s%n
+]]></source>
+
       </subsection>
     </section>
   </body>

--- a/src/site/ja/xdoc/configuration.xml
+++ b/src/site/ja/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -508,7 +508,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 MyBatis のログ出力に使用するロギング実装を指定します。未指定の場合は自動的検出されます。
               </td>
               <td>
-                SLF4J | LOG4J | LOG4J2 | JDK_LOGGING | COMMONS_LOGGING | STDOUT_LOGGING | NO_LOGGING
+                SLF4J | LOG4J(3.5.9以降非推奨) | LOG4J2 | JDK_LOGGING | COMMONS_LOGGING | STDOUT_LOGGING | NO_LOGGING
               </td>
               <td>
                 未指定

--- a/src/site/ja/xdoc/logging.xml
+++ b/src/site/ja/xdoc/logging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@
           Log4j 2
         </li>
         <li>
-          Log4j
+          Log4j (3.5.9以降非推奨)
         </li>
         <li>
           JDK logging
@@ -51,24 +51,27 @@
       </p>
       <p>アプリケーションサーバーでは、出荷時のクラスパスに Commons Logging が含まれていることがよくあります（Tomcat や WebSphere は良い例でしょう）。重要なのは、このような環境では MyBatis は Commons Logging を使用するということです。これはつまり、独自の Commons Logging 実装を使う WebSphere のような環境では、あなたが追加した Log4J の設定は無視されるということを意味しています。この現象が厄介なのは、MyBatis が Log4J の設定を無視しているように見えるということです（実は、このような環境では MyBatis が Commons Loggin を使用するため、Log4J の設定が無視されているのです）。クラスパスに Commons Logging を含む環境で動作するアプリケーションでも、mybatis-config.xml に設定を追加することで別のロギング実装を使用することができます。
       </p>
-      <source><![CDATA[<configuration>
+<source><![CDATA[
+<configuration>
   <settings>
     ...
     <setting name="logImpl" value="LOG4J"/>
     ...
   </settings>
-</configuration>]]>
-      </source>
+</configuration>
+]]></source>
       <p>指定可能な値は SLF4J, LOG4J, LOG4J2, JDK_LOGGING, COMMONS_LOGGING, STDOUT_LOGGING, NO_LOGGING ですが、<code>org.apache.ibatis.logging.Log</code> インターフェイスを実装し、コンストラクター引数として String を受け取る独自に実装したクラスの完全修飾クラス名を指定することもできます。
       </p>
       <p>下記のメソッドを呼び出すことでロギング実装を指定することも可能です。
       </p>
-      <source><![CDATA[org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
+<source><![CDATA[
+org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
 org.apache.ibatis.logging.LogFactory.useLog4JLogging();
 org.apache.ibatis.logging.LogFactory.useJdkLogging();
 org.apache.ibatis.logging.LogFactory.useCommonsLogging();
-org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
-      <p>これらのメソッドは、他の MyBatis のメソッドより前に呼び出す必要があります。また、要求された実装が実行時のクラスパスに含まれている場合にのみ切り替えることが可能です。例えば、Log4J に切り替えようとして、実行時に Log4J が見つからない場合、MyBatis は切り替えの要求を無視して通常のアルゴリズムでロギング実装を検索します。
+org.apache.ibatis.logging.LogFactory.useStdOutLogging();
+]]></source>
+      <p>これらのメソッドは、他の MyBatis のメソッドより前に呼び出す必要があります。また、要求された実装が実行時のクラスパスに含まれている場合にのみ切り替えることが可能です。例えば、Log4J2 に切り替えようとして、実行時に Log4J2 が見つからない場合、MyBatis は切り替えの要求を無視して通常のアルゴリズムでロギング実装を検索します。
       </p>
       <p>SLF4J, Apache Commons Logging, Apache Log4J, JDK Logging API についての詳細はこのドキュメントの範囲外となりますが、後述の設定例は参考になると思います。これらのフレームワークについての詳しい情報は、以下の各サイトを参照してください。
       </p>
@@ -89,54 +92,95 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
       <subsection name="Logging Configuration">
         <p>実行されるステートメントのログを出力するためには、パッケージ、Mapper の完全修飾名、ネームスペース、あるいはステートメントの完全修飾名に対してログ出力を有効にしてください。
         </p>
-        <p>具体的な設定方法は使用するロギング実装によります。以下は Log4J での設定例です。ロギングサービスの設定は、単純にいくつかの設定ファイル（例えば log4j.properties）と、場合によっては新しい JAR（例えば log4j.jar）を追加するだけのことです。以下は、Log4J をプロバイダーとして完全なロギングサービスを設定する手順です。
+        <p>具体的な設定方法は使用するロギング実装によります。以下は SLF4J(Logback) での設定例です。ロギングサービスの設定は、単純にいくつかの設定ファイル（例えば <code>logback.xml</code>）と、場合によっては新しい JARを追加するだけのことです。以下は、SLF4J(Logback) をプロバイダーとして完全なロギングサービスを設定する手順です。
         </p>
         <p></p>
         <h4>
-          ステップ１: Log4J の JAR ファイルを追加する。
+          ステップ１: SLF4J + Logback の JAR ファイルを追加する。
         </h4>
-        <p>Log4J を使うので、Log4J の JAR ファイルがアプリケーションから利用できるようにしておく必要があります。Log4J の JAR ファイルをダウンロードしてあなたのアプリケーションのクラスパスに追加してください。JAR ファイルは先ほど挙げた URL からダウンロードできます。
+        <p>SLF4J(Logback) を使うので、SLF4J(Logback) の JAR ファイルがアプリケーションから利用できるようにしておく必要があります。SLF4J(Logback) の JAR ファイルをダウンロードしてあなたのアプリケーションのクラスパスに追加してください。
         </p>
-        <p>Web あるいはエンタープライズアプリケーションの場合は、ダウンロードした <code>log4j.jar</code> を <code>WEB-INF/lib</code> ディレクトリに追加します。スタンドアローンアプリケーションの場合は起動時の JVM の引数に <code>-classpath</code> に追加するだけです。
+        <p>Web あるいはエンタープライズアプリケーションの場合は、ダウンロードした <code>logback-classic.jar</code>
+          ,<code>logback-core.jar</code>, <code>slf4j-api.jar</code> を <code>WEB-INF/lib</code> ディレクトリに追加します。スタンドアローンアプリケーションの場合は起動時の JVM 引数 <code>-classpath</code> に追加するだけです。
         </p>
+
+        <p>Mavenを利用している場合は、<code>pom.xml</code>に以下のような設定を追加することでJARファイルをダウンロードすることができます。
+        </p>
+<source><![CDATA[
+<dependency>
+  <groupId>ch.qos.logback</groupId>
+  <artifactId>logback-classic</artifactId>
+  <version>1.x.x</version>
+</dependency>
+]]></source>
+
         <p></p>
         <h4>
-          ステップ２: Log4J を設定する。
+          ステップ２: Logback を設定する。
         </h4>
-        <p>Log4J の設定はシンプルです。例えば次の Mapper のログを出力する場合：
+        <p>Logback の設定はシンプルです。例えば次の Mapper のログを出力する場合：
         </p>
-        <source><![CDATA[package org.mybatis.example;
+        <source><![CDATA[
+package org.mybatis.example;
 public interface BlogMapper {
   @Select("SELECT * FROM blog WHERE id = #{id}")
   Blog selectBlog(int id);
-}]]></source>
-        <p>次のテキストを含む <code>log4j.properties</code> というファイルを作成し、クラスパスに配置します。
+}
+]]></source>
+        <p>次のテキストを含む <code>logback.xml</code> というファイルを作成し、クラスパスに配置します。
         </p>
-        <source><![CDATA[# Global logging configuration
-log4j.rootLogger=ERROR, stdout
-# MyBatis logging configuration...
-log4j.logger.org.mybatis.example.BlogMapper=TRACE
-# Console output...
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
-        <p>上記のように設定すると、Log4J は <code>org.mybatis.example.BlogMapper</code> について詳細なログを出力し、それ以外のクラスについてはエラーのみを出力します。</p>
-        <p>ログに出力される情報を細かく調整したいのなら、Mapper ファイル全体ではなく特定のステートメントを指定することもできます。次の例では <code>selectBlog</code> ステートメントのみログを出力します。</p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
+
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%5level [%thread] - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.mybatis.example.BlogMapper">
+    <level value="trace"/>
+  </logger>
+  <root level="error">
+    <appender-ref ref="stdout"/>
+  </root>
+
+</configuration>
+]]></source>
+
+        <p>上記のように設定すると、SLF4J(Logback) は <code>org.mybatis.example.BlogMapper</code> について詳細なログを出力し、それ以外のクラスについてはエラーのみを出力します。</p>
+        <p>ログに出力される情報を細かく調整したいのなら、Mapper ファイル全体ではなく特定のステートメントを指定することもできます。</p>
+
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper.selectBlog">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>逆に、複数の Mapper に対するログを有効化したい場合もあるでしょう。その場合は、対象となる Mapper を含むパッケージを指定することができます。</p>
 
-        <source>log4j.logger.org.mybatis.example=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>クエリが大量の結果セットを返すようなケースでSQLステートメントのみを出力したい場合に対応できるよう、SQLステートメントは DEBUG（JDK logging では FINE）レベル、結果は TRACE（JDK logging では FINER）レベルで出力されるようになっています。SQLステートメントのみを出力したい場合、ログレベルに DEBUG を設定します。</p>
 
-        <source>log4j.logger.org.mybatis.example=DEBUG</source>
+<source><![CDATA[
+<logger name="org.mybatis.example">
+  <level value="debug"/>
+</logger>
+]]></source>
 
         <p>Mapper インターフェイスを使っていない場合、例えば次のような Mapper XML ファイルを使っていたらどうすれば良いのでしょうか。
         </p>
 
-      <source><![CDATA[<?xml version="1.0" encoding="UTF-8" ?>
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
@@ -144,22 +188,114 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
   <select id="selectBlog" resultType="Blog">
     select * from Blog where id = #{id}
   </select>
-</mapper>]]></source>
+</mapper>
+]]></source>
 
         <p>この場合、次のようにネームスペースを指定することでこの XML ファイル全体のログを有効化することができます。</p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>特定のステートメントのみを対象とする場合は次のように指定します。</p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper.selectBlog">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>お気づきのように、Mapper インターフェイスと XML のどちらを使っている場合でも、設定方法に違いはありません。</p>
 
-        <p><span class="label important">NOTE</span> SLF4J or Log4j 2 をお使いの場合、MyBatis のログは MYBATIS というマーカーで出力されます。</p>
+        <p><span class="label important">NOTE</span> SLF4J or Log4j 2 をお使いの場合、MyBatis のログは <code>MYBATIS</code> というマーカーで出力されます。</p>
 
-        <p>上記の <code>log4j.properties</code> の残りの部分はアペンダーの設定になっていますが、このドキュメントでは説明しません。Log4J のサイト（上記URL）を参照してください。あるいは、設定値を変更してみてどのような結果になるか試してみるのも良いでしょう。
+        <p>上記の <code>logback.xml</code> の残りの部分はアペンダーの設定になっていますが、このドキュメントでは説明しません。<a href="https://logback.qos.ch/">Logback</a> のサイトを参照してください。あるいは、設定値を変更してみてどのような結果になるか試してみるのも良いでしょう。
         </p>
+
+        <p></p>
+        <h4>
+          Log4j 2の設定例
+        </h4>
+
+        <p><code>pom.xml</code></p>
+
+<source><![CDATA[
+<dependency>
+  <groupId>org.apache.logging.log4j</groupId>
+  <artifactId>log4j-core</artifactId>
+  <version>2.x.x</version>
+</dependency>
+]]></source>
+
+        <p><code>log4j2.xml</code></p>
+
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration xmlns="http://logging.apache.org/log4j/2.0/config">
+
+  <Appenders>
+    <Console name="stdout" target="SYSTEM_OUT">
+      <PatternLayout pattern="%5level [%t] - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="org.mybatis.example.BlogMapper" level="trace"/>
+    <Root level="error" >
+      <AppenderRef ref="stdout"/>
+    </Root>
+  </Loggers>
+
+</Configuration>
+]]></source>
+
+        <p></p>
+        <h4>
+          Log4jの設定例
+        </h4>
+
+        <p><code>pom.xml</code></p>
+
+<source><![CDATA[
+<dependency>
+  <groupId>log4j</groupId>
+  <artifactId>log4j</artifactId>
+  <version>1.2.17</version>
+</dependency>
+]]></source>
+
+        <p><code>log4j.properties</code></p>
+
+<source><![CDATA[
+log4j.rootLogger=ERROR, stdout
+
+log4j.logger.org.mybatis.example.BlogMapper=TRACE
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n
+]]></source>
+
+        <p></p>
+        <h4>
+          JDK Loggingの設定例
+        </h4>
+
+        <p><code>logging.properties</code></p>
+
+        <source><![CDATA[
+handlers=java.util.logging.ConsoleHandler
+.level=SEVERE
+
+org.mybatis.example.BlogMapper=FINER
+
+java.util.logging.ConsoleHandler.level=ALL
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tT.%1$tL %4$s %3$s - %5$s%6$s%n
+]]></source>
+
       </subsection>
     </section>
   </body>

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -493,7 +493,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 이 설정을 사용하지 않으면 마이바티스가 사용할 로깅 구현체를 자동으로 찾는다.
               </td>
               <td>
-                SLF4J | LOG4J | LOG4J2 | JDK_LOGGING | COMMONS_LOGGING | STDOUT_LOGGING | NO_LOGGING
+                SLF4J | LOG4J(deprecated since 3.5.9) | LOG4J2 | JDK_LOGGING | COMMONS_LOGGING | STDOUT_LOGGING | NO_LOGGING
               </td>
               <td>
                 설정하지 않음

--- a/src/site/ko/xdoc/logging.xml
+++ b/src/site/ko/xdoc/logging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@
           Log4j 2
         </li>
         <li>
-          Log4j
+          Log4j (deprecated since 3.5.9)
         </li>
         <li>
           JDK logging
@@ -64,15 +64,17 @@
 	  만약 당신의 애플리케이션이 클래스패스에 JCL 을 포함한 환경에서 돌아가지만 다른 로깅 구현체 중 하나를 더 선호한다면
 	  다음의 메소드 중 하나를 호출하여 다른 로깅 구현체를 선택 할 수 있다.
       </p>
-      <source><![CDATA[org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
+<source><![CDATA[
+org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
 org.apache.ibatis.logging.LogFactory.useLog4JLogging();
 org.apache.ibatis.logging.LogFactory.useJdkLogging();
 org.apache.ibatis.logging.LogFactory.useCommonsLogging();
-org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
+org.apache.ibatis.logging.LogFactory.useStdOutLogging();
+]]></source>
       <p>마이바티스가 메소드를 호출하기 전에 위 메소드 중 하나를 호출해야 한다.
 	  이 메소드들은 런타임 클래스패스에 구현체가 존재하면 그 로그 구현체를 사용하게 한다.
-	  예를들어 Log4J 로깅을 선택했지만 런타임에 Log4J 구현체가 클래스패스에 없다면
-	  마이바티스는 Log4J 구현체의 사용을 무시하고 로깅 구현체를 찾아 다시 사용할 것이다.
+	  예를들어 Log4J2 로깅을 선택했지만 런타임에 Log4J2 구현체가 클래스패스에 없다면
+	  마이바티스는 Log4J2 구현체의 사용을 무시하고 로깅 구현체를 찾아 다시 사용할 것이다.
       </p>
       <p>SLF4J, Jakarta Commons 로깅, Log4J 그리고 JDK 로깅 API 에 대한 설명은 이 문서의 범위를 벗어난다.
 	  이러한 로깅 관련 프레임워크에 대해 좀더 알고 싶다면 개별 위치에서 좀더 많은 정보를 얻을 수 있을 것이다.
@@ -94,43 +96,71 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
       <subsection name="Logging Configuration">
         <p>마이바티스 로깅 구문을 보기 위해서 패키지, 매퍼의 전체 경로, 구문명의 명명공간에 대해 활성화해주어야 할것이다.
         </p>
-        <p>다시 얘기해서 사용할 로깅 구현체에 따라야 하고 우리는 Log4J를 사용하는 방법을 보여줄 것이다.
-        로깅 설정은 대부분 하나 이상의 설정파일(예를들면, log4j.properties)과 몇개의 새로운 jar파일(예륻를면, log4j.jar)을 다룬다.
-       다음의 설정예제는 Log4J를 사용하여 설정하고 2단계로 설정한다.
+        <p>다시 얘기해서 사용할 로깅 구현체에 따라야 하고 우리는 SLF4J(Logback)를 사용하는 방법을 보여줄 것이다.
+        로깅 설정은 대부분 하나 이상의 설정파일(예를들면, <code>logback.xml</code>)과 몇개의 새로운 jar파일을 다룬다.
+       다음의 설정예제는 SLF4J(Logback)를 사용하여 설정하고 2단계로 설정한다.
         </p>
         <p></p>
         <h4>
-          첫번째 단계 : Log4J JAR 파일 추가하기
+          첫번째 단계 : SLF4J + Logback JAR 파일 추가하기
         </h4>
-        <p>Log4J를 사용하기 때문에 애플리케이션에 JAR 파일이 있어야 한다.
+        <p>SLF4J(Logback)를 사용하기 때문에 애플리케이션에 JAR 파일이 있어야 한다.
 		Log4J 를 사용하기 위해 애플리케이션의 클래스패스에 JAR 파일을 추가할 필요가 있다.
-		위 URL 에서 Log4J 를 다운로드 할 수 있다.
+		위 URL 에서 SLF4J(Logback) 를 다운로드 할 수 있다.
         </p>
-        <p>웹이나 기업용 애플리케이션에서는 <code>WEB-INF/lib</code> 디렉터리에 <code>log4j.jar</code> 파일을 추가할 수 있다.
+        <p>웹이나 기업용 애플리케이션에서는 <code>WEB-INF/lib</code> 디렉터리에 <code>logback-classic.jar</code>
+          ,<code>logback-core.jar</code> and <code>slf4j-api.jar</code> 파일을 추가할 수 있다.
 		단독으로 실행되는 애플리케이션에서는 JVM의 <code>-classpath</code> 시작 파라미터에서 간단히 추가할 수 있다.
         </p>
+
+        <p>If you use the maven, you can download jar files by adding following settings on your <code>pom.xml</code>.
+        </p>
+<source><![CDATA[
+<dependency>
+  <groupId>ch.qos.logback</groupId>
+  <artifactId>logback-classic</artifactId>
+  <version>1.x.x</version>
+</dependency>
+]]></source>
+
         <p></p>
         <h4>
-          두번째 단계 : Log4J 설정하기
+          두번째 단계 : Logback 설정하기
         </h4>
-        <p>Log4J 를 설정하는 것은 간단하다.
+        <p>Logback 를 설정하는 것은 간단하다.
 		다음의 매퍼를 위한 로깅을 활성화하려고 한다고 해보자.
         </p>
-        <source><![CDATA[package org.mybatis.example;
+<source><![CDATA[
+package org.mybatis.example;
 public interface BlogMapper {
   @Select("SELECT * FROM blog WHERE id = #{id}")
   Blog selectBlog(int id);
-}]]></source>
-        <p>아래처럼 <code>log4j.properties</code>파일을 만들어서 클래스패스에 두자.
+}
+]]></source>
+        <p>아래처럼 <code>logback.xml</code>파일을 만들어서 클래스패스에 두자.
         </p>
-        <source><![CDATA[# Global logging configuration
-log4j.rootLogger=ERROR, stdout
-# 마이바티스 로딩 설정...
-log4j.logger.org.mybatis.example.BlogMapper=TRACE
-# 콘솔 출력...
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
+
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
+
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%5level [%thread] - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.mybatis.example.BlogMapper">
+    <level value="trace"/>
+  </logger>
+  <root level="error">
+    <appender-ref ref="stdout"/>
+  </root>
+
+</configuration>
+]]></source>
+
         <p>
         위 파일은 <code>org.mybatis.example.BlogMapper</code>의 상세한 로그와 애플리케이션의 에러들을 출력할 것이다.
         </p>
@@ -139,12 +169,20 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
 		다음 줄은 <code>selectBlog</code>구문의 로그를 출력하도록 한다.
         </p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper.selectBlog">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>반대로 특정 매퍼들에 대해 로깅을 원할 수 있다.
 		이 경우 매퍼의 가장 상위 패키지에 로거를 추가할 수 있다. </p>
 
-        <source>log4j.logger.org.mybatis.example=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>큰 결과를 리턴할 수 있는 쿼리가 있다.
 		이 경우 결과가 아닌 SQL구문만을 보고자 할 수 있다.
@@ -152,12 +190,17 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
         결과가 아닌 구문만 보고자 하는 경우에는 DEBUG로 레벨을 설정하자.
         </p>
 
-        <source>log4j.logger.org.mybatis.example=DEBUG</source>
+<source><![CDATA[
+<logger name="org.mybatis.example">
+  <level value="debug"/>
+</logger>
+]]></source>
 
         <p>다음처럼 매퍼 인터페이스가 아닌 매퍼 XML을 사용하다면 어떻게 해야 할까?
         </p>
 
-      <source><![CDATA[<?xml version="1.0" encoding="UTF-8" ?>
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
@@ -165,23 +208,113 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
   <select id="selectBlog" resultType="Blog">
     select * from Blog where id = #{id}
   </select>
-</mapper>]]></source>
+</mapper>
+]]></source>
 
 		<p>이런 경우에는 아래처럼 명명공간을 추가해서 XML파일 전체를 로깅할 수 있다. </p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper">
+  <level value="trace"/>
+</logger>
+]]></source>
 
 		<p>또는 특정 구문만을 로깅하기 위해서는</p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper.selectBlog">
+  <level value="trace"/>
+</logger>
+]]></source>
 
 		<p>앞서 언급한것처럼 매퍼 인터페이스와 XML매퍼 파일간의 차이는 없다. </p>
 
-        <p><code>log4j.properties</code> 파일의 나머지는 어펜더(appender)를 설정하기 위해 사용했다.
+        <p><code>logback.xml</code> 파일의 나머지는 어펜더(appender)를 설정하기 위해 사용했다.
 		어펜더는 이 문서의 범위를 넘어선다.
-		Log4J 웹사이트에서 좀더 많은 정보를 얻을 수 있다.
+		<a href="https://logback.qos.ch/">Logback</a> 웹사이트에서 좀더 많은 정보를 얻을 수 있다.
 		설정파일간의 차이는 실행을 해보면 간단히 확인할 수 있다.
         </p>
+
+        <p></p>
+        <h4>
+          Configuration example for Log4j 2
+        </h4>
+
+        <p><code>pom.xml</code></p>
+
+<source><![CDATA[
+<dependency>
+  <groupId>org.apache.logging.log4j</groupId>
+  <artifactId>log4j-core</artifactId>
+  <version>2.x.x</version>
+</dependency>
+]]></source>
+
+        <p><code>log4j2.xml</code></p>
+
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration xmlns="http://logging.apache.org/log4j/2.0/config">
+
+  <Appenders>
+    <Console name="stdout" target="SYSTEM_OUT">
+      <PatternLayout pattern="%5level [%t] - %msg%n"/>
+    </Console>
+  </Appenders>
+
+    <Root level="error" >
+      <AppenderRef ref="stdout"/>
+    </Root>
+  </Loggers>
+
+</Configuration>
+]]></source>
+
+        <p></p>
+        <h4>
+          Configuration example for Log4j
+        </h4>
+
+        <p><code>pom.xml</code></p>
+
+<source><![CDATA[
+<dependency>
+  <groupId>log4j</groupId>
+  <artifactId>log4j</artifactId>
+  <version>1.2.17</version>
+</dependency>
+]]></source>
+
+        <p><code>log4j.properties</code></p>
+
+<source><![CDATA[
+log4j.rootLogger=ERROR, stdout
+
+log4j.logger.org.mybatis.example.BlogMapper=TRACE
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n
+]]></source>
+
+        <p></p>
+        <h4>
+          Configuration example for JDK logging
+        </h4>
+
+        <p><code>logging.properties</code></p>
+
+<source><![CDATA[
+handlers=java.util.logging.ConsoleHandler
+.level=SEVERE
+
+org.mybatis.example.BlogMapper=FINER
+
+java.util.logging.ConsoleHandler.level=ALL
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tT.%1$tL %4$s %3$s - %5$s%6$s%n
+]]></source>
+
       </subsection>
     </section>
   </body>

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -569,7 +569,7 @@ SqlSessionFactory factory =
                 Specifies which logging implementation MyBatis should use. If this setting is not present logging implementation will be autodiscovered.
               </td>
               <td>
-                SLF4J | LOG4J | LOG4J2 | JDK_LOGGING | COMMONS_LOGGING | STDOUT_LOGGING | NO_LOGGING
+                SLF4J | LOG4J(deprecated since 3.5.9) | LOG4J2 | JDK_LOGGING | COMMONS_LOGGING | STDOUT_LOGGING | NO_LOGGING
               </td>
               <td>
                 Not set

--- a/src/site/xdoc/logging.xml
+++ b/src/site/xdoc/logging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@
           Log4j 2
         </li>
         <li>
-          Log4j
+          Log4j (deprecated since 3.5.9)
         </li>
         <li>
           JDK logging
@@ -68,32 +68,35 @@
         rather use one of the other logging implementations you can select a
         different logging implementation by adding a setting in mybatis-config.xml file as follows:
       </p>
-      <source><![CDATA[<configuration>
+<source><![CDATA[
+<configuration>
   <settings>
     ...
     <setting name="logImpl" value="LOG4J"/>
     ...
   </settings>
-</configuration>]]>
-      </source>
+</configuration>
+]]></source>
       <p>Valid values are SLF4J, LOG4J, LOG4J2, JDK_LOGGING, COMMONS_LOGGING, STDOUT_LOGGING, NO_LOGGING or
       a full qualified class name that implements <code>org.apache.ibatis.logging.Log</code> and gets
       an string as a constructor parameter.
       </p>
       <p>You can also select the implementation by calling one of the following methods:
       </p>
-      <source><![CDATA[org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
+<source><![CDATA[
+org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
 org.apache.ibatis.logging.LogFactory.useLog4JLogging();
 org.apache.ibatis.logging.LogFactory.useLog4J2Logging();
 org.apache.ibatis.logging.LogFactory.useJdkLogging();
 org.apache.ibatis.logging.LogFactory.useCommonsLogging();
-org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
+org.apache.ibatis.logging.LogFactory.useStdOutLogging();
+]]></source>
       <p>If you choose to call one of these methods, you should do so
         before calling any other MyBatis method. Also, these methods
         will only switch to the requested log implementation if that
         implementation is available on the runtime classpath. For example, if
-        you try to select Log4J logging and Log4J is not available at runtime,
-        then MyBatis will ignore the request to use Log4J and will use it's
+        you try to select Log4J2 logging and Log4J2 is not available at runtime,
+        then MyBatis will ignore the request to use Log4J2 and will use it's
         normal algorithm for discovering logging implementations.
       </p>
       <p>The specifics of SLF4J, Apache Commons Logging, Apache Log4J and the JDK
@@ -122,50 +125,75 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
           o a fully qualified statement name.
         </p>
         <p>Again, how you do this is dependent on the logging implementation
-          in use. We'll show how to do it with Log4J. Configuring the
+          in use. We'll show how to do it with SLF4J(Logback). Configuring the
           logging services is simply a matter of including one or more extra
-          configuration files (e.g. log4j.properties) and sometimes a new JAR
-          file (e.g. log4j.jar). The following example configuration will
-          configure full logging services using Log4J as a provider. There
+          configuration files (e.g. <code>logback.xml</code>) and sometimes a new JAR file.
+          The following example configuration will
+          configure full logging services using SLF4J(Logback) as a provider. There
           are 2 steps.
         </p>
         <p></p>
         <h4>
-          Step 1: Add the Log4J JAR file
+          Step 1: Add the SLF4J + Logback JAR files
         </h4>
-        <p>Because we are using Log4J, we will need to ensure its
-          JAR file is available to our application. To use Log4J, you need to
-          add the JAR file to your application classpath. You can download
-          Log4J from the URL above.
+        <p>Because we are using SLF4J(Logback), we will need to ensure its
+          JAR file is available to our application. To use SLF4J(Logback), you need to
+          add the JAR file to your application classpath.
         </p>
-        <p>For web or enterprise applications you can add the <code>log4j.jar</code> to
+        <p>For web or enterprise applications you can add the <code>logback-classic.jar</code>
+          ,<code>logback-core.jar</code> and <code>slf4j-api.jar</code> to
           your <code>WEB-INF/lib</code> directory, or for a standalone application you can
           simply add it to the JVM <code>-classpath</code> startup parameter.
         </p>
+        <p>If you use the maven, you can download jar files by adding following settings on your <code>pom.xml</code>.
+        </p>
+<source><![CDATA[
+<dependency>
+  <groupId>ch.qos.logback</groupId>
+  <artifactId>logback-classic</artifactId>
+  <version>1.x.x</version>
+</dependency>
+]]></source>
+
         <p></p>
         <h4>
-          Step 2: Configure Log4J
+          Step 2: Configure Logback
         </h4>
-        <p>Configuring Log4J is simple. Suppose you want to enable the log for this mapper:
+        <p>Configuring Logback is simple. Suppose you want to enable the log for this mapper:
         </p>
-        <source><![CDATA[package org.mybatis.example;
+<source><![CDATA[
+package org.mybatis.example;
 public interface BlogMapper {
   @Select("SELECT * FROM blog WHERE id = #{id}")
   Blog selectBlog(int id);
 }]]></source>
-        <p>Create a file called <code>log4j.properties</code>
+        <p>Create a file called <code>logback.xml</code>
         as shown below and place it in your classpath:
         </p>
-        <source><![CDATA[# Global logging configuration
-log4j.rootLogger=ERROR, stdout
-# MyBatis logging configuration...
-log4j.logger.org.mybatis.example.BlogMapper=TRACE
-# Console output...
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
+
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
+
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%5level [%thread] - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.mybatis.example.BlogMapper">
+    <level value="trace"/>
+  </logger>
+  <root level="error">
+    <appender-ref ref="stdout"/>
+  </root>
+
+</configuration>
+]]></source>
+
         <p>
-          The above file will cause log4J to report detailed logging for
+          The above file will cause SLF4J(Logback) to report detailed logging for
           <code>org.mybatis.example.BlogMapper</code>
           and just errors for the rest of the classes of your application.
         </p>
@@ -176,12 +204,20 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
           statement:
         </p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper.selectBlog">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>By the contrary you may want want to enable logging for a group of mappers.
         In that case you should add as a logger the root package where your mappers reside:</p>
 
-        <source>log4j.logger.org.mybatis.example=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>There are queries that can return huge result sets. In that cases you may want to see the
         SQL statement but not the results. For that purpose SQL statements are logged at the DEBUG level
@@ -189,12 +225,17 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
         you want to see the statement but not the result, set the level to DEBUG.
         </p>
 
-        <source>log4j.logger.org.mybatis.example=DEBUG</source>
+<source><![CDATA[
+<logger name="org.mybatis.example">
+  <level value="debug"/>
+</logger>
+]]></source>
 
         <p>But what about if you are not using mapper interfaces but mapper XML files like this one?
         </p>
 
-      <source><![CDATA[<?xml version="1.0" encoding="UTF-8" ?>
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
@@ -202,26 +243,117 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
   <select id="selectBlog" resultType="Blog">
     select * from Blog where id = #{id}
   </select>
-</mapper>]]></source>
+</mapper>
+]]></source>
 
         <p>In that case you can enable logging for the whole XML file by adding a logger for the namespace as shown below:</p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper">
+  <level value="trace"/>
+</logger>
+]]></source>
 
         <p>Or for an specific statement:</p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper.selectBlog">
+  <level value="trace"/>
+</logger>
+]]></source>
 
-        <p>Yes, as you may have noticed, there is no difference in configuring logging for mapper interfaces or for XML mapper files.</p>
+		<p>Yes, as you may have noticed, there is no difference in configuring
+		logging for mapper interfaces or for XML mapper files.</p>
 
-        <p><span class="label important">NOTE</span> If you are using SLF4J or Log4j 2 MyBatis will call it using the marker MYBATIS.</p>
+        <p><span class="label important">NOTE</span> If you are using SLF4J or Log4j 2 MyBatis will call it using the marker <code>MYBATIS</code>.</p>
 
-        <p>The remaining configuration in the <code>log4j.properties</code> file is used
+        <p>The remaining configuration in the <code>logback.xml</code> file is used
           to configure the appenders, which is beyond the scope of this
-          document. However, you can find more information at the Log4J
-          website (URL above). Or, you could simply experiment with it to see
-          what effects the different configuration options have.
+          document. However, you can find more information at the <a href="https://logback.qos.ch/">Logback</a> website.
+          Or, you could simply experiment with it to see what effects the different configuration options have.
         </p>
+
+        <p></p>
+        <h4>
+          Configuration example for Log4j 2
+        </h4>
+
+        <p><code>pom.xml</code></p>
+
+<source><![CDATA[
+<dependency>
+  <groupId>org.apache.logging.log4j</groupId>
+  <artifactId>log4j-core</artifactId>
+  <version>2.x.x</version>
+</dependency>
+]]></source>
+
+        <p><code>log4j2.xml</code></p>
+
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration xmlns="http://logging.apache.org/log4j/2.0/config">
+
+  <Appenders>
+    <Console name="stdout" target="SYSTEM_OUT">
+      <PatternLayout pattern="%5level [%t] - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="org.mybatis.example.BlogMapper" level="trace"/>
+    <Root level="error" >
+      <AppenderRef ref="stdout"/>
+    </Root>
+  </Loggers>
+
+</Configuration>
+]]></source>
+
+        <p></p>
+        <h4>
+          Configuration example for Log4j
+        </h4>
+
+        <p><code>pom.xml</code></p>
+
+<source><![CDATA[
+<dependency>
+  <groupId>log4j</groupId>
+  <artifactId>log4j</artifactId>
+  <version>1.2.17</version>
+</dependency>
+]]></source>
+
+        <p><code>log4j.properties</code></p>
+
+<source><![CDATA[
+log4j.rootLogger=ERROR, stdout
+
+log4j.logger.org.mybatis.example.BlogMapper=TRACE
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n
+]]></source>
+
+        <p></p>
+        <h4>
+          Configuration example for JDK logging
+        </h4>
+
+        <p><code>logging.properties</code></p>
+
+<source><![CDATA[
+handlers=java.util.logging.ConsoleHandler
+.level=SEVERE
+
+org.mybatis.example.BlogMapper=FINER
+
+java.util.logging.ConsoleHandler.level=ALL
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tT.%1$tL %4$s %3$s - %5$s%6$s%n
+]]></source>
 
       </subsection>
     </section>

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -500,7 +500,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 指定 MyBatis 所用日志的具体实现，未指定时将自动查找。
               </td>
               <td>
-                SLF4J | LOG4J | LOG4J2 | JDK_LOGGING | COMMONS_LOGGING | STDOUT_LOGGING | NO_LOGGING
+                SLF4J | LOG4J(deprecated since 3.5.9) | LOG4J2 | JDK_LOGGING | COMMONS_LOGGING | STDOUT_LOGGING | NO_LOGGING
               </td>
               <td>
                 未设置

--- a/src/site/zh/xdoc/logging.xml
+++ b/src/site/zh/xdoc/logging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -39,31 +39,37 @@
           Log4j 2
         </li>
         <li>
-          Log4j
+          Log4j (deprecated since 3.5.9)
         </li>
         <li>
           JDK logging
         </li>
       </ul>
-      <p>MyBatis 内置日志工厂会基于运行时检测信息选择日志委托实现。它会（按上面罗列的顺序）使用第一个查找到的实现。当没有找到这些实现时，将会禁用日志功能。</p>
-      <p>不少应用服务器（如 Tomcat 和 WebShpere）的类路径中已经包含 Commons Logging。注意，在这种配置环境下，MyBatis 会把 Commons Logging 作为日志工具。这就意味着在诸如 WebSphere 的环境中，由于提供了 Commons Logging 的私有实现，你的 Log4J 配置将被忽略。这个时候你就会感觉很郁闷：看起来 MyBatis 将你的 Log4J 配置忽略掉了（其实是因为在这种配置环境下，MyBatis 使用了 Commons Logging 作为日志实现）。如果你的应用部署在一个类路径已经包含 Commons Logging 的环境中，而你又想使用其它日志实现，你可以通过在 MyBatis 配置文件 mybatis-config.xml 里面添加一项 setting 来选择其它日志实现。</p>
-      <source><![CDATA[<configuration>
+      <p>MyBatis 内置日志工厂基于运行时自省机制选择合适的日志工具。它会使用第一个查找得到的工具（按上文列举的顺序查找）。如果一个都未找到，日志功能就会被禁用。</p>
+      <p>不少应用服务器（如 Tomcat 和 WebShpere）的类路径中已经包含 Commons Logging，所以在这种配置环境下的 MyBatis 会把它作为日志工具，记住这点非常重要。这将意味着，在诸如 WebSphere 的环境中，它提供了 Commons Logging 的私有实现，你的 Log4J 配置将被忽略。MyBatis 将你的 Log4J 配置忽略掉是相当令人郁闷的（事实上，正是因为在这种配置环境下，MyBatis 才会选择使用 Commons Logging 而不是 Log4J）。如果你的应用部署在一个类路径已经包含 Commons Logging 的环境中，而你又想使用其它日志工具，你可以通过在 MyBatis 配置文件 mybatis-config.xml 里面添加一项 setting 来选择别的日志工具。</p>
+<source><![CDATA[
+<configuration>
   <settings>
     ...
     <setting name="logImpl" value="LOG4J"/>
     ...
   </settings>
-</configuration>]]>
-      </source>
-      <p>可选的值有：SLF4J、LOG4J、LOG4J2、JDK_LOGGING、COMMONS_LOGGING、STDOUT_LOGGING、NO_LOGGING，或者是实现了 <code>org.apache.ibatis.logging.Log</code> 接口，且构造方法以字符串为参数的类完全限定名。</p>
-      <p>你也可以调用以下任一方法来选择日志实现：</p>
-      <source><![CDATA[org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
+</configuration>
+]]></source>
+      <p>logImpl 可选的值有：SLF4J、LOG4J、LOG4J2、JDK_LOGGING、COMMONS_LOGGING、STDOUT_LOGGING、NO_LOGGING，或者是实现了接口 <code>org.apache.ibatis.logging.Log</code> 的，且构造方法是以字符串为参数的类的完全限定名。（译者注：可以参考org.apache.ibatis.logging.slf4j.Slf4jImpl.java的实现）
+      </p>
+      <p>你也可以调用如下任一方法来使用日志工具：
+      </p>
+<source><![CDATA[
+org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
 org.apache.ibatis.logging.LogFactory.useLog4JLogging();
 org.apache.ibatis.logging.LogFactory.useJdkLogging();
 org.apache.ibatis.logging.LogFactory.useCommonsLogging();
-org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
-      <p>你应该在调用其它 MyBatis 方法之前调用以上的某个方法。另外，仅当运行时类路径中存在该日志实现时，日志实现的切换才会生效。如果你的环境中并不存在 Log4J，你却试图调用了相应的方法，MyBatis 就会忽略这一切换请求，并将以默认的查找顺序决定使用的日志实现。</p>
-      <p>关于 SLF4J、Apache Commons Logging、Apache Log4J 和 JDK Logging 的 API 介绍不在本文档介绍范围内。不过，下面的例子可以作为一个快速入门。有关这些日志框架的更多信息，可以参考以下链接：</p>
+org.apache.ibatis.logging.LogFactory.useStdOutLogging();
+]]></source>
+      <p>如果你决定要调用以上某个方法，请在调用其它 MyBatis 方法之前调用它。另外，仅当运行时类路径中存在该日志工具时，调用与该日志工具对应的方法才会生效，否则 MyBatis 一概忽略。如你环境中并不存在 Log4J2，你却调用了相应的方法，MyBatis 就会忽略这一调用，转而以默认的查找顺序查找日志工具。
+      </p>
+      <p>关于 SLF4J、Apache Commons Logging、Apache Log4J 和 JDK Logging 的 API 介绍不在本文档介绍范围内。不过，下面的例子可以作为一个快速入门。关于这些日志框架的更多信息，可以参考以下链接：</p>
       <ul>
         <li>
           <a href="http://www.slf4j.org/">SLF4J</a>
@@ -79,46 +85,97 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
         </li>
       </ul>
       <subsection name="日志配置">
-      <p>你可以通过在包、映射类的全限定名、命名空间或全限定语句名上开启日志功能，来查看 MyBatis 的日志语句。</p>
-      <p>再次提醒，具体配置步骤取决于日志实现。接下来我们会以 Log4J 作为示范。配置日志功能非常简单：添加一个或多个配置文件（如 log4j.properties），有时还需要添加 jar 包（如 log4j.jar）。下面的例子将使用 Log4J 来配置完整的日志服务。一共两个步骤：</p>
-
+        <p>你可以对包、映射类的全限定名、命名空间或全限定语句名开启日志功能来查看 MyBatis 的日志语句。
+        </p>
+        <p>再次说明下，具体怎么做，由使用的日志工具决定，这里以 SLF4J(Logback) 为例。配置日志功能非常简单：添加一个或多个配置文件（如 <code>logback.xml</code>），有时需要添加 jar 包。下面的例子将使用 SLF4J(Logback) 来配置完整的日志服务，共两个步骤：
+        </p>
+        <p></p>
         <h4>
-          步骤 1：添加 Log4J 的 jar 包
+          步骤 1：添加 SLF4J + Logback 的 jar 包
         </h4>
-        <p>由于我们使用的是 Log4J，我们要确保它的 jar 包可以被应用使用。为此，需要将 jar 包添加到应用的类路径中。Log4J 的 jar 包可以在上面的链接中下载。</p>
-        <p>对于 web 应用或企业级应用，你可以将 <code>log4j.jar</code> 添加到 <code>WEB-INF/lib</code> 目录下；对于独立应用，可以将它添加到 JVM 的 <code>-classpath</code> 启动参数中。</p>
+        <p>因为我们使用的是 SLF4J(Logback)，就要确保它的 jar 包在应用中是可用的。要启用 SLF4J(Logback)，只要将 jar 包添加到应用的类路径中即可。SLF4J(Logback) 的 jar 包可以在上面的链接中下载。
+        </p>
+        <p>对于 web 应用或企业级应用，则需要将 <code>logback-classic.jar</code>, <code>logback-core.jar</code> and <code>slf4j-api.jar</code> 添加到 <code>WEB-INF/lib</code> 目录下；对于独立应用，可以将它添加到JVM 的 <code>-classpath</code> 启动参数中。
+        </p>
+        <p>If you use the maven, you can download jar files by adding following settings on your <code>pom.xml</code>.
+        </p>
+<source><![CDATA[
+<dependency>
+  <groupId>ch.qos.logback</groupId>
+  <artifactId>logback-classic</artifactId>
+  <version>1.x.x</version>
+</dependency>
+]]></source>
 
+        <p></p>
         <h4>
-          步骤 2：配置 Log4J
+          步骤 2：配置 Logback
         </h4>
-        <p>配置 Log4J 比较简单。假设你需要记录这个映射器的日志：</p>
-        <source><![CDATA[package org.mybatis.example;
+        <p>配置 Logback 比较简单，假如你需要记录这个映射器接口的日志：
+        </p>
+<source><![CDATA[
+package org.mybatis.example;
 public interface BlogMapper {
   @Select("SELECT * FROM blog WHERE id = #{id}")
   Blog selectBlog(int id);
-}]]></source>
-        <p>在应用的类路径中创建一个名为 <code>log4j.properties</code> 的文件，文件的具体内容如下：</p>
-        <source><![CDATA[# 全局日志配置
-log4j.rootLogger=ERROR, stdout
-# MyBatis 日志配置
-log4j.logger.org.mybatis.example.BlogMapper=TRACE
-# 控制台输出
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
-        <p>上述配置将使 Log4J 详细打印 <code>org.mybatis.example.BlogMapper</code> 的日志，对于应用的其它部分，只打印错误信息。</p>
-        <p>为了实现更细粒度的日志输出，你也可以只打印特定语句的日志。以下配置将只打印语句 <code>selectBlog</code> 的日志：</p>
+}
+]]></source>
+        <p>在应用的类路径中创建一个名称为 <code>logback.xml</code> 的文件，文件的具体内容如下：
+        </p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
-        <p>或者，你也可以打印一组映射器的日志，只需要打开映射器所在的包的日志功能即可：</p>
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
 
-        <source>log4j.logger.org.mybatis.example=TRACE</source>
-        <p>某些查询可能会返回庞大的结果集。这时，你可能只想查看 SQL 语句，而忽略返回的结果集。为此，SQL 语句将会在 DEBUG 日志级别下记录（JDK 日志则为 FINE）。返回的结果集则会在 TRACE 日志级别下记录（JDK 日志则为 FINER)。因此，只要将日志级别调整为 DEBUG 即可：</p>
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%5level [%thread] - %msg%n</pattern>
+    </encoder>
+  </appender>
 
-        <source>log4j.logger.org.mybatis.example=DEBUG</source>
-        <p>但如果你要为下面的映射器 XML 文件打印日志，又该怎么办呢？</p>
+  <logger name="org.mybatis.example.BlogMapper">
+    <level value="trace"/>
+  </logger>
+  <root level="error">
+    <appender-ref ref="stdout"/>
+  </root>
 
-      <source><![CDATA[<?xml version="1.0" encoding="UTF-8" ?>
+</configuration>
+]]></source>
+
+        <p>添加以上配置后，SLF4J(Logback) 就会记录 <code>org.mybatis.example.BlogMapper</code> 的详细执行操作，且仅记录应用中其它类的错误信息（若有）。</p>
+        <p>你也可以将日志的记录方式从接口级别切换到语句级别，从而实现更细粒度的控制。如下配置只对 <code>selectBlog</code> 语句记录日志：
+        </p>
+
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper.selectBlog">
+  <level value="trace"/>
+</logger>
+]]></source>
+
+        <p>与此相对，可以对一组映射器接口记录日志，只要对映射器接口所在的包开启日志功能即可：</p>
+
+<source><![CDATA[
+<logger name="org.mybatis.example">
+  <level value="trace"/>
+</logger>
+]]></source>
+
+        <p>某些查询可能会返回庞大的结果集，此时只想记录其执行的 SQL 语句而不想记录结果该怎么办？为此，Mybatis 中 SQL 语句的日志级别被设为DEBUG（JDK 日志设为 FINE），结果的日志级别为 TRACE（JDK 日志设为 FINER)。所以，只要将日志级别调整为 DEBUG 即可达到目的：
+        </p>
+
+<source><![CDATA[
+<logger name="org.mybatis.example">
+  <level value="debug"/>
+</logger>
+]]></source>
+
+        <p>要记录日志的是类似下面的映射器文件而不是映射器接口又该怎么做呢？
+        </p>
+
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
   PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
   "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
@@ -126,16 +183,116 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
   <select id="selectBlog" resultType="Blog">
     select * from Blog where id = #{id}
   </select>
-</mapper>]]></source>
-        <p>这时，你可以通过打开命名空间的日志功能来对整个 XML 记录日志：</p>
+</mapper>
+]]></source>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper=TRACE</source>
-        <p>而要记录具体语句的日志，可以这样做：</p>
+		<p>如需对 XML 文件记录日志，只要对命名空间增加日志记录功能即可：
+		</p>
 
-        <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
-        <p>你应该会发现，为映射器和 XML 文件打开日志功能的语句毫无差别。</p>
-        <p><span class="label important">提示</span> 如果你使用的是 SLF4J 或 Log4j 2，MyBatis 会设置 tag 为 MYBATIS。</p>
-        <p>配置文件 <code>log4j.properties</code> 的余下内容用来配置输出器（appender），这一内容已经超出本文档的范围。关于 Log4J 的更多内容，可以参考上面的 Log4J 网站。或者，你也可以简单地做个实验，看看不同的配置会产生怎样的效果。</p>
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper">
+  <level value="trace"/>
+</logger>
+]]></source>
+
+		<p>要记录具体语句的日志可以这样做：</p>
+
+<source><![CDATA[
+<logger name="org.mybatis.example.BlogMapper.selectBlog">
+  <level value="trace"/>
+</logger>
+]]></source>
+
+		<p>你应该注意到了，为映射器接口和 XML 文件添加日志功能的语句毫无差别。
+		</p>
+
+		<p><span class="label important">注意</span> 如果你使用的是 SLF4J 或 Log4j 2，MyBatis 将以 <code>MYBATIS</code> 这个值进行调用。</p>
+
+        <p>配置文件 <code>log4j.properties</code> 的余下内容是针对日志输出源的，这一内容已经超出本文档范围。关于 Logback 的更多内容，可以参考<a href="https://logback.qos.ch/">Logback</a> 的网站。不过，你也可以简单地做做实验，看看不同的配置会产生怎样的效果。
+        </p>
+
+    <p></p>
+    <h4>
+      Configuration example for Log4j 2
+    </h4>
+
+    <p><code>pom.xml</code></p>
+
+<source><![CDATA[
+<dependency>
+  <groupId>org.apache.logging.log4j</groupId>
+  <artifactId>log4j-core</artifactId>
+  <version>2.x.x</version>
+</dependency>
+]]></source>
+
+    <p><code>log4j2.xml</code></p>
+
+<source><![CDATA[
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration xmlns="http://logging.apache.org/log4j/2.0/config">
+
+  <Appenders>
+    <Console name="stdout" target="SYSTEM_OUT">
+      <PatternLayout pattern="%5level [%t] - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="org.mybatis.example.BlogMapper" level="trace"/>
+    <Root level="error" >
+      <AppenderRef ref="stdout"/>
+    </Root>
+  </Loggers>
+
+</Configuration>
+]]></source>
+
+    <p></p>
+    <h4>
+      Configuration example for Log4j
+    </h4>
+
+    <p><code>pom.xml</code></p>
+
+<source><![CDATA[
+<dependency>
+  <groupId>log4j</groupId>
+  <artifactId>log4j</artifactId>
+  <version>1.2.17</version>
+</dependency>
+]]></source>
+
+    <p><code>log4j.properties</code></p>
+
+<source><![CDATA[
+log4j.rootLogger=ERROR, stdout
+
+log4j.logger.org.mybatis.example.BlogMapper=TRACE
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n
+]]></source>
+
+    <p></p>
+    <h4>
+      Configuration example for JDK logging
+    </h4>
+
+    <p><code>logging.properties</code></p>
+
+    <source><![CDATA[
+handlers=java.util.logging.ConsoleHandler
+.level=SEVERE
+
+org.mybatis.example.BlogMapper=FINER
+
+java.util.logging.ConsoleHandler.level=ALL
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=%1$tT.%1$tL %4$s %3$s - %5$s%6$s%n
+]]></source>
+
       </subsection>
     </section>
   </body>

--- a/src/test/java/log4j.properties
+++ b/src/test/java/log4j.properties
@@ -1,5 +1,5 @@
 #
-#    Copyright 2009-2016 the original author or authors.
+#    Copyright 2009-2021 the original author or authors.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -20,11 +20,9 @@ log4j.rootLogger=ERROR, stdout
 ### Uncomment for MyBatis logging
 log4j.logger.org.apache.ibatis=ERROR
 
-log4j.logger.org.apache.ibatis.session.AutoMappingUnknownColumnBehavior=WARN, lastEventSavedAppender
+log4j.logger.org.apache.ibatis.logging=DEBUG
 
 ### Console output...
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n
-
-log4j.appender.lastEventSavedAppender=org.apache.ibatis.session.AutoMappingUnknownColumnBehaviorTest$LastEventSavedAppender
+log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss.SSS} %-5p [%t] %.36c - %m%n

--- a/src/test/java/logback-test.xml
+++ b/src/test/java/logback-test.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2021 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration>
+<configuration>
+
+  <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+  <appender name="lastEventSavedAppender"
+            class="org.apache.ibatis.session.AutoMappingUnknownColumnBehaviorTest$LastEventSavedAppender"/>
+
+  <logger name="org.apache.ibatis">
+    <level value="error"/>
+  </logger>
+  <logger name="org.apache.ibatis.logging">
+    <level value="debug"/>
+  </logger>
+  <logger name="org.apache.ibatis.session.AutoMappingUnknownColumnBehavior">
+    <level value="warn"/>
+    <appender-ref ref="lastEventSavedAppender"/>
+  </logger>
+
+  <root level="error">
+    <appender-ref ref="stdout"/>
+  </root>
+
+</configuration>

--- a/src/test/java/org/apache/ibatis/logging/LogFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/logging/LogFactoryTest.java
@@ -28,9 +28,15 @@ import org.apache.ibatis.logging.nologging.NoLoggingImpl;
 import org.apache.ibatis.logging.slf4j.Slf4jImpl;
 import org.apache.ibatis.logging.stdout.StdOutImpl;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 class LogFactoryTest {
+
+  @AfterAll
+  static void restore() {
+    LogFactory.useSlf4jLogging();
+  }
 
   @Test
   void shouldUseCommonsLogging() {

--- a/src/test/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehaviorTest.java
+++ b/src/test/java/org/apache/ibatis/session/AutoMappingUnknownColumnBehaviorTest.java
@@ -21,6 +21,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.sql.DataSource;
 
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.domain.blog.Author;
@@ -28,8 +30,6 @@ import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.transaction.TransactionFactory;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
-import org.apache.log4j.spi.LoggingEvent;
-import org.apache.log4j.varia.NullAppender;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -81,11 +81,12 @@ class AutoMappingUnknownColumnBehaviorTest {
         }
     }
 
-    public static class LastEventSavedAppender extends NullAppender {
-        private static LoggingEvent event;
+    public static class LastEventSavedAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
+        private static ILoggingEvent lastEvent;
 
-        public void doAppend(LoggingEvent event) {
-            LastEventSavedAppender.event = event;
+        @Override
+        protected void append(ILoggingEvent event) {
+          lastEvent = event;
         }
     }
 
@@ -120,7 +121,7 @@ class AutoMappingUnknownColumnBehaviorTest {
             SimpleAuthor author = mapper.selectSimpleAuthor(101);
             assertThat(author.getId()).isNull();
             assertThat(author.getUsername()).isEqualTo("jim");
-            assertThat(LastEventSavedAppender.event.getMessage().toString()).isEqualTo("Unknown column is detected on 'org.apache.ibatis.session.AutoMappingUnknownColumnBehaviorTest$Mapper.selectSimpleAuthor' auto-mapping. Mapping parameters are [columnName=ID,propertyName=id,propertyType=java.util.concurrent.atomic.AtomicInteger]");
+            assertThat(LastEventSavedAppender.lastEvent.getMessage()).isEqualTo("Unknown column is detected on 'org.apache.ibatis.session.AutoMappingUnknownColumnBehaviorTest$Mapper.selectSimpleAuthor' auto-mapping. Mapping parameters are [columnName=ID,propertyName=id,propertyType=java.util.concurrent.atomic.AtomicInteger]");
         }
     }
 


### PR DESCRIPTION
I've fixed #1223 .

## Changes

### Application and Tests

* Add `@deprecated` at modules for log4j 1.x
* Change SLF4J binding library to the logback(implements SLF4J directly) from slf4j-log4j12 on test

### Docs

* Add deprecated mark
* Change example to SLF4(logback) based instead of Log4J
* Add examples for Log4j 2.x and JDK logging
* Keep example for Log4j 1.x
  