### PR TITLE
Move wasNull to subclass from BaseTypeHandler #1242

### DIFF
--- a/src/main/java/org/apache/ibatis/type/BaseTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BaseTypeHandler.java
@@ -24,8 +24,16 @@ import org.apache.ibatis.executor.result.ResultMapException;
 import org.apache.ibatis.session.Configuration;
 
 /**
+ * The base {@link TypeHandler} for references a generic type.
+ * <p>
+ * Important: Since 3.5.0, This class never call the {@link ResultSet#wasNull()} and
+ * {@link CallableStatement#wasNull()} method for handling the SQL {@code NULL} value.
+ * In other words, {@code null} value handling should be performed on subclass.
+ * </p>
+ * 
  * @author Clinton Begin
  * @author Simone Tripodi
+ * @author Kzuki Shimizu
  */
 public abstract class BaseTypeHandler<T> extends TypeReference<T> implements TypeHandler<T> {
 
@@ -69,46 +77,28 @@ public abstract class BaseTypeHandler<T> extends TypeReference<T> implements Typ
 
   @Override
   public T getResult(ResultSet rs, String columnName) throws SQLException {
-    T result;
     try {
-      result = getNullableResult(rs, columnName);
+      return getNullableResult(rs, columnName);
     } catch (Exception e) {
       throw new ResultMapException("Error attempting to get column '" + columnName + "' from result set.  Cause: " + e, e);
-    }
-    if (rs.wasNull()) {
-      return null;
-    } else {
-      return result;
     }
   }
 
   @Override
   public T getResult(ResultSet rs, int columnIndex) throws SQLException {
-    T result;
     try {
-      result = getNullableResult(rs, columnIndex);
+      return getNullableResult(rs, columnIndex);
     } catch (Exception e) {
       throw new ResultMapException("Error attempting to get column #" + columnIndex+ " from result set.  Cause: " + e, e);
-    }
-    if (rs.wasNull()) {
-      return null;
-    } else {
-      return result;
     }
   }
 
   @Override
   public T getResult(CallableStatement cs, int columnIndex) throws SQLException {
-    T result;
     try {
-      result = getNullableResult(cs, columnIndex);
+      return getNullableResult(cs, columnIndex);
     } catch (Exception e) {
       throw new ResultMapException("Error attempting to get column #" + columnIndex+ " from callable statement.  Cause: " + e, e);
-    }
-    if (cs.wasNull()) {
-      return null;
-    } else {
-      return result;
     }
   }
 

--- a/src/main/java/org/apache/ibatis/type/BooleanTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BooleanTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,18 +34,21 @@ public class BooleanTypeHandler extends BaseTypeHandler<Boolean> {
   @Override
   public Boolean getNullableResult(ResultSet rs, String columnName)
       throws SQLException {
-    return rs.getBoolean(columnName);
+    boolean result = rs.getBoolean(columnName);
+    return (!result && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Boolean getNullableResult(ResultSet rs, int columnIndex)
       throws SQLException {
-    return rs.getBoolean(columnIndex);
+    boolean result = rs.getBoolean(columnIndex);
+    return (!result && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Boolean getNullableResult(CallableStatement cs, int columnIndex)
       throws SQLException {
-    return cs.getBoolean(columnIndex);
+    boolean result = cs.getBoolean(columnIndex);
+    return (!result && cs.wasNull()) ? null : result;
   }
 }

--- a/src/main/java/org/apache/ibatis/type/ByteTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ByteTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,18 +34,21 @@ public class ByteTypeHandler extends BaseTypeHandler<Byte> {
   @Override
   public Byte getNullableResult(ResultSet rs, String columnName)
       throws SQLException {
-    return rs.getByte(columnName);
+    byte result = rs.getByte(columnName);
+    return (result == 0 && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Byte getNullableResult(ResultSet rs, int columnIndex)
       throws SQLException {
-    return rs.getByte(columnIndex);
+    byte result = rs.getByte(columnIndex);
+    return (result == 0 && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Byte getNullableResult(CallableStatement cs, int columnIndex)
       throws SQLException {
-    return cs.getByte(columnIndex);
+    byte result = cs.getByte(columnIndex);
+    return (result == 0 && cs.wasNull()) ? null : result;
   }
 }

--- a/src/main/java/org/apache/ibatis/type/ClobTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ClobTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,36 +37,26 @@ public class ClobTypeHandler extends BaseTypeHandler<String> {
   @Override
   public String getNullableResult(ResultSet rs, String columnName)
       throws SQLException {
-    String value = "";
     Clob clob = rs.getClob(columnName);
-    if (clob != null) {
-      int size = (int) clob.length();
-      value = clob.getSubString(1, size);
-    }
-    return value;
+    return toString(clob);
   }
 
   @Override
   public String getNullableResult(ResultSet rs, int columnIndex)
       throws SQLException {
-    String value = "";
     Clob clob = rs.getClob(columnIndex);
-    if (clob != null) {
-      int size = (int) clob.length();
-      value = clob.getSubString(1, size);
-    }
-    return value;
+    return toString(clob);
   }
 
   @Override
   public String getNullableResult(CallableStatement cs, int columnIndex)
       throws SQLException {
-    String value = "";
     Clob clob = cs.getClob(columnIndex);
-    if (clob != null) {
-      int size = (int) clob.length();
-      value = clob.getSubString(1, size);
-    }
-    return value;
+    return toString(clob);
   }
+
+  private String toString(Clob clob) throws SQLException {
+    return clob == null ? null : clob.getSubString(1, (int) clob.length());
+  }
+
 }

--- a/src/main/java/org/apache/ibatis/type/DoubleTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/DoubleTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,19 +34,22 @@ public class DoubleTypeHandler extends BaseTypeHandler<Double> {
   @Override
   public Double getNullableResult(ResultSet rs, String columnName)
       throws SQLException {
-    return rs.getDouble(columnName);
+    double result = rs.getDouble(columnName);
+    return (result == 0 && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Double getNullableResult(ResultSet rs, int columnIndex)
       throws SQLException {
-    return rs.getDouble(columnIndex);
+    double result = rs.getDouble(columnIndex);
+    return (result == 0 && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Double getNullableResult(CallableStatement cs, int columnIndex)
       throws SQLException {
-    return cs.getDouble(columnIndex);
+    double result = cs.getDouble(columnIndex);
+    return (result == 0 && cs.wasNull()) ? null : result;
   }
 
 }

--- a/src/main/java/org/apache/ibatis/type/EnumOrdinalTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/EnumOrdinalTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class EnumOrdinalTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E
   @Override
   public E getNullableResult(ResultSet rs, String columnName) throws SQLException {
     int i = rs.getInt(columnName);
-    if (rs.wasNull()) {
+    if (i == 0 && rs.wasNull()) {
       return null;
     } else {
       try {
@@ -61,7 +61,7 @@ public class EnumOrdinalTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E
   @Override
   public E getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
     int i = rs.getInt(columnIndex);
-    if (rs.wasNull()) {
+    if (i == 0 && rs.wasNull()) {
       return null;
     } else {
       try {
@@ -75,7 +75,7 @@ public class EnumOrdinalTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E
   @Override
   public E getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
     int i = cs.getInt(columnIndex);
-    if (cs.wasNull()) {
+    if (i == 0 && cs.wasNull()) {
       return null;
     } else {
       try {

--- a/src/main/java/org/apache/ibatis/type/FloatTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/FloatTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,18 +34,21 @@ public class FloatTypeHandler extends BaseTypeHandler<Float> {
   @Override
   public Float getNullableResult(ResultSet rs, String columnName)
       throws SQLException {
-    return rs.getFloat(columnName);
+    float result = rs.getFloat(columnName);
+    return (result == 0 && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Float getNullableResult(ResultSet rs, int columnIndex)
       throws SQLException {
-    return rs.getFloat(columnIndex);
+    float result = rs.getFloat(columnIndex);
+    return (result == 0 && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Float getNullableResult(CallableStatement cs, int columnIndex)
       throws SQLException {
-    return cs.getFloat(columnIndex);
+    float result = cs.getFloat(columnIndex);
+    return (result == 0 && cs.wasNull()) ? null : result;
   }
 }

--- a/src/main/java/org/apache/ibatis/type/IntegerTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/IntegerTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,18 +34,21 @@ public class IntegerTypeHandler extends BaseTypeHandler<Integer> {
   @Override
   public Integer getNullableResult(ResultSet rs, String columnName)
       throws SQLException {
-    return rs.getInt(columnName);
+    int result = rs.getInt(columnName);
+    return (result == 0 && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Integer getNullableResult(ResultSet rs, int columnIndex)
       throws SQLException {
-    return rs.getInt(columnIndex);
+    int result = rs.getInt(columnIndex);
+    return (result == 0 && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Integer getNullableResult(CallableStatement cs, int columnIndex)
       throws SQLException {
-    return cs.getInt(columnIndex);
+    int result = cs.getInt(columnIndex);
+    return (result == 0 && cs.wasNull()) ? null : result;
   }
 }

--- a/src/main/java/org/apache/ibatis/type/LongTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LongTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,18 +34,21 @@ public class LongTypeHandler extends BaseTypeHandler<Long> {
   @Override
   public Long getNullableResult(ResultSet rs, String columnName)
       throws SQLException {
-    return rs.getLong(columnName);
+    long result = rs.getLong(columnName);
+    return (result == 0 && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Long getNullableResult(ResultSet rs, int columnIndex)
       throws SQLException {
-    return rs.getLong(columnIndex);
+    long result = rs.getLong(columnIndex);
+    return (result == 0 && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Long getNullableResult(CallableStatement cs, int columnIndex)
       throws SQLException {
-    return cs.getLong(columnIndex);
+    long result = cs.getLong(columnIndex);
+    return (result == 0 && cs.wasNull()) ? null : result;
   }
 }

--- a/src/main/java/org/apache/ibatis/type/MonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/MonthTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -39,19 +39,19 @@ public class MonthTypeHandler extends BaseTypeHandler<Month> {
     @Override
     public Month getNullableResult(ResultSet rs, String columnName) throws SQLException {
         int month = rs.getInt(columnName);
-        return month == 0 ? null : Month.of(month);
+        return (month == 0 && rs.wasNull()) ? null : Month.of(month);
     }
 
     @Override
     public Month getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
         int month = rs.getInt(columnIndex);
-        return month == 0 ? null : Month.of(month);
+        return (month == 0 && rs.wasNull()) ? null : Month.of(month);
     }
 
     @Override
     public Month getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
         int month = cs.getInt(columnIndex);
-        return month == 0 ? null : Month.of(month);
+        return (month == 0 && cs.wasNull()) ? null : Month.of(month);
     }
     
 }

--- a/src/main/java/org/apache/ibatis/type/NClobTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/NClobTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,36 +37,26 @@ public class NClobTypeHandler extends BaseTypeHandler<String> {
   @Override
   public String getNullableResult(ResultSet rs, String columnName)
       throws SQLException {
-    String value = "";
     Clob clob = rs.getClob(columnName);
-    if (clob != null) {
-      int size = (int) clob.length();
-      value = clob.getSubString(1, size);
-    }
-    return value;
+    return toString(clob);
   }
 
   @Override
   public String getNullableResult(ResultSet rs, int columnIndex)
       throws SQLException {
-    String value = "";
     Clob clob = rs.getClob(columnIndex);
-    if (clob != null) {
-      int size = (int) clob.length();
-      value = clob.getSubString(1, size);
-    }
-    return value;
+    return toString(clob);
   }
 
   @Override
   public String getNullableResult(CallableStatement cs, int columnIndex)
       throws SQLException {
-    String value = "";
     Clob clob = cs.getClob(columnIndex);
-    if (clob != null) {
-      int size = (int) clob.length();
-      value = clob.getSubString(1, size);
-    }
-    return value;
+    return toString(clob);
   }
+
+  private String toString(Clob clob) throws SQLException {
+    return clob == null ? null : clob.getSubString(1, (int) clob.length());
+  }
+
 }

--- a/src/main/java/org/apache/ibatis/type/ShortTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ShortTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,18 +34,21 @@ public class ShortTypeHandler extends BaseTypeHandler<Short> {
   @Override
   public Short getNullableResult(ResultSet rs, String columnName)
       throws SQLException {
-    return rs.getShort(columnName);
+    short result = rs.getShort(columnName);
+    return (result == 0 && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Short getNullableResult(ResultSet rs, int columnIndex)
       throws SQLException {
-    return rs.getShort(columnIndex);
+    short result = rs.getShort(columnIndex);
+    return (result == 0 && rs.wasNull()) ? null : result;
   }
 
   @Override
   public Short getNullableResult(CallableStatement cs, int columnIndex)
       throws SQLException {
-    return cs.getShort(columnIndex);
+    short result = cs.getShort(columnIndex);
+    return (result == 0 && cs.wasNull()) ? null : result;
   }
 }

--- a/src/main/java/org/apache/ibatis/type/YearTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -38,19 +38,19 @@ public class YearTypeHandler extends BaseTypeHandler<Year> {
     @Override
     public Year getNullableResult(ResultSet rs, String columnName) throws SQLException {
         int year = rs.getInt(columnName);
-        return year == 0 ? null : Year.of(year);
+        return (year == 0 && rs.wasNull()) ? null : Year.of(year);
     }
 
     @Override
     public Year getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
         int year = rs.getInt(columnIndex);
-        return year == 0 ? null : Year.of(year);
+        return (year == 0 && rs.wasNull()) ? null : Year.of(year);
     }
 
     @Override
     public Year getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
         int year = cs.getInt(columnIndex);
-        return year == 0 ? null : Year.of(year);
+        return (year == 0 && cs.wasNull()) ? null : Year.of(year);
     }
     
 }

--- a/src/test/java/org/apache/ibatis/type/ArrayTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ArrayTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -43,7 +43,6 @@ public class ArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getArray("column")).thenReturn(mockArray);
-    when(rs.wasNull()).thenReturn(false);
     String[] stringArray = new String[]{"a", "b"};
     when(mockArray.getArray()).thenReturn(stringArray);
     assertEquals(stringArray, TYPE_HANDLER.getResult(rs, "column"));
@@ -53,7 +52,6 @@ public class ArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getArray("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
@@ -61,7 +59,6 @@ public class ArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getArray(1)).thenReturn(mockArray);
-    when(rs.wasNull()).thenReturn(false);
     String[] stringArray = new String[]{"a", "b"};
     when(mockArray.getArray()).thenReturn(stringArray);
     assertEquals(stringArray, TYPE_HANDLER.getResult(rs, 1));
@@ -71,7 +68,6 @@ public class ArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getArray(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
@@ -79,7 +75,6 @@ public class ArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getArray(1)).thenReturn(mockArray);
-    when(cs.wasNull()).thenReturn(false);
     String[] stringArray = new String[]{"a", "b"};
     when(mockArray.getArray()).thenReturn(stringArray);
     assertEquals(stringArray, TYPE_HANDLER.getResult(cs, 1));
@@ -89,7 +84,6 @@ public class ArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getArray(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 

--- a/src/test/java/org/apache/ibatis/type/BigDecimalTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/BigDecimalTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 
 public class BigDecimalTypeHandlerTest extends BaseTypeHandlerTest {
 
@@ -38,8 +41,8 @@ public class BigDecimalTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getBigDecimal("column")).thenReturn(new BigDecimal(1));
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new BigDecimal(1), TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -51,8 +54,8 @@ public class BigDecimalTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getBigDecimal(1)).thenReturn(new BigDecimal(1));
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new BigDecimal(1), TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -64,8 +67,8 @@ public class BigDecimalTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getBigDecimal(1)).thenReturn(new BigDecimal(1));
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(new BigDecimal(1), TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/BigIntegerTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/BigIntegerTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,48 +41,48 @@ public class BigIntegerTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getBigDecimal("column")).thenReturn(new BigDecimal("707070656505050302797979792923232303"));
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new BigInteger("707070656505050302797979792923232303"), TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getBigDecimal("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getBigDecimal(1)).thenReturn(new BigDecimal("707070656505050302797979792923232303"));
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new BigInteger("707070656505050302797979792923232303"), TYPE_HANDLER.getResult(rs,1 ));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getBigDecimal(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs,1 ));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getBigDecimal(1)).thenReturn(new BigDecimal("707070656505050302797979792923232303"));
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(new BigInteger("707070656505050302797979792923232303"), TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getBigDecimal(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/BlobByteObjectArrayTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/BlobByteObjectArrayTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -54,7 +54,6 @@ public class BlobByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     byte[] byteArray = new byte[]{1, 2};
     when(rs.getBlob("column")).thenReturn(blob);
-    when(rs.wasNull()).thenReturn(false);
     when(blob.length()).thenReturn((long)byteArray.length);
     when(blob.getBytes(1, 2)).thenReturn(byteArray);
     assertThat(TYPE_HANDLER.getResult(rs, "column")).isEqualTo(new Byte[]{1, 2});
@@ -65,7 +64,6 @@ public class BlobByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getBlob("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertThat(TYPE_HANDLER.getResult(rs, "column")).isNull();
   }
 
@@ -74,7 +72,6 @@ public class BlobByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     byte[] byteArray = new byte[]{1, 2};
     when(rs.getBlob(1)).thenReturn(blob);
-    when(rs.wasNull()).thenReturn(false);
     when(blob.length()).thenReturn((long)byteArray.length);
     when(blob.getBytes(1, 2)).thenReturn(byteArray);
     assertThat(TYPE_HANDLER.getResult(rs, 1)).isEqualTo(new Byte[]{1, 2});
@@ -84,7 +81,6 @@ public class BlobByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getBlob(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertThat(TYPE_HANDLER.getResult(rs, 1)).isNull();
   }
 
@@ -93,7 +89,6 @@ public class BlobByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     byte[] byteArray = new byte[]{1, 2};
     when(cs.getBlob(1)).thenReturn(blob);
-    when(cs.wasNull()).thenReturn(false);
     when(blob.length()).thenReturn((long)byteArray.length);
     when(blob.getBytes(1, 2)).thenReturn(byteArray);
     assertThat(TYPE_HANDLER.getResult(cs, 1)).isEqualTo(new Byte[]{1, 2});
@@ -103,7 +98,6 @@ public class BlobByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getBlob(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertThat(TYPE_HANDLER.getResult(cs, 1)).isNull();
   }
 

--- a/src/test/java/org/apache/ibatis/type/BlobInputStreamTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/BlobInputStreamTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -76,7 +76,6 @@ public class BlobInputStreamTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     InputStream in = new ByteArrayInputStream("Hello".getBytes());
     when(rs.getBlob("column")).thenReturn(blob);
-    when(rs.wasNull()).thenReturn(false);
     when(blob.getBinaryStream()).thenReturn(in);
     assertThat(TYPE_HANDLER.getResult(rs, "column")).isEqualTo(in);
 
@@ -86,7 +85,6 @@ public class BlobInputStreamTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getBlob("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertThat(TYPE_HANDLER.getResult(rs, "column")).isNull();
   }
 
@@ -95,7 +93,6 @@ public class BlobInputStreamTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     InputStream in = new ByteArrayInputStream("Hello".getBytes());
     when(rs.getBlob(1)).thenReturn(blob);
-    when(rs.wasNull()).thenReturn(false);
     when(blob.getBinaryStream()).thenReturn(in);
     assertThat(TYPE_HANDLER.getResult(rs, 1)).isEqualTo(in);
   }
@@ -104,7 +101,6 @@ public class BlobInputStreamTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getBlob(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertThat(TYPE_HANDLER.getResult(rs, 1)).isNull();
   }
 
@@ -113,7 +109,6 @@ public class BlobInputStreamTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     InputStream in = new ByteArrayInputStream("Hello".getBytes());
     when(cs.getBlob(1)).thenReturn(blob);
-    when(cs.wasNull()).thenReturn(false);
     when(blob.getBinaryStream()).thenReturn(in);
     assertThat(TYPE_HANDLER.getResult(cs, 1)).isEqualTo(in);
   }
@@ -122,7 +117,6 @@ public class BlobInputStreamTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getBlob(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertThat(TYPE_HANDLER.getResult(cs, 1)).isNull();
   }
 

--- a/src/test/java/org/apache/ibatis/type/BlobTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/BlobTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ public class BlobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getBlob("column")).thenReturn(blob);
-    when(rs.wasNull()).thenReturn(false);
     when(blob.length()).thenReturn(3l);
     when(blob.getBytes(1, 3)).thenReturn(new byte[] { 1, 2, 3 });
     assertArrayEquals(new byte[] { 1, 2, 3 }, TYPE_HANDLER.getResult(rs, "column"));
@@ -55,7 +54,6 @@ public class BlobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getBlob("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
@@ -63,7 +61,6 @@ public class BlobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getBlob(1)).thenReturn(blob);
-    when(rs.wasNull()).thenReturn(false);
     when(blob.length()).thenReturn(3l);
     when(blob.getBytes(1, 3)).thenReturn(new byte[] { 1, 2, 3 });
     assertArrayEquals(new byte[] { 1, 2, 3 }, TYPE_HANDLER.getResult(rs, 1));
@@ -73,7 +70,6 @@ public class BlobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getBlob(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
@@ -81,7 +77,6 @@ public class BlobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getBlob(1)).thenReturn(blob);
-    when(cs.wasNull()).thenReturn(false);
     when(blob.length()).thenReturn(3l);
     when(blob.getBytes(1, 3)).thenReturn(new byte[] { 1, 2, 3 });
     assertArrayEquals(new byte[] { 1, 2, 3 }, TYPE_HANDLER.getResult(cs, 1));
@@ -91,7 +86,6 @@ public class BlobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getBlob(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 

--- a/src/test/java/org/apache/ibatis/type/BooleanTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/BooleanTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,39 +37,53 @@ public class BooleanTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getBoolean("column")).thenReturn(true);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(true, TYPE_HANDLER.getResult(rs, "column"));
+
+    when(rs.getBoolean("column")).thenReturn(false);
+    assertEquals(false, TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    // Unnecessary
+    when(rs.getBoolean("column")).thenReturn(false);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getBoolean(1)).thenReturn(true);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(true, TYPE_HANDLER.getResult(rs, 1));
+
+    when(rs.getBoolean(1)).thenReturn(false);
+    assertEquals(false, TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    // Unnecessary
+    when(rs.getBoolean(1)).thenReturn(false);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getBoolean(1)).thenReturn(true);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(true, TYPE_HANDLER.getResult(cs, 1));
+
+    when(cs.getBoolean(1)).thenReturn(false);
+    assertEquals(false, TYPE_HANDLER.getResult(cs, 1));
   }
 
   @Override
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    // Unnecessary
+    when(cs.getBoolean(1)).thenReturn(false);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/ByteArrayTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ByteArrayTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,8 +37,8 @@ public class ByteArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getBytes("column")).thenReturn(new byte[] { 1, 2, 3 });
-    when(rs.wasNull()).thenReturn(false);
     assertArrayEquals(new byte[] { 1, 2, 3 }, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -49,8 +50,8 @@ public class ByteArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getBytes(1)).thenReturn(new byte[] { 1, 2, 3 });
-    when(rs.wasNull()).thenReturn(false);
     assertArrayEquals(new byte[] { 1, 2, 3 }, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -62,8 +63,8 @@ public class ByteArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getBytes(1)).thenReturn(new byte[] { 1, 2, 3 });
-    when(cs.wasNull()).thenReturn(false);
     assertArrayEquals(new byte[] { 1, 2, 3 }, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/ByteObjectArrayTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ByteObjectArrayTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.ibatis.type;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -37,16 +38,16 @@ public class ByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     byte[] byteArray = new byte[]{1, 2};
     when(rs.getBytes("column")).thenReturn(byteArray);
-    when(rs.wasNull()).thenReturn(false);
     assertThat(TYPE_HANDLER.getResult(rs, "column")).isEqualTo(new Byte[]{1, 2});
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getBytes("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertThat(TYPE_HANDLER.getResult(rs, "column")).isNull();
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -54,16 +55,16 @@ public class ByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     byte[] byteArray = new byte[]{1, 2};
     when(rs.getBytes(1)).thenReturn(byteArray);
-    when(rs.wasNull()).thenReturn(false);
     assertThat(TYPE_HANDLER.getResult(rs, 1)).isEqualTo(new Byte[]{1, 2});
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getBytes(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertThat(TYPE_HANDLER.getResult(rs, 1)).isNull();
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -71,16 +72,16 @@ public class ByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     byte[] byteArray = new byte[]{1, 2};
     when(cs.getBytes(1)).thenReturn(byteArray);
-    when(cs.wasNull()).thenReturn(false);
     assertThat(TYPE_HANDLER.getResult(cs, 1)).isEqualTo(new Byte[]{1, 2});
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getBytes(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertThat(TYPE_HANDLER.getResult(cs, 1)).isNull();
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/ByteTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ByteTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,39 +37,54 @@ public class ByteTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getByte("column")).thenReturn((byte) 100);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Byte((byte) 100), TYPE_HANDLER.getResult(rs, "column"));
+
+    when(rs.getByte("column")).thenReturn((byte) 0);
+    assertEquals(new Byte((byte) 0), TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    // Unnecessary
+    when(rs.getByte("column")).thenReturn((byte) 0);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getByte(1)).thenReturn((byte) 100);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Byte((byte) 100), TYPE_HANDLER.getResult(rs, 1));
+
+    when(rs.getByte(1)).thenReturn((byte) 0);
+    assertEquals(new Byte((byte) 0), TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    // Unnecessary
+    when(rs.getByte(1)).thenReturn((byte) 0);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getByte(1)).thenReturn((byte) 100);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(new Byte((byte) 100), TYPE_HANDLER.getResult(cs, 1));
+
+    when(cs.getByte(1)).thenReturn((byte) 0);
+    assertEquals(new Byte((byte) 0), TYPE_HANDLER.getResult(cs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    // Unnecessary
- }
+    when(cs.getByte(1)).thenReturn((byte) 0);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
 
 }

--- a/src/test/java/org/apache/ibatis/type/CharacterTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/CharacterTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -43,48 +44,48 @@ public class CharacterTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getString("column")).thenReturn("a");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Character('a'), TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getString("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getString(1)).thenReturn("a");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Character('a'), TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getString(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getString(1)).thenReturn("a");
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(new Character('a'), TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getString(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/ClobReaderTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ClobReaderTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -78,7 +78,6 @@ public class ClobReaderTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     Reader reader = new StringReader("Hello");
     when(rs.getClob("column")).thenReturn(clob);
-    when(rs.wasNull()).thenReturn(false);
     when(clob.getCharacterStream()).thenReturn(reader);
     assertEquals(reader, TYPE_HANDLER.getResult(rs, "column"));
   }
@@ -87,7 +86,6 @@ public class ClobReaderTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getClob("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
@@ -95,7 +93,6 @@ public class ClobReaderTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getClob(1)).thenReturn(clob);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
@@ -103,7 +100,6 @@ public class ClobReaderTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getClob(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
@@ -112,7 +108,6 @@ public class ClobReaderTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     Reader reader = new StringReader("Hello");
     when(cs.getClob(1)).thenReturn(clob);
-    when(cs.wasNull()).thenReturn(false);
     when(clob.getCharacterStream()).thenReturn(reader);
     assertEquals(reader, TYPE_HANDLER.getResult(cs, 1));
   }
@@ -121,7 +116,6 @@ public class ClobReaderTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getClob(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 

--- a/src/test/java/org/apache/ibatis/type/ClobTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ClobTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ public class ClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getClob("column")).thenReturn(clob);
-    when(rs.wasNull()).thenReturn(false);
     when(clob.length()).thenReturn(3l);
     when(clob.getSubString(1, 3)).thenReturn("Hello");
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, "column"));
@@ -55,7 +54,6 @@ public class ClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getClob("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
@@ -63,7 +61,6 @@ public class ClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getClob(1)).thenReturn(clob);
-    when(rs.wasNull()).thenReturn(false);
     when(clob.length()).thenReturn(3l);
     when(clob.getSubString(1, 3)).thenReturn("Hello");
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, 1));
@@ -73,7 +70,6 @@ public class ClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getClob(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
@@ -81,7 +77,6 @@ public class ClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getClob(1)).thenReturn(clob);
-    when(cs.wasNull()).thenReturn(false);
     when(clob.length()).thenReturn(3l);
     when(clob.getSubString(1, 3)).thenReturn("Hello");
     assertEquals("Hello", TYPE_HANDLER.getResult(cs, 1));
@@ -91,7 +86,6 @@ public class ClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getClob(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 

--- a/src/test/java/org/apache/ibatis/type/DateOnlyTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/DateOnlyTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,48 +42,48 @@ public class DateOnlyTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(SQL_DATE);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(SQL_DATE);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(SQL_DATE);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/DateTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/DateTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,48 +43,48 @@ public class DateTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/DoubleTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/DoubleTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,39 +37,54 @@ public class DoubleTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getDouble("column")).thenReturn(100d);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Double(100d), TYPE_HANDLER.getResult(rs, "column"));
+
+    when(rs.getDouble("column")).thenReturn(0d);
+    assertEquals(new Double(0d), TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    // Unnecessary
+    when(rs.getDouble("column")).thenReturn(0d);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getDouble(1)).thenReturn(100d);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Double(100d), TYPE_HANDLER.getResult(rs, 1));
+
+    when(rs.getDouble(1)).thenReturn(0d);
+    assertEquals(new Double(0d), TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    // Unnecessary
+    when(rs.getDouble(1)).thenReturn(0d);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getDouble(1)).thenReturn(100d);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(new Double(100d), TYPE_HANDLER.getResult(cs, 1));
+
+    when(cs.getDouble(1)).thenReturn(0d);
+    assertEquals(new Double(0d), TYPE_HANDLER.getResult(cs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    // Unnecessary
+    when(cs.getDouble(1)).thenReturn(0d);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/EnumTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/EnumTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -47,48 +48,48 @@ public class EnumTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getString("column")).thenReturn("ONE");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(MyEnum.ONE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getString("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getString(1)).thenReturn("ONE");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(MyEnum.ONE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getString(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getString(1)).thenReturn("ONE");
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(MyEnum.ONE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getString(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/FloatTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/FloatTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,39 +37,54 @@ public class FloatTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getFloat("column")).thenReturn(100f);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Float(100f), TYPE_HANDLER.getResult(rs, "column"));
+
+    when(rs.getFloat("column")).thenReturn(0f);
+    assertEquals(new Float(0f), TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    // Unnecessary
+    when(rs.getFloat("column")).thenReturn(0f);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getFloat(1)).thenReturn(100f);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Float(100f), TYPE_HANDLER.getResult(rs, 1));
+
+    when(rs.getFloat(1)).thenReturn(0f);
+    assertEquals(new Float(0f), TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    // Unnecessary
+    when(rs.getFloat(1)).thenReturn(0f);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getFloat(1)).thenReturn(100f);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(new Float(100f), TYPE_HANDLER.getResult(cs, 1));
+
+    when(cs.getFloat(1)).thenReturn(0f);
+    assertEquals(new Float(0f), TYPE_HANDLER.getResult(cs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    // Unnecessary
+    when(cs.getFloat(1)).thenReturn(0f);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/IntegerTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/IntegerTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,39 +37,54 @@ public class IntegerTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getInt("column")).thenReturn(100);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Integer(100), TYPE_HANDLER.getResult(rs, "column"));
+
+    when(rs.getInt("column")).thenReturn(0);
+    assertEquals(new Integer(0), TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    // Unnecessary
+    when(rs.getInt("column")).thenReturn(0);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getInt(1)).thenReturn(100);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Integer(100), TYPE_HANDLER.getResult(rs, 1));
+
+    when(rs.getInt(1)).thenReturn(0);
+    assertEquals(new Integer(0), TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    // Unnecessary
+    when(rs.getInt(1)).thenReturn(0);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getInt(1)).thenReturn(100);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(new Integer(100), TYPE_HANDLER.getResult(cs, 1));
+
+    when(cs.getInt(1)).thenReturn(0);
+    assertEquals(new Integer(0), TYPE_HANDLER.getResult(cs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    // Unnecessary
+    when(cs.getInt(1)).thenReturn(0);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/LongTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/LongTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,39 +37,54 @@ public class LongTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getLong("column")).thenReturn(100L);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Long(100L), TYPE_HANDLER.getResult(rs, "column"));
+
+    when(rs.getLong("column")).thenReturn(0L);
+    assertEquals(new Long(0L), TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    // Unnecessary
+    when(rs.getLong("column")).thenReturn(0L);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getLong(1)).thenReturn(100L);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Long(100L), TYPE_HANDLER.getResult(rs, 1));
+
+    when(rs.getLong(1)).thenReturn(0L);
+    assertEquals(new Long(0L), TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    // Unnecessary
+    when(rs.getLong(1)).thenReturn(0L);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getLong(1)).thenReturn(100L);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(new Long(100L), TYPE_HANDLER.getResult(cs, 1));
+
+    when(cs.getLong(1)).thenReturn(0L);
+    assertEquals(new Long(0L), TYPE_HANDLER.getResult(cs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    // Unnecessary
+    when(cs.getLong(1)).thenReturn(0L);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/NClobTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/NClobTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ public class NClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getClob("column")).thenReturn(clob);
-    when(rs.wasNull()).thenReturn(false);
     when(clob.length()).thenReturn(3l);
     when(clob.getSubString(1, 3)).thenReturn("Hello");
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, "column"));
@@ -55,7 +54,6 @@ public class NClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getClob("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
@@ -63,7 +61,6 @@ public class NClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getClob(1)).thenReturn(clob);
-    when(rs.wasNull()).thenReturn(false);
     when(clob.length()).thenReturn(3l);
     when(clob.getSubString(1, 3)).thenReturn("Hello");
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, 1));
@@ -73,7 +70,6 @@ public class NClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getClob(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
@@ -81,7 +77,6 @@ public class NClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getClob(1)).thenReturn(clob);
-    when(cs.wasNull()).thenReturn(false);
     when(clob.length()).thenReturn(3l);
     when(clob.getSubString(1, 3)).thenReturn("Hello");
     assertEquals("Hello", TYPE_HANDLER.getResult(cs, 1));
@@ -91,7 +86,6 @@ public class NClobTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getClob(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 

--- a/src/test/java/org/apache/ibatis/type/NStringTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/NStringTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.ibatis.type;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,8 +37,8 @@ public class NStringTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getNString("column")).thenReturn("Hello");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -49,8 +50,8 @@ public class NStringTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getNString(1)).thenReturn("Hello");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -62,8 +63,8 @@ public class NStringTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getNString(1)).thenReturn("Hello");
-    when(cs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(cs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/ObjectTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ObjectTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,10 +16,14 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.Test;
+
+import java.sql.Clob;
 
 public class ObjectTypeHandlerTest extends BaseTypeHandlerTest {
 
@@ -36,39 +40,42 @@ public class ObjectTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getObject("column")).thenReturn("Hello");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    // Unnecessary
+    when(rs.getObject("column")).thenReturn(null);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getObject(1)).thenReturn("Hello");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    // Unnecessary
+    when(rs.getObject(1)).thenReturn(null);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getObject(1)).thenReturn("Hello");
-    when(cs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(cs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    // Unnecessary
+    when(cs.getObject(1)).thenReturn(null);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/ShortTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ShortTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,39 +37,54 @@ public class ShortTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getShort("column")).thenReturn((short) 100);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Short((short) 100), TYPE_HANDLER.getResult(rs, "column"));
+
+    when(rs.getShort("column")).thenReturn((short) 0);
+    assertEquals(new Short((short) 0), TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    // Unnecessary
+    when(rs.getShort("column")).thenReturn((short) 0);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getShort(1)).thenReturn((short) 100);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(new Short((short) 100), TYPE_HANDLER.getResult(rs, 1));
+
+    when(rs.getShort(1)).thenReturn((short) 0);
+    assertEquals(new Short((short) 0), TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    // Unnecessary
+    when(rs.getShort(1)).thenReturn((short) 0);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getShort(1)).thenReturn((short) 100);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(new Short((short) 100), TYPE_HANDLER.getResult(cs, 1));
+
+    when(cs.getShort(1)).thenReturn((short) 0);
+    assertEquals(new Short((short) 0), TYPE_HANDLER.getResult(cs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    // Unnecessary
+    when(cs.getShort(1)).thenReturn((short) 0);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/SqlDateTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/SqlDateTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -39,8 +40,8 @@ public class SqlDateTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(SQL_DATE);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(SQL_DATE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -52,8 +53,8 @@ public class SqlDateTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(SQL_DATE);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(SQL_DATE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -65,8 +66,8 @@ public class SqlDateTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(SQL_DATE);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(SQL_DATE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/SqlTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/SqlTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -39,8 +40,8 @@ public class SqlTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(SQL_TIME);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(SQL_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -52,8 +53,8 @@ public class SqlTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(SQL_TIME);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(SQL_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -65,8 +66,8 @@ public class SqlTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(SQL_TIME);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(SQL_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/SqlTimetampTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/SqlTimetampTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,8 +41,8 @@ public class SqlTimetampTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(SQL_TIME);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(SQL_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -53,8 +54,8 @@ public class SqlTimetampTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(SQL_TIME);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(SQL_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -66,8 +67,8 @@ public class SqlTimetampTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(SQL_TIME);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(SQL_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/StringTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/StringTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,8 +37,8 @@ public class StringTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getString("column")).thenReturn("Hello");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -49,8 +50,8 @@ public class StringTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getString(1)).thenReturn("Hello");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -62,8 +63,8 @@ public class StringTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getString(1)).thenReturn("Hello");
-    when(cs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/TimeOnlyTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/TimeOnlyTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.type;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -41,48 +42,48 @@ public class TimeOnlyTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(SQL_TIME);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(SQL_TIME);
-    when(rs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(SQL_TIME);
-    when(cs.wasNull()).thenReturn(false);
     assertEquals(DATE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/UnknownTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/UnknownTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,13 +15,12 @@
  */
 package org.apache.ibatis.type;
 
+import java.sql.Clob;
 import java.sql.SQLException;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.spy;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.*;
 
 import org.apache.ibatis.executor.result.ResultMapException;
 import org.junit.Assert;
@@ -47,7 +46,6 @@ public class UnknownTypeHandlerTest extends BaseTypeHandlerTest {
     when(rsmd.getColumnClassName(1)).thenReturn(String.class.getName());
     when(rsmd.getColumnType(1)).thenReturn(JdbcType.VARCHAR.TYPE_CODE);
     when(rs.getString("column")).thenReturn("Hello");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, "column"));
   }
 
@@ -63,7 +61,6 @@ public class UnknownTypeHandlerTest extends BaseTypeHandlerTest {
     when(rsmd.getColumnClassName(1)).thenReturn(String.class.getName());
     when(rsmd.getColumnType(1)).thenReturn(JdbcType.VARCHAR.TYPE_CODE);
     when(rs.getString(1)).thenReturn("Hello");
-    when(rs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(rs, 1));
   }
 
@@ -76,13 +73,14 @@ public class UnknownTypeHandlerTest extends BaseTypeHandlerTest {
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getObject(1)).thenReturn("Hello");
-    when(cs.wasNull()).thenReturn(false);
     assertEquals("Hello", TYPE_HANDLER.getResult(cs, 1));
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    // Unnecessary
+    when(cs.getObject(1)).thenReturn(null);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/type/usesjava8/InstantTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/InstantTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,14 +44,15 @@ public class InstantTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
     assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -59,14 +60,15 @@ public class InstantTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -74,13 +76,14 @@ public class InstantTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/JapaneseDateTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/JapaneseDateTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,14 +45,15 @@ public class JapaneseDateTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(DATE);
     assertEquals(JAPANESE_DATE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -60,14 +61,15 @@ public class JapaneseDateTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(DATE);
     assertEquals(JAPANESE_DATE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -75,14 +77,15 @@ public class JapaneseDateTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(DATE);
     assertEquals(JAPANESE_DATE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/LocalDateTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/LocalDateTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,14 +44,15 @@ public class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
     assertEquals(LOCAL_DATE_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -59,14 +60,15 @@ public class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(LOCAL_DATE_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -74,13 +76,14 @@ public class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(LOCAL_DATE_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/LocalDateTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/LocalDateTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,14 +44,15 @@ public class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(DATE);
     assertEquals(LOCAL_DATE, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getDate("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -59,14 +60,15 @@ public class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(DATE);
     assertEquals(LOCAL_DATE, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getDate(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -74,13 +76,14 @@ public class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(DATE);
     assertEquals(LOCAL_DATE, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getDate(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/LocalTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/LocalTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,14 +45,15 @@ public class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(TIME);
     assertEquals(LOCAL_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -60,14 +61,15 @@ public class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(TIME);
     assertEquals(LOCAL_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -75,13 +77,14 @@ public class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(TIME);
     assertEquals(LOCAL_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/MonthTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/MonthTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.*;
 
 import java.time.Month;
 
+import org.apache.ibatis.executor.result.ResultMapException;
 import org.apache.ibatis.type.BaseTypeHandlerTest;
 import org.apache.ibatis.type.MonthTypeHandler;
 import org.apache.ibatis.type.TypeHandler;
@@ -46,6 +47,14 @@ public class MonthTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getInt("column")).thenReturn(INSTANT.getValue());
     assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+
+    when(rs.getInt("column")).thenReturn(0);
+    try {
+      TYPE_HANDLER.getResult(rs, "column");
+      fail();
+    } catch (ResultMapException e) {
+      assertEquals("Error attempting to get column 'column' from result set.  Cause: java.time.DateTimeException: Invalid value for MonthOfYear: 0", e.getMessage());
+    }
   }
 
   @Override
@@ -61,6 +70,14 @@ public class MonthTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getInt(1)).thenReturn(INSTANT.getValue());
     assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+
+    when(rs.getInt(1)).thenReturn(0);
+    try {
+      TYPE_HANDLER.getResult(rs, 1);
+      fail();
+    } catch (ResultMapException e) {
+      assertEquals("Error attempting to get column #1 from result set.  Cause: java.time.DateTimeException: Invalid value for MonthOfYear: 0", e.getMessage());
+    }
   }
 
   @Override
@@ -76,6 +93,14 @@ public class MonthTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getInt(1)).thenReturn(INSTANT.getValue());
     assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+
+    when(cs.getInt(1)).thenReturn(0);
+    try {
+      TYPE_HANDLER.getResult(cs, 1);
+      fail();
+    } catch (ResultMapException e) {
+      assertEquals("Error attempting to get column #1 from callable statement.  Cause: java.time.DateTimeException: Invalid value for MonthOfYear: 0", e.getMessage());
+    }
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/usesjava8/OffsetDateTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/OffsetDateTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,14 +44,15 @@ public class OffsetDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
     assertEquals(OFFSET_DATE_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -59,14 +60,15 @@ public class OffsetDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(OFFSET_DATE_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -74,13 +76,14 @@ public class OffsetDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(OFFSET_DATE_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/OffsetTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/OffsetTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,14 +45,15 @@ public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(TIME);
     assertEquals(OFFSET_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTime("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -60,14 +61,15 @@ public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(TIME);
     assertEquals(OFFSET_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTime(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -75,13 +77,14 @@ public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(TIME);
     assertEquals(OFFSET_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTime(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/YearMonthTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/YearMonthTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,13 +45,14 @@ public class YearMonthTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getString("column")).thenReturn(INSTANT.toString());
     assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -59,13 +60,14 @@ public class YearMonthTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getString(1)).thenReturn(INSTANT.toString());
     assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -73,13 +75,14 @@ public class YearMonthTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getString(1)).thenReturn(INSTANT.toString());
     assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/usesjava8/YearTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/YearTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -46,6 +46,9 @@ public class YearTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getInt("column")).thenReturn(INSTANT.getValue());
     assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, "column"));
+
+    when(rs.getInt("column")).thenReturn(0);
+    assertEquals(Year.of(0), TYPE_HANDLER.getResult(rs, "column"));
   }
 
   @Override
@@ -61,6 +64,9 @@ public class YearTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getInt(1)).thenReturn(INSTANT.getValue());
     assertEquals(INSTANT, TYPE_HANDLER.getResult(rs, 1));
+
+    when(rs.getInt(1)).thenReturn(0);
+    assertEquals(Year.of(0), TYPE_HANDLER.getResult(rs, 1));
   }
 
   @Override
@@ -76,6 +82,9 @@ public class YearTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getInt(1)).thenReturn(INSTANT.getValue());
     assertEquals(INSTANT, TYPE_HANDLER.getResult(cs, 1));
+
+    when(cs.getInt(1)).thenReturn(0);
+    assertEquals(Year.of(0), TYPE_HANDLER.getResult(cs, 1));
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/usesjava8/ZonedDateTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/usesjava8/ZonedDateTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,14 +44,15 @@ public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
     assertEquals(ZONED_DATE_TIME, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
     when(rs.getTimestamp("column")).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -59,14 +60,15 @@ public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(ZONED_DATE_TIME, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
     when(rs.getTimestamp(1)).thenReturn(null);
-    when(rs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
   }
 
   @Override
@@ -74,14 +76,15 @@ public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   public void shouldGetResultFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
     assertEquals(ZONED_DATE_TIME, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getTimestamp(1)).thenReturn(null);
-    when(cs.wasNull()).thenReturn(true);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
   }
 
 }


### PR DESCRIPTION
I've fixed #1242 based on [the comment](https://github.com/mybatis/mybatis-3/pull/1243#issuecomment-378890465) of #1243 by @harawata .

## About backword compatility

In this change, type handlers provided by the mybatis core project keeps backward compatibility. But If you used the method that returned type is primitive(e.g. `ResultSet#getInt`) in your type handler, there is need a notice that it may be lost backward compatibility.
If you used the method that returned type is primitive, please consider to change as calling `wasNull` in your type handler.
