### PR TITLE
Change to calling BaseDataTest#runScript on setup test data

### DIFF
--- a/src/test/java/org/apache/ibatis/autoconstructor/AutoConstructorTest.java
+++ b/src/test/java/org/apache/ibatis/autoconstructor/AutoConstructorTest.java
@@ -15,9 +15,9 @@
  */
 package org.apache.ibatis.autoconstructor;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -27,7 +27,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
 public class AutoConstructorTest {
@@ -41,15 +40,8 @@ public class AutoConstructorTest {
     reader.close();
 
     // populate in-memory database
-    final SqlSession session = sqlSessionFactory.openSession();
-    final Connection conn = session.getConnection();
-    final Reader dbReader = Resources.getResourceAsReader("org/apache/ibatis/autoconstructor/CreateDB.sql");
-    final ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(dbReader);
-    conn.close();
-    dbReader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/autoconstructor/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/ancestor_ref/AncestorRefTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ancestor_ref/AncestorRefTest.java
@@ -18,10 +18,9 @@ package org.apache.ibatis.submitted.ancestor_ref;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -39,15 +38,8 @@ public class AncestorRefTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ancestor_ref/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/ancestor_ref/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/array_result_type/ArrayResultTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/array_result_type/ArrayResultTypeTest.java
@@ -18,10 +18,9 @@ package org.apache.ibatis.submitted.array_result_type;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,15 +39,8 @@ public class ArrayResultTypeTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/array_result_type/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/array_result_type/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/associationtest/AssociationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/associationtest/AssociationTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.associationtest;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,15 +39,8 @@ public class AssociationTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/associationtest/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/associationtest/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/associationtype/AssociationTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/associationtype/AssociationTypeTest.java
@@ -16,14 +16,13 @@
 package org.apache.ibatis.submitted.associationtype;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.junit.Assert;
 
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -42,15 +41,8 @@ public class AssociationTypeTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/associationtype/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/associationtype/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.automapping;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.AutoMappingBehavior;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -41,15 +40,8 @@ public class AutomappingTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/automapping/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/automapping/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/awful_table/AwfulTableTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/awful_table/AwfulTableTest.java
@@ -18,11 +18,9 @@ package org.apache.ibatis.submitted.awful_table;
 import static org.junit.Assert.assertEquals;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -34,22 +32,12 @@ public class AwfulTableTest {
 
   @Before
   public void setUp() throws Exception {
-    Class.forName("org.hsqldb.jdbcDriver");
-    Connection conn = DriverManager.getConnection("jdbc:hsqldb:mem:attest", "sa", "");
-
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/awful_table/CreateDB.sql");
-
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.setErrorLogWriter(null);
-    runner.runScript(reader);
-    conn.commit();
-    conn.close();
-    reader.close();
-
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/awful_table/MapperConfig.xml");
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/awful_table/MapperConfig.xml");
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
     reader.close();
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/awful_table/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/basetest/BaseTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/basetest/BaseTest.java
@@ -16,10 +16,9 @@
 package org.apache.ibatis.submitted.basetest;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -39,15 +38,8 @@ public class BaseTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/basetest/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/basetest/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/batch_keys/BatchKeysTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_keys/BatchKeysTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,20 +17,18 @@ package org.apache.ibatis.submitted.batch_keys;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.PrintWriter;
 import java.io.Reader;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.Statement;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.junit.Assert;
 
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -44,29 +42,12 @@ public class BatchKeysTest {
 
   @Before
   public void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/batch_keys/Config.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:batch_keys", "sa", "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/batch_keys/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(new PrintWriter(System.err));
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/batch_keys/Config.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/batch_keys/CreateDB.sql");
   }
 
   public void testJdbc3Support() throws Exception {

--- a/src/test/java/org/apache/ibatis/submitted/batch_test/BatchTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_test/BatchTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 package org.apache.ibatis.submitted.batch_test;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -41,15 +40,8 @@ public class BatchTest
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/batch_test/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/batch_test/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/blobtest/BlobTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/blobtest/BlobTest.java
@@ -19,12 +19,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -36,30 +34,12 @@ public class BlobTest {
 
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Connection conn = null;
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/blobtest/MapperConfig.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
 
-        try {
-            Class.forName("org.hsqldb.jdbcDriver");
-            conn = DriverManager.getConnection("jdbc:hsqldb:mem:blobtest", "sa",
-                    "");
-
-            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/blobtest/CreateDB.sql");
-
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(null);
-            runner.runScript(reader);
-            conn.commit();
-            reader.close();
-
-            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/blobtest/MapperConfig.xml");
-            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-            reader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/blobtest/CreateDB.sql");
     }
 
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/blocking_cache/BlockingCacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/blocking_cache/BlockingCacheTest.java
@@ -16,12 +16,11 @@
 package org.apache.ibatis.submitted.blocking_cache;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -42,15 +41,8 @@ public class BlockingCacheTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/blocking_cache/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/blocking_cache/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/cache/CacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cache/CacheTest.java
@@ -17,8 +17,8 @@ package org.apache.ibatis.submitted.cache;
 
 import java.io.Reader;
 import java.lang.reflect.Field;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.annotations.CacheNamespace;
 import org.apache.ibatis.annotations.Property;
 import org.apache.ibatis.cache.Cache;
@@ -26,7 +26,6 @@ import org.apache.ibatis.cache.CacheException;
 import org.apache.ibatis.annotations.CacheNamespaceRef;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -50,15 +49,8 @@ public class CacheTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cache/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/cache/CreateDB.sql");
   }
 
   /*

--- a/src/test/java/org/apache/ibatis/submitted/cacheorder/CacheOrderTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cacheorder/CacheOrderTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,13 +18,11 @@ package org.apache.ibatis.submitted.cacheorder;
 import static org.junit.Assert.assertEquals;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.MappedStatement;
-import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.BeforeClass;
@@ -42,15 +40,8 @@ public class CacheOrderTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cacheorder/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/cacheorder/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/CallSettersOnNullsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/CallSettersOnNullsTest.java
@@ -15,8 +15,8 @@
  */
 package org.apache.ibatis.submitted.call_setters_on_nulls;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -25,7 +25,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 import java.util.Map;
 
@@ -42,16 +41,8 @@ public class CallSettersOnNullsTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/call_setters_on_nulls/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/call_setters_on_nulls/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/DoNotCallSettersOnNullsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/DoNotCallSettersOnNullsTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.call_setters_on_nulls;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,15 +39,8 @@ public class DoNotCallSettersOnNullsTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/call_setters_on_nulls/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/call_setters_on_nulls/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/camelcase/CamelCaseMappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/camelcase/CamelCaseMappingTest.java
@@ -16,13 +16,11 @@
 package org.apache.ibatis.submitted.camelcase;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -36,28 +34,12 @@ public class CamelCaseMappingTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/camelcase/MapperConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:gname", "sa", "");
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/camelcase/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/camelcase/MapperConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/camelcase/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/CglibNPELazyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/CglibNPELazyTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,11 +16,9 @@
 package org.apache.ibatis.submitted.cglib_lazy_error;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -34,32 +32,14 @@ public class CglibNPELazyTest {
 
   @BeforeClass
   public static void initDatabase() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cglib_lazy_error/ibatisConfigLazy.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    sqlSessionFactory.getConfiguration().setLazyLoadingEnabled(true);
+    sqlSessionFactory.getConfiguration().setAggressiveLazyLoading(false);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:cglib_lazy_error", "sa",
-          "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cglib_lazy_error/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cglib_lazy_error/ibatisConfigLazy.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      sqlSessionFactory.getConfiguration().setLazyLoadingEnabled(true);
-      sqlSessionFactory.getConfiguration().setAggressiveLazyLoading(false);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/cglib_lazy_error/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/CglibNPETest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/CglibNPETest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import java.io.Reader;
 import java.sql.Connection;
 import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
@@ -34,30 +35,12 @@ public class CglibNPETest {
 
   @BeforeClass
   public static void initDatabase() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cglib_lazy_error/ibatisConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:cglib_lazy_eager_no_error", "sa",
-          "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cglib_lazy_error/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cglib_lazy_error/ibatisConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/cglib_lazy_error/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/collectionparameters/CollectionParametersTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/collectionparameters/CollectionParametersTest.java
@@ -16,14 +16,13 @@
 package org.apache.ibatis.submitted.collectionparameters;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -43,15 +42,8 @@ public class CollectionParametersTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/collectionparameters/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/collectionparameters/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/column_forwarding/ColumnForwardingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_forwarding/ColumnForwardingTest.java
@@ -16,10 +16,9 @@
 package org.apache.ibatis.submitted.column_forwarding;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -39,15 +38,8 @@ public class ColumnForwardingTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/column_forwarding/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/column_forwarding/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/column_prefix/ColumnPrefixTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_prefix/ColumnPrefixTest.java
@@ -18,12 +18,10 @@ package org.apache.ibatis.submitted.column_prefix;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -36,28 +34,12 @@ public class ColumnPrefixTest {
 
   @Before
   public void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader(getConfigPath());
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:clmpfx", "sa", "");
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/column_prefix/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader(getConfigPath());
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/column_prefix/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/complex_column/ComplexColumnTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_column/ComplexColumnTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.apache.ibatis.submitted.complex_column;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -25,8 +25,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
 public class ComplexColumnTest {
     
@@ -34,30 +32,12 @@ public class ComplexColumnTest {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Connection conn = null;
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/complex_column/ibatisConfig.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
 
-        try {
-            Class.forName("org.hsqldb.jdbcDriver");
-            conn = DriverManager.getConnection("jdbc:hsqldb:mem:complex_column", "sa",
-                    "");
-
-            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/complex_column/CreateDB.sql");
-
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(null);
-            runner.runScript(reader);
-            conn.commit();
-            reader.close();
-
-            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/complex_column/ibatisConfig.xml");
-            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-            reader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/complex_column/CreateDB.sql");
     }
     
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/complex_property/ComponentTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_property/ComponentTest.java
@@ -16,18 +16,16 @@
 package org.apache.ibatis.submitted.complex_property;
 
 import static org.junit.Assert.assertNotNull;
+
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.SQLException;
 import java.util.Calendar;
 
 public class ComponentTest {
@@ -35,8 +33,12 @@ public class ComponentTest {
 
   @BeforeClass
   public static void setup() throws Exception {
-    setupSqlSessionFactory();
-    runDBScript();
+    String resource = "org/apache/ibatis/submitted/complex_property/Configuration.xml";
+    Reader reader = Resources.getResourceAsReader(resource);
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/complex_property/db.sql");
   }
 
 
@@ -59,23 +61,6 @@ public class ComponentTest {
 
       sqlSession.rollback();
     }
-  }
-
-  private static void runDBScript() throws SQLException, IOException {
-    Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.setErrorLogWriter(null);
-    String resource = "org/apache/ibatis/submitted/complex_property/db.sql";
-    Reader reader = Resources.getResourceAsReader(resource);
-    runner.runScript(reader);
-    conn.close();
-  }
-
-  private static void setupSqlSessionFactory() throws IOException {
-    String resource = "org/apache/ibatis/submitted/complex_property/Configuration.xml";
-    Reader reader = Resources.getResourceAsReader(resource);
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/complex_type/ComplexTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_type/ComplexTypeTest.java
@@ -16,12 +16,11 @@
 package org.apache.ibatis.submitted.complex_type;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,15 +39,8 @@ public class ComplexTypeTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/complex_type/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/complex_type/CreateDB.sql");
   }
 
   // see https://issues.apache.org/jira/browse/IBATIS-653

--- a/src/test/java/org/apache/ibatis/submitted/count/CountTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/count/CountTest.java
@@ -18,11 +18,9 @@ package org.apache.ibatis.submitted.count;
 import static org.junit.Assert.assertEquals;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -35,30 +33,12 @@ public class CountTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/count/MapperConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:gname", "sa",
-          "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/count/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/count/MapperConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/count/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/criterion/CriterionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/criterion/CriterionTest.java
@@ -18,13 +18,11 @@ package org.apache.ibatis.submitted.criterion;
 import static org.junit.Assert.assertEquals;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -37,30 +35,12 @@ public class CriterionTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/criterion/MapperConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:aname", "sa",
-          "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/criterion/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/criterion/MapperConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/criterion/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
@@ -15,9 +15,9 @@
  */
 package org.apache.ibatis.submitted.cursor_nested;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.RowBounds;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -27,7 +27,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.Iterator;
 
 public class CursorNestedTest {
@@ -42,15 +41,8 @@ public class CursorNestedTest {
         reader.close();
 
         // populate in-memory database
-        SqlSession session = sqlSessionFactory.openSession();
-        Connection conn = session.getConnection();
-        reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cursor_nested/CreateDB.sql");
-        ScriptRunner runner = new ScriptRunner(conn);
-        runner.setLogWriter(null);
-        runner.runScript(reader);
-        conn.close();
-        reader.close();
-        session.close();
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/cursor_nested/CreateDB.sql");
     }
 
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
@@ -15,9 +15,9 @@
  */
 package org.apache.ibatis.submitted.cursor_simple;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.RowBounds;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -28,7 +28,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -46,15 +45,8 @@ public class CursorSimpleTest {
         reader.close();
 
         // populate in-memory database
-        SqlSession session = sqlSessionFactory.openSession();
-        Connection conn = session.getConnection();
-        reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cursor_simple/CreateDB.sql");
-        ScriptRunner runner = new ScriptRunner(conn);
-        runner.setLogWriter(null);
-        runner.runScript(reader);
-        conn.close();
-        reader.close();
-        session.close();
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/cursor_simple/CreateDB.sql");
     }
 
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomCollectionHandlingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomCollectionHandlingTest.java
@@ -18,13 +18,12 @@ package org.apache.ibatis.submitted.custom_collection_handling;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.io.Reader;
-import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
+
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -76,26 +75,13 @@ public class CustomCollectionHandlingTest {
         SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
         configReader.close();
 
-        Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-        initDb(conn);
-        conn.close();
+        initDb(sqlSessionFactory);
 
         return sqlSessionFactory;
     }
 
-    private static void initDb(Connection conn) throws IOException, SQLException {
-        try {
-            Reader scriptReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/custom_collection_handling/CreateDB.sql");
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(new PrintWriter(System.err));
-            runner.runScript(scriptReader);
-            conn.commit();
-            scriptReader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+    private static void initDb(SqlSessionFactory sqlSessionFactory) throws IOException, SQLException {
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/custom_collection_handling/CreateDB.sql");
     }
 }

--- a/src/test/java/org/apache/ibatis/submitted/deferload_common_property/CommonPropertyDeferLoadError.java
+++ b/src/test/java/org/apache/ibatis/submitted/deferload_common_property/CommonPropertyDeferLoadError.java
@@ -18,13 +18,11 @@ package org.apache.ibatis.submitted.deferload_common_property;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.ResultContext;
 import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.SqlSession;
@@ -40,32 +38,15 @@ public class CommonPropertyDeferLoadError {
 
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Connection conn = null;
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/deferload_common_property/ibatisConfig.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
+        reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/deferload_common_property/lazyLoadIbatisConfig.xml");
+        lazyLoadSqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
 
-        try {
-            Class.forName("org.hsqldb.jdbcDriver");
-            conn = DriverManager.getConnection("jdbc:hsqldb:mem:deferload_common_property", "sa",
-                    "");
-
-            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/deferload_common_property/CreateDB.sql");
-
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(null);
-            runner.runScript(reader);
-            conn.commit();
-            reader.close();
-
-            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/deferload_common_property/ibatisConfig.xml");
-            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/deferload_common_property/lazyLoadIbatisConfig.xml");
-            lazyLoadSqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-            reader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/deferload_common_property/CreateDB.sql");
     }
 
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/dml_return_types/DmlMapperReturnTypesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dml_return_types/DmlMapperReturnTypesTest.java
@@ -15,8 +15,8 @@
  */
 package org.apache.ibatis.submitted.dml_return_types;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -26,7 +26,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.Reader;
-import java.sql.Connection;
 
 import static org.junit.Assert.assertEquals;
 
@@ -51,18 +50,8 @@ public class DmlMapperReturnTypesTest {
     }
 
     // populate in-memory database
-    try (SqlSession session = sqlSessionFactory.openSession()) {
-      Connection conn = session.getConnection();
-      reader = Resources.getResourceAsReader(SQL);
-      try {
-        ScriptRunner runner = new ScriptRunner(conn);
-        runner.setLogWriter(null);
-        runner.runScript(reader);
-        conn.close();
-      } finally {
-        reader.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(), SQL);
+
   }
 
   @Before

--- a/src/test/java/org/apache/ibatis/submitted/duplicate_statements/DuplicateStatementsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/duplicate_statements/DuplicateStatementsTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.duplicate_statements;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.RowBounds;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -42,15 +41,8 @@ public class DuplicateStatementsTest {
       reader.close();
       
       // populate in-memory database
-      SqlSession session = sqlSessionFactory.openSession();
-      Connection conn = session.getConnection();
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/duplicate_statements/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.runScript(reader);
-      conn.close();
-      reader.close();
-      session.close();
+      BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+              "org/apache/ibatis/submitted/duplicate_statements/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/dynsql/DynSqlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dynsql/DynSqlTest.java
@@ -18,8 +18,8 @@ package org.apache.ibatis.submitted.dynsql;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -29,7 +29,6 @@ import org.junit.Test;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -40,26 +39,12 @@ public class DynSqlTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Connection conn = null;
-    try {
-      Reader configReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/dynsql/MapperConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-      configReader.close();
-      conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
+    Reader configReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/dynsql/MapperConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
+    configReader.close();
 
-      Reader scriptReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/dynsql/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(scriptReader);
-      conn.commit();
-      scriptReader.close();
-
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/dynsql/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/dynsql2/DynSqlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dynsql2/DynSqlTest.java
@@ -19,14 +19,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,30 +38,12 @@ public class DynSqlTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/dynsql2/MapperConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:bname", "sa",
-          "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/dynsql2/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/dynsql2/MapperConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/dynsql2/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/empty_row/ReturnInstanceForEmptyRowTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/empty_row/ReturnInstanceForEmptyRowTest.java
@@ -18,11 +18,10 @@ package org.apache.ibatis.submitted.empty_row;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -43,16 +42,8 @@ public class ReturnInstanceForEmptyRowTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/empty_row/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/empty_row/CreateDB.sql");
   }
 
   @Before

--- a/src/test/java/org/apache/ibatis/submitted/enum_interface_type_handler/EnumInterfaceTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/enum_interface_type_handler/EnumInterfaceTypeHandlerTest.java
@@ -18,10 +18,9 @@ package org.apache.ibatis.submitted.enum_interface_type_handler;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -41,16 +40,8 @@ public class EnumInterfaceTypeHandlerTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/enum_interface_type_handler/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/enum_interface_type_handler/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_annotation/EnumTypeHandlerUsingAnnotationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_annotation/EnumTypeHandlerUsingAnnotationTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.apache.ibatis.submitted.enumtypehandler_on_annotation;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -26,8 +26,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -49,30 +47,13 @@ public class EnumTypeHandlerUsingAnnotationTest {
 
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Connection conn = null;
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/enumtypehandler_on_annotation/mybatis-config.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        sqlSessionFactory.getConfiguration().getMapperRegistry().addMapper(PersonMapper.class);
+        reader.close();
 
-        try {
-            Class.forName("org.hsqldb.jdbcDriver");
-            conn = DriverManager.getConnection("jdbc:hsqldb:mem:enumtypehandler_on_annotation", "sa", "");
-
-            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/enumtypehandler_on_annotation/CreateDB.sql");
-
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(null);
-            runner.runScript(reader);
-            conn.commit();
-            reader.close();
-
-            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/enumtypehandler_on_annotation/mybatis-config.xml");
-            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-            sqlSessionFactory.getConfiguration().getMapperRegistry().addMapper(PersonMapper.class);
-            reader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/enumtypehandler_on_annotation/CreateDB.sql");
     }
 
     @Before

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/EnumTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/EnumTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,12 +16,10 @@
 package org.apache.ibatis.submitted.enumtypehandler_on_map;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -37,30 +35,12 @@ public class EnumTypeHandlerTest {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Connection conn = null;
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/enumtypehandler_on_map/ibatisConfig.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
 
-        try {
-            Class.forName("org.hsqldb.jdbcDriver");
-            conn = DriverManager.getConnection("jdbc:hsqldb:mem:enumtypehandler_on_map", "sa",
-                    "");
-
-            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/enumtypehandler_on_map/CreateDB.sql");
-
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(null);
-            runner.runScript(reader);
-            conn.commit();
-            reader.close();
-
-            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/enumtypehandler_on_map/ibatisConfig.xml");
-            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-            reader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/enumtypehandler_on_map/CreateDB.sql");
     }
     
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/extend/ExtendTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/extend/ExtendTest.java
@@ -18,11 +18,9 @@ package org.apache.ibatis.submitted.extend;
 import static org.junit.Assert.assertEquals;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -35,29 +33,12 @@ public class ExtendTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/extend/ExtendConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:extend", "sa", "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/extend/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/extend/ExtendConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/extend/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/extendresultmap/ExtendResultMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/extendresultmap/ExtendResultMapTest.java
@@ -16,10 +16,9 @@
 package org.apache.ibatis.submitted.extendresultmap;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -38,15 +37,8 @@ public class ExtendResultMapTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/extendresultmap/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/extendresultmap/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/NpeExtendsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/NpeExtendsTest.java
@@ -17,14 +17,10 @@ package org.apache.ibatis.submitted.extends_with_constructor;
 
 import static org.junit.Assert.*;
 
-import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.Properties;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory;
-import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.AutoMappingBehavior;
 import org.apache.ibatis.session.Configuration;
@@ -41,28 +37,15 @@ import org.junit.Test;
  * @author poitrac
  */
 public class NpeExtendsTest {
+
+    private static SqlSessionFactory sqlSessionFactory;
+
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Connection conn = null;
+        sqlSessionFactory = getSqlSessionFactoryWithConstructor();
 
-        try {
-            Class.forName("org.hsqldb.jdbcDriver");
-            conn = DriverManager.getConnection("jdbc:hsqldb:mem:extends_with_constructor", "sa",
-                    "");
-
-            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/extends_with_constructor/CreateDB.sql");
-
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(null);
-            runner.runScript(reader);
-            conn.commit();
-            reader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/extends_with_constructor/CreateDB.sql");
     }
     
     @Test
@@ -80,7 +63,7 @@ public class NpeExtendsTest {
         configuration.getMappedStatementNames();
     }
     
-    private SqlSessionFactory getSqlSessionFactoryWithConstructor() {
+    private static SqlSessionFactory getSqlSessionFactoryWithConstructor() {
         UnpooledDataSourceFactory unpooledDataSourceFactory = new UnpooledDataSourceFactory();
         Properties properties = new Properties();
         properties.setProperty("driver", "org.hsqldb.jdbcDriver");

--- a/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/FlushStatementNpeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/FlushStatementNpeTest.java
@@ -16,11 +16,9 @@
 package org.apache.ibatis.submitted.flush_statement_npe;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -34,30 +32,12 @@ public class FlushStatementNpeTest {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Connection conn = null;
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/flush_statement_npe/ibatisConfig.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
 
-        try {
-            Class.forName("org.hsqldb.jdbcDriver");
-            conn = DriverManager.getConnection("jdbc:hsqldb:mem:flush_statement_npe", "sa",
-                    "");
-
-            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/flush_statement_npe/CreateDB.sql");
-
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(null);
-            runner.runScript(reader);
-            conn.commit();
-            reader.close();
-
-            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/flush_statement_npe/ibatisConfig.xml");
-            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-            reader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/flush_statement_npe/CreateDB.sql");
     }
     
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/force_flush_on_select/ForceFlushOnSelectTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/force_flush_on_select/ForceFlushOnSelectTest.java
@@ -19,13 +19,12 @@ import static org.junit.Assert.*;
 
 import java.io.Reader;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.LocalCacheScope;
 import org.apache.ibatis.session.SqlSession;
@@ -40,28 +39,12 @@ public class ForceFlushOnSelectTest {
 
   @Before
   public void initDatabase() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/force_flush_on_select/ibatisConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:force_flush_on_select", "sa", "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/force_flush_on_select/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/force_flush_on_select/ibatisConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/force_flush_on_select/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/foreach/ForEachTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/foreach/ForEachTest.java
@@ -16,14 +16,13 @@
 package org.apache.ibatis.submitted.foreach;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -46,15 +45,8 @@ public class ForEachTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/foreach/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/foreach/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/foreach_map/ForEachMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/foreach_map/ForEachMapTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.foreach_map;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -42,15 +41,8 @@ public class ForEachMapTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/foreach_map/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/foreach_map/CreateDB.sql");
   }
 
   @Before

--- a/src/test/java/org/apache/ibatis/submitted/generictyperesolution/GenericTypeResolutionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/generictyperesolution/GenericTypeResolutionTest.java
@@ -18,10 +18,9 @@ package org.apache.ibatis.submitted.generictyperesolution;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,15 +39,8 @@ public class GenericTypeResolutionTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/generictyperesolution/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/generictyperesolution/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/generictypes/GenericTypesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/generictypes/GenericTypesTest.java
@@ -15,15 +15,12 @@
  */
 package org.apache.ibatis.submitted.generictypes;
 
-import java.io.PrintWriter;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.junit.Assert;
 
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -36,29 +33,12 @@ public class GenericTypesTest {
 
   @Before
   public void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/generictypes/Config.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:generictypes", "sa", "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/generictypes/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(new PrintWriter(System.err));
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/generictypes/Config.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/generictypes/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/global_variables/BaseTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables/BaseTest.java
@@ -17,11 +17,10 @@ package org.apache.ibatis.submitted.global_variables;
 
 import java.io.Reader;
 import java.lang.reflect.Field;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -41,15 +40,8 @@ public class BaseTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/global_variables/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/global_variables/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/hashmaptypehandler/HashMapTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/hashmaptypehandler/HashMapTypeHandlerTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.hashmaptypehandler;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.HashMap;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,15 +39,8 @@ public class HashMapTypeHandlerTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/hashmaptypehandler/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/hashmaptypehandler/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOTest.java
@@ -15,14 +15,11 @@
  */
 package org.apache.ibatis.submitted.immutable_constructor;
 
-import java.io.PrintWriter;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -41,29 +38,12 @@ public final class ImmutablePOJOTest {
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/immutable_constructor/ibatisConfig.xml");
+    factory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:immutable_constructor", "sa", "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/immutable_constructor/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(new PrintWriter(System.err));
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/immutable_constructor/ibatisConfig.xml");
-      factory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(factory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/immutable_constructor/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/include_property/IncludePropertyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/include_property/IncludePropertyTest.java
@@ -18,13 +18,12 @@ package org.apache.ibatis.submitted.include_property;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -43,15 +42,8 @@ public class IncludePropertyTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/include_property/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/include_property/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/includes/IncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/includes/IncludeTest.java
@@ -15,15 +15,14 @@
  */
 package org.apache.ibatis.submitted.includes;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.Map;
 
 import org.apache.ibatis.session.SqlSession;
@@ -41,15 +40,8 @@ public class IncludeTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/includes/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/includes/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/inheritance/InheritanceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/inheritance/InheritanceTest.java
@@ -16,10 +16,9 @@
 package org.apache.ibatis.submitted.inheritance;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,15 +39,8 @@ public class InheritanceTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/inheritance/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/inheritance/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/initialized_collection_property/AuthorDAOTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/initialized_collection_property/AuthorDAOTest.java
@@ -15,8 +15,8 @@
  */
 package org.apache.ibatis.submitted.initialized_collection_property;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -27,7 +27,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
 public class AuthorDAOTest {
@@ -39,17 +38,10 @@ public class AuthorDAOTest {
     final String resource = "org/apache/ibatis/submitted/initialized_collection_property/mybatis-config.xml";
     Reader reader = Resources.getResourceAsReader(resource);
     factory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    SqlSession session = factory.openSession();
-
-    Connection conn = session.getConnection();
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.setErrorLogWriter(null);
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/initialized_collection_property/create.sql");
-    runner.runScript(reader);
-    conn.close();
-    session.close();
+    BaseDataTest.runScript(factory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/initialized_collection_property/create.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/inline_association_with_dot/InlineCollectionWithDotTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/inline_association_with_dot/InlineCollectionWithDotTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,10 +18,9 @@ package org.apache.ibatis.submitted.inline_association_with_dot;
 import static org.junit.Assert.assertEquals;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -47,17 +46,8 @@ public class InlineCollectionWithDotTest {
 
     batisConfigReader.close();
 
-    SqlSession session = sqlSessionFactory.openSession();
-
-    Connection conn = session.getConnection();
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.setErrorLogWriter(null);
-    Reader createScriptReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/inline_association_with_dot/create.sql");
-    runner.runScript(createScriptReader);
-    createScriptReader.close();
-    conn.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/inline_association_with_dot/create.sql");
 
     sqlSession = sqlSessionFactory.openSession();
   }

--- a/src/test/java/org/apache/ibatis/submitted/javassist/JavassistTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/javassist/JavassistTest.java
@@ -18,12 +18,11 @@ package org.apache.ibatis.submitted.javassist;
 import static org.junit.Assert.assertTrue;
 
 import java.io.Reader;
-import java.sql.Connection;
 
 import javassist.util.proxy.Proxy;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -43,15 +42,8 @@ public class JavassistTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/javassist/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/javassist/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/keygen/Jdbc3KeyGeneratorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/Jdbc3KeyGeneratorTest.java
@@ -18,13 +18,12 @@ package org.apache.ibatis.submitted.keygen;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -49,15 +48,8 @@ public class Jdbc3KeyGeneratorTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/keygen/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/keygen/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/language/LanguageTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/language/LanguageTest.java
@@ -16,13 +16,12 @@
 package org.apache.ibatis.submitted.language;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,29 +39,12 @@ public class LanguageTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/language/MapperConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:language", "sa", "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/language/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/language/MapperConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/language/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/lazy_deserialize/LazyDeserializeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazy_deserialize/LazyDeserializeTest.java
@@ -21,19 +21,15 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.PrintWriter;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.executor.ExecutorException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,31 +50,13 @@ public final class LazyDeserializeTest {
 
   @Before
   public void setupClass() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/lazy_deserialize/ibatisConfig.xml");
+    factory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:lazy_deserialize", "sa", "");
-
-      Reader reader = Resources
-          .getResourceAsReader("org/apache/ibatis/submitted/lazy_deserialize/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(new PrintWriter(System.err));
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources
-          .getResourceAsReader("org/apache/ibatis/submitted/lazy_deserialize/ibatisConfig.xml");
-      factory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(factory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/lazy_deserialize/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/lazy_immutable/ImmutablePOJOTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazy_immutable/ImmutablePOJOTest.java
@@ -15,6 +15,7 @@
  */
 package org.apache.ibatis.submitted.lazy_immutable;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.jdbc.ScriptRunner;
 
@@ -38,29 +39,12 @@ public final class ImmutablePOJOTest {
 
     @BeforeClass
     public static void setupClass() throws Exception {
-        Connection conn = null;
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazy_immutable/ibatisConfig.xml");
+        factory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
 
-        try {
-            Class.forName("org.hsqldb.jdbcDriver");
-            conn = DriverManager.getConnection("jdbc:hsqldb:mem:lazy_immutable", "sa", "");
-
-            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazy_immutable/CreateDB.sql");
-
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(new PrintWriter(System.err));
-            runner.runScript(reader);
-            conn.commit();
-            reader.close();
-
-            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazy_immutable/ibatisConfig.xml");
-            factory = new SqlSessionFactoryBuilder().build(reader);
-            reader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+        BaseDataTest.runScript(factory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/lazy_immutable/CreateDB.sql");
     }
 
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/lazy_properties/LazyPropertiesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazy_properties/LazyPropertiesTest.java
@@ -18,15 +18,14 @@ package org.apache.ibatis.submitted.lazy_properties;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.Collections;
 import java.util.HashSet;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.executor.loader.ProxyFactory;
 import org.apache.ibatis.executor.loader.cglib.CglibProxyFactory;
 import org.apache.ibatis.executor.loader.javassist.JavassistProxyFactory;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -47,16 +46,8 @@ public class LazyPropertiesTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/lazy_properties/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/lazy_properties/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/CommonPropertyLazyLoadError.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/CommonPropertyLazyLoadError.java
@@ -16,11 +16,9 @@
 package org.apache.ibatis.submitted.lazyload_common_property;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -33,30 +31,12 @@ public class CommonPropertyLazyLoadError {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Connection conn = null;
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazyload_common_property/ibatisConfig.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
 
-        try {
-            Class.forName("org.hsqldb.jdbcDriver");
-            conn = DriverManager.getConnection("jdbc:hsqldb:mem:lazyload_common_property", "sa",
-                    "");
-
-            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazyload_common_property/CreateDB.sql");
-
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(null);
-            runner.runScript(reader);
-            conn.commit();
-            reader.close();
-
-            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazyload_common_property/ibatisConfig.xml");
-            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-            reader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/lazyload_common_property/CreateDB.sql");
     }
     
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/AbstractLazyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/AbstractLazyTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,10 +16,9 @@
 package org.apache.ibatis.submitted.lazyload_proxyfactory_comparison;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -44,15 +43,8 @@ public abstract class AbstractLazyTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/CreateDB.sql");
 
     sqlSession = sqlSessionFactory.openSession();
     mapper = sqlSession.getMapper(Mapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/mapper_extend/MapperExtendTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/mapper_extend/MapperExtendTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.mapper_extend;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.binding.BindingException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -43,15 +42,8 @@ public class MapperExtendTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/mapper_extend/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/mapper_extend/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/mapper_type_parameter/MapperTypeParameterTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/mapper_type_parameter/MapperTypeParameterTest.java
@@ -18,13 +18,12 @@ package org.apache.ibatis.submitted.mapper_type_parameter;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -42,15 +41,8 @@ public class MapperTypeParameterTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/mapper_type_parameter/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/mapper_type_parameter/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/maptypehandler/MapTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/maptypehandler/MapTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,13 +16,12 @@
 package org.apache.ibatis.submitted.maptypehandler;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -46,15 +45,8 @@ public class MapTypeHandlerTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/maptypehandler/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/maptypehandler/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/missing_id_property/MissingIdPropertyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/missing_id_property/MissingIdPropertyTest.java
@@ -16,10 +16,9 @@
 package org.apache.ibatis.submitted.missing_id_property;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -39,15 +38,8 @@ public class MissingIdPropertyTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/missing_id_property/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/missing_id_property/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/multidb/MultiDbTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multidb/MultiDbTest.java
@@ -18,11 +18,9 @@ package org.apache.ibatis.submitted.multidb;
 import static org.junit.Assert.assertEquals;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -36,29 +34,12 @@ public class MultiDbTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multidb/MultiDbConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:multidb", "sa", "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multidb/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multidb/MultiDbConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/multidb/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/MultipleDiscriminatorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/MultipleDiscriminatorTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,11 +16,9 @@
 package org.apache.ibatis.submitted.multiple_discriminator;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -34,30 +32,12 @@ public class MultipleDiscriminatorTest {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Connection conn = null;
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multiple_discriminator/ibatisConfig.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
 
-        try {
-            Class.forName("org.hsqldb.jdbcDriver");
-            conn = DriverManager.getConnection("jdbc:hsqldb:mem:multiple_discriminator", "sa",
-                    "");
-
-            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multiple_discriminator/CreateDB.sql");
-
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(null);
-            runner.runScript(reader);
-            conn.commit();
-            reader.close();
-
-            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multiple_discriminator/ibatisConfig.xml");
-            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-            reader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/multiple_discriminator/CreateDB.sql");
     }
     
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/multipleiterates/MultipleIteratesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multipleiterates/MultipleIteratesTest.java
@@ -16,10 +16,9 @@
 package org.apache.ibatis.submitted.multipleiterates;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -38,15 +37,8 @@ public class MultipleIteratesTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multipleiterates/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/multipleiterates/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/named_constructor_args/InvalidNamedConstructorArgsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/named_constructor_args/InvalidNamedConstructorArgsTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,16 +16,14 @@
 package org.apache.ibatis.submitted.named_constructor_args;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.annotations.Arg;
 import org.apache.ibatis.annotations.ConstructorArgs;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.Configuration;
-import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.BeforeClass;
@@ -47,16 +45,8 @@ public class InvalidNamedConstructorArgsTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/named_constructor_args/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/named_constructor_args/CreateDB.sql");
   }
 
   interface NoMatchingConstructorMapper {

--- a/src/test/java/org/apache/ibatis/submitted/named_constructor_args/NamedConstructorArgsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/named_constructor_args/NamedConstructorArgsTest.java
@@ -18,10 +18,9 @@ package org.apache.ibatis.submitted.named_constructor_args;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -45,15 +44,8 @@ public class NamedConstructorArgsTest {
     configuration.addMapper(Mapper.class);
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/named_constructor_args/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/named_constructor_args/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/named_constructor_args/usesjava8/NamedConstructorArgsUseActualNameTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/named_constructor_args/usesjava8/NamedConstructorArgsUseActualNameTest.java
@@ -18,14 +18,12 @@ package org.apache.ibatis.submitted.named_constructor_args.usesjava8;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
-import org.apache.ibatis.submitted.named_constructor_args.usesjava8.Mapper;
 import org.apache.ibatis.submitted.named_constructor_args.User;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -44,15 +42,8 @@ public class NamedConstructorArgsUseActualNameTest {
     sqlSessionFactory.getConfiguration().addMapper(Mapper.class);
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/named_constructor_args/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/named_constructor_args/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/nested/NestedForEachTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested/NestedForEachTest.java
@@ -18,14 +18,12 @@ package org.apache.ibatis.submitted.nested;
 import static org.junit.Assert.assertEquals;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -38,30 +36,12 @@ public class NestedForEachTest {
   
   @BeforeClass
   public static void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nested/MapperConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:nested", "sa",
-          "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nested/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nested/MapperConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/nested/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/NestedResultHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/NestedResultHandlerTest.java
@@ -16,12 +16,11 @@
 package org.apache.ibatis.submitted.nestedresulthandler;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.ResultContext;
 import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.SqlSession;
@@ -42,15 +41,8 @@ public class NestedResultHandlerTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nestedresulthandler/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/nestedresulthandler/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler_association/NestedResultHandlerAssociationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler_association/NestedResultHandlerAssociationTest.java
@@ -18,14 +18,13 @@ package org.apache.ibatis.submitted.nestedresulthandler_association;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.ResultContext;
 import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.RowBounds;
@@ -47,15 +46,8 @@ public class NestedResultHandlerAssociationTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nestedresulthandler_association/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/nestedresulthandler_association/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler_multiple_association/NestedResultHandlerMultipleAssociationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler_multiple_association/NestedResultHandlerMultipleAssociationTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 package org.apache.ibatis.submitted.nestedresulthandler_multiple_association;
 
 import java.io.Reader;
-import java.sql.Connection;
+
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -41,16 +41,8 @@ public class NestedResultHandlerMultipleAssociationTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/nestedresulthandler_multiple_association/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/nestedresulthandler_multiple_association/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/no_param_type/NoParamTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/no_param_type/NoParamTypeTest.java
@@ -18,12 +18,11 @@ package org.apache.ibatis.submitted.no_param_type;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.executor.BatchResult;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -43,15 +42,8 @@ public class NoParamTypeTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/no_param_type/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/no_param_type/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/nonexistentvariables/NonExistentVariablesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nonexistentvariables/NonExistentVariablesTest.java
@@ -18,12 +18,10 @@ package org.apache.ibatis.submitted.nonexistentvariables;
 import static org.junit.Assert.fail;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -36,30 +34,12 @@ public class NonExistentVariablesTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nonexistentvariables/mybatis-config.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:nonexistentvariables", "sa", "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nonexistentvariables/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nonexistentvariables/mybatis-config.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/nonexistentvariables/CreateDB.sql");
   }
 
   @Test(expected = PersistenceException.class)

--- a/src/test/java/org/apache/ibatis/submitted/not_null_column/NotNullColumnTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/not_null_column/NotNullColumnTest.java
@@ -18,11 +18,9 @@ package org.apache.ibatis.submitted.not_null_column;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -35,30 +33,12 @@ public class NotNullColumnTest {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Connection conn = null;
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/not_null_column/ibatisConfig.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
 
-        try {
-            Class.forName("org.hsqldb.jdbcDriver");
-            conn = DriverManager.getConnection("jdbc:hsqldb:mem:not_null_column", "sa",
-                    "");
-
-            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/not_null_column/CreateDB.sql");
-
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(null);
-            runner.runScript(reader);
-            conn.commit();
-            reader.close();
-
-            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/not_null_column/ibatisConfig.xml");
-            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-            reader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/not_null_column/CreateDB.sql");
     }
     
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/null_associations/FooMapperTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/null_associations/FooMapperTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,14 +15,13 @@
  */
 package org.apache.ibatis.submitted.null_associations;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.*;
 
-import java.io.Reader;
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -33,20 +32,13 @@ public class FooMapperTest {
   private static Connection conn;
 
   @BeforeClass
-  public static void setUpBeforeClass() {
-    try {
-      final SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(Resources.getResourceAsReader(SQL_MAP_CONFIG));
-      session = factory.openSession();
-      conn = session.getConnection();
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/null_associations/create-schema-mysql.sql");
-      runner.runScript(reader);
-      reader.close();
-    } catch (Exception ex) {
-      Assert.fail(ex.getMessage());
-    }
+  public static void setUpBeforeClass() throws Exception {
+    final SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(Resources.getResourceAsReader(SQL_MAP_CONFIG));
+    session = factory.openSession();
+    conn = session.getConnection();
+
+    BaseDataTest.runScript(factory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/null_associations/create-schema-mysql.sql");
   }
 
   @Before

--- a/src/test/java/org/apache/ibatis/submitted/ognl_enum/EnumWithOgnlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognl_enum/EnumWithOgnlTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,12 +16,10 @@
 package org.apache.ibatis.submitted.ognl_enum;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -37,30 +35,12 @@ public class EnumWithOgnlTest {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Connection conn = null;
+        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ognl_enum/ibatisConfig.xml");
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        reader.close();
 
-        try {
-            Class.forName("org.hsqldb.jdbcDriver");
-            conn = DriverManager.getConnection("jdbc:hsqldb:mem:ognl_enum", "sa",
-                    "");
-
-            Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ognl_enum/CreateDB.sql");
-
-            ScriptRunner runner = new ScriptRunner(conn);
-            runner.setLogWriter(null);
-            runner.setErrorLogWriter(null);
-            runner.runScript(reader);
-            conn.commit();
-            reader.close();
-
-            reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ognl_enum/ibatisConfig.xml");
-            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-            reader.close();
-        } finally {
-            if (conn != null) {
-                conn.close();
-            }
-        }
+        BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+                "org/apache/ibatis/submitted/ognl_enum/CreateDB.sql");
     }
     
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/ognlstatic/OgnlStaticTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognlstatic/OgnlStaticTest.java
@@ -16,10 +16,9 @@
 package org.apache.ibatis.submitted.ognlstatic;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -39,15 +38,8 @@ public class OgnlStaticTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ognlstatic/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/ognlstatic/CreateDB.sql");
   }
 
   /**

--- a/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/OrderPrefixRemoved.java
+++ b/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/OrderPrefixRemoved.java
@@ -18,11 +18,9 @@ package org.apache.ibatis.submitted.order_prefix_removed;
 import static org.junit.Assert.assertNotNull;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -36,29 +34,12 @@ public class OrderPrefixRemoved {
 
   @BeforeClass
   public static void initDatabase() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/order_prefix_removed/ibatisConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:order_prefix_removed", "sa", "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/order_prefix_removed/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/order_prefix_removed/ibatisConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/order_prefix_removed/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/overwritingproperties/FooMapperTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/overwritingproperties/FooMapperTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,12 +15,11 @@
  */
 package org.apache.ibatis.submitted.overwritingproperties;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.*;
 import org.junit.*;
 
-import java.io.Reader;
 import java.sql.Connection;
 import java.sql.SQLException;
 
@@ -34,20 +33,13 @@ public class FooMapperTest {
   private static Connection conn;
 
   @BeforeClass
-  public static void setUpBeforeClass() {
-    try {
-      final SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(Resources.getResourceAsReader(SQL_MAP_CONFIG));
-      session = factory.openSession();
-      conn = session.getConnection();
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/overwritingproperties/create-schema-mysql.sql");
-      runner.runScript(reader);
-      reader.close();
-    } catch (Exception ex) {
-      Assert.fail(ex.getMessage());
-    }
+  public static void setUpBeforeClass() throws Exception {
+    final SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(Resources.getResourceAsReader(SQL_MAP_CONFIG));
+    session = factory.openSession();
+    conn = session.getConnection();
+
+    BaseDataTest.runScript(factory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/overwritingproperties/create-schema-mysql.sql");
   }
 
   @Before

--- a/src/test/java/org/apache/ibatis/submitted/parametrizedlist/ParametrizedListTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/parametrizedlist/ParametrizedListTest.java
@@ -15,17 +15,14 @@
  */
 package org.apache.ibatis.submitted.parametrizedlist;
 
-import java.io.PrintWriter;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.junit.Assert;
 
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -38,29 +35,12 @@ public class ParametrizedListTest {
 
   @Before
   public void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/parametrizedlist/Config.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:parametrizedlist", "sa", "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/parametrizedlist/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(new PrintWriter(System.err));
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/parametrizedlist/Config.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/parametrizedlist/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/parent_childs/ParentChildTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/parent_childs/ParentChildTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.parent_childs;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,15 +39,8 @@ public class ParentChildTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/parent_childs/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/parent_childs/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/BlogTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/BlogTest.java
@@ -18,11 +18,9 @@ package org.apache.ibatis.submitted.parent_reference_3level;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,28 +38,12 @@ public class BlogTest {
 
   @Before
   public void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader(getConfigPath());
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:parent_reference_3level", "sa", "");
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/parent_reference_3level/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader(getConfigPath());
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/parent_reference_3level/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/permissions/PermissionsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/permissions/PermissionsTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.permissions;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,16 +39,8 @@ public class PermissionsTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/permissions/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.setErrorLogWriter(null);
-    runner.runScript(reader);
-    conn.commit();
-    conn.close();
-    reader.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/permissions/CreateDB.sql");
   }
 
   @Test // see issue #168

--- a/src/test/java/org/apache/ibatis/submitted/primitive_array/PrimitiveArrayTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitive_array/PrimitiveArrayTest.java
@@ -16,10 +16,9 @@
 package org.apache.ibatis.submitted.primitive_array;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -39,15 +38,8 @@ public class PrimitiveArrayTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/primitive_array/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/primitive_array/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/primitive_result_type/IbatisConfig.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitive_result_type/IbatisConfig.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -46,4 +46,10 @@ public class IbatisConfig {
     }
     return sqlSessionFactory.openSession();
   }
+
+  public static SqlSessionFactory getSqlSessionFactory() {
+    init();
+    return sqlSessionFactory;
+  }
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/primitive_result_type/PrimitiveResultTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitive_result_type/PrimitiveResultTypeTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,31 +15,20 @@
  */
 package org.apache.ibatis.submitted.primitive_result_type;
 
-import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
-import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.BaseDataTest;
 import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.Reader;
 import java.math.BigDecimal;
-import java.sql.Connection;
 import java.util.List;
 
 public class PrimitiveResultTypeTest {
 
   @BeforeClass
   public static void setup() throws Exception {
-    SqlSession session = IbatisConfig.getSession();
-    Connection conn = session.getConnection();
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.setErrorLogWriter(null);
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/primitive_result_type/create.sql");
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
+    BaseDataTest.runScript(IbatisConfig.getSqlSessionFactory().getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/primitive_result_type/create.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/primitives/PrimitivesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitives/PrimitivesTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.primitives;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,15 +39,8 @@ public class PrimitivesTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/primitives/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/primitives/CreateDB.sql");
   }
 
   @Test // issue #69

--- a/src/test/java/org/apache/ibatis/submitted/propertiesinmapperfiles/PropertiesInMappersTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/propertiesinmapperfiles/PropertiesInMappersTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.propertiesinmapperfiles;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.Properties;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -45,15 +44,8 @@ public class PropertiesInMappersTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/propertiesinmapperfiles/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/propertiesinmapperfiles/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/quotedcolumnnames/QuotedColumnNamesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/quotedcolumnnames/QuotedColumnNamesTest.java
@@ -16,13 +16,11 @@
 package org.apache.ibatis.submitted.quotedcolumnnames;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -36,28 +34,12 @@ public class QuotedColumnNamesTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/quotedcolumnnames/MapperConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:gname", "sa", "");
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/quotedcolumnnames/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/quotedcolumnnames/MapperConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/quotedcolumnnames/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/raw_sql_source/RawSqlSourceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/raw_sql_source/RawSqlSourceTest.java
@@ -16,10 +16,9 @@
 package org.apache.ibatis.submitted.raw_sql_source;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.scripting.defaults.RawSqlSource;
 import org.apache.ibatis.scripting.xmltags.DynamicSqlSource;
@@ -42,15 +41,8 @@ public class RawSqlSourceTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/raw_sql_source/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/raw_sql_source/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/result_handler/ResulthandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/result_handler/ResulthandlerTest.java
@@ -16,10 +16,9 @@
 package org.apache.ibatis.submitted.result_handler;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,15 +39,8 @@ public class ResulthandlerTest {
     sqlSessionFactory.getConfiguration().addMapper(Mapper.class);
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/result_handler/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/result_handler/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/result_handler_type/DefaultResultHandlerTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/result_handler_type/DefaultResultHandlerTypeTest.java
@@ -17,15 +17,12 @@ package org.apache.ibatis.submitted.result_handler_type;
 
 import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -74,28 +71,10 @@ public class DefaultResultHandlerTypeTest {
     SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
     configReader.close();
 
-    Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-    initDb(conn);
-    conn.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/result_handler_type/CreateDB.sql");
 
     return sqlSessionFactory;
-  }
-
-  private static void initDb(Connection conn) throws IOException, SQLException {
-    try {
-      Reader scriptReader = Resources
-          .getResourceAsReader("org/apache/ibatis/submitted/result_handler_type/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(scriptReader);
-      conn.commit();
-      scriptReader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/resultmapwithassociationstest/ResultMapWithAssociationsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/resultmapwithassociationstest/ResultMapWithAssociationsTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.resultmapwithassociationstest;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,15 +39,8 @@ public class ResultMapWithAssociationsTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/resultmapwithassociationstest/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/resultmapwithassociationstest/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/results_id/ResultsIdTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/ResultsIdTest.java
@@ -18,11 +18,10 @@ package org.apache.ibatis.submitted.results_id;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -41,15 +40,8 @@ public class ResultsIdTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/results_id/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/results_id/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/rounding/RoundingHandlersTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/rounding/RoundingHandlersTest.java
@@ -18,10 +18,9 @@ package org.apache.ibatis.submitted.rounding;
 import java.io.Reader;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -42,15 +41,8 @@ public class RoundingHandlersTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/rounding/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/rounding/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/selectkey/SelectKeyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/selectkey/SelectKeyTest.java
@@ -15,9 +15,9 @@
  */
 package org.apache.ibatis.submitted.selectkey;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -29,8 +29,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -40,31 +38,13 @@ public class SelectKeyTest {
 
   @Before
   public void setUp() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/selectkey/MapperConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
+    sqlSessionFactory.getConfiguration().addMapper(AnnotatedMapper.class);
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:lname", "sa",
-          "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/selectkey/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/selectkey/MapperConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-      sqlSessionFactory.getConfiguration().addMapper(AnnotatedMapper.class);
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/selectkey/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/SerializeCircularTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/SerializeCircularTest.java
@@ -15,13 +15,10 @@
  */
 package org.apache.ibatis.submitted.serializecircular;
 
-import java.io.IOException;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.SQLException;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -112,28 +109,10 @@ public class SerializeCircularTest {
     SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
     configReader.close();
 
-    Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-    initDb(conn);
-    conn.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/serializecircular/CreateDB.sql");
 
     return sqlSessionFactory;
-  }
-
-  private static void initDb(Connection conn) throws IOException, SQLException {
-    try {
-      Reader scriptReader = Resources
-          .getResourceAsReader("org/apache/ibatis/submitted/serializecircular/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(scriptReader);
-      conn.commit();
-      scriptReader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/simplelistparameter/SimpleListParameterTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/simplelistparameter/SimpleListParameterTest.java
@@ -16,12 +16,11 @@
 package org.apache.ibatis.submitted.simplelistparameter;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -41,15 +40,8 @@ public class SimpleListParameterTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/simplelistparameter/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/simplelistparameter/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/sptests/SPTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sptests/SPTest.java
@@ -21,14 +21,13 @@ import static org.junit.Assert.assertNull;
 
 import java.io.Reader;
 import java.sql.Array;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
@@ -42,30 +41,15 @@ public class SPTest {
 
   @BeforeClass
   public static void initDatabase() throws Exception {
-    Connection conn = null;
+    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/sptests/MapperConfig.xml");
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    reader.close();
 
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:sptest", "sa", "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/sptests/CreateDB.sql");
-
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setDelimiter("go");
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(reader);
-      conn.commit();
-      reader.close();
-
-      reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/sptests/MapperConfig.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+    ScriptRunner runner = new ScriptRunner(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection());
+    runner.setDelimiter("go");
+    runner.setLogWriter(null);
+    runner.setErrorLogWriter(null);
+    BaseDataTest.runScript(runner, "org/apache/ibatis/submitted/sptests/CreateDB.sql");
   }
 
   /*

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
@@ -23,19 +23,18 @@ import static org.junit.Assert.fail;
 
 import java.io.Reader;
 import java.lang.reflect.Method;
-import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.SelectProvider;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.builder.annotation.ProviderContext;
 import org.apache.ibatis.builder.annotation.ProviderSqlSource;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
@@ -57,16 +56,8 @@ public class SqlProviderTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/sqlprovider/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/sqlprovider/CreateDB.sql");
   }
 
   // Test for list

--- a/src/test/java/org/apache/ibatis/submitted/stringlist/StringListTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/stringlist/StringListTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.stringlist;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -40,15 +39,8 @@ public class StringListTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/stringlist/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/stringlist/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/substitution_in_annots/SubstitutionInAnnotsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/substitution_in_annots/SubstitutionInAnnotsTest.java
@@ -17,13 +17,8 @@ package org.apache.ibatis.submitted.substitution_in_annots;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
-
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
-import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -40,24 +35,14 @@ public class SubstitutionInAnnotsTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Class.forName("org.hsqldb.jdbcDriver");
-    Connection c = DriverManager.getConnection("jdbc:hsqldb:mem:annots", "sa", "");
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/substitution_in_annots/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(c);
-    runner.setLogWriter(null);
-    runner.setErrorLogWriter(null);
-    runner.runScript(reader);
-    c.commit();
-    reader.close();
-
     Configuration configuration = new Configuration();
     Environment environment = new Environment("test", new JdbcTransactionFactory(), new UnpooledDataSource("org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:annots", null));
     configuration.setEnvironment(environment);
-
     configuration.addMapper(SubstitutionInAnnotsMapper.class);
-
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
-    c.close();
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/substitution_in_annots/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/typehandler/TypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/typehandler/TypeHandlerTest.java
@@ -18,11 +18,10 @@ package org.apache.ibatis.submitted.typehandler;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -46,15 +45,8 @@ public class TypeHandlerTest {
     sqlSessionFactory.getConfiguration().getTypeHandlerRegistry().register(StringTrimmingTypeHandler.class);
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/typehandler/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/typehandler/CreateDB.sql");
   }
 
   // Some tests need to register additional type handler

--- a/src/test/java/org/apache/ibatis/submitted/typehandlerinjection/TypeHandlerInjectionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/typehandlerinjection/TypeHandlerInjectionTest.java
@@ -16,11 +16,10 @@
 package org.apache.ibatis.submitted.typehandlerinjection;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -45,15 +44,8 @@ public class TypeHandlerInjectionTest {
     sqlSessionFactory.getConfiguration().addMapper(Mapper.class);
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/typehandlerinjection/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/typehandlerinjection/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/usesjava8/default_method/DefaultMethodTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/usesjava8/default_method/DefaultMethodTest.java
@@ -18,10 +18,9 @@ package org.apache.ibatis.submitted.usesjava8.default_method;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -42,16 +41,8 @@ public class DefaultMethodTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader(
-        "org/apache/ibatis/submitted/usesjava8/default_method/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/usesjava8/default_method/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/usesjava8/keycolumn/InsertTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/usesjava8/keycolumn/InsertTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,16 +18,13 @@ package org.apache.ibatis.submitted.usesjava8.keycolumn;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import java.io.Reader;
 import java.nio.file.Paths;
-import java.sql.Connection;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.executor.BatchResult;
-import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.ExecutorType;
@@ -66,13 +63,8 @@ public class InsertTest {
     configuration.addMapper(InsertMapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
 
-    try (SqlSession session = sqlSessionFactory.openSession();
-        Connection conn = session.getConnection();
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/usesjava8/keycolumn/CreateDB.sql")) {
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.runScript(reader);
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/usesjava8/keycolumn/CreateDB.sql");
   }
 
   @AfterClass

--- a/src/test/java/org/apache/ibatis/submitted/usesjava8/multiple_resultsets/MultipleResultTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/usesjava8/multiple_resultsets/MultipleResultTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,15 +16,12 @@
 package org.apache.ibatis.submitted.usesjava8.multiple_resultsets;
 
 import java.io.IOException;
-import java.io.Reader;
 import java.nio.file.Paths;
-import java.sql.Connection;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
-import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -65,13 +62,8 @@ public class MultipleResultTest {
     configuration.addMapper(Mapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
 
-    try (SqlSession session = sqlSessionFactory.openSession();
-        Connection conn = session.getConnection();
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/usesjava8/multiple_resultsets/CreateDB.sql")) {
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.runScript(reader);
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/usesjava8/multiple_resultsets/CreateDB.sql");
   }
 
   @AfterClass

--- a/src/test/java/org/apache/ibatis/submitted/usesjava8/optional_on_mapper_method/OptionalOnMapperMethodTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/usesjava8/optional_on_mapper_method/OptionalOnMapperMethodTest.java
@@ -15,8 +15,8 @@
  */
 package org.apache.ibatis.submitted.usesjava8.optional_on_mapper_method;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.Optional;
 
 import static org.hamcrest.core.Is.is;
@@ -54,15 +53,8 @@ public class OptionalOnMapperMethodTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader(
-        "org/apache/ibatis/submitted/usesjava8/optional_on_mapper_method/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/usesjava8/optional_on_mapper_method/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/usesjava8/postgres_genkeys/PostgresGeneratedKeysTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/usesjava8/postgres_genkeys/PostgresGeneratedKeysTest.java
@@ -17,20 +17,16 @@ package org.apache.ibatis.submitted.usesjava8.postgres_genkeys;
 
 import static org.junit.Assert.*;
 
-import java.io.Reader;
 import java.nio.file.Paths;
-import java.sql.Connection;
 import java.util.Collections;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
-import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
-import org.apache.ibatis.submitted.usesjava8.keycolumn.InsertMapper;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -58,13 +54,8 @@ public class PostgresGeneratedKeysTest {
     configuration.addMapper(Mapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
 
-    try (SqlSession session = sqlSessionFactory.openSession();
-        Connection conn = session.getConnection();
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/usesjava8/postgres_genkeys/CreateDB.sql")) {
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.runScript(reader);
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/usesjava8/postgres_genkeys/CreateDB.sql");
   }
 
   @AfterClass

--- a/src/test/java/org/apache/ibatis/submitted/usesjava8/refcursor/RefCursorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/usesjava8/refcursor/RefCursorTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,18 +18,15 @@ package org.apache.ibatis.submitted.usesjava8.refcursor;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
-import java.io.Reader;
 import java.nio.file.Paths;
-import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
-import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.ResultContext;
@@ -69,13 +66,8 @@ public class RefCursorTest {
     configuration.addMapper(OrdersMapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
 
-    try (SqlSession session = sqlSessionFactory.openSession();
-        Connection conn = session.getConnection();
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/usesjava8/refcursor/CreateDB.sql")) {
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.runScript(reader);
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/usesjava8/refcursor/CreateDB.sql");
   }
 
   @AfterClass

--- a/src/test/java/org/apache/ibatis/submitted/usesjava8/use_actual_param_name/UseActualParamNameTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/usesjava8/use_actual_param_name/UseActualParamNameTest.java
@@ -18,12 +18,11 @@ package org.apache.ibatis.submitted.usesjava8.use_actual_param_name;
 import static org.junit.Assert.*;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -43,16 +42,8 @@ public class UseActualParamNameTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader(
-        "org/apache/ibatis/submitted/usesjava8/use_actual_param_name/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/usesjava8/use_actual_param_name/CreateDB.sql");
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/uuid_test/UUIDTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/uuid_test/UUIDTest.java
@@ -16,12 +16,11 @@
 package org.apache.ibatis.submitted.uuid_test;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.UUID;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -41,15 +40,8 @@ public class UUIDTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/uuid_test/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/uuid_test/CreateDB.sql");
   }
 
   @Test(expected=PersistenceException.class)

--- a/src/test/java/org/apache/ibatis/submitted/valueinmap/ValueInMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/valueinmap/ValueInMapTest.java
@@ -16,15 +16,14 @@
 package org.apache.ibatis.submitted.valueinmap;
 
 import java.io.Reader;
-import java.sql.Connection;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
@@ -44,15 +43,8 @@ public class ValueInMapTest {
     reader.close();
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/valueinmap/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/valueinmap/CreateDB.sql");
   }
 
   @Test // issue #165

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeTest.java
@@ -19,14 +19,12 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.session.Configuration;
@@ -89,44 +87,28 @@ public class MultipleCrossIncludeTest {
     SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
     configReader.close();
 
-    Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-    initDb(conn);
-    conn.close();
+    initDb(sqlSessionFactory);
 
     return sqlSessionFactory;
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {
-    Class.forName("org.hsqldb.jdbcDriver");
-    Connection c = DriverManager.getConnection("jdbc:hsqldb:mem:xmlextref", "sa", "");
-    initDb(c);
-
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(), new UnpooledDataSource(
         "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:xmlextref", null));
     configuration.setEnvironment(environment);
-
     configuration.addMapper(MultipleCrossIncludePersonMapper.class);
     configuration.addMapper(MultipleCrossIncludePetMapper.class);
-    c.close();
+    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
 
-    return new SqlSessionFactoryBuilder().build(configuration);
+    initDb(sqlSessionFactory);
+
+    return sqlSessionFactory;
   }
 
-  private static void initDb(Connection conn) throws IOException, SQLException {
-    try {
-      Reader scriptReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(scriptReader);
-      conn.commit();
-      scriptReader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+  private static void initDb(SqlSessionFactory sqlSessionFactory) throws IOException, SQLException {
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleIncludeTest.java
@@ -20,12 +20,11 @@ import static org.junit.Assert.*;
 import java.io.IOException;
 import java.io.Reader;
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -62,42 +61,29 @@ public class MultipleIncludeTest {
     configReader.close();
 
     Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-    initDb(conn);
+    initDb(sqlSessionFactory);
     conn.close();
 
     return sqlSessionFactory;
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {
-    Class.forName("org.hsqldb.jdbcDriver");
-    Connection c = DriverManager.getConnection("jdbc:hsqldb:mem:xmlextref", "sa", "");
-    initDb(c);
 
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(), new UnpooledDataSource(
         "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:xmlextref", null));
     configuration.setEnvironment(environment);
-
     configuration.addMapper(MultipleIncludePersonMapper.class);
-    c.close();
+    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
 
-    return new SqlSessionFactoryBuilder().build(configuration);
+    initDb(sqlSessionFactory);
+
+    return sqlSessionFactory;
   }
 
-  private static void initDb(Connection conn) throws IOException, SQLException {
-    try {
-      Reader scriptReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(scriptReader);
-      conn.commit();
-      scriptReader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+  private static void initDb(SqlSessionFactory sqlSessionFactory) throws IOException, SQLException {
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleReverseIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleReverseIncludeTest.java
@@ -19,13 +19,11 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -61,43 +59,28 @@ public class MultipleReverseIncludeTest {
     SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
     configReader.close();
 
-    Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-    initDb(conn);
-    conn.close();
+    initDb(sqlSessionFactory);
 
     return sqlSessionFactory;
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {
-    Class.forName("org.hsqldb.jdbcDriver");
-    Connection c = DriverManager.getConnection("jdbc:hsqldb:mem:xmlextref", "sa", "");
-    initDb(c);
-
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(), new UnpooledDataSource(
         "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:xmlextref", null));
     configuration.setEnvironment(environment);
-
     configuration.addMapper(MultipleReverseIncludePersonMapper.class);
-    c.close();
 
-    return new SqlSessionFactoryBuilder().build(configuration);
+    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+
+    initDb(sqlSessionFactory);
+
+    return sqlSessionFactory;
   }
 
-  private static void initDb(Connection conn) throws IOException, SQLException {
-    try {
-      Reader scriptReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(scriptReader);
-      conn.commit();
-      scriptReader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+  private static void initDb(SqlSessionFactory sqlSessionFactory) throws IOException, SQLException {
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ParameterMapReferenceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ParameterMapReferenceTest.java
@@ -19,13 +19,11 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -62,44 +60,30 @@ public class ParameterMapReferenceTest {
     SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
     configReader.close();
 
-    Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-    initDb(conn);
-    conn.close();
+    initDb(sqlSessionFactory);
 
     return sqlSessionFactory;
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {
-    Class.forName("org.hsqldb.jdbcDriver");
-    Connection c = DriverManager.getConnection("jdbc:hsqldb:mem:xmlextref", "sa", "");
-    initDb(c);
-
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(), new UnpooledDataSource(
         "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:xmlextref", null));
     configuration.setEnvironment(environment);
-
     configuration.addMapper(ParameterMapReferencePersonMapper.class);
     configuration.addMapper(ParameterMapReferencePetMapper.class);
-    c.close();
 
-    return new SqlSessionFactoryBuilder().build(configuration);
+    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+
+    initDb(sqlSessionFactory);
+
+    return sqlSessionFactory;
   }
 
-  private static void initDb(Connection conn) throws IOException, SQLException {
-    try {
-      Reader scriptReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(scriptReader);
-      conn.commit();
-      scriptReader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+
+  private static void initDb(SqlSessionFactory sqlSessionFactory) throws IOException, SQLException {
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ResultMapExtendsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ResultMapExtendsTest.java
@@ -19,13 +19,11 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -61,44 +59,29 @@ public class ResultMapExtendsTest {
     SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
     configReader.close();
 
-    Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-    initDb(conn);
-    conn.close();
+    initDb(sqlSessionFactory);
 
     return sqlSessionFactory;
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {
-    Class.forName("org.hsqldb.jdbcDriver");
-    Connection c = DriverManager.getConnection("jdbc:hsqldb:mem:xmlextref", "sa", "");
-    initDb(c);
-
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(), new UnpooledDataSource(
         "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:xmlextref", null));
     configuration.setEnvironment(environment);
-
     configuration.addMapper(ResultMapReferencePersonMapper.class);
     configuration.addMapper(ResultMapReferencePetMapper.class);
-    c.close();
 
-    return new SqlSessionFactoryBuilder().build(configuration);
+    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+
+    initDb(sqlSessionFactory);
+
+    return sqlSessionFactory;
   }
 
-  private static void initDb(Connection conn) throws IOException, SQLException {
-    try {
-      Reader scriptReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(scriptReader);
-      conn.commit();
-      scriptReader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+  private static void initDb(SqlSessionFactory sqlSessionFactory) throws IOException, SQLException {
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ResultMapReferenceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ResultMapReferenceTest.java
@@ -19,13 +19,11 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -61,44 +59,29 @@ public class ResultMapReferenceTest {
     SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
     configReader.close();
 
-    Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-    initDb(conn);
-    conn.close();
+    initDb(sqlSessionFactory);
 
     return sqlSessionFactory;
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {
-    Class.forName("org.hsqldb.jdbcDriver");
-    Connection c = DriverManager.getConnection("jdbc:hsqldb:mem:xmlextref", "sa", "");
-    initDb(c);
-
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(), new UnpooledDataSource(
         "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:xmlextref", null));
     configuration.setEnvironment(environment);
-
     configuration.addMapper(ResultMapReferencePersonMapper.class);
     configuration.addMapper(ResultMapReferencePetMapper.class);
-    c.close();
 
-    return new SqlSessionFactoryBuilder().build(configuration);
+    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+
+    initDb(sqlSessionFactory);
+
+    return sqlSessionFactory;
   }
 
-  private static void initDb(Connection conn) throws IOException, SQLException {
-    try {
-      Reader scriptReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(scriptReader);
-      conn.commit();
-      scriptReader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+  private static void initDb(SqlSessionFactory sqlSessionFactory) throws IOException, SQLException {
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ReverseIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ReverseIncludeTest.java
@@ -19,13 +19,11 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -61,43 +59,28 @@ public class ReverseIncludeTest {
     SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
     configReader.close();
 
-    Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-    initDb(conn);
-    conn.close();
+    initDb(sqlSessionFactory);
 
     return sqlSessionFactory;
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {
-    Class.forName("org.hsqldb.jdbcDriver");
-    Connection c = DriverManager.getConnection("jdbc:hsqldb:mem:xmlextref", "sa", "");
-    initDb(c);
-
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(), new UnpooledDataSource(
         "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:xmlextref", null));
     configuration.setEnvironment(environment);
-
     configuration.addMapper(ReverseIncludePersonMapper.class);
-    c.close();
 
-    return new SqlSessionFactoryBuilder().build(configuration);
+    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+
+    initDb(sqlSessionFactory);
+
+    return sqlSessionFactory;
   }
 
-  private static void initDb(Connection conn) throws IOException, SQLException {
-    try {
-      Reader scriptReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(scriptReader);
-      conn.commit();
-      scriptReader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+  private static void initDb(SqlSessionFactory sqlSessionFactory) throws IOException, SQLException {
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/SameIdTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/SameIdTest.java
@@ -19,13 +19,11 @@ import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.SQLException;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -70,44 +68,29 @@ public class SameIdTest {
     SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
     configReader.close();
 
-    Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-    initDb(conn);
-    conn.close();
+    initDb(sqlSessionFactory);
 
     return sqlSessionFactory;
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {
-    Class.forName("org.hsqldb.jdbcDriver");
-    Connection c = DriverManager.getConnection("jdbc:hsqldb:mem:xmlextref", "sa", "");
-    initDb(c);
-
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(), new UnpooledDataSource(
         "org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:xmlextref", null));
     configuration.setEnvironment(environment);
-
     configuration.addMapper(SameIdPersonMapper.class);
     configuration.addMapper(SameIdPetMapper.class);
-    c.close();
 
-    return new SqlSessionFactoryBuilder().build(configuration);
+    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+
+    initDb(sqlSessionFactory);
+
+    return sqlSessionFactory;
   }
 
-  private static void initDb(Connection conn) throws IOException, SQLException {
-    try {
-      Reader scriptReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.setErrorLogWriter(null);
-      runner.runScript(scriptReader);
-      conn.commit();
-      scriptReader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
-    }
+  private static void initDb(SqlSessionFactory sqlSessionFactory) throws IOException, SQLException {
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/xml_external_ref/CreateDB.sql");
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/BlobInputStreamTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/BlobInputStreamTypeHandlerTest.java
@@ -55,12 +55,14 @@ public class BlobInputStreamTypeHandlerTest extends BaseTypeHandlerTest {
   @BeforeClass
   public static void setupSqlSessionFactory() throws Exception {
     DataSource dataSource = BaseDataTest.createUnpooledDataSource("org/apache/ibatis/type/jdbc.properties");
-    BaseDataTest.runScript(dataSource, "org/apache/ibatis/type/BlobInputStreamTypeHandlerTest.sql");
     TransactionFactory transactionFactory = new JdbcTransactionFactory();
     Environment environment = new Environment("Production", transactionFactory, dataSource);
     Configuration configuration = new Configuration(environment);
     configuration.addMapper(Mapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/type/BlobInputStreamTypeHandlerTest.sql");
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/ClobReaderTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ClobReaderTypeHandlerTest.java
@@ -57,12 +57,14 @@ public class ClobReaderTypeHandlerTest extends BaseTypeHandlerTest {
   @BeforeClass
   public static void setupSqlSessionFactory() throws Exception {
     DataSource dataSource = BaseDataTest.createUnpooledDataSource("org/apache/ibatis/type/jdbc.properties");
-    BaseDataTest.runScript(dataSource, "org/apache/ibatis/type/ClobReaderTypeHandlerTest.sql");
     TransactionFactory transactionFactory = new JdbcTransactionFactory();
     Environment environment = new Environment("Production", transactionFactory, dataSource);
     Configuration configuration = new Configuration(environment);
     configuration.addMapper(Mapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/type/ClobReaderTypeHandlerTest.sql");
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/SqlxmlTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/SqlxmlTypeHandlerTest.java
@@ -20,17 +20,15 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.Reader;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.SQLXML;
 import java.util.Collections;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
-import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -74,14 +72,8 @@ public class SqlxmlTypeHandlerTest extends BaseTypeHandlerTest {
     configuration.addMapper(Mapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
 
-    try (SqlSession session = sqlSessionFactory.openSession();
-        Connection conn = session.getConnection();
-        Reader reader = Resources
-            .getResourceAsReader("org/apache/ibatis/type/SqlxmlTypeHandlerTest.sql")) {
-      ScriptRunner runner = new ScriptRunner(conn);
-      runner.setLogWriter(null);
-      runner.runScript(reader);
-    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/type/SqlxmlTypeHandlerTest.sql");
   }
 
   @AfterClass


### PR DESCRIPTION
Before (e.x):

```java
SqlSession session = sqlSessionFactory.openSession();
Connection conn = session.getConnection();
reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ancestor_ref/CreateDB.sql");
ScriptRunner runner = new ScriptRunner(conn);
runner.setLogWriter(null);
runner.runScript(reader);
conn.close();
reader.close();
session.close();
```

After:
```java
BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
       "org/apache/ibatis/submitted/ancestor_ref/CreateDB.sql");
```

The `BaseDataTest#runScript` is more simply and safely.