### PR TITLE
Add new attribute generatedKeys instead of useGeneratedKeys on @Options for fixing #1252

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/Options.java
+++ b/src/main/java/org/apache/ibatis/annotations/Options.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Target;
 
 import org.apache.ibatis.mapping.ResultSetType;
 import org.apache.ibatis.mapping.StatementType;
+import org.apache.ibatis.session.Configuration;
 
 /**
  * @author Clinton Begin
@@ -44,6 +45,46 @@ public @interface Options {
     FALSE
   }
 
+  /**
+   * The options for the {@link Options#generatedKeys()}.
+   * 
+   * @author Kazuki Shimizu
+   * @since 3.5.0
+   */
+  enum GeneratedKeysPolicy {
+    /**
+     * Follow global configuration (See {@link Configuration#isUseGeneratedKeys()})
+     */
+    DEFAULT(null),
+    /**
+     * Use the JDBC standard generated keys
+     */
+    USE(Boolean.TRUE),
+    /**
+     * Not use the JDBC standard generated keys
+     */
+    NOT_USE(Boolean.FALSE);
+
+    private final Boolean useGeneratedKeys;
+
+    GeneratedKeysPolicy(Boolean useGeneratedKeys) {
+      this.useGeneratedKeys = useGeneratedKeys;
+    }
+
+    /**
+     * Return whether use the JDBC standard generated keys.
+     * @param defaultValue a value when policy is {@link #DEFAULT}.
+     * @return If use the JDBC standard generated keys, return {@code true}.
+     */
+    public boolean isUseGeneratedKeys(boolean defaultValue) {
+      if (this.useGeneratedKeys == null) {
+        return defaultValue;
+      }
+      return this.useGeneratedKeys;
+    }
+
+  }
+
   boolean useCache() default true;
 
   FlushCachePolicy flushCache() default FlushCachePolicy.DEFAULT;
@@ -56,11 +97,27 @@ public @interface Options {
 
   int timeout() default -1;
 
+  /**
+   * If set to {@code true}, mark to use the JDBC standard generated keys. Otherwise, depends on
+   * {@link #generatedKeys()}.
+   *
+   * @deprecated Since 3.5.0, Please change to use the {@link #generatedKeys()} instead of this.
+   *             This attribute will remove at future.
+   */
+  @Deprecated
   boolean useGeneratedKeys() default false;
+
+  /**
+   * @return A usage policy for the JDBC standard generated keys
+   * @see GeneratedKeysPolicy
+   * @since 3.5.0
+   */
+  GeneratedKeysPolicy generatedKeys() default GeneratedKeysPolicy.DEFAULT;
 
   String keyProperty() default "";
 
   String keyColumn() default "";
   
   String resultSets() default "";
+
 }

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -48,6 +48,7 @@ import org.apache.ibatis.annotations.Lang;
 import org.apache.ibatis.annotations.MapKey;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Options.FlushCachePolicy;
+import org.apache.ibatis.annotations.Options.GeneratedKeysPolicy;
 import org.apache.ibatis.annotations.Property;
 import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.ResultMap;
@@ -316,7 +317,9 @@ public class MapperAnnotationBuilder {
         } else if (options == null) {
           keyGenerator = configuration.isUseGeneratedKeys() ? Jdbc3KeyGenerator.INSTANCE : NoKeyGenerator.INSTANCE;
         } else {
-          keyGenerator = options.useGeneratedKeys() ? Jdbc3KeyGenerator.INSTANCE : NoKeyGenerator.INSTANCE;
+          boolean isUseGeneratedKeys = (options.generatedKeys() == GeneratedKeysPolicy.DEFAULT && options.useGeneratedKeys())
+                  || options.generatedKeys().isUseGeneratedKeys(configuration.isUseGeneratedKeys() && SqlCommandType.INSERT.equals(sqlCommandType));
+          keyGenerator = isUseGeneratedKeys ? Jdbc3KeyGenerator.INSTANCE : NoKeyGenerator.INSTANCE;
           keyProperty = options.keyProperty();
           keyColumn = options.keyColumn();
         }

--- a/src/test/java/org/apache/ibatis/submitted/selectkey/AnnotatedMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/selectkey/AnnotatedMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Map;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.InsertProvider;
 import org.apache.ibatis.annotations.Options;
+import org.apache.ibatis.annotations.Options.GeneratedKeysPolicy;
 import org.apache.ibatis.annotations.SelectKey;
 import org.apache.ibatis.annotations.Update;
 
@@ -72,4 +73,21 @@ public interface AnnotatedMapper {
     int updateTable2WithSelectKeyWithKeyObject(Name name);
 
     int updateTable2WithSelectKeyWithKeyObjectXml(Name name);
+
+    @Insert("insert into table2 (name) values(#{name})")
+    @Options(generatedKeys = GeneratedKeysPolicy.USE, keyProperty="nameId,generatedName", keyColumn="ID,NAME_FRED")
+    int insertUsingGeneratedKeysPolicyIsUse(Name name);
+
+    @Insert("insert into table2 (name) values(#{name})")
+    @Options(generatedKeys = GeneratedKeysPolicy.NOT_USE, keyProperty="nameId,generatedName", keyColumn="ID,NAME_FRED")
+    int insertUsingGeneratedKeysPolicyIsNotUse(Name name);
+
+    @Insert("insert into table2 (name) values(#{name})")
+    @Options(keyProperty="nameId,generatedName", keyColumn="ID,NAME_FRED")
+    int insertUsingGeneratedKeysPolicyIsDefault(Name name);
+
+    @Insert("insert into table2 (name) values(#{name})")
+    @Options(useGeneratedKeys = true, generatedKeys = GeneratedKeysPolicy.NOT_USE, keyProperty="nameId,generatedName", keyColumn="ID,NAME_FRED")
+    int insertSpecifyUseGeneratedKeysAndGeneratedKeysPolicy(Name name);
+
 }


### PR DESCRIPTION
I've tried for fixing the #1252 .

I've added the the `generatedKeys`(`DEFAULT`, `USE`, `NOT_USE`)  attribute instead of `useGeneratedKeys`(`true`, `false`) on `@Options`. And mark `useGeneratedKeys` as deprecated API(Will remove at future version). 

### Main specifications

* When use `generatedKeys=DEFAULT`(or omit), allow the `useGeneratedKeys=true` for keeping backward compatibility with 3.4.x or older versions
* Ignore `useGeneratedKeys=false`(= or omit) . If set `Configuration#useGeneratedKeys=true`, breaks backward compatibility with 3.4.x or older versions
* If use both attributes, ignore the `useGeneratedKeys`

WDYT?
