### PR TITLE
Avoiding internal calls causes interceptor methods invalid.

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/BatchExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BatchExecutor.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ public class BatchExecutor extends BaseExecutor {
       int last = statementList.size() - 1;
       stmt = statementList.get(last);
       applyTransactionTimeout(stmt);
-     handler.parameterize(stmt);//fix Issues 322
+      handler.parameterize(stmt);//fix Issues 322
       BatchResult batchResult = batchResultList.get(last);
       batchResult.addParameterObject(parameterObject);
     } else {
@@ -84,7 +84,7 @@ public class BatchExecutor extends BaseExecutor {
       throws SQLException {
     Statement stmt = null;
     try {
-      flushStatements();
+      wrapper.flushStatements();
       Configuration configuration = ms.getConfiguration();
       StatementHandler handler = configuration.newStatementHandler(wrapper, ms, parameterObject, rowBounds, resultHandler, boundSql);
       Connection connection = getConnection(ms.getStatementLog());
@@ -98,7 +98,7 @@ public class BatchExecutor extends BaseExecutor {
 
   @Override
   protected <E> Cursor<E> doQueryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds, BoundSql boundSql) throws SQLException {
-    flushStatements();
+    wrapper.flushStatements();
     Configuration configuration = ms.getConfiguration();
     StatementHandler handler = configuration.newStatementHandler(wrapper, ms, parameter, rowBounds, null, boundSql);
     Connection connection = getConnection(ms.getStatementLog());

--- a/src/main/java/org/apache/ibatis/executor/CachingExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/CachingExecutor.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -39,11 +39,12 @@ import org.apache.ibatis.transaction.Transaction;
 public class CachingExecutor implements Executor {
 
   private final Executor delegate;
+  protected Executor wrapper;
   private final TransactionalCacheManager tcm = new TransactionalCacheManager();
 
   public CachingExecutor(Executor delegate) {
     this.delegate = delegate;
-    delegate.setExecutorWrapper(this);
+    this.setExecutorWrapper(this);
   }
 
   @Override
@@ -79,8 +80,8 @@ public class CachingExecutor implements Executor {
   @Override
   public <E> List<E> query(MappedStatement ms, Object parameterObject, RowBounds rowBounds, ResultHandler resultHandler) throws SQLException {
     BoundSql boundSql = ms.getBoundSql(parameterObject);
-    CacheKey key = createCacheKey(ms, parameterObject, rowBounds, boundSql);
-    return query(ms, parameterObject, rowBounds, resultHandler, key, boundSql);
+    CacheKey key = wrapper.createCacheKey(ms, parameterObject, rowBounds, boundSql);
+    return wrapper.query(ms, parameterObject, rowBounds, resultHandler, key, boundSql);
   }
 
   @Override
@@ -169,8 +170,9 @@ public class CachingExecutor implements Executor {
   }
 
   @Override
-  public void setExecutorWrapper(Executor executor) {
-    throw new UnsupportedOperationException("This method should not be called");
+  public void setExecutorWrapper(Executor wrapper) {
+    this.wrapper = wrapper;
+    this.delegate.setExecutorWrapper(wrapper);
   }
 
 }

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -579,6 +579,7 @@ public class Configuration {
       executor = new CachingExecutor(executor);
     }
     executor = (Executor) interceptorChain.pluginAll(executor);
+    executor.setExecutorWrapper(executor);
     return executor;
   }
 


### PR DESCRIPTION
There are a few internally invoked methods in the executor implementation that the interceptor cannot intercept.

Especially the following method:
```java
<E> List<E> query(MappedStatement ms, Object parameter, 
                               RowBounds rowBounds, ResultHandler resultHandler) throws SQLException
```

Binding the intercepted object can be accomplished through the interface provided by Executor.
```java
void setExecutorWrapper(Executor executor)
```

```java
executor = (Executor) interceptorChain.pluginAll(executor);
executor.setExecutorWrapper(executor);
```