### PR TITLE
solved when keyGenerator.processBefore exception thread unsafe

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/statement/BaseStatementHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/statement/BaseStatementHandler.java
@@ -138,8 +138,14 @@ public abstract class BaseStatementHandler implements StatementHandler {
   protected void generateKeys(Object parameter) {
     KeyGenerator keyGenerator = mappedStatement.getKeyGenerator();
     ErrorContext.instance().store();
-    keyGenerator.processBefore(executor, mappedStatement, null, parameter);
-    ErrorContext.instance().recall();
+    try {
+    	 keyGenerator.processBefore(executor, mappedStatement, null, parameter);
+	}catch (Exception e) {
+		throw e;
+	} finally {
+		ErrorContext.instance().recall();
+	}
+    
   }
 
 }


### PR DESCRIPTION
solved when keyGenerator.processBefore exception thread unsafe，in Thread executors ErrorContext.instance().recall() need clear