### PR TITLE
Add closed check at Cursor.iterator

### DIFF
--- a/src/main/java/org/apache/ibatis/cursor/defaults/DefaultCursor.java
+++ b/src/main/java/org/apache/ibatis/cursor/defaults/DefaultCursor.java
@@ -94,6 +94,9 @@ public class DefaultCursor<T> implements Cursor<T> {
 
     @Override
     public Iterator<T> iterator() {
+        if (isClosed()) {
+            throw new IllegalStateException("A Cursor is already closed.");
+        }
         if (iteratorRetrieved) {
             throw new IllegalStateException("Cannot open more than one iterator on a Cursor");
         }

--- a/src/main/java/org/apache/ibatis/cursor/defaults/DefaultCursor.java
+++ b/src/main/java/org/apache/ibatis/cursor/defaults/DefaultCursor.java
@@ -94,11 +94,11 @@ public class DefaultCursor<T> implements Cursor<T> {
 
     @Override
     public Iterator<T> iterator() {
-        if (isClosed()) {
-            throw new IllegalStateException("A Cursor is already closed.");
-        }
         if (iteratorRetrieved) {
             throw new IllegalStateException("Cannot open more than one iterator on a Cursor");
+        }
+        if (isClosed()) {
+            throw new IllegalStateException("A Cursor is already closed.");
         }
         iteratorRetrieved = true;
         return cursorIterator;

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
@@ -361,4 +361,18 @@ public class CursorSimpleTest {
         }
     }
 
+    @Test
+    public void shouldThrowIllegalStateExceptionUsingIteratorOnSessionClosed() {
+        Cursor<User> usersCursor;
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            usersCursor = sqlSession.getMapper(Mapper.class).getAllUsers();
+        }
+        try {
+            usersCursor.iterator();
+            Assert.fail("Should throws the IllegalStateException when call the iterator method after session is closed.");
+        } catch (IllegalStateException e) {
+            Assert.assertEquals("A Cursor is already closed.", e.getMessage());
+        }
+    }
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
@@ -373,6 +373,19 @@ public class CursorSimpleTest {
         } catch (IllegalStateException e) {
             Assert.assertEquals("A Cursor is already closed.", e.getMessage());
         }
+
+        // verify for checking order
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            usersCursor = sqlSession.getMapper(Mapper.class).getAllUsers();
+            usersCursor.iterator();
+        }
+        try {
+            usersCursor.iterator();
+            Assert.fail("Should throws the IllegalStateException when call the iterator already.");
+        } catch (IllegalStateException e) {
+            Assert.assertEquals("Cannot open more than one iterator on a Cursor", e.getMessage());
+        }
+
     }
 
 }


### PR DESCRIPTION
Fixes #1297

I've fixed to throws the `IllegalStateException` on `Cursor.iterator` when a `Cursor` is already closed.
WDYT?
