### PR TITLE
Support default method

### DIFF
--- a/src/main/java/org/apache/ibatis/cache/Cache.java
+++ b/src/main/java/org/apache/ibatis/cache/Cache.java
@@ -93,6 +93,8 @@ public interface Cache {
    *
    * @return A ReadWriteLock
    */
-  ReadWriteLock getReadWriteLock();
+  default ReadWriteLock getReadWriteLock() {
+    return null;
+  }
 
 }

--- a/src/main/java/org/apache/ibatis/cache/decorators/BlockingCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/BlockingCache.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.apache.ibatis.cache.decorators;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.ibatis.cache.Cache;
@@ -84,11 +83,6 @@ public class BlockingCache implements Cache {
   @Override
   public void clear() {
     delegate.clear();
-  }
-
-  @Override
-  public ReadWriteLock getReadWriteLock() {
-    return null;
   }
 
   private ReentrantLock getLockForKey(Object key) {

--- a/src/main/java/org/apache/ibatis/cache/decorators/FifoCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/FifoCache.java
@@ -17,7 +17,6 @@ package org.apache.ibatis.cache.decorators;
 
 import java.util.Deque;
 import java.util.LinkedList;
-import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apache.ibatis.cache.Cache;
 
@@ -72,11 +71,6 @@ public class FifoCache implements Cache {
   public void clear() {
     delegate.clear();
     keyList.clear();
-  }
-
-  @Override
-  public ReadWriteLock getReadWriteLock() {
-    return null;
   }
 
   private void cycleKeyList(Object key) {

--- a/src/main/java/org/apache/ibatis/cache/decorators/LoggingCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/LoggingCache.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  *    limitations under the License.
  */
 package org.apache.ibatis.cache.decorators;
-
-import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.logging.Log;
@@ -72,11 +70,6 @@ public class LoggingCache implements Cache {
   @Override
   public void clear() {
     delegate.clear();
-  }
-
-  @Override
-  public ReadWriteLock getReadWriteLock() {
-    return null;
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/cache/decorators/LruCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/LruCache.java
@@ -17,7 +17,6 @@ package org.apache.ibatis.cache.decorators;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apache.ibatis.cache.Cache;
 
@@ -83,11 +82,6 @@ public class LruCache implements Cache {
   public void clear() {
     delegate.clear();
     keyMap.clear();
-  }
-
-  @Override
-  public ReadWriteLock getReadWriteLock() {
-    return null;
   }
 
   private void cycleKeyList(Object key) {

--- a/src/main/java/org/apache/ibatis/cache/decorators/ScheduledCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/ScheduledCache.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -14,8 +14,6 @@
  *    limitations under the License.
  */
 package org.apache.ibatis.cache.decorators;
-
-import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apache.ibatis.cache.Cache;
 
@@ -70,11 +68,6 @@ public class ScheduledCache implements Cache {
   public void clear() {
     lastClear = System.currentTimeMillis();
     delegate.clear();
-  }
-
-  @Override
-  public ReadWriteLock getReadWriteLock() {
-    return null;
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/cache/decorators/SerializedCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/SerializedCache.java
@@ -23,7 +23,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamClass;
 import java.io.Serializable;
-import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.cache.CacheException;
@@ -73,11 +72,6 @@ public class SerializedCache implements Cache {
   @Override
   public void clear() {
     delegate.clear();
-  }
-
-  @Override
-  public ReadWriteLock getReadWriteLock() {
-    return null;
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/cache/decorators/SoftCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/SoftCache.java
@@ -19,7 +19,6 @@ import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
 import java.util.Deque;
 import java.util.LinkedList;
-import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apache.ibatis.cache.Cache;
 
@@ -99,11 +98,6 @@ public class SoftCache implements Cache {
     }
     removeGarbageCollectedItems();
     delegate.clear();
-  }
-
-  @Override
-  public ReadWriteLock getReadWriteLock() {
-    return null;
   }
 
   private void removeGarbageCollectedItems() {

--- a/src/main/java/org/apache/ibatis/cache/decorators/SynchronizedCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/SynchronizedCache.java
@@ -15,8 +15,6 @@
  */
 package org.apache.ibatis.cache.decorators;
 
-import java.util.concurrent.locks.ReadWriteLock;
-
 import org.apache.ibatis.cache.Cache;
 
 /**
@@ -68,11 +66,6 @@ public class SynchronizedCache implements Cache {
   @Override
   public boolean equals(Object obj) {
     return delegate.equals(obj);
-  }
-
-  @Override
-  public ReadWriteLock getReadWriteLock() {
-    return null;
   }
 
 }

--- a/src/main/java/org/apache/ibatis/cache/decorators/TransactionalCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/TransactionalCache.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.logging.Log;
@@ -75,11 +74,6 @@ public class TransactionalCache implements Cache {
     } else {
       return object;
     }
-  }
-
-  @Override
-  public ReadWriteLock getReadWriteLock() {
-    return null;
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/cache/decorators/WeakCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/WeakCache.java
@@ -19,7 +19,6 @@ import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.Deque;
 import java.util.LinkedList;
-import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apache.ibatis.cache.Cache;
 
@@ -93,11 +92,6 @@ public class WeakCache implements Cache {
     hardLinksToAvoidGarbageCollection.clear();
     removeGarbageCollectedItems();
     delegate.clear();
-  }
-
-  @Override
-  public ReadWriteLock getReadWriteLock() {
-    return null;
   }
 
   private void removeGarbageCollectedItems() {

--- a/src/main/java/org/apache/ibatis/cache/impl/PerpetualCache.java
+++ b/src/main/java/org/apache/ibatis/cache/impl/PerpetualCache.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.apache.ibatis.cache.impl;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.locks.ReadWriteLock;
 
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.cache.CacheException;
@@ -63,11 +62,6 @@ public class PerpetualCache implements Cache {
   @Override
   public void clear() {
     cache.clear();
-  }
-
-  @Override
-  public ReadWriteLock getReadWriteLock() {
-    return null;
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/executor/loader/ProxyFactory.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/ProxyFactory.java
@@ -26,7 +26,9 @@ import org.apache.ibatis.session.Configuration;
  */
 public interface ProxyFactory {
 
-  void setProperties(Properties properties);
+  default void setProperties(Properties properties) {
+    // NOP
+  }
 
   Object createProxy(Object target, ResultLoaderMap lazyLoader, Configuration configuration, ObjectFactory objectFactory, List<Class<?>> constructorArgTypes, List<Object> constructorArgs);
 

--- a/src/main/java/org/apache/ibatis/executor/loader/cglib/CglibProxyFactory.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/cglib/CglibProxyFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.apache.ibatis.executor.loader.cglib;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 import net.sf.cglib.proxy.Callback;
@@ -63,11 +62,6 @@ public class CglibProxyFactory implements ProxyFactory {
 
   public Object createDeserializationProxy(Object target, Map<String, ResultLoaderMap.LoadPair> unloadedProperties, ObjectFactory objectFactory, List<Class<?>> constructorArgTypes, List<Object> constructorArgs) {
     return EnhancedDeserializationProxyImpl.createProxy(target, unloadedProperties, objectFactory, constructorArgTypes, constructorArgs);
-  }
-
-  @Override
-  public void setProperties(Properties properties) {
-      // Not Implemented
   }
 
   static Object crateProxy(Class<?> type, Callback callback, List<Class<?>> constructorArgTypes, List<Object> constructorArgs) {

--- a/src/main/java/org/apache/ibatis/executor/loader/javassist/JavassistProxyFactory.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/javassist/JavassistProxyFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.apache.ibatis.executor.loader.javassist;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 import javassist.util.proxy.MethodHandler;
@@ -62,11 +61,6 @@ public class JavassistProxyFactory implements org.apache.ibatis.executor.loader.
 
   public Object createDeserializationProxy(Object target, Map<String, ResultLoaderMap.LoadPair> unloadedProperties, ObjectFactory objectFactory, List<Class<?>> constructorArgTypes, List<Object> constructorArgs) {
     return EnhancedDeserializationProxyImpl.createProxy(target, unloadedProperties, objectFactory, constructorArgTypes, constructorArgs);
-  }
-
-  @Override
-  public void setProperties(Properties properties) {
-      // Not Implemented
   }
 
   static Object crateProxy(Class<?> type, MethodHandler callback, List<Class<?>> constructorArgTypes, List<Object> constructorArgs) {

--- a/src/main/java/org/apache/ibatis/mapping/DatabaseIdProvider.java
+++ b/src/main/java/org/apache/ibatis/mapping/DatabaseIdProvider.java
@@ -29,7 +29,9 @@ import javax.sql.DataSource;
  */
 public interface DatabaseIdProvider {
 
-  void setProperties(Properties p);
+  default void setProperties(Properties p) {
+    // NOP
+  }
 
   String getDatabaseId(DataSource dataSource) throws SQLException;
 }

--- a/src/main/java/org/apache/ibatis/plugin/Interceptor.java
+++ b/src/main/java/org/apache/ibatis/plugin/Interceptor.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,8 +24,12 @@ public interface Interceptor {
 
   Object intercept(Invocation invocation) throws Throwable;
 
-  Object plugin(Object target);
+  default Object plugin(Object target) {
+    return Plugin.wrap(target, this);
+  }
 
-  void setProperties(Properties properties);
+  default void setProperties(Properties properties) {
+    // NOP
+  }
 
 }

--- a/src/main/java/org/apache/ibatis/reflection/factory/DefaultObjectFactory.java
+++ b/src/main/java/org/apache/ibatis/reflection/factory/DefaultObjectFactory.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -52,11 +51,6 @@ public class DefaultObjectFactory implements ObjectFactory, Serializable {
     Class<?> classToCreate = resolveInterface(type);
     // we know types are assignable
     return (T) instantiateClass(classToCreate, constructorArgTypes, constructorArgs);
-  }
-
-  @Override
-  public void setProperties(Properties properties) {
-    // no props for default
   }
 
   private  <T> T instantiateClass(Class<T> type, List<Class<?>> constructorArgTypes, List<Object> constructorArgs) {

--- a/src/main/java/org/apache/ibatis/reflection/factory/ObjectFactory.java
+++ b/src/main/java/org/apache/ibatis/reflection/factory/ObjectFactory.java
@@ -29,7 +29,9 @@ public interface ObjectFactory {
    * Sets configuration properties.
    * @param properties configuration properties
    */
-  void setProperties(Properties properties);
+  default void setProperties(Properties properties) {
+    // NOP
+  }
 
   /**
    * Creates a new object with default constructor.

--- a/src/main/java/org/apache/ibatis/transaction/TransactionFactory.java
+++ b/src/main/java/org/apache/ibatis/transaction/TransactionFactory.java
@@ -33,7 +33,9 @@ public interface TransactionFactory {
    * Sets transaction factory custom properties.
    * @param props
    */
-  void setProperties(Properties props);
+  default void setProperties(Properties props) {
+    // NOP
+  }
 
   /**
    * Creates a {@link Transaction} out of an existing connection.

--- a/src/main/java/org/apache/ibatis/transaction/jdbc/JdbcTransactionFactory.java
+++ b/src/main/java/org/apache/ibatis/transaction/jdbc/JdbcTransactionFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.apache.ibatis.transaction.jdbc;
 
 import java.sql.Connection;
-import java.util.Properties;
 
 import javax.sql.DataSource;
 
@@ -32,10 +31,6 @@ import org.apache.ibatis.transaction.TransactionFactory;
  * @see JdbcTransaction
  */
 public class JdbcTransactionFactory implements TransactionFactory {
-
-  @Override
-  public void setProperties(Properties props) {
-  }
 
   @Override
   public Transaction newTransaction(Connection conn) {

--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -1507,13 +1507,15 @@ public class ExampleObjectFactory extends DefaultObjectFactory {
   method = "update",
   args = {MappedStatement.class,Object.class})})
 public class ExamplePlugin implements Interceptor {
+  private Properties properties = new Properties();
   public Object intercept(Invocation invocation) throws Throwable {
-    return invocation.proceed();
-  }
-  public Object plugin(Object target) {
-    return Plugin.wrap(target, this);
+    // implement pre processing if need
+    Object returnObject = invocation.proceed();
+    // implement post processing if need
+    return returnObject;
   }
   public void setProperties(Properties properties) {
+    this.properties = properties;
   }
 }]]></source>
 
@@ -1603,7 +1605,9 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
         <p>Ninguno de estos TransactionManagers necesita ninguna propiedad. Sin embargo ambos son Type Aliases, es decir, en lugar de usarlos puedes informar el nombre totalmente cualificado o el Type Alias de tu propia implementación del interfaz TransactionFactory:
         </p>
         <source><![CDATA[public interface TransactionFactory {
-  void setProperties(Properties props);
+  default void setProperties(Properties props) { // Since 3.5.2, change to default method
+    // NOP
+  }
   Transaction newTransaction(Connection conn);
   Transaction newTransaction(DataSource dataSource, TransactionIsolationLevel level, boolean autoCommit);
 }]]></source>
@@ -1771,7 +1775,9 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
 		</p>
 
         <source><![CDATA[public interface DatabaseIdProvider {
-  void setProperties(Properties p);
+  default void setProperties(Properties p) { // Since 3.5.2, change to default method
+    // NOP
+  }
   String getDatabaseId(DataSource dataSource) throws SQLException;
 }]]></source>
 

--- a/src/site/ja/xdoc/configuration.xml
+++ b/src/site/ja/xdoc/configuration.xml
@@ -1551,13 +1551,15 @@ public class ExampleObjectFactory extends DefaultObjectFactory {
   method = "update",
   args = {MappedStatement.class,Object.class})})
 public class ExamplePlugin implements Interceptor {
+  private Properties properties = new Properties();
   public Object intercept(Invocation invocation) throws Throwable {
-    return invocation.proceed();
-  }
-  public Object plugin(Object target) {
-    return Plugin.wrap(target, this);
+    // implement pre processing if need
+    Object returnObject = invocation.proceed();
+    // implement post processing if need
+    return returnObject;
   }
   public void setProperties(Properties properties) {
+    this.properties = properties;
   }
 }]]></source>
 
@@ -1679,7 +1681,9 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
           トランザクションマネージャーに必須のプロパティはありませんが、これらはともにタイプエイリアスです。つまり、TransactionFactory インターフェイスの実装クラスの完全修飾クラス名を指定すれば、MyBatis が用意した二種類のトランザクションマネージャーの代わりに独自に実装したトランザクションマネージャーを利用することが可能です。
         </p>
         <source><![CDATA[public interface TransactionFactory {
-  void setProperties(Properties props);
+  default void setProperties(Properties props) { // Since 3.5.2, change to default method
+    // NOP
+  }
   Transaction newTransaction(Connection conn);
   Transaction newTransaction(DataSource dataSource, TransactionIsolationLevel level, boolean autoCommit);
 }]]></source>
@@ -1878,7 +1882,9 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
     </p>
 
         <source><![CDATA[public interface DatabaseIdProvider {
-  void setProperties(Properties p);
+  default void setProperties(Properties p) { // Since 3.5.2, change to default method
+    // NOP
+  }
   String getDatabaseId(DataSource dataSource) throws SQLException;
 }]]></source>
 

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -1474,13 +1474,15 @@ public class ExampleObjectFactory extends DefaultObjectFactory {
   method = "update",
   args = {MappedStatement.class,Object.class})})
 public class ExamplePlugin implements Interceptor {
+  private Properties properties = new Properties();
   public Object intercept(Invocation invocation) throws Throwable {
-    return invocation.proceed();
-  }
-  public Object plugin(Object target) {
-    return Plugin.wrap(target, this);
+    // implement pre processing if need
+    Object returnObject = invocation.proceed();
+    // implement post processing if need
+    return returnObject;
   }
   public void setProperties(Properties properties) {
+    this.properties = properties;
   }
 }]]></source>
 
@@ -1573,7 +1575,9 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
 		어쨌든 둘다 타입 별칭이 있다.
 		즉 TransactionFactory를 위한 클래스 명이나 타입 별칭 중 하나를 사용할 수 있다.</p>
         <source><![CDATA[public interface TransactionFactory {
-  void setProperties(Properties props);
+  default void setProperties(Properties props) { // Since 3.5.2, change to default method
+    // NOP
+  }
   Transaction newTransaction(Connection conn);
   Transaction newTransaction(DataSource dataSource, TransactionIsolationLevel level, boolean autoCommit);
 }]]></source>
@@ -1724,7 +1728,9 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
     </p>
 
         <source><![CDATA[public interface DatabaseIdProvider {
-  void setProperties(Properties p);
+  default void setProperties(Properties p) { // Since 3.5.2, change to default method
+    // NOP
+  }
   String getDatabaseId(DataSource dataSource) throws SQLException;
 }]]></source>
 

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -1675,13 +1675,15 @@ public class ExampleObjectFactory extends DefaultObjectFactory {
   method = "update",
   args = {MappedStatement.class,Object.class})})
 public class ExamplePlugin implements Interceptor {
+  private Properties properties = new Properties();
   public Object intercept(Invocation invocation) throws Throwable {
-    return invocation.proceed();
-  }
-  public Object plugin(Object target) {
-    return Plugin.wrap(target, this);
+    // implement pre processing if need
+    Object returnObject = invocation.proceed();
+    // implement post processing if need
+    return returnObject;
   }
   public void setProperties(Properties properties) {
+    this.properties = properties;
   }
 }]]></source>
 
@@ -1846,7 +1848,9 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, propert
           TransactionFactory interface.
         </p>
         <source><![CDATA[public interface TransactionFactory {
-  void setProperties(Properties props);
+  default void setProperties(Properties props) { // Since 3.5.2, change to default method
+    // NOP
+  }
   Transaction newTransaction(Connection conn);
   Transaction newTransaction(DataSource dataSource, TransactionIsolationLevel level, boolean autoCommit);
 }]]></source>
@@ -2098,7 +2102,9 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
         </p>
 
         <source><![CDATA[public interface DatabaseIdProvider {
-  void setProperties(Properties p);
+  default void setProperties(Properties p) { // Since 3.5.2, change to default method
+    // NOP
+  }
   String getDatabaseId(DataSource dataSource) throws SQLException;
 }]]></source>
 

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -1515,13 +1515,15 @@ public class ExampleObjectFactory extends DefaultObjectFactory {
   method = "update",
   args = {MappedStatement.class,Object.class})})
 public class ExamplePlugin implements Interceptor {
+  private Properties properties = new Properties();
   public Object intercept(Invocation invocation) throws Throwable {
-    return invocation.proceed();
-  }
-  public Object plugin(Object target) {
-    return Plugin.wrap(target, this);
+    // implement pre processing if need
+    Object returnObject = invocation.proceed();
+    // implement post processing if need
+    return returnObject;
   }
   public void setProperties(Properties properties) {
+    this.properties = properties;
   }
 }]]></source>
 
@@ -1632,7 +1634,9 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, propert
           TransactionFactory 接口的实现类的完全限定名或类型别名代替它们。
         </p>
         <source><![CDATA[public interface TransactionFactory {
-  void setProperties(Properties props);
+  default void setProperties(Properties props) { // Since 3.5.2, change to default method
+    // NOP
+  }
   Transaction newTransaction(Connection conn);
   Transaction newTransaction(DataSource dataSource, TransactionIsolationLevel level, boolean autoCommit);
 }]]></source>
@@ -1793,7 +1797,9 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
         </p>
 
         <source><![CDATA[public interface DatabaseIdProvider {
-  void setProperties(Properties p);
+  default void setProperties(Properties p) { // Since 3.5.2, change to default method
+    // NOP
+  }
   String getDatabaseId(DataSource dataSource) throws SQLException;
 }]]></source>
 

--- a/src/test/java/org/apache/ibatis/plugin/PluginTest.java
+++ b/src/test/java/org/apache/ibatis/plugin/PluginTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -47,14 +46,6 @@ class PluginTest {
       return "Always";
     }
 
-    @Override
-    public Object plugin(Object target) {
-      return Plugin.wrap(target, this);
-    }
-
-    @Override
-    public void setProperties(Properties properties) {
-    }
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectFactory.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectFactory.java
@@ -23,7 +23,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -44,11 +43,6 @@ public class CustomObjectFactory implements ObjectFactory {
         @SuppressWarnings("unchecked") // we know types are assignable
         T created = (T) instantiateClass(classToCreate, constructorArgTypes, constructorArgs);
         return created;
-    }
-
-    @Override
-    public void setProperties(Properties properties) {
-        // no props for default
     }
 
     private <T> T instantiateClass(Class<T> type, List<Class<?>> constructorArgTypes, List<Object> constructorArgs) {


### PR DESCRIPTION
I will propose to support default method on following interface method:

* `Cache#getReadWriteLock`
* ~~`DataSourceFactory#setProperties`~~
* ~~`KeyGenerator#processBefore`~~
* ~~`KeyGenerator#processAfter`~~
* `ProxyFactory#setProperties`
* `DatabaseIdProvider#setProperties`
* `Interceptor#plugin`
* `Interceptor#setProperties`
* `ObjectFactory#setProperties`
* ~~`Transaction#getTimeout`~~
* `TransactionFactory#setProperties`

As apply this changes, source code becomes a little slim.

Adding as follows: (2018-04-11)

* ~~`SqlSession#*`~~
* ~~`SqlSessionFactory#*`~~

Fix conflict as follows: (2018-06-23)

* ~~`DefaultSqlSession`~~

WDYT?