### PR TITLE
Test to demonstrate incorrect NUMERIC database type automapping to inherited generic field

### DIFF
--- a/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/AbstractLevel1.java
+++ b/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/AbstractLevel1.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2009-2017 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.submitted.numeric_type_automapping;
+
+public abstract class AbstractLevel1<ID> {
+
+    protected ID id;
+
+    public ID getId() {
+        return this.id;
+    }
+
+    public void setId(ID id) {
+        this.id = id;
+    }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/AbstractLevel2.java
+++ b/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/AbstractLevel2.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2009-2017 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.submitted.numeric_type_automapping;
+
+public abstract class AbstractLevel2<ID> extends AbstractLevel1<ID> {
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/AbstractLevel3.java
+++ b/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/AbstractLevel3.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2009-2017 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.submitted.numeric_type_automapping;
+
+public abstract class AbstractLevel3<ID> extends AbstractLevel2<ID> {
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/Concrete1.java
+++ b/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/Concrete1.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2009-2017 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.submitted.numeric_type_automapping;
+
+public class Concrete1 extends AbstractLevel1<Integer> {
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/Concrete2.java
+++ b/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/Concrete2.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2009-2017 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.submitted.numeric_type_automapping;
+
+public class Concrete2 extends AbstractLevel2<Integer> {
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/Concrete3.java
+++ b/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/Concrete3.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2009-2017 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.submitted.numeric_type_automapping;
+
+public class Concrete3 extends AbstractLevel3<Integer> {
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/CreateDB.sql
@@ -1,0 +1,23 @@
+--
+--    Copyright 2009-2016 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table items if exists;
+
+create table items (
+  id  NUMERIC,
+);
+
+insert into items (id) values(1);

--- a/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/Mapper.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2009-2015 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.submitted.numeric_type_automapping;
+
+public interface Mapper {
+
+    Concrete1 getFirstLevelInheritance(Integer id);
+
+    Concrete2 getSecondLevelInheritance(Integer id);
+
+    Concrete3 getThirdLevelInheritance(Integer id);
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/Mapper.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2016 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.numeric_type_automapping.Mapper">
+
+    <select id="getFirstLevelInheritance" resultType="org.apache.ibatis.submitted.numeric_type_automapping.Concrete1">
+		select * from items where id = #{id}
+	</select>
+
+
+    <select id="getSecondLevelInheritance" resultType="org.apache.ibatis.submitted.numeric_type_automapping.Concrete2">
+		select * from items where id = #{id}
+	</select>
+
+
+    <select id="getThirdLevelInheritance" resultType="org.apache.ibatis.submitted.numeric_type_automapping.Concrete3">
+		select * from items where id = #{id}
+	</select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/NumericTypeAutomappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/NumericTypeAutomappingTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2009-2017 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.submitted.numeric_type_automapping;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.jdbc.ScriptRunner;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.Reader;
+import java.sql.Connection;
+
+public class NumericTypeAutomappingTest {
+
+    private static final int EXISTING_ITEM_ID = 1;
+
+    private static SqlSessionFactory sqlSessionFactory;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // create an SqlSessionFactory
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/numeric_type_automapping/mybatis-config.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
+
+        // populate in-memory database
+        SqlSession session = sqlSessionFactory.openSession();
+        Connection conn = session.getConnection();
+        reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/numeric_type_automapping/CreateDB.sql");
+        ScriptRunner runner = new ScriptRunner(conn);
+        runner.setLogWriter(null);
+        runner.runScript(reader);
+        conn.close();
+        reader.close();
+        session.close();
+    }
+
+    @Test
+    public void firstLevelInheritedField() {
+        SqlSession sqlSession = sqlSessionFactory.openSession();
+        Mapper mapper = sqlSession.getMapper(Mapper.class);
+
+        Concrete1 concrete1 = mapper.getFirstLevelInheritance(EXISTING_ITEM_ID);
+
+        Assert.assertEquals(Integer.class, concrete1.getId().getClass());
+    }
+
+    @Test
+    public void secondLevelInheritedField() {
+        SqlSession sqlSession = sqlSessionFactory.openSession();
+        Mapper mapper = sqlSession.getMapper(Mapper.class);
+
+        Concrete2 concrete2 = mapper.getSecondLevelInheritance(EXISTING_ITEM_ID);
+
+        Assert.assertEquals(Integer.class, concrete2.getId().getClass());
+    }
+
+    @Test
+    public void thirdLevelInheritedField() {
+        SqlSession sqlSession = sqlSessionFactory.openSession();
+        Mapper mapper = sqlSession.getMapper(Mapper.class);
+
+        Concrete3 concrete3 = mapper.getThirdLevelInheritance(EXISTING_ITEM_ID);
+
+        Assert.assertEquals(Integer.class, concrete3.getId().getClass());
+    }
+}

--- a/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/numeric_type_automapping/mybatis-config.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2016 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value=""/>
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="org.hsqldb.jdbcDriver"/>
+                <property name="url" value="jdbc:hsqldb:mem:basetest"/>
+                <property name="username" value="sa"/>
+            </dataSource>
+        </environment>
+    </environments>
+
+    <mappers>
+        <mapper class="org.apache.ibatis.submitted.numeric_type_automapping.Mapper"/>
+    </mappers>
+
+</configuration>


### PR DESCRIPTION
NUMERIC type is not correctly automapped to generic field when filed is declared in 3rd and higher parent class.

Commit contains three JUnit tests:
1. firstLevelInheritedField -> PASSING
2. secondLevelInheritedField -> PASSING
3. thirdLevelInheritedField -> FAILING, Inherited filed `ID id` should be automapped to `Integer` like in previous test cases. But field is of type `BigDecimal` at runtime.
