### PR TITLE
Change to use try-with-resources on test

### DIFF
--- a/src/test/java/org/apache/ibatis/autoconstructor/AutoConstructorTest.java
+++ b/src/test/java/org/apache/ibatis/autoconstructor/AutoConstructorTest.java
@@ -35,9 +35,9 @@ public class AutoConstructorTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    final Reader reader = Resources.getResourceAsReader("org/apache/ibatis/autoconstructor/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/autoconstructor/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/binding/BindingTest.java
+++ b/src/test/java/org/apache/ibatis/binding/BindingTest.java
@@ -86,7 +86,6 @@ public class BindingTest {
       BoundBlogMapper mapper = session.getMapper(BoundBlogMapper.class);
       Blog b = mapper.selectBlogWithPostsUsingSubSelect(1);
       assertEquals(1, b.getId());
-      session.close();
       assertNotNull(b.getAuthor());
       assertEquals(101, b.getAuthor().getId());
       assertEquals("jim", b.getAuthor().getUsername());
@@ -637,14 +636,12 @@ public class BindingTest {
   public void executeWithCursorAndRowBounds() {
     try (SqlSession session = sqlSessionFactory.openSession()) {
       BoundBlogMapper mapper = session.getMapper(BoundBlogMapper.class);
-      Cursor<Blog> blogs = mapper.openRangeBlogs(new RowBounds(1, 1));
-
-      Iterator<Blog> blogIterator = blogs.iterator();
-      Blog blog = blogIterator.next();
-      assertEquals(2, blog.getId());
-      assertFalse(blogIterator.hasNext());
-
-      blogs.close();
+      try (Cursor<Blog> blogs = mapper.openRangeBlogs(new RowBounds(1, 1)) ) {
+        Iterator<Blog> blogIterator = blogs.iterator();
+        Blog blog = blogIterator.next();
+        assertEquals(2, blog.getId());
+        assertFalse(blogIterator.hasNext());
+      }
     } catch (IOException e) {
       Assert.fail(e.getMessage());
     }

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -72,35 +72,35 @@ public class XmlConfigBuilderTest {
   @Test
   public void shouldSuccessfullyLoadMinimalXMLConfigFile() throws Exception {
     String resource = "org/apache/ibatis/builder/MinimalMapperConfig.xml";
-    InputStream inputStream = Resources.getResourceAsStream(resource);
-    XMLConfigBuilder builder = new XMLConfigBuilder(inputStream);
-    Configuration config = builder.parse();
-    assertNotNull(config);
-    assertThat(config.getAutoMappingBehavior()).isEqualTo(AutoMappingBehavior.PARTIAL);
-    assertThat(config.getAutoMappingUnknownColumnBehavior()).isEqualTo(AutoMappingUnknownColumnBehavior.NONE);
-    assertThat(config.isCacheEnabled()).isTrue();
-    assertThat(config.getProxyFactory()).isInstanceOf(JavassistProxyFactory.class);
-    assertThat(config.isLazyLoadingEnabled()).isFalse();
-    assertThat(config.isAggressiveLazyLoading()).isFalse();
-    assertThat(config.isMultipleResultSetsEnabled()).isTrue();
-    assertThat(config.isUseColumnLabel()).isTrue();
-    assertThat(config.isUseGeneratedKeys()).isFalse();
-    assertThat(config.getDefaultExecutorType()).isEqualTo(ExecutorType.SIMPLE);
-    assertNull(config.getDefaultStatementTimeout());
-    assertNull(config.getDefaultFetchSize());
-    assertThat(config.isMapUnderscoreToCamelCase()).isFalse();
-    assertThat(config.isSafeRowBoundsEnabled()).isFalse();
-    assertThat(config.getLocalCacheScope()).isEqualTo(LocalCacheScope.SESSION);
-    assertThat(config.getJdbcTypeForNull()).isEqualTo(JdbcType.OTHER);
-    assertThat(config.getLazyLoadTriggerMethods()).isEqualTo((Set<String>) new HashSet<String>(Arrays.asList("equals", "clone", "hashCode", "toString")));
-    assertThat(config.isSafeResultHandlerEnabled()).isTrue();
-    assertThat(config.getDefaultScriptingLanuageInstance()).isInstanceOf(XMLLanguageDriver.class);
-    assertThat(config.isCallSettersOnNulls()).isFalse();
-    assertNull(config.getLogPrefix());
-    assertNull(config.getLogImpl());
-    assertNull(config.getConfigurationFactory());
-    assertThat(config.getTypeHandlerRegistry().getTypeHandler(RoundingMode.class)).isInstanceOf(EnumTypeHandler.class);
-    inputStream.close();
+    try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+      XMLConfigBuilder builder = new XMLConfigBuilder(inputStream);
+      Configuration config = builder.parse();
+      assertNotNull(config);
+      assertThat(config.getAutoMappingBehavior()).isEqualTo(AutoMappingBehavior.PARTIAL);
+      assertThat(config.getAutoMappingUnknownColumnBehavior()).isEqualTo(AutoMappingUnknownColumnBehavior.NONE);
+      assertThat(config.isCacheEnabled()).isTrue();
+      assertThat(config.getProxyFactory()).isInstanceOf(JavassistProxyFactory.class);
+      assertThat(config.isLazyLoadingEnabled()).isFalse();
+      assertThat(config.isAggressiveLazyLoading()).isFalse();
+      assertThat(config.isMultipleResultSetsEnabled()).isTrue();
+      assertThat(config.isUseColumnLabel()).isTrue();
+      assertThat(config.isUseGeneratedKeys()).isFalse();
+      assertThat(config.getDefaultExecutorType()).isEqualTo(ExecutorType.SIMPLE);
+      assertNull(config.getDefaultStatementTimeout());
+      assertNull(config.getDefaultFetchSize());
+      assertThat(config.isMapUnderscoreToCamelCase()).isFalse();
+      assertThat(config.isSafeRowBoundsEnabled()).isFalse();
+      assertThat(config.getLocalCacheScope()).isEqualTo(LocalCacheScope.SESSION);
+      assertThat(config.getJdbcTypeForNull()).isEqualTo(JdbcType.OTHER);
+      assertThat(config.getLazyLoadTriggerMethods()).isEqualTo((Set<String>) new HashSet<String>(Arrays.asList("equals", "clone", "hashCode", "toString")));
+      assertThat(config.isSafeResultHandlerEnabled()).isTrue();
+      assertThat(config.getDefaultScriptingLanuageInstance()).isInstanceOf(XMLLanguageDriver.class);
+      assertThat(config.isCallSettersOnNulls()).isFalse();
+      assertNull(config.getLogPrefix());
+      assertNull(config.getLogImpl());
+      assertNull(config.getConfigurationFactory());
+      assertThat(config.getTypeHandlerRegistry().getTypeHandler(RoundingMode.class)).isInstanceOf(EnumTypeHandler.class);
+    }
   }
 
   enum MyEnum {
@@ -163,96 +163,96 @@ public class XmlConfigBuilderTest {
     @Test
     public void shouldSuccessfullyLoadXMLConfigFile() throws Exception {
       String resource = "org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml";
-      InputStream inputStream = Resources.getResourceAsStream(resource);
-      Properties props = new Properties();
-      props.put("prop2", "cccc");
-      XMLConfigBuilder builder = new XMLConfigBuilder(inputStream, null, props);
-      Configuration config = builder.parse();
+      try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+        Properties props = new Properties();
+        props.put("prop2", "cccc");
+        XMLConfigBuilder builder = new XMLConfigBuilder(inputStream, null, props);
+        Configuration config = builder.parse();
 
-      assertThat(config.getAutoMappingBehavior()).isEqualTo(AutoMappingBehavior.NONE);
-      assertThat(config.getAutoMappingUnknownColumnBehavior()).isEqualTo(AutoMappingUnknownColumnBehavior.WARNING);
-      assertThat(config.isCacheEnabled()).isFalse();
-      assertThat(config.getProxyFactory()).isInstanceOf(CglibProxyFactory.class);
-      assertThat(config.isLazyLoadingEnabled()).isTrue();
-      assertThat(config.isAggressiveLazyLoading()).isTrue();
-      assertThat(config.isMultipleResultSetsEnabled()).isFalse();
-      assertThat(config.isUseColumnLabel()).isFalse();
-      assertThat(config.isUseGeneratedKeys()).isTrue();
-      assertThat(config.getDefaultExecutorType()).isEqualTo(ExecutorType.BATCH);
-      assertThat(config.getDefaultStatementTimeout()).isEqualTo(10);
-      assertThat(config.getDefaultFetchSize()).isEqualTo(100);
-      assertThat(config.isMapUnderscoreToCamelCase()).isTrue();
-      assertThat(config.isSafeRowBoundsEnabled()).isTrue();
-      assertThat(config.getLocalCacheScope()).isEqualTo(LocalCacheScope.STATEMENT);
-      assertThat(config.getJdbcTypeForNull()).isEqualTo(JdbcType.NULL);
-      assertThat(config.getLazyLoadTriggerMethods()).isEqualTo((Set<String>) new HashSet<String>(Arrays.asList("equals", "clone", "hashCode", "toString", "xxx")));
-      assertThat(config.isSafeResultHandlerEnabled()).isFalse();
-      assertThat(config.getDefaultScriptingLanuageInstance()).isInstanceOf(RawLanguageDriver.class);
-      assertThat(config.isCallSettersOnNulls()).isTrue();
-      assertThat(config.getLogPrefix()).isEqualTo("mybatis_");
-      assertThat(config.getLogImpl().getName()).isEqualTo(Slf4jImpl.class.getName());
-      assertThat(config.getVfsImpl().getName()).isEqualTo(JBoss6VFS.class.getName());
-      assertThat(config.getConfigurationFactory().getName()).isEqualTo(String.class.getName());
+        assertThat(config.getAutoMappingBehavior()).isEqualTo(AutoMappingBehavior.NONE);
+        assertThat(config.getAutoMappingUnknownColumnBehavior()).isEqualTo(AutoMappingUnknownColumnBehavior.WARNING);
+        assertThat(config.isCacheEnabled()).isFalse();
+        assertThat(config.getProxyFactory()).isInstanceOf(CglibProxyFactory.class);
+        assertThat(config.isLazyLoadingEnabled()).isTrue();
+        assertThat(config.isAggressiveLazyLoading()).isTrue();
+        assertThat(config.isMultipleResultSetsEnabled()).isFalse();
+        assertThat(config.isUseColumnLabel()).isFalse();
+        assertThat(config.isUseGeneratedKeys()).isTrue();
+        assertThat(config.getDefaultExecutorType()).isEqualTo(ExecutorType.BATCH);
+        assertThat(config.getDefaultStatementTimeout()).isEqualTo(10);
+        assertThat(config.getDefaultFetchSize()).isEqualTo(100);
+        assertThat(config.isMapUnderscoreToCamelCase()).isTrue();
+        assertThat(config.isSafeRowBoundsEnabled()).isTrue();
+        assertThat(config.getLocalCacheScope()).isEqualTo(LocalCacheScope.STATEMENT);
+        assertThat(config.getJdbcTypeForNull()).isEqualTo(JdbcType.NULL);
+        assertThat(config.getLazyLoadTriggerMethods()).isEqualTo((Set<String>) new HashSet<String>(Arrays.asList("equals", "clone", "hashCode", "toString", "xxx")));
+        assertThat(config.isSafeResultHandlerEnabled()).isFalse();
+        assertThat(config.getDefaultScriptingLanuageInstance()).isInstanceOf(RawLanguageDriver.class);
+        assertThat(config.isCallSettersOnNulls()).isTrue();
+        assertThat(config.getLogPrefix()).isEqualTo("mybatis_");
+        assertThat(config.getLogImpl().getName()).isEqualTo(Slf4jImpl.class.getName());
+        assertThat(config.getVfsImpl().getName()).isEqualTo(JBoss6VFS.class.getName());
+        assertThat(config.getConfigurationFactory().getName()).isEqualTo(String.class.getName());
 
-      assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("blogauthor").equals(Author.class));
-      assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("blog").equals(Blog.class));
-      assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("cart").equals(Cart.class));
+        assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("blogauthor").equals(Author.class));
+        assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("blog").equals(Blog.class));
+        assertTrue(config.getTypeAliasRegistry().getTypeAliases().get("cart").equals(Cart.class));
 
-      assertThat(config.getTypeHandlerRegistry().getTypeHandler(Integer.class)).isInstanceOf(CustomIntegerTypeHandler.class);
-      assertThat(config.getTypeHandlerRegistry().getTypeHandler(Long.class)).isInstanceOf(CustomLongTypeHandler.class);
-      assertThat(config.getTypeHandlerRegistry().getTypeHandler(String.class)).isInstanceOf(CustomStringTypeHandler.class);
-      assertThat(config.getTypeHandlerRegistry().getTypeHandler(String.class, JdbcType.VARCHAR)).isInstanceOf(CustomStringTypeHandler.class);
-      assertThat(config.getTypeHandlerRegistry().getTypeHandler(RoundingMode.class)).isInstanceOf(EnumOrdinalTypeHandler.class);
+        assertThat(config.getTypeHandlerRegistry().getTypeHandler(Integer.class)).isInstanceOf(CustomIntegerTypeHandler.class);
+        assertThat(config.getTypeHandlerRegistry().getTypeHandler(Long.class)).isInstanceOf(CustomLongTypeHandler.class);
+        assertThat(config.getTypeHandlerRegistry().getTypeHandler(String.class)).isInstanceOf(CustomStringTypeHandler.class);
+        assertThat(config.getTypeHandlerRegistry().getTypeHandler(String.class, JdbcType.VARCHAR)).isInstanceOf(CustomStringTypeHandler.class);
+        assertThat(config.getTypeHandlerRegistry().getTypeHandler(RoundingMode.class)).isInstanceOf(EnumOrdinalTypeHandler.class);
 
-      ExampleObjectFactory objectFactory = (ExampleObjectFactory)config.getObjectFactory();
-      assertThat(objectFactory.getProperties().size()).isEqualTo(1);
-      assertThat(objectFactory.getProperties().getProperty("objectFactoryProperty")).isEqualTo("100");
+        ExampleObjectFactory objectFactory = (ExampleObjectFactory) config.getObjectFactory();
+        assertThat(objectFactory.getProperties().size()).isEqualTo(1);
+        assertThat(objectFactory.getProperties().getProperty("objectFactoryProperty")).isEqualTo("100");
 
-      assertThat(config.getObjectWrapperFactory()).isInstanceOf(CustomObjectWrapperFactory.class);
+        assertThat(config.getObjectWrapperFactory()).isInstanceOf(CustomObjectWrapperFactory.class);
 
-      assertThat(config.getReflectorFactory()).isInstanceOf(CustomReflectorFactory.class);
+        assertThat(config.getReflectorFactory()).isInstanceOf(CustomReflectorFactory.class);
 
-      ExamplePlugin plugin = (ExamplePlugin)config.getInterceptors().get(0);
-      assertThat(plugin.getProperties().size()).isEqualTo(1);
-      assertThat(plugin.getProperties().getProperty("pluginProperty")).isEqualTo("100");
+        ExamplePlugin plugin = (ExamplePlugin) config.getInterceptors().get(0);
+        assertThat(plugin.getProperties().size()).isEqualTo(1);
+        assertThat(plugin.getProperties().getProperty("pluginProperty")).isEqualTo("100");
 
-      Environment environment = config.getEnvironment();
-      assertThat(environment.getId()).isEqualTo("development");
-      assertThat(environment.getDataSource()).isInstanceOf(UnpooledDataSource.class);
-      assertThat(environment.getTransactionFactory()).isInstanceOf(JdbcTransactionFactory.class);
+        Environment environment = config.getEnvironment();
+        assertThat(environment.getId()).isEqualTo("development");
+        assertThat(environment.getDataSource()).isInstanceOf(UnpooledDataSource.class);
+        assertThat(environment.getTransactionFactory()).isInstanceOf(JdbcTransactionFactory.class);
 
-      assertThat(config.getDatabaseId()).isEqualTo("derby");
+        assertThat(config.getDatabaseId()).isEqualTo("derby");
 
-      assertThat(config.getMapperRegistry().getMappers().size()).isEqualTo(4);
-      assertThat(config.getMapperRegistry().hasMapper(CachedAuthorMapper.class)).isTrue();
-      assertThat(config.getMapperRegistry().hasMapper(CustomMapper.class)).isTrue();
-      assertThat(config.getMapperRegistry().hasMapper(BlogMapper.class)).isTrue();
-      assertThat(config.getMapperRegistry().hasMapper(NestedBlogMapper.class)).isTrue();
-      inputStream.close();
+        assertThat(config.getMapperRegistry().getMappers().size()).isEqualTo(4);
+        assertThat(config.getMapperRegistry().hasMapper(CachedAuthorMapper.class)).isTrue();
+        assertThat(config.getMapperRegistry().hasMapper(CustomMapper.class)).isTrue();
+        assertThat(config.getMapperRegistry().hasMapper(BlogMapper.class)).isTrue();
+        assertThat(config.getMapperRegistry().hasMapper(NestedBlogMapper.class)).isTrue();
+      }
     }
 
   @Test
   public void shouldSuccessfullyLoadXMLConfigFileWithPropertiesUrl() throws Exception {
     String resource = "org/apache/ibatis/builder/PropertiesUrlMapperConfig.xml";
-    InputStream inputStream = Resources.getResourceAsStream(resource);
-    XMLConfigBuilder builder = new XMLConfigBuilder(inputStream);
-    Configuration config = builder.parse();
-    assertThat(config.getVariables().get("driver").toString()).isEqualTo("org.apache.derby.jdbc.EmbeddedDriver");
-    assertThat(config.getVariables().get("prop1").toString()).isEqualTo("bbbb");
-    inputStream.close();
+    try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+      XMLConfigBuilder builder = new XMLConfigBuilder(inputStream);
+      Configuration config = builder.parse();
+      assertThat(config.getVariables().get("driver").toString()).isEqualTo("org.apache.derby.jdbc.EmbeddedDriver");
+      assertThat(config.getVariables().get("prop1").toString()).isEqualTo("bbbb");
+    }
   }
 
   @Test
   public void parseIsTwice() throws Exception {
     String resource = "org/apache/ibatis/builder/MinimalMapperConfig.xml";
-    InputStream inputStream = Resources.getResourceAsStream(resource);
-    XMLConfigBuilder builder = new XMLConfigBuilder(inputStream);
-    builder.parse();
+    try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+      XMLConfigBuilder builder = new XMLConfigBuilder(inputStream);
+      builder.parse();
 
-    when(builder).parse();
-    then(caughtException()).isInstanceOf(BuilderException.class)
-      .hasMessage("Each XMLConfigBuilder can only be used once.");
-    inputStream.close();
+      when(builder).parse();
+      then(caughtException()).isInstanceOf(BuilderException.class)
+              .hasMessage("Each XMLConfigBuilder can only be used once.");
+    }
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/builder/XmlMapperBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlMapperBuilderTest.java
@@ -43,28 +43,28 @@ public class XmlMapperBuilderTest {
   public void shouldSuccessfullyLoadXMLMapperFile() throws Exception {
     Configuration configuration = new Configuration();
     String resource = "org/apache/ibatis/builder/AuthorMapper.xml";
-    InputStream inputStream = Resources.getResourceAsStream(resource);
-    XMLMapperBuilder builder = new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments());
-    builder.parse();
-    inputStream.close();
+    try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+      XMLMapperBuilder builder = new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments());
+      builder.parse();
+    }
   }
 
   @Test
   public void mappedStatementWithOptions() throws Exception {
     Configuration configuration = new Configuration();
     String resource = "org/apache/ibatis/builder/AuthorMapper.xml";
-    InputStream inputStream = Resources.getResourceAsStream(resource);
-    XMLMapperBuilder builder = new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments());
-    builder.parse();
+    try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+      XMLMapperBuilder builder = new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments());
+      builder.parse();
 
-    MappedStatement mappedStatement = configuration.getMappedStatement("selectWithOptions");
-    assertThat(mappedStatement.getFetchSize()).isEqualTo(200);
-    assertThat(mappedStatement.getTimeout()).isEqualTo(10);
-    assertThat(mappedStatement.getStatementType()).isEqualTo(StatementType.PREPARED);
-    assertThat(mappedStatement.getResultSetType()).isEqualTo(ResultSetType.SCROLL_SENSITIVE);
-    assertThat(mappedStatement.isFlushCacheRequired()).isFalse();
-    assertThat(mappedStatement.isUseCache()).isFalse();
-    inputStream.close();
+      MappedStatement mappedStatement = configuration.getMappedStatement("selectWithOptions");
+      assertThat(mappedStatement.getFetchSize()).isEqualTo(200);
+      assertThat(mappedStatement.getTimeout()).isEqualTo(10);
+      assertThat(mappedStatement.getStatementType()).isEqualTo(StatementType.PREPARED);
+      assertThat(mappedStatement.getResultSetType()).isEqualTo(ResultSetType.SCROLL_SENSITIVE);
+      assertThat(mappedStatement.isFlushCacheRequired()).isFalse();
+      assertThat(mappedStatement.isUseCache()).isFalse();
+    }
   }
 
   @Test
@@ -178,9 +178,10 @@ public class XmlMapperBuilderTest {
     expectedEx.expectMessage("Error parsing Mapper XML. The XML location is 'org/apache/ibatis/builder/ProblemMapper.xml'");
     Configuration configuration = new Configuration();
     String resource = "org/apache/ibatis/builder/ProblemMapper.xml";
-    InputStream inputStream = Resources.getResourceAsStream(resource);
-    XMLMapperBuilder builder = new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments());
-    builder.parse();
+    try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+      XMLMapperBuilder builder = new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments());
+      builder.parse();
+    }
   }
 
 //  @Test

--- a/src/test/java/org/apache/ibatis/databases/blog/StoredProcedures.java
+++ b/src/test/java/org/apache/ibatis/databases/blog/StoredProcedures.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,42 +19,39 @@ import java.sql.*;
 
 public class StoredProcedures {
   public static void selectTwoSetsOfTwoAuthors(int p1, int p2, ResultSet[] rs1, ResultSet[] rs2) throws SQLException {
-    Connection conn = DriverManager.getConnection("jdbc:default:connection");
-    PreparedStatement ps1 = conn.prepareStatement("select * from author where id in (?,?)");
-    ps1.setInt(1, p1);
-    ps1.setInt(2, p2);
-    rs1[0] = ps1.executeQuery();
-    PreparedStatement ps2 = conn.prepareStatement("select * from author where id in (?,?)");
-    ps2.setInt(1, p2);
-    ps2.setInt(2, p1);
-    rs2[0] = ps2.executeQuery();
-    conn.close();
+    try (Connection conn = DriverManager.getConnection("jdbc:default:connection")) {
+      PreparedStatement ps1 = conn.prepareStatement("select * from author where id in (?,?)");
+      ps1.setInt(1, p1);
+      ps1.setInt(2, p2);
+      rs1[0] = ps1.executeQuery();
+      PreparedStatement ps2 = conn.prepareStatement("select * from author where id in (?,?)");
+      ps2.setInt(1, p2);
+      ps2.setInt(2, p1);
+      rs2[0] = ps2.executeQuery();
+    }
   }
 
   public static void insertAuthor(int id, String username, String password, String email) throws SQLException {
-    Connection conn = DriverManager.getConnection("jdbc:default:connection");
-    try {
+    try (Connection conn = DriverManager.getConnection("jdbc:default:connection")) {
       PreparedStatement ps = conn.prepareStatement("INSERT INTO author (id, username, password, email) VALUES (?,?,?,?)");
       ps.setInt(1, id);
       ps.setString(2, username);
       ps.setString(3, password);
       ps.setString(4, email);
       ps.executeUpdate();
-    } finally {
-      conn.close();
     }
   }
 
   public static void selectAuthorViaOutParams(int id, String[] username, String[] password, String[] email, String[] bio) throws SQLException {
-    Connection conn = DriverManager.getConnection("jdbc:default:connection");
-    PreparedStatement ps = conn.prepareStatement("select * from author where id = ?");
-    ps.setInt(1, id);
-    ResultSet rs = ps.executeQuery();
-    rs.next();
-    username[0] = rs.getString("username");
-    password[0] = rs.getString("password");
-    email[0] = rs.getString("email");
-    bio[0] = rs.getString("bio");
-    conn.close();
+    try (Connection conn = DriverManager.getConnection("jdbc:default:connection")) {
+      PreparedStatement ps = conn.prepareStatement("select * from author where id = ?");
+      ps.setInt(1, id);
+      ResultSet rs = ps.executeQuery();
+      rs.next();
+      username[0] = rs.getString("username");
+      password[0] = rs.getString("password");
+      email[0] = rs.getString("email");
+      bio[0] = rs.getString("bio");
+    }
   }
 }

--- a/src/test/java/org/apache/ibatis/datasource/unpooled/UnpooledDataSourceTest.java
+++ b/src/test/java/org/apache/ibatis/datasource/unpooled/UnpooledDataSourceTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -33,10 +33,10 @@ public class UnpooledDataSourceTest {
     // https://code.google.com/p/mybatis/issues/detail?id=430
     UnpooledDataSource dataSource = null;
     dataSource = new UnpooledDataSource("org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:multipledrivers", "sa", "");
-    dataSource.getConnection();
+    dataSource.getConnection().close();
     int before = countRegisteredDrivers();
     dataSource = new UnpooledDataSource("org.hsqldb.jdbcDriver", "jdbc:hsqldb:mem:multipledrivers", "sa", "");
-    dataSource.getConnection();
+    dataSource.getConnection().close();
     assertEquals(before, countRegisteredDrivers());
   }
 
@@ -48,11 +48,11 @@ public class UnpooledDataSourceTest {
     UnpooledDataSource dataSource = null;
     driverClassLoader = new URLClassLoader(new URL[] { new URL("jar:file:/PATH_TO/mysql-connector-java-5.1.25.jar!/") });
     dataSource = new UnpooledDataSource(driverClassLoader, "com.mysql.jdbc.Driver", "jdbc:mysql://127.0.0.1/test", "root", "");
-    dataSource.getConnection();
+    dataSource.getConnection().close();
     assertEquals(before + 1, countRegisteredDrivers());
     driverClassLoader = new URLClassLoader(new URL[] { new URL("jar:file:/PATH_TO/mysql-connector-java-5.1.25.jar!/") });
     dataSource = new UnpooledDataSource(driverClassLoader, "com.mysql.jdbc.Driver", "jdbc:mysql://127.0.0.1/test", "root", "");
-    dataSource.getConnection();
+    dataSource.getConnection().close();
     assertEquals(before + 1, countRegisteredDrivers());
   }
 

--- a/src/test/java/org/apache/ibatis/executor/loader/SerializableProxyTest.java
+++ b/src/test/java/org/apache/ibatis/executor/loader/SerializableProxyTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -176,20 +176,19 @@ public abstract class SerializableProxyTest {
   }
 
   protected byte[] serialize(Serializable value) throws Exception {
-    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    ObjectOutputStream oos = new ObjectOutputStream(bos);
-    oos.writeObject(value);
-    oos.flush();
-    oos.close();
-    return bos.toByteArray();
+    try(ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(value);
+      oos.flush();
+      return bos.toByteArray();
+    }
   }
 
   protected Serializable deserialize(byte[] value) throws Exception {
-    ByteArrayInputStream bis = new ByteArrayInputStream(value);
-    ObjectInputStream ois = new ObjectInputStream(bis);
-    Serializable result = (Serializable) ois.readObject();
-    ois.close();
-    return result;
+    try(ByteArrayInputStream bis = new ByteArrayInputStream(value);
+    ObjectInputStream ois = new ObjectInputStream(bis)) {
+      return (Serializable) ois.readObject();
+    }
   }
 
   public static class AuthorWithWriteReplaceMethod extends Author {

--- a/src/test/java/org/apache/ibatis/io/ExternalResourcesTest.java
+++ b/src/test/java/org/apache/ibatis/io/ExternalResourcesTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -82,11 +82,9 @@ public class ExternalResourcesTest {
   public void testGetConfiguredTemplate() {
     String templateName = "";
 
-    try {
-      FileWriter fileWriter = new FileWriter(tempFile);
+    try (FileWriter fileWriter = new FileWriter(tempFile)) {
       fileWriter.append("new_command.template=templates/col_new_template_migration.sql");
       fileWriter.flush();
-      fileWriter.close();
       templateName = ExternalResources.getConfiguredTemplate(tempFile.getAbsolutePath(), "new_command.template");
       assertEquals("templates/col_new_template_migration.sql", templateName);
     } catch (Exception e) {

--- a/src/test/java/org/apache/ibatis/io/ResourcesTest.java
+++ b/src/test/java/org/apache/ibatis/io/ResourcesTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -56,31 +56,31 @@ public class ResourcesTest extends BaseDataTest {
   @Test
   public void shouldGetUrlAsStream() throws Exception {
     URL url = Resources.getResourceURL(CLASS_LOADER, JPETSTORE_PROPERTIES);
-    InputStream in = Resources.getUrlAsStream(url.toString());
-    assertNotNull(in);
-    in.close();
+    try (InputStream in = Resources.getUrlAsStream(url.toString())) {
+      assertNotNull(in);
+    }
   }
 
   @Test
   public void shouldGetUrlAsReader() throws Exception {
     URL url = Resources.getResourceURL(CLASS_LOADER, JPETSTORE_PROPERTIES);
-    Reader in = Resources.getUrlAsReader(url.toString());
-    assertNotNull(in);
-    in.close();
+    try (Reader in = Resources.getUrlAsReader(url.toString())) {
+      assertNotNull(in);
+    }
   }
 
   @Test
   public void shouldGetResourceAsStream() throws Exception {
-    InputStream in = Resources.getResourceAsStream(CLASS_LOADER, JPETSTORE_PROPERTIES);
-    assertNotNull(in);
-    in.close();
+    try (InputStream in = Resources.getResourceAsStream(CLASS_LOADER, JPETSTORE_PROPERTIES)) {
+      assertNotNull(in);
+    }
   }
 
   @Test
   public void shouldGetResourceAsReader() throws Exception {
-    Reader in = Resources.getResourceAsReader(CLASS_LOADER, JPETSTORE_PROPERTIES);
-    assertNotNull(in);
-    in.close();
+    try(Reader in = Resources.getResourceAsReader(CLASS_LOADER, JPETSTORE_PROPERTIES)) {
+      assertNotNull(in);
+    }
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/jdbc/PooledDataSourceTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/PooledDataSourceTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -137,12 +137,11 @@ public class PooledDataSourceTest extends BaseDataTest {
   }
 
   private void exexuteQuery(Connection con) throws SQLException {
-    PreparedStatement st = con.prepareStatement("select 1");
-    ResultSet rs = st.executeQuery();
-    while (rs.next()) {
-      assertEquals(1, rs.getInt(1));
+    try (PreparedStatement st = con.prepareStatement("select 1");
+         ResultSet rs = st.executeQuery()) {
+      while (rs.next()) {
+        assertEquals(1, rs.getInt(1));
+      }
     }
-    rs.close();
-    st.close();
   }
 }

--- a/src/test/java/org/apache/ibatis/jdbc/ScriptRunnerTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/ScriptRunnerTest.java
@@ -62,14 +62,14 @@ public class ScriptRunnerTest extends BaseDataTest {
   @Test
   public void shouldRunScriptsUsingConnection() throws Exception {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
-    Connection conn = ds.getConnection();
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setAutoCommit(true);
-    runner.setStopOnError(false);
-    runner.setErrorLogWriter(null);
-    runner.setLogWriter(null);
-    runJPetStoreScripts(runner);
-    conn.close();
+    try (Connection conn = ds.getConnection()) {
+      ScriptRunner runner = new ScriptRunner(conn);
+      runner.setAutoCommit(true);
+      runner.setStopOnError(false);
+      runner.setErrorLogWriter(null);
+      runner.setLogWriter(null);
+      runJPetStoreScripts(runner);
+    }
     assertProductsTableExistsAndLoaded();
   }
 
@@ -93,139 +93,120 @@ public class ScriptRunnerTest extends BaseDataTest {
   @Test
   public void shouldReturnWarningIfEndOfLineTerminatorNotFound() throws Exception {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
-    Connection conn = ds.getConnection();
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setAutoCommit(true);
-    runner.setStopOnError(false);
-    runner.setErrorLogWriter(null);
-    runner.setLogWriter(null);
-
     String resource = "org/apache/ibatis/jdbc/ScriptMissingEOLTerminator.sql";
-    Reader reader = Resources.getResourceAsReader(resource);
+    try (Connection conn = ds.getConnection();
+         Reader reader = Resources.getResourceAsReader(resource)) {
+      ScriptRunner runner = new ScriptRunner(conn);
+      runner.setAutoCommit(true);
+      runner.setStopOnError(false);
+      runner.setErrorLogWriter(null);
+      runner.setLogWriter(null);
 
-    try {
-      runner.runScript(reader);
-      fail("Expected script runner to fail due to missing end of line terminator.");
-    } catch (Exception e) {
-      assertTrue(e.getMessage().contains("end-of-line terminator"));
+      try {
+        runner.runScript(reader);
+        fail("Expected script runner to fail due to missing end of line terminator.");
+      } catch (Exception e) {
+        assertTrue(e.getMessage().contains("end-of-line terminator"));
+      }
     }
-    reader.close();
-    conn.close();
   }
 
   @Test
   public void commentAferStatementDelimiterShouldNotCauseRunnerFail() throws Exception {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
-    Connection conn = ds.getConnection();
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setAutoCommit(true);
-    runner.setStopOnError(true);
-    runner.setErrorLogWriter(null);
-    runner.setLogWriter(null);
-    runJPetStoreScripts(runner);
-
     String resource = "org/apache/ibatis/jdbc/ScriptCommentAfterEOLTerminator.sql";
-    Reader reader = Resources.getResourceAsReader(resource);
-
-    try {
+    try (Connection conn = ds.getConnection();
+         Reader reader = Resources.getResourceAsReader(resource)) {
+      ScriptRunner runner = new ScriptRunner(conn);
+      runner.setAutoCommit(true);
+      runner.setStopOnError(true);
+      runner.setErrorLogWriter(null);
+      runner.setLogWriter(null);
+      runJPetStoreScripts(runner);
       runner.runScript(reader);
-    } catch (Exception e) {
-      fail(e.getMessage());
     }
-    reader.close();
-    conn.close();
   }
 
   @Test
   public void shouldReturnWarningIfNotTheCurrentDelimiterUsed() throws Exception {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
-    Connection conn = ds.getConnection();
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setAutoCommit(false);
-    runner.setStopOnError(true);
-    runner.setErrorLogWriter(null);
-    runner.setLogWriter(null);
-
     String resource = "org/apache/ibatis/jdbc/ScriptChangingDelimiterMissingDelimiter.sql";
-    Reader reader = Resources.getResourceAsReader(resource);
-
-    try {
-      runner.runScript(reader);
-      fail("Expected script runner to fail due to the usage of invalid delimiter.");
-    } catch (Exception e) {
-      assertTrue(e.getMessage().contains("end-of-line terminator"));
+    try (Connection conn = ds.getConnection();
+         Reader reader = Resources.getResourceAsReader(resource)) {
+      ScriptRunner runner = new ScriptRunner(conn);
+      runner.setAutoCommit(false);
+      runner.setStopOnError(true);
+      runner.setErrorLogWriter(null);
+      runner.setLogWriter(null);
+      try {
+        runner.runScript(reader);
+        fail("Expected script runner to fail due to the usage of invalid delimiter.");
+      } catch (Exception e) {
+        assertTrue(e.getMessage().contains("end-of-line terminator"));
+      }
     }
-    reader.close();
-    conn.close();
   }
 
   @Test
   public void changingDelimiterShouldNotCauseRunnerFail() throws Exception {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
-    Connection conn = ds.getConnection();
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setAutoCommit(false);
-    runner.setStopOnError(true);
-    runner.setErrorLogWriter(null);
-    runner.setLogWriter(null);
-    runJPetStoreScripts(runner);
-
     String resource = "org/apache/ibatis/jdbc/ScriptChangingDelimiter.sql";
-    Reader reader = Resources.getResourceAsReader(resource);
-
-    try {
+    try (Connection conn = ds.getConnection();
+         Reader reader = Resources.getResourceAsReader(resource)) {
+      ScriptRunner runner = new ScriptRunner(conn);
+      runner.setAutoCommit(false);
+      runner.setStopOnError(true);
+      runner.setErrorLogWriter(null);
+      runner.setLogWriter(null);
+      runJPetStoreScripts(runner);
       runner.runScript(reader);
-    } catch (Exception e) {
-      fail(e.getMessage());
     }
-    reader.close();
-    conn.close();
   }
 
   @Test
   public void testLogging() throws Exception {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
-    Connection conn = ds.getConnection();
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setAutoCommit(true);
-    runner.setStopOnError(false);
-    runner.setErrorLogWriter(null);
-    runner.setSendFullScript(false);
-    StringWriter sw = new StringWriter();
-    PrintWriter logWriter = new PrintWriter(sw);
-    runner.setLogWriter(logWriter);
+    try (Connection conn = ds.getConnection()) {
+      ScriptRunner runner = new ScriptRunner(conn);
+      runner.setAutoCommit(true);
+      runner.setStopOnError(false);
+      runner.setErrorLogWriter(null);
+      runner.setSendFullScript(false);
+      StringWriter sw = new StringWriter();
+      PrintWriter logWriter = new PrintWriter(sw);
+      runner.setLogWriter(logWriter);
 
-    Reader reader = new StringReader("select userid from account where userid = 'j2ee';");
-    runner.runScript(reader);
-    conn.close();
+      Reader reader = new StringReader("select userid from account where userid = 'j2ee';");
+      runner.runScript(reader);
 
-    assertEquals(
-            "select userid from account where userid = 'j2ee'" + LINE_SEPARATOR
-                    + LINE_SEPARATOR + "USERID\t" + LINE_SEPARATOR
-                    + "j2ee\t" + LINE_SEPARATOR, sw.toString());
+      assertEquals(
+              "select userid from account where userid = 'j2ee'" + LINE_SEPARATOR
+                      + LINE_SEPARATOR + "USERID\t" + LINE_SEPARATOR
+                      + "j2ee\t" + LINE_SEPARATOR, sw.toString());
+    }
   }
 
   @Test
   public void testLoggingFullScipt() throws Exception {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
-    Connection conn = ds.getConnection();
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setAutoCommit(true);
-    runner.setStopOnError(false);
-    runner.setErrorLogWriter(null);
-    runner.setSendFullScript(true);
-    StringWriter sw = new StringWriter();
-    PrintWriter logWriter = new PrintWriter(sw);
-    runner.setLogWriter(logWriter);
+    try (Connection conn = ds.getConnection()) {
+      ScriptRunner runner = new ScriptRunner(conn);
+      runner.setAutoCommit(true);
+      runner.setStopOnError(false);
+      runner.setErrorLogWriter(null);
+      runner.setSendFullScript(true);
+      StringWriter sw = new StringWriter();
+      PrintWriter logWriter = new PrintWriter(sw);
+      runner.setLogWriter(logWriter);
 
-    Reader reader = new StringReader("select userid from account where userid = 'j2ee';");
-    runner.runScript(reader);
-    conn.close();
+      Reader reader = new StringReader("select userid from account where userid = 'j2ee';");
+      runner.runScript(reader);
 
-    assertEquals(
-            "select userid from account where userid = 'j2ee';" + LINE_SEPARATOR
-                    + LINE_SEPARATOR + "USERID\t" + LINE_SEPARATOR
-                    + "j2ee\t" + LINE_SEPARATOR, sw.toString());
+      assertEquals(
+              "select userid from account where userid = 'j2ee';" + LINE_SEPARATOR
+                      + LINE_SEPARATOR + "USERID\t" + LINE_SEPARATOR
+                      + "j2ee\t" + LINE_SEPARATOR, sw.toString());
+    }
   }
 
   private void runJPetStoreScripts(ScriptRunner runner) throws IOException, SQLException {
@@ -235,12 +216,10 @@ public class ScriptRunnerTest extends BaseDataTest {
 
   private void assertProductsTableExistsAndLoaded() throws IOException, SQLException {
     PooledDataSource ds = createPooledDataSource(JPETSTORE_PROPERTIES);
-    try {
-      Connection conn = ds.getConnection();
+    try (Connection conn = ds.getConnection()) {
       SqlRunner executor = new SqlRunner(conn);
       List<Map<String, Object>> products = executor.selectAll("SELECT * FROM PRODUCT");
       assertEquals(16, products.size());
-      conn.close();
     } finally {
       ds.forceCloseAll();
     }

--- a/src/test/java/org/apache/ibatis/jdbc/SqlRunnerTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/SqlRunnerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,11 +34,11 @@ public class SqlRunnerTest extends BaseDataTest {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
     runScript(ds, JPETSTORE_DDL);
     runScript(ds, JPETSTORE_DATA);
-    Connection connection = ds.getConnection();
-    SqlRunner exec = new SqlRunner(connection);
-    Map<String, Object> row = exec.selectOne("SELECT * FROM PRODUCT WHERE PRODUCTID = ?", "FI-SW-01");
-    connection.close();
-    assertEquals("FI-SW-01", row.get("PRODUCTID"));
+    try (Connection connection = ds.getConnection()) {
+      SqlRunner exec = new SqlRunner(connection);
+      Map<String, Object> row = exec.selectOne("SELECT * FROM PRODUCT WHERE PRODUCTID = ?", "FI-SW-01");
+      assertEquals("FI-SW-01", row.get("PRODUCTID"));
+    }
   }
 
   @Test
@@ -46,26 +46,26 @@ public class SqlRunnerTest extends BaseDataTest {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
     runScript(ds, JPETSTORE_DDL);
     runScript(ds, JPETSTORE_DATA);
-    Connection connection = ds.getConnection();
-    SqlRunner exec = new SqlRunner(connection);
-    List<Map<String, Object>> rows = exec.selectAll("SELECT * FROM PRODUCT");
-    connection.close();
-    assertEquals(16, rows.size());
+    try (Connection connection = ds.getConnection()) {
+      SqlRunner exec = new SqlRunner(connection);
+      List<Map<String, Object>> rows = exec.selectAll("SELECT * FROM PRODUCT");
+      assertEquals(16, rows.size());
+    }
   }
 
   @Test
   public void shouldInsert() throws Exception {
     DataSource ds = createUnpooledDataSource(BLOG_PROPERTIES);
     runScript(ds, BLOG_DDL);
-    Connection connection = ds.getConnection();
-    SqlRunner exec = new SqlRunner(connection);
-    exec.setUseGeneratedKeySupport(true);
-    int id = exec.insert("INSERT INTO author (username, password, email, bio) VALUES (?,?,?,?)", "someone", "******", "someone@apache.org", Null.LONGVARCHAR);
-    Map<String,Object> row = exec.selectOne("SELECT * FROM author WHERE username = ?", "someone");
-    connection.rollback();
-    connection.close();
-    assertTrue(SqlRunner.NO_GENERATED_KEY != id);
-    assertEquals("someone", row.get("USERNAME"));
+    try (Connection connection = ds.getConnection()) {
+      SqlRunner exec = new SqlRunner(connection);
+      exec.setUseGeneratedKeySupport(true);
+      int id = exec.insert("INSERT INTO author (username, password, email, bio) VALUES (?,?,?,?)", "someone", "******", "someone@apache.org", Null.LONGVARCHAR);
+      Map<String, Object> row = exec.selectOne("SELECT * FROM author WHERE username = ?", "someone");
+      connection.rollback();
+      assertTrue(SqlRunner.NO_GENERATED_KEY != id);
+      assertEquals("someone", row.get("USERNAME"));
+    }
   }
 
   @Test
@@ -73,13 +73,13 @@ public class SqlRunnerTest extends BaseDataTest {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
     runScript(ds, JPETSTORE_DDL);
     runScript(ds, JPETSTORE_DATA);
-    Connection connection = ds.getConnection();
-    SqlRunner exec = new SqlRunner(connection);
-    int count = exec.update("update product set category = ? where productid = ?", "DOGS", "FI-SW-01");
-    Map<String,Object> row = exec.selectOne("SELECT * FROM PRODUCT WHERE PRODUCTID = ?", "FI-SW-01");
-    connection.close();
-    assertEquals("DOGS", row.get("CATEGORY"));
-    assertEquals(1, count);
+    try (Connection connection = ds.getConnection()) {
+      SqlRunner exec = new SqlRunner(connection);
+      int count = exec.update("update product set category = ? where productid = ?", "DOGS", "FI-SW-01");
+      Map<String, Object> row = exec.selectOne("SELECT * FROM PRODUCT WHERE PRODUCTID = ?", "FI-SW-01");
+      assertEquals("DOGS", row.get("CATEGORY"));
+      assertEquals(1, count);
+    }
   }
 
   @Test
@@ -87,25 +87,25 @@ public class SqlRunnerTest extends BaseDataTest {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
     runScript(ds, JPETSTORE_DDL);
     runScript(ds, JPETSTORE_DATA);
-    Connection connection = ds.getConnection();
-    SqlRunner exec = new SqlRunner(connection);
-    int count = exec.delete("delete from item");
-    List<Map<String,Object>> rows = exec.selectAll("SELECT * FROM ITEM");
-    connection.close();
-    assertEquals(28, count);
-    assertEquals(0, rows.size());
+    try (Connection connection = ds.getConnection()) {
+      SqlRunner exec = new SqlRunner(connection);
+      int count = exec.delete("delete from item");
+      List<Map<String, Object>> rows = exec.selectAll("SELECT * FROM ITEM");
+      assertEquals(28, count);
+      assertEquals(0, rows.size());
+    }
   }
 
   @Test
   public void shouldDemonstrateDDLThroughRunMethod() throws Exception {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
-    Connection connection = ds.getConnection();
-    SqlRunner exec = new SqlRunner(connection);
-    exec.run("CREATE TABLE BLAH(ID INTEGER)");
-    exec.run("insert into BLAH values (1)");
-    List<Map<String,Object>> rows = exec.selectAll("SELECT * FROM BLAH");
-    exec.run("DROP TABLE BLAH");
-    connection.close();
-    assertEquals(1, rows.size());
+    try (Connection connection = ds.getConnection()) {
+      SqlRunner exec = new SqlRunner(connection);
+      exec.run("CREATE TABLE BLAH(ID INTEGER)");
+      exec.run("insert into BLAH values (1)");
+      List<Map<String, Object>> rows = exec.selectAll("SELECT * FROM BLAH");
+      exec.run("DROP TABLE BLAH");
+      assertEquals(1, rows.size());
+    }
   }
 }

--- a/src/test/java/org/apache/ibatis/logging/LogFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/logging/LogFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -90,10 +90,10 @@ public class LogFactoryTest {
 
   @Test
   public void shouldReadLogImplFromSettings() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/logging/mybatis-config.xml");
-    new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
-    
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/logging/mybatis-config.xml")) {
+      new SqlSessionFactoryBuilder().build(reader);
+    }
+
     Log log = LogFactory.getLog(Object.class);
     log.debug("Debug message.");
     assertEquals(log.getClass().getName(), NoLoggingImpl.class.getName());

--- a/src/test/java/org/apache/ibatis/parsing/XPathParserTest.java
+++ b/src/test/java/org/apache/ibatis/parsing/XPathParserTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,21 +27,21 @@ public class XPathParserTest {
   @Test
   public void shouldTestXPathParserMethods() throws Exception {
     String resource = "resources/nodelet_test.xml";
-    InputStream inputStream = Resources.getResourceAsStream(resource);
-    XPathParser parser = new XPathParser(inputStream, false, null, null);
-    assertEquals((Long)1970l, parser.evalLong("/employee/birth_date/year"));
-    assertEquals((short) 6, (short) parser.evalShort("/employee/birth_date/month"));
-    assertEquals((Integer) 15, parser.evalInteger("/employee/birth_date/day"));
-    assertEquals((Float) 5.8f, parser.evalFloat("/employee/height"));
-    assertEquals((Double) 5.8d, parser.evalDouble("/employee/height"));
-    assertEquals("${id_var}", parser.evalString("/employee/@id"));
-    assertEquals(Boolean.TRUE, parser.evalBoolean("/employee/active"));
-    assertEquals("<id>${id_var}</id>", parser.evalNode("/employee/@id").toString().trim());
-    assertEquals(7, parser.evalNodes("/employee/*").size());
-    XNode node = parser.evalNode("/employee/height");
-    assertEquals("employee/height", node.getPath());
-    assertEquals("employee[${id_var}]_height", node.getValueBasedIdentifier());
-    inputStream.close();
+    try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+      XPathParser parser = new XPathParser(inputStream, false, null, null);
+      assertEquals((Long) 1970l, parser.evalLong("/employee/birth_date/year"));
+      assertEquals((short) 6, (short) parser.evalShort("/employee/birth_date/month"));
+      assertEquals((Integer) 15, parser.evalInteger("/employee/birth_date/day"));
+      assertEquals((Float) 5.8f, parser.evalFloat("/employee/height"));
+      assertEquals((Double) 5.8d, parser.evalDouble("/employee/height"));
+      assertEquals("${id_var}", parser.evalString("/employee/@id"));
+      assertEquals(Boolean.TRUE, parser.evalBoolean("/employee/active"));
+      assertEquals("<id>${id_var}</id>", parser.evalNode("/employee/@id").toString().trim());
+      assertEquals(7, parser.evalNodes("/employee/*").size());
+      XNode node = parser.evalNode("/employee/height");
+      assertEquals("employee/height", node.getPath());
+      assertEquals("employee[${id_var}]_height", node.getValueBasedIdentifier());
+    }
   }
 
 }

--- a/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
+++ b/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
@@ -732,15 +732,12 @@ public class SqlSessionTest extends BaseDataTest {
 
   @Test
   public void shouldFindPostsWithAuthorIdUsingDynamicSql() throws Exception {
-    SqlSession session = sqlMapper.openSession();
-    try {
+    try (SqlSession session = sqlMapper.openSession()) {
       List<Post> posts = session.selectList("org.apache.ibatis.domain.blog.mappers.PostMapper.findPost",
           new HashMap<String, Integer>() {{
             put("author_id", 101);
           }});
       assertEquals(3, posts.size());
-    } finally {
-      session.close();
     }
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/ancestor_ref/AncestorRefTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ancestor_ref/AncestorRefTest.java
@@ -33,9 +33,9 @@ public class AncestorRefTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ancestor_ref/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ancestor_ref/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/array_result_type/ArrayResultTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/array_result_type/ArrayResultTypeTest.java
@@ -34,9 +34,9 @@ public class ArrayResultTypeTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/array_result_type/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/array_result_type/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/association_nested/FolderMapperTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/association_nested/FolderMapperTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,19 +35,15 @@ public class FolderMapperTest {
 
   @Test
   public void testFindWithChildren() throws Exception {
-    Connection conn = DriverManager.getConnection("jdbc:hsqldb:mem:association_nested", "SA", "");
-    Statement stmt = conn.createStatement();
-    stmt.execute("create table folder (id int, name varchar(100), parent_id int)");
-
-
-    stmt.execute("insert into folder (id, name) values(1, 'Root')");
-    stmt.execute("insert into folder values(2, 'Folder 1', 1)");
-    stmt.execute("insert into folder values(3, 'Folder 2', 1)");
-    stmt.execute("insert into folder values(4, 'Folder 2_1', 3)");
-    stmt.execute("insert into folder values(5, 'Folder 2_2', 3)");
-
-    stmt.close();
-    conn.close();
+    try (Connection conn = DriverManager.getConnection("jdbc:hsqldb:mem:association_nested", "SA", "");
+         Statement stmt = conn.createStatement()) {
+      stmt.execute("create table folder (id int, name varchar(100), parent_id int)");
+      stmt.execute("insert into folder (id, name) values(1, 'Root')");
+      stmt.execute("insert into folder values(2, 'Folder 1', 1)");
+      stmt.execute("insert into folder values(3, 'Folder 2', 1)");
+      stmt.execute("insert into folder values(4, 'Folder 2_1', 3)");
+      stmt.execute("insert into folder values(5, 'Folder 2_2', 3)");
+    }
 
     /**
      * Root/
@@ -58,18 +54,16 @@ public class FolderMapperTest {
      */
 
     String resource = "org/apache/ibatis/submitted/association_nested/mybatis-config.xml";
-    InputStream inputStream = Resources.getResourceAsStream(resource);
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream);
+    try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream);
+      try (SqlSession session = sqlSessionFactory.openSession()) {
+        FolderMapper postMapper = session.getMapper(FolderMapper.class);
 
-    SqlSession session = sqlSessionFactory.openSession();
-    FolderMapper postMapper = session.getMapper(FolderMapper.class);
+        List<FolderFlatTree> folders = postMapper.findWithSubFolders("Root");
 
-    List<FolderFlatTree> folders = postMapper.findWithSubFolders("Root");
-
-    Assert.assertEquals(3, folders.size());
-
-    inputStream.close();
-    session.close();
+        Assert.assertEquals(3, folders.size());
+      }
+    }
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/associationtest/AssociationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/associationtest/AssociationTest.java
@@ -34,9 +34,9 @@ public class AssociationTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/associationtest/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/associationtest/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/associationtype/AssociationTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/associationtype/AssociationTypeTest.java
@@ -36,9 +36,9 @@ public class AssociationTypeTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/associationtype/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/associationtype/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/autodiscover/AutodiscoverTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/autodiscover/AutodiscoverTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,9 +35,9 @@ public class AutodiscoverTest {
 
   @BeforeClass
   public static void setup() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/autodiscover/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/autodiscover/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
@@ -35,9 +35,9 @@ public class AutomappingTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/automapping/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/automapping/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/awful_table/AwfulTableTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/awful_table/AwfulTableTest.java
@@ -32,9 +32,9 @@ public class AwfulTableTest {
 
   @Before
   public void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/awful_table/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/awful_table/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/awful_table/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/basetest/BaseTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/basetest/BaseTest.java
@@ -33,9 +33,9 @@ public class BaseTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/basetest/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/basetest/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/blobtest/BlobTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/blobtest/BlobTest.java
@@ -34,9 +34,9 @@ public class BlobTest {
 
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/blobtest/MapperConfig.xml");
-        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-        reader.close();
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/blobtest/MapperConfig.xml")) {
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        }
 
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/blobtest/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/blocking_cache/BlockingCacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/blocking_cache/BlockingCacheTest.java
@@ -36,9 +36,9 @@ public class BlockingCacheTest {
   @Before
   public void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/blocking_cache/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/blocking_cache/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/bringrags/SimpleObjectTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/bringrags/SimpleObjectTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,22 +36,21 @@ public class SimpleObjectTest {
 
   @Before
   public void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/bringrags/mybatis-config.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/bringrags/mybatis-config.xml")) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
 
-    sqlSession = sqlSessionFactory.openSession();
-    conn = sqlSession.getConnection();
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(new StringReader("DROP TABLE IF EXISTS SimpleObject;"));
-    runner.runScript(new StringReader("DROP TABLE IF EXISTS SimpleChildObject;"));
-    runner.runScript(new StringReader("CREATE TABLE SimpleObject (id VARCHAR(5) NOT NULL);"));
-    runner.runScript(new StringReader("CREATE TABLE SimpleChildObject (id VARCHAR(5) NOT NULL, simple_object_id VARCHAR(5) NOT NULL);"));
-    runner.runScript(new StringReader("INSERT INTO SimpleObject (id) values ('10000');"));
-    runner.runScript(new StringReader("INSERT INTO SimpleChildObject (id, simple_object_id) values ('20000', '10000');"));
-    reader.close();
-    simpleChildObjectMapper = (SimpleChildObjectMapper) sqlSession.getMapper(SimpleChildObjectMapper.class);
+      sqlSession = sqlSessionFactory.openSession();
+      conn = sqlSession.getConnection();
+      ScriptRunner runner = new ScriptRunner(conn);
+      runner.setLogWriter(null);
+      runner.runScript(new StringReader("DROP TABLE IF EXISTS SimpleObject;"));
+      runner.runScript(new StringReader("DROP TABLE IF EXISTS SimpleChildObject;"));
+      runner.runScript(new StringReader("CREATE TABLE SimpleObject (id VARCHAR(5) NOT NULL);"));
+      runner.runScript(new StringReader("CREATE TABLE SimpleChildObject (id VARCHAR(5) NOT NULL, simple_object_id VARCHAR(5) NOT NULL);"));
+      runner.runScript(new StringReader("INSERT INTO SimpleObject (id) values ('10000');"));
+      runner.runScript(new StringReader("INSERT INTO SimpleChildObject (id, simple_object_id) values ('20000', '10000');"));
+      simpleChildObjectMapper = sqlSession.getMapper(SimpleChildObjectMapper.class);
+    }
   }
 
   @After

--- a/src/test/java/org/apache/ibatis/submitted/cacheorder/CacheOrderTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cacheorder/CacheOrderTest.java
@@ -35,9 +35,9 @@ public class CacheOrderTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cacheorder/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cacheorder/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/CallSettersOnNullsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/CallSettersOnNullsTest.java
@@ -35,10 +35,10 @@ public class CallSettersOnNullsTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/call_setters_on_nulls/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/call_setters_on_nulls/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/DoNotCallSettersOnNullsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/DoNotCallSettersOnNullsTest.java
@@ -34,9 +34,9 @@ public class DoNotCallSettersOnNullsTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/call_setters_on_nulls/mybatis-config-2.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/call_setters_on_nulls/mybatis-config-2.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls_again/MyBatisTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls_again/MyBatisTest.java
@@ -32,9 +32,9 @@ public class MyBatisTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/call_setters_on_nulls_again/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/call_setters_on_nulls_again/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/camelcase/CamelCaseMappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/camelcase/CamelCaseMappingTest.java
@@ -34,9 +34,9 @@ public class CamelCaseMappingTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/camelcase/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/camelcase/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/camelcase/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/CglibNPELazyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/CglibNPELazyTest.java
@@ -32,11 +32,11 @@ public class CglibNPELazyTest {
 
   @BeforeClass
   public static void initDatabase() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cglib_lazy_error/ibatisConfigLazy.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    sqlSessionFactory.getConfiguration().setLazyLoadingEnabled(true);
-    sqlSessionFactory.getConfiguration().setAggressiveLazyLoading(false);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cglib_lazy_error/ibatisConfigLazy.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().setLazyLoadingEnabled(true);
+      sqlSessionFactory.getConfiguration().setAggressiveLazyLoading(false);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/cglib_lazy_error/CreateDB.sql");
@@ -44,65 +44,65 @@ public class CglibNPELazyTest {
 
   @Test
   public void testNoParent() {
-    SqlSession sqlSession = sqlSessionFactory.openSession();
-    PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-    Person person = personMapper.selectById(1);
-    Assert.assertNotNull("Persons must not be null", person);
-    Person parent = person.getParent();
-    Assert.assertNull("Parent must be null", parent);
-    sqlSession.close();
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+      Person person = personMapper.selectById(1);
+      Assert.assertNotNull("Persons must not be null", person);
+      Person parent = person.getParent();
+      Assert.assertNull("Parent must be null", parent);
+    }
   }
 
   @Test
   public void testAncestorSelf() {
-    SqlSession sqlSession = sqlSessionFactory.openSession();
-    PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-    Person person = personMapper.selectById(1);
-    Assert.assertNotNull("Persons must not be null", person);
-    Person ancestor = person.getAncestor();
-    Assert.assertEquals("Ancestor must be John Smith sr.", person, ancestor);
-    sqlSession.close();
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+      Person person = personMapper.selectById(1);
+      Assert.assertNotNull("Persons must not be null", person);
+      Person ancestor = person.getAncestor();
+      Assert.assertEquals("Ancestor must be John Smith sr.", person, ancestor);
+    }
   }
 
   @Test
   public void testAncestorAfterQueryingParents() {
-    SqlSession sqlSession = sqlSessionFactory.openSession();
-    PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-    Person expectedAncestor = personMapper.selectById(1);
-    Person person = personMapper.selectById(3);
-    // Load ancestor indirectly.
-    Assert.assertNotNull("Persons must not be null", person);
-    Assert.assertNotNull("Parent must not be null", person.getParent());
-    Assert.assertNotNull("Grandparent must not be null", person.getParent().getParent());
-    Assert.assertEquals("Ancestor must be John Smith sr.", expectedAncestor, person.getAncestor());
-    sqlSession.close();
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+      Person expectedAncestor = personMapper.selectById(1);
+      Person person = personMapper.selectById(3);
+      // Load ancestor indirectly.
+      Assert.assertNotNull("Persons must not be null", person);
+      Assert.assertNotNull("Parent must not be null", person.getParent());
+      Assert.assertNotNull("Grandparent must not be null", person.getParent().getParent());
+      Assert.assertEquals("Ancestor must be John Smith sr.", expectedAncestor, person.getAncestor());
+    }
   }
 
   @Test
   public void testGrandParent() {
-    SqlSession sqlSession = sqlSessionFactory.openSession();
-    PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-    Person expectedParent = personMapper.selectById(2);
-    Person expectedGrandParent = personMapper.selectById(1);
-    Person person = personMapper.selectById(3);
-    Assert.assertNotNull("Persons must not be null", person);
-    final Person actualParent = person.getParent();
-    final Person actualGrandParent = person.getParent().getParent();
-    Assert.assertEquals(expectedParent, actualParent);
-    Assert.assertEquals(expectedGrandParent, actualGrandParent);
-    sqlSession.close();
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+      Person expectedParent = personMapper.selectById(2);
+      Person expectedGrandParent = personMapper.selectById(1);
+      Person person = personMapper.selectById(3);
+      Assert.assertNotNull("Persons must not be null", person);
+      final Person actualParent = person.getParent();
+      final Person actualGrandParent = person.getParent().getParent();
+      Assert.assertEquals(expectedParent, actualParent);
+      Assert.assertEquals(expectedGrandParent, actualGrandParent);
+    }
   }
 
   @Test
   public void testAncestor() {
-    SqlSession sqlSession = sqlSessionFactory.openSession();
-    PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-    Person expectedAncestor = personMapper.selectById(1);
-    Person person = personMapper.selectById(3);
-    Assert.assertNotNull("Persons must not be null", person);
-    final Person actualAncestor = person.getAncestor();
-    Assert.assertEquals(expectedAncestor, actualAncestor);
-    sqlSession.close();
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+      Person expectedAncestor = personMapper.selectById(1);
+      Person person = personMapper.selectById(3);
+      Assert.assertNotNull("Persons must not be null", person);
+      final Person actualAncestor = person.getAncestor();
+      Assert.assertEquals(expectedAncestor, actualAncestor);
+    }
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/collectionparameters/CollectionParametersTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/collectionparameters/CollectionParametersTest.java
@@ -37,9 +37,9 @@ public class CollectionParametersTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/collectionparameters/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/collectionparameters/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/column_forwarding/ColumnForwardingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_forwarding/ColumnForwardingTest.java
@@ -33,9 +33,9 @@ public class ColumnForwardingTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/column_forwarding/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/column_forwarding/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/column_prefix/ColumnPrefixTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_prefix/ColumnPrefixTest.java
@@ -34,9 +34,9 @@ public class ColumnPrefixTest {
 
   @Before
   public void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader(getConfigPath());
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader(getConfigPath())) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/column_prefix/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/complex_column/ComplexColumnTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_column/ComplexColumnTest.java
@@ -32,9 +32,9 @@ public class ComplexColumnTest {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/complex_column/ibatisConfig.xml");
-        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-        reader.close();
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/complex_column/ibatisConfig.xml")) {
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        }
 
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/complex_column/CreateDB.sql");
@@ -42,97 +42,94 @@ public class ComplexColumnTest {
     
     @Test
     public void testWithoutComplex() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        Person person = personMapper.getWithoutComplex(2l);
-        Assert.assertNotNull("person must not be null", person);
-        Assert.assertEquals("Christian", person.getFirstName());
-        Assert.assertEquals("Poitras", person.getLastName());
-        Person parent = person.getParent();
-        Assert.assertNotNull("parent must not be null", parent);
-        Assert.assertEquals("John", parent.getFirstName());
-        Assert.assertEquals("Smith", parent.getLastName());
-      sqlSession.close();
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            Person person = personMapper.getWithoutComplex(2l);
+            Assert.assertNotNull("person must not be null", person);
+            Assert.assertEquals("Christian", person.getFirstName());
+            Assert.assertEquals("Poitras", person.getLastName());
+            Person parent = person.getParent();
+            Assert.assertNotNull("parent must not be null", parent);
+            Assert.assertEquals("John", parent.getFirstName());
+            Assert.assertEquals("Smith", parent.getLastName());
+        }
     }
     
     @Test
     public void testWithComplex() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        Person person = personMapper.getWithComplex(2l);
-        Assert.assertNotNull("person must not be null", person);
-        Assert.assertEquals("Christian", person.getFirstName());
-        Assert.assertEquals("Poitras", person.getLastName());
-        Person parent = person.getParent();
-        Assert.assertNotNull("parent must not be null", parent);
-        Assert.assertEquals("John", parent.getFirstName());
-        Assert.assertEquals("Smith", parent.getLastName());
-      sqlSession.close();
-
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            Person person = personMapper.getWithComplex(2l);
+            Assert.assertNotNull("person must not be null", person);
+            Assert.assertEquals("Christian", person.getFirstName());
+            Assert.assertEquals("Poitras", person.getLastName());
+            Person parent = person.getParent();
+            Assert.assertNotNull("parent must not be null", parent);
+            Assert.assertEquals("John", parent.getFirstName());
+            Assert.assertEquals("Smith", parent.getLastName());
+        }
     }
 
     @Test
     public void testWithComplex2() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        Person person = personMapper.getWithComplex2(2l);
-        Assert.assertNotNull("person must not be null", person);
-        Assert.assertEquals("Christian", person.getFirstName());
-        Assert.assertEquals("Poitras", person.getLastName());
-        Person parent = person.getParent();
-        Assert.assertNotNull("parent must not be null", parent);
-        Assert.assertEquals("John", parent.getFirstName());
-        Assert.assertEquals("Smith", parent.getLastName());
-      sqlSession.close();
-
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            Person person = personMapper.getWithComplex2(2l);
+            Assert.assertNotNull("person must not be null", person);
+            Assert.assertEquals("Christian", person.getFirstName());
+            Assert.assertEquals("Poitras", person.getLastName());
+            Person parent = person.getParent();
+            Assert.assertNotNull("parent must not be null", parent);
+            Assert.assertEquals("John", parent.getFirstName());
+            Assert.assertEquals("Smith", parent.getLastName());
+        }
     }
 
     @Test
     public void testWithComplex3() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        Person person = personMapper.getWithComplex3(2l);
-        Assert.assertNotNull("person must not be null", person);
-        Assert.assertEquals("Christian", person.getFirstName());
-        Assert.assertEquals("Poitras", person.getLastName());
-        Person parent = person.getParent();
-        Assert.assertNotNull("parent must not be null", parent);
-        Assert.assertEquals("John", parent.getFirstName());
-        Assert.assertEquals("Smith", parent.getLastName());
-      sqlSession.close();
-
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            Person person = personMapper.getWithComplex3(2l);
+            Assert.assertNotNull("person must not be null", person);
+            Assert.assertEquals("Christian", person.getFirstName());
+            Assert.assertEquals("Poitras", person.getLastName());
+            Person parent = person.getParent();
+            Assert.assertNotNull("parent must not be null", parent);
+            Assert.assertEquals("John", parent.getFirstName());
+            Assert.assertEquals("Smith", parent.getLastName());
+        }
     }
 
     @Test
     public void testWithComplex4() {
-      SqlSession sqlSession = sqlSessionFactory.openSession();
-      PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-      Person criteria = new Person();
-      criteria.setFirstName("Christian");
-      criteria.setLastName("Poitras");
-      Person person = personMapper.getParentWithComplex(criteria);
-      Assert.assertNotNull("person must not be null", person);
-      Assert.assertEquals("Christian", person.getFirstName());
-      Assert.assertEquals("Poitras", person.getLastName());
-      Person parent = person.getParent();
-      Assert.assertNotNull("parent must not be null", parent);
-      Assert.assertEquals("John", parent.getFirstName());
-      Assert.assertEquals("Smith", parent.getLastName());
-      sqlSession.close();
+      try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+          PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+          Person criteria = new Person();
+          criteria.setFirstName("Christian");
+          criteria.setLastName("Poitras");
+          Person person = personMapper.getParentWithComplex(criteria);
+          Assert.assertNotNull("person must not be null", person);
+          Assert.assertEquals("Christian", person.getFirstName());
+          Assert.assertEquals("Poitras", person.getLastName());
+          Person parent = person.getParent();
+          Assert.assertNotNull("parent must not be null", parent);
+          Assert.assertEquals("John", parent.getFirstName());
+          Assert.assertEquals("Smith", parent.getLastName());
+      }
     }
 
     @Test
     public void testWithParamAttributes() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        Person person = personMapper.getComplexWithParamAttributes(2l);
-        Assert.assertNotNull("person must not be null", person);
-        Assert.assertEquals("Christian", person.getFirstName());
-        Assert.assertEquals("Poitras", person.getLastName());
-        Person parent = person.getParent();
-        Assert.assertNotNull("parent must not be null", parent);
-        Assert.assertEquals("John", parent.getFirstName());
-        Assert.assertEquals("Smith", parent.getLastName());
-        sqlSession.close();
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            Person person = personMapper.getComplexWithParamAttributes(2l);
+            Assert.assertNotNull("person must not be null", person);
+            Assert.assertEquals("Christian", person.getFirstName());
+            Assert.assertEquals("Poitras", person.getLastName());
+            Person parent = person.getParent();
+            Assert.assertNotNull("parent must not be null", parent);
+            Assert.assertEquals("John", parent.getFirstName());
+            Assert.assertEquals("Smith", parent.getLastName());
+        }
     }
 }

--- a/src/test/java/org/apache/ibatis/submitted/complex_type/ComplexTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_type/ComplexTypeTest.java
@@ -34,9 +34,9 @@ public class ComplexTypeTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/complex_type/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/complex_type/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/count/CountTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/count/CountTest.java
@@ -33,9 +33,9 @@ public class CountTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/count/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/count/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/count/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/criterion/CriterionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/criterion/CriterionTest.java
@@ -35,9 +35,9 @@ public class CriterionTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/criterion/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/criterion/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/criterion/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
@@ -36,9 +36,9 @@ public class CursorNestedTest {
     @BeforeClass
     public static void setUp() throws Exception {
         // create a SqlSessionFactory
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cursor_nested/mybatis-config.xml");
-        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-        reader.close();
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cursor_nested/mybatis-config.xml")) {
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        }
 
         // populate in-memory database
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomCollectionHandlingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomCollectionHandlingTest.java
@@ -40,15 +40,12 @@ public class CustomCollectionHandlingTest {
     public void testSelectListWithNestedResultMap() throws Exception {
         String xmlConfig = "org/apache/ibatis/submitted/custom_collection_handling/MapperConfig.xml";
         SqlSessionFactory sqlSessionFactory = getSqlSessionFactoryXmlConfig(xmlConfig);
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        try {
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             List<Person> list = sqlSession.selectList("org.apache.ibatis.submitted.custom_collection_handling.PersonMapper.findWithResultMap");
             assertEquals(2, list.size());
             assertEquals(2, list.get(0).getContacts().size());
             assertEquals(1, list.get(1).getContacts().size());
             assertEquals("3 Wall Street", list.get(0).getContacts().get(1).getAddress());
-        } finally {
-            sqlSession.close();
         }
     }
 
@@ -71,13 +68,13 @@ public class CustomCollectionHandlingTest {
     }
 
     private SqlSessionFactory getSqlSessionFactoryXmlConfig(String resource) throws Exception {
-        Reader configReader = Resources.getResourceAsReader(resource);
-        SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-        configReader.close();
+        try (Reader configReader = Resources.getResourceAsReader(resource)) {
+            SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-        initDb(sqlSessionFactory);
+            initDb(sqlSessionFactory);
 
-        return sqlSessionFactory;
+            return sqlSessionFactory;
+        }
     }
 
     private static void initDb(SqlSessionFactory sqlSessionFactory) throws IOException, SQLException {

--- a/src/test/java/org/apache/ibatis/submitted/deferload_common_property/CommonPropertyDeferLoadError.java
+++ b/src/test/java/org/apache/ibatis/submitted/deferload_common_property/CommonPropertyDeferLoadError.java
@@ -38,12 +38,12 @@ public class CommonPropertyDeferLoadError {
 
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/deferload_common_property/ibatisConfig.xml");
-        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-        reader.close();
-        reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/deferload_common_property/lazyLoadIbatisConfig.xml");
-        lazyLoadSqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-        reader.close();
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/deferload_common_property/ibatisConfig.xml")) {
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        }
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/deferload_common_property/lazyLoadIbatisConfig.xml")) {
+            lazyLoadSqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        }
 
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/deferload_common_property/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/dml_return_types/DmlMapperReturnTypesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dml_return_types/DmlMapperReturnTypesTest.java
@@ -42,11 +42,8 @@ public class DmlMapperReturnTypesTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader(XML);
-    try {
+    try (Reader reader = Resources.getResourceAsReader(XML)) {
       sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    } finally {
-      reader.close();
     }
 
     // populate in-memory database

--- a/src/test/java/org/apache/ibatis/submitted/duplicate_statements/DuplicateStatementsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/duplicate_statements/DuplicateStatementsTest.java
@@ -36,10 +36,10 @@ public class DuplicateStatementsTest {
   @Before
   public void setupDb() throws Exception {
       // create a SqlSessionFactory
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/duplicate_statements/mybatis-config.xml");
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-      
+      try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/duplicate_statements/mybatis-config.xml")) {
+        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      }
+
       // populate in-memory database
       BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
               "org/apache/ibatis/submitted/duplicate_statements/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/dynsql/DynSqlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dynsql/DynSqlTest.java
@@ -39,9 +39,9 @@ public class DynSqlTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader configReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/dynsql/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/dynsql/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/dynsql/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/dynsql2/DynSqlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dynsql2/DynSqlTest.java
@@ -38,9 +38,9 @@ public class DynSqlTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/dynsql2/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/dynsql2/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/dynsql2/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/empty_namespace/EmptyNamespaceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/empty_namespace/EmptyNamespaceTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,11 +25,8 @@ import org.junit.Test;
 public class EmptyNamespaceTest {
   @Test(expected = PersistenceException.class)
   public void testEmptyNamespace() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/empty_namespace/ibatisConfig.xml");
-    try {
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/empty_namespace/ibatisConfig.xml")) {
       new SqlSessionFactoryBuilder().build(reader);
-    } finally {
-      reader.close();
     }
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/empty_row/ReturnInstanceForEmptyRowTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/empty_row/ReturnInstanceForEmptyRowTest.java
@@ -36,10 +36,10 @@ public class ReturnInstanceForEmptyRowTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/empty_row/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/empty_row/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/emptycollection/DaoTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/emptycollection/DaoTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,11 +36,10 @@ public class DaoTest {
 
   @Before
   public void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/emptycollection/mybatis-config.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
-
-    sqlSession = sqlSessionFactory.openSession();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/emptycollection/mybatis-config.xml")) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSession = sqlSessionFactory.openSession();
+    }
     conn = sqlSession.getConnection();
     ScriptRunner runner = new ScriptRunner(conn);
     runner.setLogWriter(null);

--- a/src/test/java/org/apache/ibatis/submitted/encoding/EncodingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/encoding/EncodingTest.java
@@ -34,9 +34,9 @@ public class EncodingTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/encoding/EncodingConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/encoding/EncodingConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     Charset charset = Resources.getCharset();
     try {

--- a/src/test/java/org/apache/ibatis/submitted/enum_interface_type_handler/EnumInterfaceTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/enum_interface_type_handler/EnumInterfaceTypeHandlerTest.java
@@ -34,10 +34,10 @@ public class EnumInterfaceTypeHandlerTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader(
-        "org/apache/ibatis/submitted/enum_interface_type_handler/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader(
+        "org/apache/ibatis/submitted/enum_interface_type_handler/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_annotation/EnumTypeHandlerUsingAnnotationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_annotation/EnumTypeHandlerUsingAnnotationTest.java
@@ -47,10 +47,10 @@ public class EnumTypeHandlerUsingAnnotationTest {
 
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/enumtypehandler_on_annotation/mybatis-config.xml");
-        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-        sqlSessionFactory.getConfiguration().getMapperRegistry().addMapper(PersonMapper.class);
-        reader.close();
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/enumtypehandler_on_annotation/mybatis-config.xml")) {
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+            sqlSessionFactory.getConfiguration().getMapperRegistry().addMapper(PersonMapper.class);
+        }
 
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/enumtypehandler_on_annotation/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/EnumTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/EnumTypeHandlerTest.java
@@ -35,9 +35,9 @@ public class EnumTypeHandlerTest {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/enumtypehandler_on_map/ibatisConfig.xml");
-        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-        reader.close();
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/enumtypehandler_on_map/ibatisConfig.xml")) {
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        }
 
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/enumtypehandler_on_map/CreateDB.sql");
@@ -45,29 +45,30 @@ public class EnumTypeHandlerTest {
     
     @Test
     public void testEnumWithParam() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        List<Person> persons = personMapper.getByType(Person.Type.PERSON, "");
-        Assert.assertNotNull("Persons must not be null", persons);
-        Assert.assertEquals("Persons must contain exactly 1 person", 1, persons.size());
-      sqlSession.close();
+        try (SqlSession sqlSession = sqlSessionFactory.openSession() ) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            List<Person> persons = personMapper.getByType(Person.Type.PERSON, "");
+            Assert.assertNotNull("Persons must not be null", persons);
+            Assert.assertEquals("Persons must contain exactly 1 person", 1, persons.size());
+        }
     }
     @Test
     public void testEnumWithoutParam() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        List<Person> persons = personMapper.getByTypeNoParam(new TypeName() {
-            @Override
-            public String getName() {
-                return "";
-            }
-            @Override
-            public Type getType() {
-                return Person.Type.PERSON;
-            }
-        });
-        Assert.assertNotNull("Persons must not be null", persons);
-        Assert.assertEquals("Persons must contain exactly 1 person", 1, persons.size());
-      sqlSession.close();
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            List<Person> persons = personMapper.getByTypeNoParam(new TypeName() {
+                @Override
+                public String getName() {
+                    return "";
+                }
+
+                @Override
+                public Type getType() {
+                    return Person.Type.PERSON;
+                }
+            });
+            Assert.assertNotNull("Persons must not be null", persons);
+            Assert.assertEquals("Persons must contain exactly 1 person", 1, persons.size());
+        }
     }
 }

--- a/src/test/java/org/apache/ibatis/submitted/extend/ExtendTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/extend/ExtendTest.java
@@ -33,9 +33,9 @@ public class ExtendTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/extend/ExtendConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/extend/ExtendConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/extend/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/extendresultmap/ExtendResultMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/extendresultmap/ExtendResultMapTest.java
@@ -32,9 +32,9 @@ public class ExtendResultMapTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/extendresultmap/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/extendresultmap/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/FlushStatementNpeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/FlushStatementNpeTest.java
@@ -32,9 +32,9 @@ public class FlushStatementNpeTest {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/flush_statement_npe/ibatisConfig.xml");
-        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-        reader.close();
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/flush_statement_npe/ibatisConfig.xml")) {
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        }
 
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/flush_statement_npe/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/force_flush_on_select/ForceFlushOnSelectTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/force_flush_on_select/ForceFlushOnSelectTest.java
@@ -39,9 +39,9 @@ public class ForceFlushOnSelectTest {
 
   @Before
   public void initDatabase() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/force_flush_on_select/ibatisConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/force_flush_on_select/ibatisConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/force_flush_on_select/CreateDB.sql");
@@ -96,9 +96,9 @@ public class ForceFlushOnSelectTest {
   }
 
   private void updateDatabase(Connection conn) throws SQLException {
-    Statement stmt = conn.createStatement();
-    stmt.executeUpdate("UPDATE person SET firstName = 'Simone' WHERE id = 1");
-    stmt.close();
+    try (Statement stmt = conn.createStatement()) {
+      stmt.executeUpdate("UPDATE person SET firstName = 'Simone' WHERE id = 1");
+    }
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/foreach/ForEachTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/foreach/ForEachTest.java
@@ -40,9 +40,9 @@ public class ForEachTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/foreach/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/foreach/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/foreach_map/ForEachMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/foreach_map/ForEachMapTest.java
@@ -36,9 +36,9 @@ public class ForEachMapTest {
   @BeforeClass
   public static void setUpClass() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/foreach_map/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/foreach_map/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/generictyperesolution/GenericTypeResolutionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/generictyperesolution/GenericTypeResolutionTest.java
@@ -34,9 +34,9 @@ public class GenericTypeResolutionTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/generictyperesolution/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/generictyperesolution/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/generictypes/GenericTypesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/generictypes/GenericTypesTest.java
@@ -33,9 +33,9 @@ public class GenericTypesTest {
 
   @Before
   public void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/generictypes/Config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/generictypes/Config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/generictypes/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/global_variables/BaseTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables/BaseTest.java
@@ -35,9 +35,9 @@ public class BaseTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/global_variables/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/global_variables/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/hashmaptypehandler/HashMapTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/hashmaptypehandler/HashMapTypeHandlerTest.java
@@ -34,9 +34,9 @@ public class HashMapTypeHandlerTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/hashmaptypehandler/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/hashmaptypehandler/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/heavy_initial_load/HeavyInitialLoadTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/heavy_initial_load/HeavyInitialLoadTest.java
@@ -36,20 +36,11 @@ public class HeavyInitialLoadTest {
 
   @BeforeClass
   public static void initSqlSessionFactory() throws Exception {
-    Connection conn = null;
-
-    try {
-      Class.forName("org.hsqldb.jdbcDriver");
-      conn = DriverManager.getConnection("jdbc:hsqldb:mem:heavy_initial_load", "sa", "");
-
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/heavy_initial_load/ibatisConfig.xml");
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/heavy_initial_load/ibatisConfig.xml")) {
       sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      reader.close();
-    } finally {
-      if (conn != null) {
-        conn.close();
-      }
     }
+
+    sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection().close();
   }
 
   private static final int THREAD_COUNT = 5;

--- a/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOTest.java
@@ -38,9 +38,9 @@ public final class ImmutablePOJOTest {
 
   @BeforeClass
   public static void setupClass() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/immutable_constructor/ibatisConfig.xml");
-    factory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/immutable_constructor/ibatisConfig.xml")) {
+      factory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(factory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/immutable_constructor/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/include_property/IncludePropertyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/include_property/IncludePropertyTest.java
@@ -37,9 +37,9 @@ public class IncludePropertyTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/include_property/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/include_property/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/includes/IncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/includes/IncludeTest.java
@@ -35,9 +35,9 @@ public class IncludeTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/includes/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/includes/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/inheritance/InheritanceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/inheritance/InheritanceTest.java
@@ -34,9 +34,9 @@ public class InheritanceTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/inheritance/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/inheritance/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/initialized_collection_property/AuthorDAOTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/initialized_collection_property/AuthorDAOTest.java
@@ -36,9 +36,9 @@ public class AuthorDAOTest {
   @BeforeClass
   public static void testGetMessageForEmptyDatabase() throws Exception {
     final String resource = "org/apache/ibatis/submitted/initialized_collection_property/mybatis-config.xml";
-    Reader reader = Resources.getResourceAsReader(resource);
-    factory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader(resource)) {
+      factory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(factory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/initialized_collection_property/create.sql");

--- a/src/test/java/org/apache/ibatis/submitted/inline_association_with_dot/InlineCollectionWithDotTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/inline_association_with_dot/InlineCollectionWithDotTest.java
@@ -34,22 +34,15 @@ public class InlineCollectionWithDotTest {
   public void openSession(String aConfig) throws Exception {
 
     final String resource = "org/apache/ibatis/submitted/inline_association_with_dot/ibatis-" + aConfig + ".xml";
-    Reader batisConfigReader = Resources.getResourceAsReader(resource);
+    try (Reader batisConfigReader = Resources.getResourceAsReader(resource)) {
 
-    SqlSessionFactory sqlSessionFactory;
-    try {
-      sqlSessionFactory = new SqlSessionFactoryBuilder().build(batisConfigReader);
-    } catch(Exception anException) {
-      batisConfigReader.close();
-      throw new RuntimeException("Mapper configuration failed, expected this to work: " + anException.getMessage(), anException);
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(batisConfigReader);
+
+      BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+              "org/apache/ibatis/submitted/inline_association_with_dot/create.sql");
+
+      sqlSession = sqlSessionFactory.openSession();
     }
-
-    batisConfigReader.close();
-
-    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
-            "org/apache/ibatis/submitted/inline_association_with_dot/create.sql");
-
-    sqlSession = sqlSessionFactory.openSession();
   }
 
   @After

--- a/src/test/java/org/apache/ibatis/submitted/javassist/JavassistTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/javassist/JavassistTest.java
@@ -37,9 +37,9 @@ public class JavassistTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/javassist/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/javassist/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/language/LanguageTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/language/LanguageTest.java
@@ -39,9 +39,9 @@ public class LanguageTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/language/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/language/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/language/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/lazy_deserialize/LazyDeserializeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazy_deserialize/LazyDeserializeTest.java
@@ -50,10 +50,10 @@ public final class LazyDeserializeTest {
 
   @Before
   public void setupClass() throws Exception {
-    Reader reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/lazy_deserialize/ibatisConfig.xml");
-    factory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/lazy_deserialize/ibatisConfig.xml")) {
+      factory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(factory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/lazy_deserialize/CreateDB.sql");
@@ -93,20 +93,18 @@ public final class LazyDeserializeTest {
   }
 
   private byte[] serializeFoo(final LazyObjectFoo foo) throws Exception {
-    final ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    final ObjectOutputStream oos = new ObjectOutputStream(bos);
-    oos.writeObject(foo);
-    oos.close();
-
-    return bos.toByteArray();
+    try (ByteArrayOutputStream bos = new ByteArrayOutputStream();
+         ObjectOutputStream oos = new ObjectOutputStream(bos)) {
+      oos.writeObject(foo);
+      return bos.toByteArray();
+    }
   }
 
   private LazyObjectFoo deserializeFoo(final byte[] serializedFoo) throws Exception {
-    final ByteArrayInputStream bis = new ByteArrayInputStream(serializedFoo);
-    final ObjectInputStream ios = new ObjectInputStream(bis);
-    final LazyObjectFoo foo = LazyObjectFoo.class.cast(ios.readObject());
-    ios.close();
-    return foo;
+    try (ByteArrayInputStream bis = new ByteArrayInputStream(serializedFoo);
+         ObjectInputStream ios = new ObjectInputStream(bis)) {
+      return LazyObjectFoo.class.cast(ios.readObject());
+    }
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/lazy_immutable/ImmutablePOJOTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazy_immutable/ImmutablePOJOTest.java
@@ -39,9 +39,9 @@ public final class ImmutablePOJOTest {
 
     @BeforeClass
     public static void setupClass() throws Exception {
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazy_immutable/ibatisConfig.xml");
-        factory = new SqlSessionFactoryBuilder().build(reader);
-        reader.close();
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazy_immutable/ibatisConfig.xml")) {
+            factory = new SqlSessionFactoryBuilder().build(reader);
+        }
 
         BaseDataTest.runScript(factory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/lazy_immutable/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/lazy_properties/LazyPropertiesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazy_properties/LazyPropertiesTest.java
@@ -40,10 +40,10 @@ public class LazyPropertiesTest {
   @Before
   public void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/lazy_properties/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/lazy_properties/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/CommonPropertyLazyLoadError.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/CommonPropertyLazyLoadError.java
@@ -31,9 +31,9 @@ public class CommonPropertyLazyLoadError {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazyload_common_property/ibatisConfig.xml");
-        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-        reader.close();
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazyload_common_property/ibatisConfig.xml")) {
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        }
 
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/lazyload_common_property/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/AbstractLazyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/AbstractLazyTest.java
@@ -38,9 +38,9 @@ public abstract class AbstractLazyTest {
   @Before
   public void before() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/mybatis-config-" + getConfiguration() + ".xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/mybatis-config-" + getConfiguration() + ".xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/manyanno/ManyAnnoTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/manyanno/ManyAnnoTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,19 +36,17 @@ public class ManyAnnoTest extends BaseDataTest {
     final Configuration config = new Configuration(environment);
     config.addMapper(PostMapper.class);
     final SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(config);
-    final SqlSession session = factory.openSession();
-    
-    PostMapper mapper = session.getMapper(PostMapper.class);
-    List<AnnoPost> posts = mapper.getPosts(101);
+    try (SqlSession session = factory.openSession()) {
+
+      PostMapper mapper = session.getMapper(PostMapper.class);
+      List<AnnoPost> posts = mapper.getPosts(101);
 
 
-    assertEquals(3,posts.size());
-    assertEquals(3,posts.get(0).getTags().size());
-    assertEquals(1,posts.get(1).getTags().size());
-    assertEquals(0,posts.get(2).getTags().size());
-
-    session.close();
-
+      assertEquals(3, posts.size());
+      assertEquals(3, posts.get(0).getTags().size());
+      assertEquals(1, posts.get(1).getTags().size());
+      assertEquals(0, posts.get(2).getTags().size());
+    }
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/mapper_extend/MapperExtendTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/mapper_extend/MapperExtendTest.java
@@ -37,9 +37,9 @@ public class MapperExtendTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/mapper_extend/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/mapper_extend/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/mapper_type_parameter/MapperTypeParameterTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/mapper_type_parameter/MapperTypeParameterTest.java
@@ -36,9 +36,9 @@ public class MapperTypeParameterTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/mapper_type_parameter/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/mapper_type_parameter/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/maptypehandler/MapTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/maptypehandler/MapTypeHandlerTest.java
@@ -40,9 +40,9 @@ public class MapTypeHandlerTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/maptypehandler/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/maptypehandler/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
@@ -51,28 +51,22 @@ public class MapTypeHandlerTest {
 
   @Test
   public void shouldGetAUserFromAnnotation() {
-    SqlSession sqlSession = sqlSessionFactory.openSession();
-    try {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = mapper.getUser(1, "User1");
       Assert.assertEquals("User1", user.getName());
-    } finally {
-      sqlSession.close();
     }
   }
 
   @Test(expected=PersistenceException.class)
   public void shouldGetAUserFromXML() {
-    SqlSession sqlSession = sqlSessionFactory.openSession();
-    try {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       Map<String, Object> params = new HashMap<String, Object>();
       params.put("id", 1);
       params.put("name", "User1");
       User user = mapper.getUserXML(params);
       Assert.assertEquals("User1", user.getName());
-    } finally {
-      sqlSession.close();
     }
   }
   

--- a/src/test/java/org/apache/ibatis/submitted/missing_id_property/MissingIdPropertyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/missing_id_property/MissingIdPropertyTest.java
@@ -33,9 +33,9 @@ public class MissingIdPropertyTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/missing_id_property/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/missing_id_property/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/multidb/MultiDbTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multidb/MultiDbTest.java
@@ -34,9 +34,9 @@ public class MultiDbTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multidb/MultiDbConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multidb/MultiDbConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/multidb/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/MultipleDiscriminatorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/MultipleDiscriminatorTest.java
@@ -32,9 +32,9 @@ public class MultipleDiscriminatorTest {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multiple_discriminator/ibatisConfig.xml");
-        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-        reader.close();
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multiple_discriminator/ibatisConfig.xml")) {
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        }
 
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/multiple_discriminator/CreateDB.sql");
@@ -42,28 +42,27 @@ public class MultipleDiscriminatorTest {
     
     @Test
     public void testMultipleDiscriminator() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        Person person = personMapper.get(1L);
-        Assert.assertNotNull("Person must not be null", person);
-        Assert.assertEquals("Person must be a director", Director.class, person.getClass());
-      sqlSession.close();
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            Person person = personMapper.get(1L);
+            Assert.assertNotNull("Person must not be null", person);
+            Assert.assertEquals("Person must be a director", Director.class, person.getClass());
+        }
     }
     @Test
     public void testMultipleDiscriminator2() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        Person person = personMapper.get2(1L);
-        Assert.assertNotNull("Person must not be null", person);
-        Assert.assertEquals("Person must be a director", Director.class, person.getClass());
-      sqlSession.close();
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            Person person = personMapper.get2(1L);
+            Assert.assertNotNull("Person must not be null", person);
+            Assert.assertEquals("Person must be a director", Director.class, person.getClass());
+        }
     }
     @Test(timeout=20000)
     public void testMultipleDiscriminatorLoop() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        personMapper.getLoop();
-      sqlSession.close();
-      
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            personMapper.getLoop();
+        }
     }
 }

--- a/src/test/java/org/apache/ibatis/submitted/multipleiterates/MultipleIteratesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multipleiterates/MultipleIteratesTest.java
@@ -32,9 +32,9 @@ public class MultipleIteratesTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multipleiterates/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multipleiterates/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/MultipleResultSetTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/MultipleResultSetTest.java
@@ -40,26 +40,25 @@ public class MultipleResultSetTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multipleresultsetswithassociation/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
-    
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multipleresultsetswithassociation/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+
     // populate in-memory database
     // Could not get the table creation, procedure creation, and data population to work from the same script.
     // Once it was in three scripts, all seemed well.
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multipleresultsetswithassociation/CreateDB1.sql");
-    runReaderScript(conn, session, reader);
-    reader.close();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multipleresultsetswithassociation/CreateDB2.sql");
-    runReaderScript(conn, session, reader);
-    reader.close();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multipleresultsetswithassociation/CreateDB3.sql");
-    runReaderScript(conn, session, reader);
-    reader.close();
-    conn.close();
-    session.close();
+    try (SqlSession session = sqlSessionFactory.openSession();
+         Connection conn = session.getConnection()) {
+      try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multipleresultsetswithassociation/CreateDB1.sql")) {
+        runReaderScript(conn, session, reader);
+      }
+      try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multipleresultsetswithassociation/CreateDB2.sql")) {
+        runReaderScript(conn, session, reader);
+      }
+      try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multipleresultsetswithassociation/CreateDB3.sql")) {
+        runReaderScript(conn, session, reader);
+      }
+    }
   }
   
   private static void runReaderScript(Connection conn, SqlSession session, Reader reader) throws Exception {

--- a/src/test/java/org/apache/ibatis/submitted/named_constructor_args/InvalidNamedConstructorArgsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/named_constructor_args/InvalidNamedConstructorArgsTest.java
@@ -39,10 +39,10 @@ public class InvalidNamedConstructorArgsTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader(
-        "org/apache/ibatis/submitted/named_constructor_args/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader(
+        "org/apache/ibatis/submitted/named_constructor_args/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/named_constructor_args/NamedConstructorArgsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/named_constructor_args/NamedConstructorArgsTest.java
@@ -35,9 +35,9 @@ public class NamedConstructorArgsTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/named_constructor_args/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/named_constructor_args/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     Configuration configuration = sqlSessionFactory.getConfiguration();
     configuration.setUseActualParamName(false);

--- a/src/test/java/org/apache/ibatis/submitted/named_constructor_args/usesjava8/NamedConstructorArgsUseActualNameTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/named_constructor_args/usesjava8/NamedConstructorArgsUseActualNameTest.java
@@ -35,9 +35,9 @@ public class NamedConstructorArgsUseActualNameTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/named_constructor_args/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/named_constructor_args/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     sqlSessionFactory.getConfiguration().addMapper(Mapper.class);
 

--- a/src/test/java/org/apache/ibatis/submitted/nested/NestedForEachTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested/NestedForEachTest.java
@@ -36,9 +36,9 @@ public class NestedForEachTest {
   
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nested/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nested/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/nested/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/nested_query_cache/NestedQueryCacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested_query_cache/NestedQueryCacheTest.java
@@ -36,9 +36,9 @@ public class NestedQueryCacheTest extends BaseDataTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nested_query_cache/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nested_query_cache/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     createBlogDataSource();
   }

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/NestedResultHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/NestedResultHandlerTest.java
@@ -36,9 +36,9 @@ public class NestedResultHandlerTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nestedresulthandler/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nestedresulthandler/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler_association/NestedResultHandlerAssociationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler_association/NestedResultHandlerAssociationTest.java
@@ -41,9 +41,9 @@ public class NestedResultHandlerAssociationTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nestedresulthandler_association/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nestedresulthandler_association/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/no_param_type/NoParamTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/no_param_type/NoParamTypeTest.java
@@ -37,9 +37,9 @@ public class NoParamTypeTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/no_param_type/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/no_param_type/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/nonexistentvariables/NonExistentVariablesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nonexistentvariables/NonExistentVariablesTest.java
@@ -34,9 +34,9 @@ public class NonExistentVariablesTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nonexistentvariables/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nonexistentvariables/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/nonexistentvariables/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/not_null_column/NotNullColumnTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/not_null_column/NotNullColumnTest.java
@@ -33,9 +33,9 @@ public class NotNullColumnTest {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/not_null_column/ibatisConfig.xml");
-        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-        reader.close();
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/not_null_column/ibatisConfig.xml")) {
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        }
 
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/not_null_column/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/ognl_enum/EnumWithOgnlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognl_enum/EnumWithOgnlTest.java
@@ -35,9 +35,9 @@ public class EnumWithOgnlTest {
     
     @BeforeClass
     public static void initDatabase() throws Exception {
-        Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ognl_enum/ibatisConfig.xml");
-        sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-        reader.close();
+        try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ognl_enum/ibatisConfig.xml")) {
+            sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+        }
 
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/ognl_enum/CreateDB.sql");
@@ -45,55 +45,55 @@ public class EnumWithOgnlTest {
     
     @Test
     public void testEnumWithOgnl() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        List<Person> persons = personMapper.selectAllByType(null);
-        Assert.assertEquals("Persons must contain 3 persons", 3, persons.size());
-      sqlSession.close();
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            List<Person> persons = personMapper.selectAllByType(null);
+            Assert.assertEquals("Persons must contain 3 persons", 3, persons.size());
+        }
     }
 
   @Test
     public void testEnumWithOgnlDirector() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        List<Person> persons = personMapper.selectAllByType(Person.Type.DIRECTOR);
-        Assert.assertEquals("Persons must contain 1 persons", 1, persons.size());
-    sqlSession.close();
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            List<Person> persons = personMapper.selectAllByType(Person.Type.DIRECTOR);
+            Assert.assertEquals("Persons must contain 1 persons", 1, persons.size());
+        }
     }
 
     @Test
     public void testEnumWithOgnlDirectorNameAttribute() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        List<Person> persons = personMapper.selectAllByTypeNameAttribute(Person.Type.DIRECTOR);
-        Assert.assertEquals("Persons must contain 1 persons", 1, persons.size());
-      sqlSession.close();
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            List<Person> persons = personMapper.selectAllByTypeNameAttribute(Person.Type.DIRECTOR);
+            Assert.assertEquals("Persons must contain 1 persons", 1, persons.size());
+        }
     }
 
   @Test
     public void testEnumWithOgnlDirectorWithInterface() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        List<Person> persons = personMapper.selectAllByTypeWithInterface(new PersonType() {
-            @Override
-            public Type getType() {
-                return Person.Type.DIRECTOR;
-            }
-        });
-        Assert.assertEquals("Persons must contain 1 persons", 1, persons.size());
-    sqlSession.close();
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            List<Person> persons = personMapper.selectAllByTypeWithInterface(new PersonType() {
+                @Override
+                public Type getType() {
+                    return Person.Type.DIRECTOR;
+                }
+            });
+            Assert.assertEquals("Persons must contain 1 persons", 1, persons.size());
+        }
     }
     @Test
     public void testEnumWithOgnlDirectorNameAttributeWithInterface() {
-        SqlSession sqlSession = sqlSessionFactory.openSession();
-        PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
-        List<Person> persons = personMapper.selectAllByTypeNameAttributeWithInterface(new PersonType() {
-            @Override
-            public Type getType() {
-                return Person.Type.DIRECTOR;
-            }
-        });
-        Assert.assertEquals("Persons must contain 1 persons", 1, persons.size());
-      sqlSession.close();
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            List<Person> persons = personMapper.selectAllByTypeNameAttributeWithInterface(new PersonType() {
+                @Override
+                public Type getType() {
+                    return Person.Type.DIRECTOR;
+                }
+            });
+            Assert.assertEquals("Persons must contain 1 persons", 1, persons.size());
+        }
     }
 }

--- a/src/test/java/org/apache/ibatis/submitted/ognlstatic/OgnlStaticTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognlstatic/OgnlStaticTest.java
@@ -33,9 +33,9 @@ public class OgnlStaticTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ognlstatic/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ognlstatic/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/OrderPrefixRemoved.java
+++ b/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/OrderPrefixRemoved.java
@@ -34,9 +34,9 @@ public class OrderPrefixRemoved {
 
   @BeforeClass
   public static void initDatabase() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/order_prefix_removed/ibatisConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/order_prefix_removed/ibatisConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/order_prefix_removed/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/parametrizedlist/ParametrizedListTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/parametrizedlist/ParametrizedListTest.java
@@ -35,9 +35,9 @@ public class ParametrizedListTest {
 
   @Before
   public void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/parametrizedlist/Config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/parametrizedlist/Config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/parametrizedlist/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/parent_childs/ParentChildTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/parent_childs/ParentChildTest.java
@@ -34,9 +34,9 @@ public class ParentChildTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/parent_childs/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/parent_childs/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/BlogTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/BlogTest.java
@@ -38,9 +38,9 @@ public class BlogTest {
 
   @Before
   public void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader(getConfigPath());
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader(getConfigPath())) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/parent_reference_3level/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/permissions/PermissionsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/permissions/PermissionsTest.java
@@ -34,9 +34,9 @@ public class PermissionsTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/permissions/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/permissions/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/primitive_array/PrimitiveArrayTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitive_array/PrimitiveArrayTest.java
@@ -33,9 +33,9 @@ public class PrimitiveArrayTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/primitive_array/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/primitive_array/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/primitive_result_type/ProductDAO.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitive_result_type/ProductDAO.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,50 +23,38 @@ import java.util.List;
 public class ProductDAO {
 
   public static List<Integer> selectProductCodes() {
-    SqlSession session = IbatisConfig.getSession();
-    try {
+    try (SqlSession session = IbatisConfig.getSession()) {
       ProductMapper productMapper = session.getMapper(ProductMapper.class);
       return productMapper.selectProductCodes();
     } catch (Exception e) {
       throw new RuntimeException(e);
-    } finally {
-      session.close();
     }
   }
 
   public static List<Long> selectProductCodesL() {
-    SqlSession session = IbatisConfig.getSession();
-    try {
+    try (SqlSession session = IbatisConfig.getSession()) {
       ProductMapper productMapper = session.getMapper(ProductMapper.class);
       return productMapper.selectProductCodesL();
     } catch (Exception e) {
       throw new RuntimeException(e);
-    } finally {
-      session.close();
     }
   }
 
   public static List<BigDecimal> selectProductCodesB() {
-    SqlSession session = IbatisConfig.getSession();
-    try {
+    try (SqlSession session = IbatisConfig.getSession()) {
       ProductMapper productMapper = session.getMapper(ProductMapper.class);
       return productMapper.selectProductCodesB();
     } catch (Exception e) {
       throw new RuntimeException(e);
-    } finally {
-      session.close();
     }
   }
 
   public static List<Product> selectAllProducts() {
-    SqlSession session = IbatisConfig.getSession();
-    try {
+    try (SqlSession session = IbatisConfig.getSession()) {
       ProductMapper productMapper = session.getMapper(ProductMapper.class);
       return productMapper.selectAllProducts();
     } catch (Exception e) {
       throw new RuntimeException(e);
-    } finally {
-      session.close();
     }
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/primitives/PrimitivesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitives/PrimitivesTest.java
@@ -34,9 +34,9 @@ public class PrimitivesTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/primitives/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/primitives/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/propertiesinmapperfiles/PropertiesInMappersTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/propertiesinmapperfiles/PropertiesInMappersTest.java
@@ -39,9 +39,9 @@ public class PropertiesInMappersTest {
     p.put("property", "id");
     
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/propertiesinmapperfiles/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader, p);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/propertiesinmapperfiles/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader, p);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/quotedcolumnnames/QuotedColumnNamesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/quotedcolumnnames/QuotedColumnNamesTest.java
@@ -34,9 +34,9 @@ public class QuotedColumnNamesTest {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/quotedcolumnnames/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/quotedcolumnnames/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/quotedcolumnnames/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/raw_sql_source/RawSqlSourceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/raw_sql_source/RawSqlSourceTest.java
@@ -36,9 +36,9 @@ public class RawSqlSourceTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/raw_sql_source/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/raw_sql_source/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/refid_resolution/ExternalRefidResolutionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/refid_resolution/ExternalRefidResolutionTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,10 +29,10 @@ public class ExternalRefidResolutionTest {
   @Test
   public void testExternalRefAfterSelectKey() throws Exception {
     String resource = "org/apache/ibatis/submitted/refid_resolution/ExternalMapperConfig.xml";
-    Reader reader = Resources.getResourceAsReader(resource);
-    SqlSessionFactoryBuilder builder = new SqlSessionFactoryBuilder();
-    SqlSessionFactory sqlSessionFactory = builder.build(reader);
-    reader.close();
-    sqlSessionFactory.getConfiguration().getMappedStatementNames();
+    try (Reader reader = Resources.getResourceAsReader(resource)) {
+      SqlSessionFactoryBuilder builder = new SqlSessionFactoryBuilder();
+      SqlSessionFactory sqlSessionFactory = builder.build(reader);
+      sqlSessionFactory.getConfiguration().getMappedStatementNames();
+    }
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/result_handler/ResulthandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/result_handler/ResulthandlerTest.java
@@ -33,10 +33,10 @@ public class ResulthandlerTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/result_handler/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
-    sqlSessionFactory.getConfiguration().addMapper(Mapper.class);
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/result_handler/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().addMapper(Mapper.class);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/result_handler_type/DefaultResultHandlerTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/result_handler_type/DefaultResultHandlerTypeTest.java
@@ -67,14 +67,13 @@ public class DefaultResultHandlerTypeTest {
   }
 
   private SqlSessionFactory getSqlSessionFactoryXmlConfig(String resource) throws Exception {
-    Reader configReader = Resources.getResourceAsReader(resource);
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
-
-    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+    try (Reader configReader = Resources.getResourceAsReader(resource)) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
+      BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/result_handler_type/CreateDB.sql");
 
-    return sqlSessionFactory;
+      return sqlSessionFactory;
+    }
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/resultmapwithassociationstest/ResultMapWithAssociationsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/resultmapwithassociationstest/ResultMapWithAssociationsTest.java
@@ -34,9 +34,9 @@ public class ResultMapWithAssociationsTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/resultmapwithassociationstest/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/resultmapwithassociationstest/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/results_id/ResultsIdTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/ResultsIdTest.java
@@ -35,9 +35,9 @@ public class ResultsIdTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/results_id/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/results_id/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/rounding/RoundingHandlersTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/rounding/RoundingHandlersTest.java
@@ -36,9 +36,9 @@ public class RoundingHandlersTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/rounding/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/rounding/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/selectkey/SelectKeyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/selectkey/SelectKeyTest.java
@@ -38,10 +38,10 @@ public class SelectKeyTest {
 
   @Before
   public void setUp() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/selectkey/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
-    sqlSessionFactory.getConfiguration().addMapper(AnnotatedMapper.class);
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/selectkey/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().addMapper(AnnotatedMapper.class);
+    }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
             "org/apache/ibatis/submitted/selectkey/CreateDB.sql");

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/SerializeCircularTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/SerializeCircularTest.java
@@ -105,14 +105,14 @@ public class SerializeCircularTest {
   }
 
   private SqlSessionFactory getSqlSessionFactoryXmlConfig(String resource) throws Exception {
-    Reader configReader = Resources.getResourceAsReader(resource);
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources.getResourceAsReader(resource)) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
-            "org/apache/ibatis/submitted/serializecircular/CreateDB.sql");
+      BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+              "org/apache/ibatis/submitted/serializecircular/CreateDB.sql");
 
-    return sqlSessionFactory;
+      return sqlSessionFactory;
+    }
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/UtilityTester.java
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/UtilityTester.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,9 +37,9 @@ public class UtilityTester {
       ByteArrayOutputStream myByteArrayOutputStream = new ByteArrayOutputStream();
 
       // Serialize to a byte array
-      ObjectOutputStream myObjectOutputStream = new ObjectOutputStream(myByteArrayOutputStream) ;
-      myObjectOutputStream.writeObject(myObject);
-      myObjectOutputStream.close();
+      try (ObjectOutputStream myObjectOutputStream = new ObjectOutputStream(myByteArrayOutputStream)) {
+        myObjectOutputStream.writeObject(myObject);
+      }
 
       // Get the bytes of the serialized object
       byte[] myResult = myByteArrayOutputStream.toByteArray();
@@ -50,14 +50,11 @@ public class UtilityTester {
   }
 
   private static Object deserialzeObject(byte[] aSerializedObject) {
-    try {
-      // Deserialize from a byte array
-      ObjectInputStream myObjectInputStream = new ObjectInputStream(new ByteArrayInputStream(aSerializedObject));
-      Object myResult = myObjectInputStream.readObject();
-      myObjectInputStream.close();
-
-      return myResult;
-    } catch (Exception anException) {
+    // Deserialize from a byte array
+    try (ObjectInputStream myObjectInputStream = new ObjectInputStream(new ByteArrayInputStream(aSerializedObject))) {
+      return myObjectInputStream.readObject();
+    }
+    catch (Exception anException) {
       throw new RuntimeException("Problem deserializing", anException);
     }
   }

--- a/src/test/java/org/apache/ibatis/submitted/simplelistparameter/SimpleListParameterTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/simplelistparameter/SimpleListParameterTest.java
@@ -35,9 +35,9 @@ public class SimpleListParameterTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/simplelistparameter/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/simplelistparameter/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/sptests/SPTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sptests/SPTest.java
@@ -41,9 +41,9 @@ public class SPTest {
 
   @BeforeClass
   public static void initDatabase() throws Exception {
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/sptests/MapperConfig.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/sptests/MapperConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     ScriptRunner runner = new ScriptRunner(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection());
     runner.setDelimiter("go");

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
@@ -49,11 +49,11 @@ public class SqlProviderTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/sqlprovider/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    sqlSessionFactory.getConfiguration().addMapper(StaticMethodSqlProviderMapper.class);
-    reader.close();
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/sqlprovider/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().addMapper(StaticMethodSqlProviderMapper.class);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
@@ -329,8 +329,7 @@ public class SqlProviderTest {
 
   @Test
   public void shouldInsertUser() {
-    SqlSession sqlSession = sqlSessionFactory.openSession();
-    try {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = new User();
       user.setId(999);
@@ -339,9 +338,6 @@ public class SqlProviderTest {
 
       User loadedUser = mapper.getUser(999);
       assertEquals("MyBatis", loadedUser.getName());
-
-    } finally {
-      sqlSession.close();
     }
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/stringlist/StringListTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/stringlist/StringListTest.java
@@ -34,9 +34,9 @@ public class StringListTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/stringlist/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/stringlist/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/typehandler/TypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/typehandler/TypeHandlerTest.java
@@ -39,10 +39,10 @@ public class TypeHandlerTest {
   @Before
   public void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/typehandler/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
-    sqlSessionFactory.getConfiguration().getTypeHandlerRegistry().register(StringTrimmingTypeHandler.class);
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/typehandler/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().getTypeHandlerRegistry().register(StringTrimmingTypeHandler.class);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/typehandlerinjection/TypeHandlerInjectionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/typehandlerinjection/TypeHandlerInjectionTest.java
@@ -36,9 +36,9 @@ public class TypeHandlerInjectionTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/typehandlerinjection/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/typehandlerinjection/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     sqlSessionFactory.getConfiguration().getTypeHandlerRegistry().register(handler);
     sqlSessionFactory.getConfiguration().addMapper(Mapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/unknownobject/UnknownObjectTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/unknownobject/UnknownObjectTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,12 +16,10 @@
 package org.apache.ibatis.submitted.unknownobject;
 
 import java.io.Reader;
-import java.sql.Connection;
 
+import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.jdbc.ScriptRunner;
-import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.Test;
@@ -33,20 +31,13 @@ public class UnknownObjectTest {
   @Test(expected=PersistenceException.class)
   public void shouldFailBecauseThereIsAPropertyWithoutTypeHandler() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/unknownobject/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/unknownobject/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
-    SqlSession session = sqlSessionFactory.openSession();
-    Connection conn = session.getConnection();
-    reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/unknownobject/CreateDB.sql");
-    ScriptRunner runner = new ScriptRunner(conn);
-    runner.setLogWriter(null);
-    runner.runScript(reader);
-    conn.close();
-    reader.close();
-    session.close();
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/unknownobject/CreateDB.sql");
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/usesjava8/default_method/DefaultMethodTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/usesjava8/default_method/DefaultMethodTest.java
@@ -35,10 +35,10 @@ public class DefaultMethodTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader(
-        "org/apache/ibatis/submitted/usesjava8/default_method/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader(
+        "org/apache/ibatis/submitted/usesjava8/default_method/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/usesjava8/use_actual_param_name/UseActualParamNameTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/usesjava8/use_actual_param_name/UseActualParamNameTest.java
@@ -36,10 +36,10 @@ public class UseActualParamNameTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader(
-        "org/apache/ibatis/submitted/usesjava8/use_actual_param_name/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader(
+        "org/apache/ibatis/submitted/usesjava8/use_actual_param_name/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/uuid_test/UUIDTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/uuid_test/UUIDTest.java
@@ -35,9 +35,9 @@ public class UUIDTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create an SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/uuid_test/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/uuid_test/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/valueinmap/ValueInMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/valueinmap/ValueInMapTest.java
@@ -38,9 +38,9 @@ public class ValueInMapTest {
   @BeforeClass
   public static void setUp() throws Exception {
     // create a SqlSessionFactory
-    Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/valueinmap/mybatis-config.xml");
-    sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-    reader.close();
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/valueinmap/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeTest.java
@@ -48,19 +48,18 @@ public class MultipleCrossIncludeTest {
 
   @Test
   public void testMappedStatementCache() throws Exception {
-    Reader configReader = Resources
-    .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeMapperConfig.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeMapperConfig.xml")) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-    Configuration configuration = sqlSessionFactory.getConfiguration();
-    configuration.getMappedStatementNames();
-    
-    MappedStatement selectPetStatement = configuration.getMappedStatement("org.apache.ibatis.submitted.xml_external_ref.MultipleCrossIncludePetMapper.select");
-    MappedStatement selectPersonStatement = configuration.getMappedStatement("org.apache.ibatis.submitted.xml_external_ref.MultipleCrossIncludePersonMapper.select");
-    Cache cache = selectPetStatement.getCache();
-    assertEquals("org.apache.ibatis.submitted.xml_external_ref.MultipleCrossIncludePetMapper", cache.getId());
-    assertSame(cache, selectPersonStatement.getCache());
+      Configuration configuration = sqlSessionFactory.getConfiguration();
+      configuration.getMappedStatementNames();
+
+      MappedStatement selectPetStatement = configuration.getMappedStatement("org.apache.ibatis.submitted.xml_external_ref.MultipleCrossIncludePetMapper.select");
+      MappedStatement selectPersonStatement = configuration.getMappedStatement("org.apache.ibatis.submitted.xml_external_ref.MultipleCrossIncludePersonMapper.select");
+      Cache cache = selectPetStatement.getCache();
+      assertEquals("org.apache.ibatis.submitted.xml_external_ref.MultipleCrossIncludePetMapper", cache.getId());
+      assertSame(cache, selectPersonStatement.getCache());
+    }
   }
 
   private void testCrossReference(SqlSessionFactory sqlSessionFactory) throws Exception {
@@ -82,14 +81,14 @@ public class MultipleCrossIncludeTest {
   }
 
   private SqlSessionFactory getSqlSessionFactoryXmlConfig() throws Exception {
-    Reader configReader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeMapperConfig.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeMapperConfig.xml")) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-    initDb(sqlSessionFactory);
+      initDb(sqlSessionFactory);
 
-    return sqlSessionFactory;
+      return sqlSessionFactory;
+    }
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleIncludeTest.java
@@ -55,16 +55,14 @@ public class MultipleIncludeTest {
   }
 
   private SqlSessionFactory getSqlSessionFactoryXmlConfig() throws Exception {
-    Reader configReader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MultipleIncludeMapperConfig.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MultipleIncludeMapperConfig.xml");) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-    Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection();
-    initDb(sqlSessionFactory);
-    conn.close();
+      initDb(sqlSessionFactory);
 
-    return sqlSessionFactory;
+      return sqlSessionFactory;
+    }
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleReverseIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleReverseIncludeTest.java
@@ -54,14 +54,14 @@ public class MultipleReverseIncludeTest {
   }
 
   private SqlSessionFactory getSqlSessionFactoryXmlConfig() throws Exception {
-    Reader configReader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MultipleReverseIncludeMapperConfig.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MultipleReverseIncludeMapperConfig.xml")) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-    initDb(sqlSessionFactory);
+      initDb(sqlSessionFactory);
 
-    return sqlSessionFactory;
+      return sqlSessionFactory;
+    }
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/NonFullyQualifiedNamespaceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/NonFullyQualifiedNamespaceTest.java
@@ -33,32 +33,32 @@ import org.junit.Test;
 public class NonFullyQualifiedNamespaceTest {
     @Test
     public void testCrossReferenceXmlConfig() throws Exception {
-        Reader configReader = Resources
-                .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/NonFullyQualifiedNamespaceConfig.xml");
-        SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-        configReader.close();
+        try (Reader configReader = Resources
+                .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/NonFullyQualifiedNamespaceConfig.xml")) {
+            SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-        Configuration configuration = sqlSessionFactory.getConfiguration();
+            Configuration configuration = sqlSessionFactory.getConfiguration();
 
-        MappedStatement selectPerson = configuration.getMappedStatement("person namespace.select");
-        assertEquals(
-                "org/apache/ibatis/submitted/xml_external_ref/NonFullyQualifiedNamespacePersonMapper.xml",
-                selectPerson.getResource());
+            MappedStatement selectPerson = configuration.getMappedStatement("person namespace.select");
+            assertEquals(
+                    "org/apache/ibatis/submitted/xml_external_ref/NonFullyQualifiedNamespacePersonMapper.xml",
+                    selectPerson.getResource());
 
-        initDb(sqlSessionFactory);
+            initDb(sqlSessionFactory);
 
-        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
-            Person person = (Person) sqlSession.selectOne("person namespace.select", 1);
-            assertEquals((Integer)1, person.getId());
-            assertEquals(2, person.getPets().size());
-            assertEquals((Integer)2, person.getPets().get(1).getId());
+            try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+                Person person = (Person) sqlSession.selectOne("person namespace.select", 1);
+                assertEquals((Integer) 1, person.getId());
+                assertEquals(2, person.getPets().size());
+                assertEquals((Integer) 2, person.getPets().get(1).getId());
 
-            Pet pet = (Pet) sqlSession.selectOne("person namespace.selectPet", 1);
-            assertEquals(Integer.valueOf(1), pet.getId());
+                Pet pet = (Pet) sqlSession.selectOne("person namespace.selectPet", 1);
+                assertEquals(Integer.valueOf(1), pet.getId());
 
-            Pet pet2 = (Pet) sqlSession.selectOne("pet namespace.select", 3);
-            assertEquals((Integer)3, pet2.getId());
-            assertEquals((Integer)2, pet2.getOwner().getId());
+                Pet pet2 = (Pet) sqlSession.selectOne("pet namespace.select", 3);
+                assertEquals((Integer) 3, pet2.getId());
+                assertEquals((Integer) 2, pet2.getOwner().getId());
+            }
         }
     }
 

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ParameterMapReferenceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ParameterMapReferenceTest.java
@@ -55,14 +55,14 @@ public class ParameterMapReferenceTest {
   }
 
   private SqlSessionFactory getSqlSessionFactoryXmlConfig() throws Exception {
-    Reader configReader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/ParameterMapReferenceMapperConfig.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/ParameterMapReferenceMapperConfig.xml")) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-    initDb(sqlSessionFactory);
+      initDb(sqlSessionFactory);
 
-    return sqlSessionFactory;
+      return sqlSessionFactory;
+    }
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ResultMapExtendsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ResultMapExtendsTest.java
@@ -54,14 +54,14 @@ public class ResultMapExtendsTest {
   }
 
   private SqlSessionFactory getSqlSessionFactoryXmlConfig() throws Exception {
-    Reader configReader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/ResultMapExtendsMapperConfig.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources
+            .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/ResultMapExtendsMapperConfig.xml")) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-    initDb(sqlSessionFactory);
+      initDb(sqlSessionFactory);
 
-    return sqlSessionFactory;
+      return sqlSessionFactory;
+    }
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ResultMapReferenceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ResultMapReferenceTest.java
@@ -54,14 +54,14 @@ public class ResultMapReferenceTest {
   }
 
   private SqlSessionFactory getSqlSessionFactoryXmlConfig() throws Exception {
-    Reader configReader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/ResultMapReferenceMapperConfig.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/ResultMapReferenceMapperConfig.xml")) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-    initDb(sqlSessionFactory);
+      initDb(sqlSessionFactory);
 
-    return sqlSessionFactory;
+      return sqlSessionFactory;
+    }
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ReverseIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ReverseIncludeTest.java
@@ -54,14 +54,14 @@ public class ReverseIncludeTest {
   }
 
   private SqlSessionFactory getSqlSessionFactoryXmlConfig() throws Exception {
-    Reader configReader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/ReverseIncludeMapperConfig.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/ReverseIncludeMapperConfig.xml")) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-    initDb(sqlSessionFactory);
+      initDb(sqlSessionFactory);
 
-    return sqlSessionFactory;
+      return sqlSessionFactory;
+    }
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/SameIdTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/SameIdTest.java
@@ -63,14 +63,14 @@ public class SameIdTest {
   }
 
   private SqlSessionFactory getSqlSessionFactoryXmlConfig() throws Exception {
-    Reader configReader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/SameIdMapperConfig.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/SameIdMapperConfig.xml")) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-    initDb(sqlSessionFactory);
+      initDb(sqlSessionFactory);
 
-    return sqlSessionFactory;
+      return sqlSessionFactory;
+    }
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ShortNameTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ShortNameTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,10 +45,10 @@ public class ShortNameTest {
     }
 
     private Configuration getConfiguration() throws IOException {
-        Reader configReader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MapperConfig.xml");
-        SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-        configReader.close();
-        return sqlSessionFactory.getConfiguration();
+        try (Reader configReader = Resources
+                .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MapperConfig.xml")) {
+            SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
+            return sqlSessionFactory.getConfiguration();
+        }
     }
 }

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/XmlExternalRefTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/XmlExternalRefTest.java
@@ -72,19 +72,18 @@ public class XmlExternalRefTest {
 
   @Test
   public void testMappedStatementCache() throws Exception {
-    Reader configReader = Resources
-    .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MapperConfig.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MapperConfig.xml")) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-    Configuration configuration = sqlSessionFactory.getConfiguration();
-    configuration.getMappedStatementNames();
+      Configuration configuration = sqlSessionFactory.getConfiguration();
+      configuration.getMappedStatementNames();
 
-    MappedStatement selectPetStatement = configuration.getMappedStatement("org.apache.ibatis.submitted.xml_external_ref.PetMapper.select");
-    MappedStatement selectPersonStatement = configuration.getMappedStatement("org.apache.ibatis.submitted.xml_external_ref.PersonMapper.select");
-    Cache cache = selectPetStatement.getCache();
-    assertEquals("org.apache.ibatis.submitted.xml_external_ref.PetMapper", cache.getId());
-    assertSame(cache, selectPersonStatement.getCache());
+      MappedStatement selectPetStatement = configuration.getMappedStatement("org.apache.ibatis.submitted.xml_external_ref.PetMapper.select");
+      MappedStatement selectPersonStatement = configuration.getMappedStatement("org.apache.ibatis.submitted.xml_external_ref.PersonMapper.select");
+      Cache cache = selectPetStatement.getCache();
+      assertEquals("org.apache.ibatis.submitted.xml_external_ref.PetMapper", cache.getId());
+      assertSame(cache, selectPersonStatement.getCache());
+    }
   }
 
   private void testCrossReference(SqlSessionFactory sqlSessionFactory) {
@@ -106,14 +105,14 @@ public class XmlExternalRefTest {
   }
 
   private SqlSessionFactory getSqlSessionFactoryXmlConfig() throws Exception {
-    Reader configReader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MapperConfig.xml");
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
-    configReader.close();
+    try (Reader configReader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MapperConfig.xml")) {
+      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);
 
-    initDb(sqlSessionFactory);
+      initDb(sqlSessionFactory);
 
-    return sqlSessionFactory;
+      return sqlSessionFactory;
+    }
   }
 
   private SqlSessionFactory getSqlSessionFactoryJavaConfig() throws Exception {

--- a/src/test/java/org/apache/ibatis/submitted/xml_references/EnumWithOgnlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_references/EnumWithOgnlTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -48,9 +48,9 @@ public class EnumWithOgnlTest {
     }
     @Test
     public void testMixedConfiguration() throws Exception {
-      Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_references/ibatisConfig.xml");
-      SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
-      sqlSessionFactory.getConfiguration().addMapper(PersonMapper2.class);
-      reader.close();
+      try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_references/ibatisConfig.xml")) {
+          SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+          sqlSessionFactory.getConfiguration().addMapper(PersonMapper2.class);
+      }
     }
 }


### PR DESCRIPTION
In current implementation, close a external resource explicitly.

**Before:**
e.g.

```java
Connection connection = ....;
try {
    // ...
} finally {
    connection.close();
}
```

or

```java
Reader reader = ....;
// ...
reader.close();  // If an exception is occurred, there is possible that an external resource does not close 
```

I've modified to use the try-with-resources supported by JDK 7 as follow: 

**After:**
```java
try (Connection connection = ....) {
    // ...
}
```