### PR TITLE
add NullableBaseTypeHandler for avoid unnecessary wasNull() call

### DIFF
--- a/src/main/java/org/apache/ibatis/type/BaseTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BaseTypeHandler.java
@@ -16,18 +16,16 @@
 package org.apache.ibatis.type;
 
 import java.sql.CallableStatement;
-import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import org.apache.ibatis.executor.result.ResultMapException;
 import org.apache.ibatis.session.Configuration;
 
 /**
  * @author Clinton Begin
  * @author Simone Tripodi
  */
-public abstract class BaseTypeHandler<T> extends TypeReference<T> implements TypeHandler<T> {
+public abstract class BaseTypeHandler<T> extends NullableBaseTypeHandler<T> {
 
   /**
    * @deprecated Since 3.5.0 - See https://github.com/mybatis/mybatis-3/issues/1203. This field will remove future.
@@ -44,37 +42,8 @@ public abstract class BaseTypeHandler<T> extends TypeReference<T> implements Typ
   }
 
   @Override
-  public void setParameter(PreparedStatement ps, int i, T parameter, JdbcType jdbcType) throws SQLException {
-    if (parameter == null) {
-      if (jdbcType == null) {
-        throw new TypeException("JDBC requires that the JdbcType must be specified for all nullable parameters.");
-      }
-      try {
-        ps.setNull(i, jdbcType.TYPE_CODE);
-      } catch (SQLException e) {
-        throw new TypeException("Error setting null for parameter #" + i + " with JdbcType " + jdbcType + " . " +
-                "Try setting a different JdbcType for this parameter or a different jdbcTypeForNull configuration property. " +
-                "Cause: " + e, e);
-      }
-    } else {
-      try {
-        setNonNullParameter(ps, i, parameter, jdbcType);
-      } catch (Exception e) {
-        throw new TypeException("Error setting non null for parameter #" + i + " with JdbcType " + jdbcType + " . " +
-                "Try setting a different JdbcType for this parameter or a different configuration property. " +
-                "Cause: " + e, e);
-      }
-    }
-  }
-
-  @Override
   public T getResult(ResultSet rs, String columnName) throws SQLException {
-    T result;
-    try {
-      result = getNullableResult(rs, columnName);
-    } catch (Exception e) {
-      throw new ResultMapException("Error attempting to get column '" + columnName + "' from result set.  Cause: " + e, e);
-    }
+    T result = super.getResult(rs, columnName);
     if (rs.wasNull()) {
       return null;
     } else {
@@ -84,12 +53,7 @@ public abstract class BaseTypeHandler<T> extends TypeReference<T> implements Typ
 
   @Override
   public T getResult(ResultSet rs, int columnIndex) throws SQLException {
-    T result;
-    try {
-      result = getNullableResult(rs, columnIndex);
-    } catch (Exception e) {
-      throw new ResultMapException("Error attempting to get column #" + columnIndex+ " from result set.  Cause: " + e, e);
-    }
+    T result = super.getResult(rs, columnIndex);
     if (rs.wasNull()) {
       return null;
     } else {
@@ -99,25 +63,12 @@ public abstract class BaseTypeHandler<T> extends TypeReference<T> implements Typ
 
   @Override
   public T getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    T result;
-    try {
-      result = getNullableResult(cs, columnIndex);
-    } catch (Exception e) {
-      throw new ResultMapException("Error attempting to get column #" + columnIndex+ " from callable statement.  Cause: " + e, e);
-    }
+    T result = super.getResult(cs, columnIndex);
     if (cs.wasNull()) {
       return null;
     } else {
       return result;
     }
   }
-
-  public abstract void setNonNullParameter(PreparedStatement ps, int i, T parameter, JdbcType jdbcType) throws SQLException;
-
-  public abstract T getNullableResult(ResultSet rs, String columnName) throws SQLException;
-
-  public abstract T getNullableResult(ResultSet rs, int columnIndex) throws SQLException;
-
-  public abstract T getNullableResult(CallableStatement cs, int columnIndex) throws SQLException;
 
 }

--- a/src/main/java/org/apache/ibatis/type/BigDecimalTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BigDecimalTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class BigDecimalTypeHandler extends BaseTypeHandler<BigDecimal> {
+public class BigDecimalTypeHandler extends NullableBaseTypeHandler<BigDecimal> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, BigDecimal parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/BigIntegerTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BigIntegerTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.sql.SQLException;
 /**
  * @author Paul Krause
  */
-public class BigIntegerTypeHandler extends BaseTypeHandler<BigInteger> {
+public class BigIntegerTypeHandler extends NullableBaseTypeHandler<BigInteger> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, BigInteger parameter, JdbcType jdbcType) throws SQLException {

--- a/src/main/java/org/apache/ibatis/type/ByteArrayTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ByteArrayTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class ByteArrayTypeHandler extends BaseTypeHandler<byte[]> {
+public class ByteArrayTypeHandler extends NullableBaseTypeHandler<byte[]> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, byte[] parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/ByteObjectArrayTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ByteObjectArrayTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class ByteObjectArrayTypeHandler extends BaseTypeHandler<Byte[]> {
+public class ByteObjectArrayTypeHandler extends NullableBaseTypeHandler<Byte[]> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Byte[] parameter, JdbcType jdbcType) throws SQLException {

--- a/src/main/java/org/apache/ibatis/type/CharacterTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/CharacterTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class CharacterTypeHandler extends BaseTypeHandler<Character> {
+public class CharacterTypeHandler extends NullableBaseTypeHandler<Character> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Character parameter, JdbcType jdbcType) throws SQLException {

--- a/src/main/java/org/apache/ibatis/type/DateOnlyTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/DateOnlyTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.util.Date;
 /**
  * @author Clinton Begin
  */
-public class DateOnlyTypeHandler extends BaseTypeHandler<Date> {
+public class DateOnlyTypeHandler extends NullableBaseTypeHandler<Date> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Date parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/DateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/DateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.util.Date;
 /**
  * @author Clinton Begin
  */
-public class DateTypeHandler extends BaseTypeHandler<Date> {
+public class DateTypeHandler extends NullableBaseTypeHandler<Date> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Date parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/EnumTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/EnumTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class EnumTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E> {
+public class EnumTypeHandler<E extends Enum<E>> extends NullableBaseTypeHandler<E> {
 
   private final Class<E> type;
 

--- a/src/main/java/org/apache/ibatis/type/InstantTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/InstantTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class InstantTypeHandler extends BaseTypeHandler<Instant> {
+public class InstantTypeHandler extends NullableBaseTypeHandler<Instant> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Instant parameter, JdbcType jdbcType) throws SQLException {

--- a/src/main/java/org/apache/ibatis/type/JapaneseDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/JapaneseDateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Kazuki Shimizu
  */
 @UsesJava8
-public class JapaneseDateTypeHandler extends BaseTypeHandler<JapaneseDate> {
+public class JapaneseDateTypeHandler extends NullableBaseTypeHandler<JapaneseDate> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, JapaneseDate parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/LocalDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class LocalDateTimeTypeHandler extends BaseTypeHandler<LocalDateTime> {
+public class LocalDateTimeTypeHandler extends NullableBaseTypeHandler<LocalDateTime> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, LocalDateTime parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/LocalDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalDateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class LocalDateTypeHandler extends BaseTypeHandler<LocalDate> {
+public class LocalDateTypeHandler extends NullableBaseTypeHandler<LocalDate> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, LocalDate parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/LocalTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class LocalTimeTypeHandler extends BaseTypeHandler<LocalTime> {
+public class LocalTimeTypeHandler extends NullableBaseTypeHandler<LocalTime> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, LocalTime parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/NStringTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/NStringTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class NStringTypeHandler extends BaseTypeHandler<String> {
+public class NStringTypeHandler extends NullableBaseTypeHandler<String> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, String parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/NullableBaseTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/NullableBaseTypeHandler.java
@@ -1,0 +1,90 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.apache.ibatis.executor.result.ResultMapException;
+
+/**
+ * @author Clinton Begin
+ * @author Simone Tripodi
+ */
+public abstract class NullableBaseTypeHandler<T> extends TypeReference<T> implements TypeHandler<T> {
+
+  @Override
+  public void setParameter(PreparedStatement ps, int i, T parameter, JdbcType jdbcType) throws SQLException {
+    if (parameter == null) {
+      if (jdbcType == null) {
+        throw new TypeException("JDBC requires that the JdbcType must be specified for all nullable parameters.");
+      }
+      try {
+        ps.setNull(i, jdbcType.TYPE_CODE);
+      } catch (SQLException e) {
+        throw new TypeException("Error setting null for parameter #" + i + " with JdbcType " + jdbcType + " . " +
+                "Try setting a different JdbcType for this parameter or a different jdbcTypeForNull configuration property. " +
+                "Cause: " + e, e);
+      }
+    } else {
+      try {
+        setNonNullParameter(ps, i, parameter, jdbcType);
+      } catch (Exception e) {
+        throw new TypeException("Error setting non null for parameter #" + i + " with JdbcType " + jdbcType + " . " +
+                "Try setting a different JdbcType for this parameter or a different configuration property. " +
+                "Cause: " + e, e);
+      }
+    }
+  }
+
+  @Override
+  public T getResult(ResultSet rs, String columnName) throws SQLException {
+    try {
+      return getNullableResult(rs, columnName);
+    } catch (Exception e) {
+      throw new ResultMapException("Error attempting to get column '" + columnName + "' from result set.  Cause: " + e, e);
+    }
+  }
+
+  @Override
+  public T getResult(ResultSet rs, int columnIndex) throws SQLException {
+    try {
+      return getNullableResult(rs, columnIndex);
+    } catch (Exception e) {
+      throw new ResultMapException("Error attempting to get column #" + columnIndex+ " from result set.  Cause: " + e, e);
+    }
+  }
+
+  @Override
+  public T getResult(CallableStatement cs, int columnIndex) throws SQLException {
+    try {
+      return getNullableResult(cs, columnIndex);
+    } catch (Exception e) {
+      throw new ResultMapException("Error attempting to get column #" + columnIndex+ " from callable statement.  Cause: " + e, e);
+    }
+  }
+
+  public abstract void setNonNullParameter(PreparedStatement ps, int i, T parameter, JdbcType jdbcType) throws SQLException;
+
+  public abstract T getNullableResult(ResultSet rs, String columnName) throws SQLException;
+
+  public abstract T getNullableResult(ResultSet rs, int columnIndex) throws SQLException;
+
+  public abstract T getNullableResult(CallableStatement cs, int columnIndex) throws SQLException;
+
+}

--- a/src/main/java/org/apache/ibatis/type/OffsetDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/OffsetDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class OffsetDateTimeTypeHandler extends BaseTypeHandler<OffsetDateTime> {
+public class OffsetDateTimeTypeHandler extends NullableBaseTypeHandler<OffsetDateTime> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, OffsetDateTime parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/OffsetTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/OffsetTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class OffsetTimeTypeHandler extends BaseTypeHandler<OffsetTime> {
+public class OffsetTimeTypeHandler extends NullableBaseTypeHandler<OffsetTime> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, OffsetTime parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/SqlDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/SqlDateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class SqlDateTypeHandler extends BaseTypeHandler<Date> {
+public class SqlDateTypeHandler extends NullableBaseTypeHandler<Date> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Date parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/SqlTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/SqlTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.sql.Time;
 /**
  * @author Clinton Begin
  */
-public class SqlTimeTypeHandler extends BaseTypeHandler<Time> {
+public class SqlTimeTypeHandler extends NullableBaseTypeHandler<Time> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Time parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/SqlTimestampTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/SqlTimestampTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.sql.Timestamp;
 /**
  * @author Clinton Begin
  */
-public class SqlTimestampTypeHandler extends BaseTypeHandler<Timestamp> {
+public class SqlTimestampTypeHandler extends NullableBaseTypeHandler<Timestamp> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Timestamp parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/StringTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/StringTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class StringTypeHandler extends BaseTypeHandler<String> {
+public class StringTypeHandler extends NullableBaseTypeHandler<String> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, String parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/TimeOnlyTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/TimeOnlyTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.util.Date;
 /**
  * @author Clinton Begin
  */
-public class TimeOnlyTypeHandler extends BaseTypeHandler<Date> {
+public class TimeOnlyTypeHandler extends NullableBaseTypeHandler<Date> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Date parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/YearMonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearMonthTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Björn Raupach
  */
 @UsesJava8
-public class YearMonthTypeHandler extends BaseTypeHandler<YearMonth> {
+public class YearMonthTypeHandler extends NullableBaseTypeHandler<YearMonth> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, YearMonth yearMonth, JdbcType jt) throws SQLException {

--- a/src/main/java/org/apache/ibatis/type/ZonedDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ZonedDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class ZonedDateTimeTypeHandler extends BaseTypeHandler<ZonedDateTime> {
+public class ZonedDateTimeTypeHandler extends NullableBaseTypeHandler<ZonedDateTime> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, ZonedDateTime parameter, JdbcType jdbcType)


### PR DESCRIPTION
Current MyBatis type handlers always check SQL NULL by ResultSet.wasNull() call that could decrease  performance.
On my case on Oracle R12, profiling found about 30% delay on VARCHAR types by wasNull() call.

Following java.sql.ResultSet get methods are declared returns java null on SQL NULL value, so these types are can use returned null value as-is.
- getAsciiStream()
- getBigDecimal()
- getBinaryStream()
- getBytes()
- getCharacterStream()
- getDate()
- getNCharacterStream()
- getNString()
- getRowId()
- getString()
- getTime()
- getTimestamp()
- getUnicodeStream()
- getURL()

This pull request add NullableBaseTypeHandler class that do not call wasNull() and inherits it on TypeHandlers using above listed methods.
