### PR TITLE
Prevent known vulnerable classes from being deserialized.

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/loader/AbstractSerialStateHolder.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/AbstractSerialStateHolder.java
@@ -19,11 +19,13 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.Externalizable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InvalidClassException;
 import java.io.ObjectInput;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutput;
 import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
 import java.io.ObjectStreamException;
 import java.io.StreamCorruptedException;
 import java.util.Arrays;
@@ -107,8 +109,7 @@ public abstract class AbstractSerialStateHolder implements Externalizable {
     }
 
     /* First run */
-    try {
-      final ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(this.userBeanBytes));
+    try (final ObjectInputStream in = new LookAheadObjectInputStream(new ByteArrayInputStream(this.userBeanBytes))) {
       this.userBean = in.readObject();
       this.unloadedProperties = (Map<String, ResultLoaderMap.LoadPair>) in.readObject();
       this.objectFactory = (ObjectFactory) in.readObject();
@@ -129,4 +130,30 @@ public abstract class AbstractSerialStateHolder implements Externalizable {
 
   protected abstract Object createDeserializationProxy(Object target, Map<String, ResultLoaderMap.LoadPair> unloadedProperties, ObjectFactory objectFactory,
           List<Class<?>> constructorArgTypes, List<Object> constructorArgs);
+
+  private static class LookAheadObjectInputStream extends ObjectInputStream {
+    private static final List<String> blacklist = Arrays.asList(
+        "org.apache.commons.collections.functors.InvokerTransformer",
+        "org.apache.commons.collections.functors.InstantiateTransformer",
+        "org.apache.commons.collections4.functors.InvokerTransformer",
+        "org.apache.commons.collections4.functors.InstantiateTransformer",
+        "org.codehaus.groovy.runtime.ConvertedClosure", "org.codehaus.groovy.runtime.MethodClosure",
+        "org.springframework.beans.factory.ObjectFactory",
+        "com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl");
+
+    public LookAheadObjectInputStream(InputStream in) throws IOException {
+      super(in);
+    }
+
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+      String className = desc.getName();
+      if (blacklist.contains(className)) {
+        throw new InvalidClassException(className, "Deserialization is not allowed for security reasons. "
+            + "It is strongly recommended to configure the deserialization filter provided by JDK. "
+            + "See http://openjdk.java.net/jeps/290 for the details.");
+      }
+      return super.resolveClass(desc);
+    }
+  }
 }

--- a/src/main/java/org/apache/ibatis/executor/loader/AbstractSerialStateHolder.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/AbstractSerialStateHolder.java
@@ -133,12 +133,15 @@ public abstract class AbstractSerialStateHolder implements Externalizable {
 
   private static class LookAheadObjectInputStream extends ObjectInputStream {
     private static final List<String> blacklist = Arrays.asList(
+        "org.apache.commons.beanutils.BeanComparator",
         "org.apache.commons.collections.functors.InvokerTransformer",
         "org.apache.commons.collections.functors.InstantiateTransformer",
         "org.apache.commons.collections4.functors.InvokerTransformer",
         "org.apache.commons.collections4.functors.InstantiateTransformer",
-        "org.codehaus.groovy.runtime.ConvertedClosure", "org.codehaus.groovy.runtime.MethodClosure",
+        "org.codehaus.groovy.runtime.ConvertedClosure",
+        "org.codehaus.groovy.runtime.MethodClosure",
         "org.springframework.beans.factory.ObjectFactory",
+        "org.springframework.transaction.jta.JtaTransactionManager",
         "com.sun.org.apache.xalan.internal.xsltc.trax.TemplatesImpl");
 
     public LookAheadObjectInputStream(InputStream in) throws IOException {


### PR DESCRIPTION
- `org.apache.ibatis.executor.loader.AbstractSerialStateHolder` can lead to deserialization blacklist bypass when look ahead class validation [1] is used to implement the blacklist.
- This does not affect users that use JEP-290 serialization filter [2].
- Users using the look-ahead class validation method should migrate their blacklist to JEP-290.
- With this PR, a default blacklist is added to offer some protection, but the list is not complete and only offers protection from the most commonly known vulnerable classes.

Many thanks to Man Yue Mo of Semmle and LGTM.com for reporting the issue with the details!

[1] https://www.ibm.com/developerworks/library/se-lookahead/index.html
[2] http://openjdk.java.net/jeps/290
