### PR TITLE
Add new base type handler for using nullable JDBC APIs

### DIFF
--- a/src/main/java/org/apache/ibatis/type/BaseTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BaseTypeHandler.java
@@ -24,8 +24,11 @@ import org.apache.ibatis.executor.result.ResultMapException;
 import org.apache.ibatis.session.Configuration;
 
 /**
+ * The base {@link TypeHandler} for references a generic type.
+ *
  * @author Clinton Begin
  * @author Simone Tripodi
+ * @author Kzuki Shimizu
  */
 public abstract class BaseTypeHandler<T> extends TypeReference<T> implements TypeHandler<T> {
 
@@ -75,11 +78,7 @@ public abstract class BaseTypeHandler<T> extends TypeReference<T> implements Typ
     } catch (Exception e) {
       throw new ResultMapException("Error attempting to get column '" + columnName + "' from result set.  Cause: " + e, e);
     }
-    if (rs.wasNull()) {
-      return null;
-    } else {
-      return result;
-    }
+    return handleResult(rs, result);
   }
 
   @Override
@@ -90,11 +89,7 @@ public abstract class BaseTypeHandler<T> extends TypeReference<T> implements Typ
     } catch (Exception e) {
       throw new ResultMapException("Error attempting to get column #" + columnIndex+ " from result set.  Cause: " + e, e);
     }
-    if (rs.wasNull()) {
-      return null;
-    } else {
-      return result;
-    }
+    return handleResult(rs, result);
   }
 
   @Override
@@ -105,6 +100,40 @@ public abstract class BaseTypeHandler<T> extends TypeReference<T> implements Typ
     } catch (Exception e) {
       throw new ResultMapException("Error attempting to get column #" + columnIndex+ " from callable statement.  Cause: " + e, e);
     }
+    return handleResult(cs, result);
+  }
+
+  /**
+   * Handle a fetched result value from {@link ResultSet}.
+   * 
+   * @param rs a {@link ResultSet}
+   * @param result a fetched value
+   * @return If {@link ResultSet#wasNull()} return {@code true}, it return {@code null}. Otherwise
+   *         return a fetched result value.
+   * @exception SQLException if a database access error occurs or this method is
+   *            called on a closed result set
+   * @since 3.5.0
+   */
+  protected T handleResult(ResultSet rs, T result) throws SQLException {
+    if (rs.wasNull()) {
+      return null;
+    } else {
+      return result;
+    }
+  }
+
+  /**
+   * Handle a fetched result value
+   *
+   * @param cs a {@link CallableStatement}
+   * @param result a fetched value
+   * @return If {@link ResultSet#wasNull()} return {@code true}, it return {@code null}. Otherwise
+   *         return a fetched result value.
+   * @exception SQLException if a database access error occurs or this method is
+   *            called on a closed result set
+   * @since 3.5.0
+   */
+  protected T handleResult(CallableStatement cs, T result) throws SQLException {
     if (cs.wasNull()) {
       return null;
     } else {

--- a/src/main/java/org/apache/ibatis/type/BigDecimalTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BigDecimalTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class BigDecimalTypeHandler extends BaseTypeHandler<BigDecimal> {
+public class BigDecimalTypeHandler extends NullableApiBasedTypeHandler<BigDecimal> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, BigDecimal parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/BigIntegerTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BigIntegerTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.sql.SQLException;
 /**
  * @author Paul Krause
  */
-public class BigIntegerTypeHandler extends BaseTypeHandler<BigInteger> {
+public class BigIntegerTypeHandler extends NullableApiBasedTypeHandler<BigInteger> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, BigInteger parameter, JdbcType jdbcType) throws SQLException {

--- a/src/main/java/org/apache/ibatis/type/ByteArrayTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ByteArrayTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class ByteArrayTypeHandler extends BaseTypeHandler<byte[]> {
+public class ByteArrayTypeHandler extends NullableApiBasedTypeHandler<byte[]> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, byte[] parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/ByteObjectArrayTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ByteObjectArrayTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class ByteObjectArrayTypeHandler extends BaseTypeHandler<Byte[]> {
+public class ByteObjectArrayTypeHandler extends NullableApiBasedTypeHandler<Byte[]> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Byte[] parameter, JdbcType jdbcType) throws SQLException {

--- a/src/main/java/org/apache/ibatis/type/CharacterTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/CharacterTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class CharacterTypeHandler extends BaseTypeHandler<Character> {
+public class CharacterTypeHandler extends NullableApiBasedTypeHandler<Character> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Character parameter, JdbcType jdbcType) throws SQLException {

--- a/src/main/java/org/apache/ibatis/type/DateOnlyTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/DateOnlyTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.util.Date;
 /**
  * @author Clinton Begin
  */
-public class DateOnlyTypeHandler extends BaseTypeHandler<Date> {
+public class DateOnlyTypeHandler extends NullableApiBasedTypeHandler<Date> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Date parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/DateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/DateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.util.Date;
 /**
  * @author Clinton Begin
  */
-public class DateTypeHandler extends BaseTypeHandler<Date> {
+public class DateTypeHandler extends NullableApiBasedTypeHandler<Date> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Date parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/EnumTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/EnumTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class EnumTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E> {
+public class EnumTypeHandler<E extends Enum<E>> extends NullableApiBasedTypeHandler<E> {
 
   private final Class<E> type;
 

--- a/src/main/java/org/apache/ibatis/type/InstantTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/InstantTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class InstantTypeHandler extends BaseTypeHandler<Instant> {
+public class InstantTypeHandler extends NullableApiBasedTypeHandler<Instant> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Instant parameter, JdbcType jdbcType) throws SQLException {

--- a/src/main/java/org/apache/ibatis/type/JapaneseDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/JapaneseDateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Kazuki Shimizu
  */
 @UsesJava8
-public class JapaneseDateTypeHandler extends BaseTypeHandler<JapaneseDate> {
+public class JapaneseDateTypeHandler extends NullableApiBasedTypeHandler<JapaneseDate> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, JapaneseDate parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/LocalDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class LocalDateTimeTypeHandler extends BaseTypeHandler<LocalDateTime> {
+public class LocalDateTimeTypeHandler extends NullableApiBasedTypeHandler<LocalDateTime> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, LocalDateTime parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/LocalDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalDateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class LocalDateTypeHandler extends BaseTypeHandler<LocalDate> {
+public class LocalDateTypeHandler extends NullableApiBasedTypeHandler<LocalDate> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, LocalDate parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/LocalTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class LocalTimeTypeHandler extends BaseTypeHandler<LocalTime> {
+public class LocalTimeTypeHandler extends NullableApiBasedTypeHandler<LocalTime> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, LocalTime parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/NStringTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/NStringTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class NStringTypeHandler extends BaseTypeHandler<String> {
+public class NStringTypeHandler extends NullableApiBasedTypeHandler<String> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, String parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/NullableApiBasedTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/NullableApiBasedTypeHandler.java
@@ -23,6 +23,7 @@ import java.sql.ResultSet;
  * if the value is SQL <code>NULL</code>).
  * <p>
  * Nullable JDBC APIs are follows on {@link ResultSet} or {@link CallableStatement}:
+ * </p>
  * <ul>
  * <li><code>getAsciiStream()</code></li>
  * <li><code>getBigDecimal()</code></li>
@@ -39,7 +40,6 @@ import java.sql.ResultSet;
  * <li><code>getUnicodeStream()</code></li>
  * <li><code>getURL()</code></li>
  * </ul>
- * </p>
  * <p>
  * If you create a custom {@link TypeHandler} using above APIs, we propose to use this class instead
  * of the {@link BaseTypeHandler}. This class is efficient than the {@link BaseTypeHandler} because

--- a/src/main/java/org/apache/ibatis/type/NullableApiBasedTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/NullableApiBasedTypeHandler.java
@@ -1,0 +1,76 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+
+/**
+ * The base {@link TypeHandler} for using nullable JDBC APIs (APIs that it return <code>null</code>,
+ * if the value is SQL <code>NULL</code>).
+ * <p>
+ * Nullable JDBC APIs are follows on {@link ResultSet} or {@link CallableStatement}:
+ * <ul>
+ * <li><code>getAsciiStream()</code></li>
+ * <li><code>getBigDecimal()</code></li>
+ * <li><code>getBinaryStream()</code></li>
+ * <li><code>getBytes()</code></li>
+ * <li><code>getCharacterStream()</code></li>
+ * <li><code>getDate()</code></li>
+ * <li><code>getNCharacterStream()</code></li>
+ * <li><code>getNString()</code></li>
+ * <li><code>getRowId()</code></li>
+ * <li><code>getString()</code></li>
+ * <li><code>getTime()</code></li>
+ * <li><code>getTimestamp()</code></li>
+ * <li><code>getUnicodeStream()</code></li>
+ * <li><code>getURL()</code></li>
+ * </ul>
+ * </p>
+ * <p>
+ * If you create a custom {@link TypeHandler} using above APIs, we propose to use this class instead
+ * of the {@link BaseTypeHandler}. This class is efficient than the {@link BaseTypeHandler} because
+ * it does not call the <code>wasNull()</code> on {@link ResultSet} or {@link CallableStatement} for
+ * handling null value.
+ * </p>
+ *
+ * @param <T> the referenced type
+ * @author Kazuki Shimizu
+ * @since 3.5.0
+ */
+public abstract class NullableApiBasedTypeHandler<T> extends BaseTypeHandler<T> {
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @return Always return a fetched result
+   */
+  @Override
+  protected T handleResult(ResultSet rs, T result) {
+    return result;
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @return Always return a fetched result
+   */
+  @Override
+  protected T handleResult(CallableStatement cs, T result) {
+    return result;
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/type/OffsetDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/OffsetDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class OffsetDateTimeTypeHandler extends BaseTypeHandler<OffsetDateTime> {
+public class OffsetDateTimeTypeHandler extends NullableApiBasedTypeHandler<OffsetDateTime> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, OffsetDateTime parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/OffsetTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/OffsetTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class OffsetTimeTypeHandler extends BaseTypeHandler<OffsetTime> {
+public class OffsetTimeTypeHandler extends NullableApiBasedTypeHandler<OffsetTime> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, OffsetTime parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/SqlDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/SqlDateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class SqlDateTypeHandler extends BaseTypeHandler<Date> {
+public class SqlDateTypeHandler extends NullableApiBasedTypeHandler<Date> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Date parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/SqlTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/SqlTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.sql.Time;
 /**
  * @author Clinton Begin
  */
-public class SqlTimeTypeHandler extends BaseTypeHandler<Time> {
+public class SqlTimeTypeHandler extends NullableApiBasedTypeHandler<Time> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Time parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/SqlTimestampTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/SqlTimestampTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import java.sql.Timestamp;
 /**
  * @author Clinton Begin
  */
-public class SqlTimestampTypeHandler extends BaseTypeHandler<Timestamp> {
+public class SqlTimestampTypeHandler extends NullableApiBasedTypeHandler<Timestamp> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Timestamp parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/StringTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/StringTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.sql.SQLException;
 /**
  * @author Clinton Begin
  */
-public class StringTypeHandler extends BaseTypeHandler<String> {
+public class StringTypeHandler extends NullableApiBasedTypeHandler<String> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, String parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/TimeOnlyTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/TimeOnlyTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.util.Date;
 /**
  * @author Clinton Begin
  */
-public class TimeOnlyTypeHandler extends BaseTypeHandler<Date> {
+public class TimeOnlyTypeHandler extends NullableApiBasedTypeHandler<Date> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, Date parameter, JdbcType jdbcType)

--- a/src/main/java/org/apache/ibatis/type/YearMonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearMonthTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Björn Raupach
  */
 @UsesJava8
-public class YearMonthTypeHandler extends BaseTypeHandler<YearMonth> {
+public class YearMonthTypeHandler extends NullableApiBasedTypeHandler<YearMonth> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, YearMonth yearMonth, JdbcType jt) throws SQLException {

--- a/src/main/java/org/apache/ibatis/type/ZonedDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ZonedDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.apache.ibatis.lang.UsesJava8;
  * @author Tomas Rohovsky
  */
 @UsesJava8
-public class ZonedDateTimeTypeHandler extends BaseTypeHandler<ZonedDateTime> {
+public class ZonedDateTimeTypeHandler extends NullableApiBasedTypeHandler<ZonedDateTime> {
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, ZonedDateTime parameter, JdbcType jdbcType)

--- a/src/test/java/org/apache/ibatis/type/BigDecimalTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/BigDecimalTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 public class BigDecimalTypeHandlerTest extends BaseTypeHandlerTest {
 
@@ -38,8 +41,8 @@ public class BigDecimalTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getBigDecimal("column")).thenReturn(new BigDecimal(1));
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new BigDecimal(1), TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -51,8 +54,8 @@ public class BigDecimalTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getBigDecimal(1)).thenReturn(new BigDecimal(1));
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new BigDecimal(1), TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -64,8 +67,8 @@ public class BigDecimalTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getBigDecimal(1)).thenReturn(new BigDecimal(1));
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(new BigDecimal(1), TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/BigIntegerTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/BigIntegerTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,48 +41,48 @@ public class BigIntegerTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getBigDecimal("column")).thenReturn(new BigDecimal("707070656505050302797979792923232303"));
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new BigInteger("707070656505050302797979792923232303"), TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getBigDecimal("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getBigDecimal(1)).thenReturn(new BigDecimal("707070656505050302797979792923232303"));
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new BigInteger("707070656505050302797979792923232303"), TYPE_HANDLER.getResult(rs,1 ));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getBigDecimal(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs,1 ));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getBigDecimal(1)).thenReturn(new BigDecimal("707070656505050302797979792923232303"));
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(new BigInteger("707070656505050302797979792923232303"), TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getBigDecimal(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/ByteArrayTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ByteArrayTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,8 +37,8 @@ public class ByteArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getBytes("column")).thenReturn(new byte[] { 1, 2, 3 });
-    when(rs.wasNull()).thenReturn(false);
     assertArrayEquals(new byte[] { 1, 2, 3 }, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -49,8 +50,8 @@ public class ByteArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getBytes(1)).thenReturn(new byte[] { 1, 2, 3 });
-    when(rs.wasNull()).thenReturn(false);
     assertArrayEquals(new byte[] { 1, 2, 3 }, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -62,8 +63,8 @@ public class ByteArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getBytes(1)).thenReturn(new byte[] { 1, 2, 3 });
-    when(cs.wasNull()).thenReturn(false);
     assertArrayEquals(new byte[] { 1, 2, 3 }, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/ByteObjectArrayTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ByteObjectArrayTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.ibatis.type;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,16 +38,16 @@ public class ByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     byte[] byteArray = new byte[]{1, 2};
     when(rs.getBytes("column")).thenReturn(byteArray);
-    when(rs.wasNull()).thenReturn(false);
     assertThat(TYPE_HANDLER.getResult(rs, "column")).isEqualTo(new Byte[]{1, 2});
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getBytes("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertThat(TYPE_HANDLER.getResult(rs, "column")).isNull();
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -54,16 +55,16 @@ public class ByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     byte[] byteArray = new byte[]{1, 2};
     when(rs.getBytes(1)).thenReturn(byteArray);
-    when(rs.wasNull()).thenReturn(false);
     assertThat(TYPE_HANDLER.getResult(rs, 1)).isEqualTo(new Byte[]{1, 2});
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getBytes(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertThat(TYPE_HANDLER.getResult(rs, 1)).isNull();
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -71,16 +72,16 @@ public class ByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     byte[] byteArray = new byte[]{1, 2};
     when(cs.getBytes(1)).thenReturn(byteArray);
-    when(cs.wasNull()).thenReturn(false);
     assertThat(TYPE_HANDLER.getResult(cs, 1)).isEqualTo(new Byte[]{1, 2});
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getBytes(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertThat(TYPE_HANDLER.getResult(cs, 1)).isNull();
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/CharacterTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/CharacterTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -43,48 +44,48 @@ public class CharacterTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getString("column")).thenReturn("a");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Character('a'), TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getString("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getString(1)).thenReturn("a");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Character('a'), TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getString(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getString(1)).thenReturn("a");
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(new Character('a'), TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getString(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/DateOnlyTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/DateOnlyTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,48 +42,48 @@ public class DateOnlyTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(SQL_DATE);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(SQL_DATE);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(SQL_DATE);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/DateTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/DateTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,48 +43,48 @@ public class DateTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/EnumTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/EnumTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,48 +48,48 @@ public class EnumTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getString("column")).thenReturn("ONE");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(MyEnum.ONE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getString("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getString(1)).thenReturn("ONE");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(MyEnum.ONE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getString(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getString(1)).thenReturn("ONE");
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(MyEnum.ONE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getString(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/NStringTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/NStringTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.ibatis.type;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,8 +37,8 @@ public class NStringTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getNString("column")).thenReturn("Hello");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -49,8 +50,8 @@ public class NStringTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getNString(1)).thenReturn("Hello");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -62,8 +63,8 @@ public class NStringTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getNString(1)).thenReturn("Hello");
-    when(cs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(cs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/SqlDateTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/SqlDateTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -39,8 +40,8 @@ public class SqlDateTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(SQL_DATE);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(SQL_DATE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -52,8 +53,8 @@ public class SqlDateTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(SQL_DATE);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(SQL_DATE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -65,8 +66,8 @@ public class SqlDateTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(SQL_DATE);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(SQL_DATE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/SqlTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/SqlTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -39,8 +40,8 @@ public class SqlTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(SQL_TIME);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(SQL_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -52,8 +53,8 @@ public class SqlTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(SQL_TIME);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(SQL_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -65,8 +66,8 @@ public class SqlTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(SQL_TIME);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(SQL_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/SqlTimetampTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/SqlTimetampTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,8 +41,8 @@ public class SqlTimetampTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(SQL_TIME);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(SQL_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -53,8 +54,8 @@ public class SqlTimetampTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(SQL_TIME);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(SQL_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -66,8 +67,8 @@ public class SqlTimetampTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(SQL_TIME);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(SQL_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/StringTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/StringTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,8 +37,8 @@ public class StringTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getString("column")).thenReturn("Hello");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -49,8 +50,8 @@ public class StringTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getString(1)).thenReturn("Hello");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -62,8 +63,8 @@ public class StringTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getString(1)).thenReturn("Hello");
-    when(cs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/TimeOnlyTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/TimeOnlyTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,48 +42,48 @@ public class TimeOnlyTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(SQL_TIME);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(SQL_TIME);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(SQL_TIME);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/InstantTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/InstantTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,14 +44,15 @@ public class InstantTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
     assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -59,14 +60,15 @@ public class InstantTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -74,13 +76,14 @@ public class InstantTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/JapaneseDateTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/JapaneseDateTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,14 +45,15 @@ public class JapaneseDateTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(DATE);
     assertEquals(JAPANESE_DATE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -60,14 +61,15 @@ public class JapaneseDateTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(DATE);
     assertEquals(JAPANESE_DATE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -75,14 +77,15 @@ public class JapaneseDateTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(DATE);
     assertEquals(JAPANESE_DATE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/LocalDateTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/LocalDateTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,14 +44,15 @@ public class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
     assertEquals(LOCAL_DATE_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -59,14 +60,15 @@ public class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(LOCAL_DATE_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -74,13 +76,14 @@ public class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(LOCAL_DATE_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/LocalDateTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/LocalDateTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,14 +44,15 @@ public class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(DATE);
     assertEquals(LOCAL_DATE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -59,14 +60,15 @@ public class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(DATE);
     assertEquals(LOCAL_DATE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -74,13 +76,14 @@ public class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(DATE);
     assertEquals(LOCAL_DATE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/LocalTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/LocalTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,14 +45,15 @@ public class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(TIME);
     assertEquals(LOCAL_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -60,14 +61,15 @@ public class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(TIME);
     assertEquals(LOCAL_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -75,13 +77,14 @@ public class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(TIME);
     assertEquals(LOCAL_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/OffsetDateTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/OffsetDateTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,14 +44,15 @@ public class OffsetDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
     assertEquals(OFFSET_DATE_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -59,14 +60,15 @@ public class OffsetDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(OFFSET_DATE_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -74,13 +76,14 @@ public class OffsetDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(OFFSET_DATE_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/OffsetTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/OffsetTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,14 +45,15 @@ public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(TIME);
     assertEquals(OFFSET_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -60,14 +61,15 @@ public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(TIME);
     assertEquals(OFFSET_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -75,13 +77,14 @@ public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(TIME);
     assertEquals(OFFSET_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/YearMonthTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/YearMonthTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,13 +45,14 @@ public class YearMonthTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getString("column")).thenReturn(INSTANT.toString());
     assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -59,13 +60,14 @@ public class YearMonthTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getString(1)).thenReturn(INSTANT.toString());
     assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -73,13 +75,14 @@ public class YearMonthTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getString(1)).thenReturn(INSTANT.toString());
     assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/ZonedDateTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/ZonedDateTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,14 +44,15 @@ public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
     assertEquals(ZONED_DATE_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -59,14 +60,15 @@ public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(ZONED_DATE_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -74,14 +76,15 @@ public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(ZONED_DATE_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }


### PR DESCRIPTION
I've fixed #1242 by another approach(adding an extension point on `BaseTypeHandler` and adding extension class). 

@harawata @mnesarco Which is better?

