### PR TITLE
fix npe

### DIFF
--- a/src/main/java/org/apache/ibatis/cache/decorators/BlockingCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/BlockingCache.java
@@ -115,7 +115,7 @@ public class BlockingCache implements Cache {
   
   private void releaseLock(Object key) {
     ReentrantLock lock = locks.get(key);
-    if (lock.isHeldByCurrentThread()) {
+    if (lock != null && lock.isHeldByCurrentThread()) {
       lock.unlock();
     }
   }


### PR DESCRIPTION
In some  cases like 
```
PerpetualCache delegate = new PerpetualCache("12312");
BlockingCache cache = new BlockingCache(delegate);
cache.putObject("abc", "def");
```
it may throw NullPointerException, because the variable **lock** in method **releaseLock** may be null