### PR TITLE
Drop special logics and annotation that indicates using java 8 and 7

### DIFF
--- a/src/main/java/org/apache/ibatis/binding/MapperMethod.java
+++ b/src/main/java/org/apache/ibatis/binding/MapperMethod.java
@@ -21,9 +21,7 @@ import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.mapping.SqlCommandType;
 import org.apache.ibatis.mapping.StatementType;
-import org.apache.ibatis.reflection.Jdk;
 import org.apache.ibatis.reflection.MetaObject;
-import org.apache.ibatis.reflection.OptionalUtil;
 import org.apache.ibatis.reflection.ParamNameResolver;
 import org.apache.ibatis.reflection.TypeParameterResolver;
 import org.apache.ibatis.session.Configuration;
@@ -86,7 +84,7 @@ public class MapperMethod {
           result = sqlSession.selectOne(command.getName(), param);
           if (method.returnsOptional() &&
               (result == null || !method.getReturnType().equals(result.getClass()))) {
-            result = OptionalUtil.ofNullable(result);
+            result = Optional.ofNullable(result);
           }
         }
         break;
@@ -296,7 +294,7 @@ public class MapperMethod {
       this.returnsVoid = void.class.equals(this.returnType);
       this.returnsMany = configuration.getObjectFactory().isCollection(this.returnType) || this.returnType.isArray();
       this.returnsCursor = Cursor.class.equals(this.returnType);
-      this.returnsOptional = Jdk.optionalExists && Optional.class.equals(this.returnType);
+      this.returnsOptional = Optional.class.equals(this.returnType);
       this.mapKey = getMapKey(method);
       this.returnsMap = this.mapKey != null;
       this.rowBoundsIndex = getUniqueParamIndex(method, RowBounds.class);

--- a/src/main/java/org/apache/ibatis/binding/MapperProxy.java
+++ b/src/main/java/org/apache/ibatis/binding/MapperProxy.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Map;
 
-import org.apache.ibatis.lang.UsesJava7;
 import org.apache.ibatis.reflection.ExceptionUtil;
 import org.apache.ibatis.session.SqlSession;
 
@@ -63,7 +62,6 @@ public class MapperProxy<T> implements InvocationHandler, Serializable {
     return methodCache.computeIfAbsent(method, k -> new MapperMethod(mapperInterface, method, sqlSession.getConfiguration()));
   }
 
-  @UsesJava7
   private Object invokeDefaultMethod(Object proxy, Method method, Object[] args)
       throws Throwable {
     final Constructor<MethodHandles.Lookup> constructor = MethodHandles.Lookup.class

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -81,7 +81,6 @@ import org.apache.ibatis.mapping.SqlCommandType;
 import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.mapping.StatementType;
 import org.apache.ibatis.parsing.PropertyParser;
-import org.apache.ibatis.reflection.Jdk;
 import org.apache.ibatis.reflection.TypeParameterResolver;
 import org.apache.ibatis.scripting.LanguageDriver;
 import org.apache.ibatis.session.Configuration;
@@ -451,7 +450,7 @@ public class MapperAnnotationBuilder {
               returnType = (Class<?>) ((ParameterizedType) returnTypeParameter).getRawType();
             }
           }
-      } else if (Jdk.optionalExists && Optional.class.equals(rawType)) {
+      } else if (Optional.class.equals(rawType)) {
         Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
         Type returnTypeParameter = actualTypeArguments[0];
         if (returnTypeParameter instanceof Class<?>) {

--- a/src/main/java/org/apache/ibatis/mapping/ResultMap.java
+++ b/src/main/java/org/apache/ibatis/mapping/ResultMap.java
@@ -28,7 +28,6 @@ import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.logging.LogFactory;
-import org.apache.ibatis.reflection.Jdk;
 import org.apache.ibatis.reflection.ParamNameUtil;
 import org.apache.ibatis.session.Configuration;
 
@@ -193,7 +192,7 @@ public class ResultMap {
             break;
           }
         }
-        if (name == null && resultMap.configuration.isUseActualParamName() && Jdk.parameterExists) {
+        if (name == null && resultMap.configuration.isUseActualParamName()) {
           if (actualParamNames == null) {
             actualParamNames = ParamNameUtil.getParamNames(constructor);
           }

--- a/src/main/java/org/apache/ibatis/reflection/Jdk.java
+++ b/src/main/java/org/apache/ibatis/reflection/Jdk.java
@@ -24,7 +24,9 @@ public class Jdk {
 
   /**
    * <code>true</code> if <code>java.lang.reflect.Parameter</code> is available.
+   * @deprecated Since 3.5.0, Will remove this field at feature(next major version up)
    */
+  @Deprecated
   public static final boolean parameterExists;
 
   static {
@@ -38,6 +40,10 @@ public class Jdk {
     parameterExists = available;
   }
 
+  /**
+   * @deprecated Since 3.5.0, Will remove this field at feature(next major version up)
+   */
+  @Deprecated
   public static final boolean dateAndTimeApiExists;
 
   static {
@@ -51,6 +57,10 @@ public class Jdk {
     dateAndTimeApiExists = available;
   }
 
+  /**
+   * @deprecated Since 3.5.0, Will remove this field at feature(next major version up)
+   */
+  @Deprecated
   public static final boolean optionalExists;
 
   static {

--- a/src/main/java/org/apache/ibatis/reflection/OptionalUtil.java
+++ b/src/main/java/org/apache/ibatis/reflection/OptionalUtil.java
@@ -18,11 +18,12 @@ package org.apache.ibatis.reflection;
 
 import java.util.Optional;
 
-import org.apache.ibatis.lang.UsesJava8;
-
+/**
+ * @deprecated Since 3.5.0, Will remove this class at future(next major version up).
+ */
+@Deprecated
 public abstract class OptionalUtil {
 
-  @UsesJava8
   public static Object ofNullable(Object value) {
     return Optional.ofNullable(value);
   }

--- a/src/main/java/org/apache/ibatis/reflection/ParamNameResolver.java
+++ b/src/main/java/org/apache/ibatis/reflection/ParamNameResolver.java
@@ -85,10 +85,7 @@ public class ParamNameResolver {
   }
 
   private String getActualParamName(Method method, int paramIndex) {
-    if (Jdk.parameterExists) {
-      return ParamNameUtil.getParamNames(method).get(paramIndex);
-    }
-    return null;
+    return ParamNameUtil.getParamNames(method).get(paramIndex);
   }
 
   private static boolean isSpecialParameter(Class<?> clazz) {

--- a/src/main/java/org/apache/ibatis/reflection/ParamNameUtil.java
+++ b/src/main/java/org/apache/ibatis/reflection/ParamNameUtil.java
@@ -22,9 +22,6 @@ import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.ibatis.lang.UsesJava8;
-
-@UsesJava8
 public class ParamNameUtil {
   public static List<String> getParamNames(Method method) {
     return getParameterNames(method);

--- a/src/main/java/org/apache/ibatis/type/InstantTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/InstantTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,13 +22,10 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 
-import org.apache.ibatis.lang.UsesJava8;
-
 /**
  * @since 3.4.5
  * @author Tomas Rohovsky
  */
-@UsesJava8
 public class InstantTypeHandler extends BaseTypeHandler<Instant> {
 
   @Override

--- a/src/main/java/org/apache/ibatis/type/JapaneseDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/JapaneseDateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,15 +23,12 @@ import java.sql.SQLException;
 import java.time.LocalDate;
 import java.time.chrono.JapaneseDate;
 
-import org.apache.ibatis.lang.UsesJava8;
-
 /**
  * Type Handler for {@link JapaneseDate}.
  *
  * @since 3.4.5
  * @author Kazuki Shimizu
  */
-@UsesJava8
 public class JapaneseDateTypeHandler extends BaseTypeHandler<JapaneseDate> {
 
   @Override

--- a/src/main/java/org/apache/ibatis/type/LocalDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,13 +22,10 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
-import org.apache.ibatis.lang.UsesJava8;
-
 /**
  * @since 3.4.5
  * @author Tomas Rohovsky
  */
-@UsesJava8
 public class LocalDateTimeTypeHandler extends BaseTypeHandler<LocalDateTime> {
 
   @Override

--- a/src/main/java/org/apache/ibatis/type/LocalDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalDateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,13 +22,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.LocalDate;
 
-import org.apache.ibatis.lang.UsesJava8;
-
 /**
  * @since 3.4.5
  * @author Tomas Rohovsky
  */
-@UsesJava8
 public class LocalDateTypeHandler extends BaseTypeHandler<LocalDate> {
 
   @Override

--- a/src/main/java/org/apache/ibatis/type/LocalTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,13 +22,10 @@ import java.sql.SQLException;
 import java.sql.Time;
 import java.time.LocalTime;
 
-import org.apache.ibatis.lang.UsesJava8;
-
 /**
  * @since 3.4.5
  * @author Tomas Rohovsky
  */
-@UsesJava8
 public class LocalTimeTypeHandler extends BaseTypeHandler<LocalTime> {
 
   @Override

--- a/src/main/java/org/apache/ibatis/type/MonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/MonthTypeHandler.java
@@ -21,14 +21,11 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Month;
 
-import org.apache.ibatis.lang.UsesJava8;
-
 /**
  *
  * @since 3.4.5
  * @author Björn Raupach
  */
-@UsesJava8
 public class MonthTypeHandler extends BaseTypeHandler<Month> {
     
     @Override

--- a/src/main/java/org/apache/ibatis/type/OffsetDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/OffsetDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,13 +23,10 @@ import java.sql.Timestamp;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 
-import org.apache.ibatis.lang.UsesJava8;
-
 /**
  * @since 3.4.5
  * @author Tomas Rohovsky
  */
-@UsesJava8
 public class OffsetDateTimeTypeHandler extends BaseTypeHandler<OffsetDateTime> {
 
   @Override

--- a/src/main/java/org/apache/ibatis/type/OffsetTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/OffsetTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,13 +22,10 @@ import java.sql.SQLException;
 import java.sql.Time;
 import java.time.OffsetTime;
 
-import org.apache.ibatis.lang.UsesJava8;
-
 /**
  * @since 3.4.5
  * @author Tomas Rohovsky
  */
-@UsesJava8
 public class OffsetTimeTypeHandler extends BaseTypeHandler<OffsetTime> {
 
   @Override

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.ibatis.binding.MapperMethod.ParamMap;
 import org.apache.ibatis.io.ResolverUtil;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.reflection.Jdk;
 
 /**
  * @author Clinton Begin
@@ -147,20 +146,17 @@ public final class TypeHandlerRegistry {
 
     register(String.class, JdbcType.SQLXML, new SqlxmlTypeHandler());
 
-    // mybatis-typehandlers-jsr310
-    if (Jdk.dateAndTimeApiExists) {
-      this.register(Instant.class, InstantTypeHandler.class);
-      this.register(LocalDateTime.class, LocalDateTimeTypeHandler.class);
-      this.register(LocalDate.class, LocalDateTypeHandler.class);
-      this.register(LocalTime.class, LocalTimeTypeHandler.class);
-      this.register(OffsetDateTime.class, OffsetDateTimeTypeHandler.class);
-      this.register(OffsetTime.class, OffsetTimeTypeHandler.class);
-      this.register(ZonedDateTime.class, ZonedDateTimeTypeHandler.class);
-      this.register(Month.class, MonthTypeHandler.class);
-      this.register(Year.class, YearTypeHandler.class);
-      this.register(YearMonth.class, YearMonthTypeHandler.class);
-      this.register(JapaneseDate.class, JapaneseDateTypeHandler.class);
-    }
+    register(Instant.class, InstantTypeHandler.class);
+    register(LocalDateTime.class, LocalDateTimeTypeHandler.class);
+    register(LocalDate.class, LocalDateTypeHandler.class);
+    register(LocalTime.class, LocalTimeTypeHandler.class);
+    register(OffsetDateTime.class, OffsetDateTimeTypeHandler.class);
+    register(OffsetTime.class, OffsetTimeTypeHandler.class);
+    register(ZonedDateTime.class, ZonedDateTimeTypeHandler.class);
+    register(Month.class, MonthTypeHandler.class);
+    register(Year.class, YearTypeHandler.class);
+    register(YearMonth.class, YearMonthTypeHandler.class);
+    register(JapaneseDate.class, JapaneseDateTypeHandler.class);
 
     // issue #273
     register(Character.class, new CharacterTypeHandler());

--- a/src/main/java/org/apache/ibatis/type/YearMonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearMonthTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,8 +21,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.YearMonth;
 
-import org.apache.ibatis.lang.UsesJava8;
-
 /**
  * Type Handler for {@link java.time.YearMonth}
  *
@@ -33,7 +31,6 @@ import org.apache.ibatis.lang.UsesJava8;
  * @since 3.4.5
  * @author Björn Raupach
  */
-@UsesJava8
 public class YearMonthTypeHandler extends BaseTypeHandler<YearMonth> {
 
   @Override

--- a/src/main/java/org/apache/ibatis/type/YearTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearTypeHandler.java
@@ -21,13 +21,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Year;
 
-import org.apache.ibatis.lang.UsesJava8;
-
 /**
  * @since 3.4.5
  * @author Björn Raupach
  */
-@UsesJava8
 public class YearTypeHandler extends BaseTypeHandler<Year> {
     
     @Override

--- a/src/main/java/org/apache/ibatis/type/ZonedDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ZonedDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,13 +23,10 @@ import java.sql.Timestamp;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
-import org.apache.ibatis.lang.UsesJava8;
-
 /**
  * @since 3.4.5
  * @author Tomas Rohovsky
  */
-@UsesJava8
 public class ZonedDateTimeTypeHandler extends BaseTypeHandler<ZonedDateTime> {
 
   @Override


### PR DESCRIPTION
Related with #1207 

Since 3.5.0, the mybatis will support Java 8+. Hence I've dropped special logics and annotation that indicates using java 8 and 7.
