### PR TITLE
Add api for reset loaded mapper information

### DIFF
--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -15,16 +15,6 @@
  */
 package org.apache.ibatis.session;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-
 import org.apache.ibatis.binding.MapperRegistry;
 import org.apache.ibatis.builder.CacheRefResolver;
 import org.apache.ibatis.builder.ResultMapResolver;
@@ -90,6 +80,16 @@ import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeAliasRegistry;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
 
 /**
  * @author Clinton Begin
@@ -758,6 +758,15 @@ public class Configuration {
       buildAllStatements();
     }
     return mappedStatements.containsKey(statementName);
+  }
+
+  /*
+   * Used for reset the loaded xml mappers
+   */
+  public void resetLoadedMapperInfos() {
+    this.loadedResources.clear();
+    this.mappedStatements.clear();
+    this.resultMaps.clear();
   }
 
   public void addCacheRef(String namespace, String referencedNamespace) {


### PR DESCRIPTION
I would like to implement a new feature for MyBatis3.

Everytime developer modified the SQL in XML mapper files, they have to restart the application to reload the mybatis-spring context. That's frequent and normal action for a developer but that also made us crazy. 

> "What if I call some function or api, then, I can reload the mybatis xml file at runtime. That will be nice."

So, I want mybatis support this API to clear loaded resources. Then I will submit the other PR in MyBatis-Spring project and I will modify the SqlSessionFactoryBean.java to support the feature that `MyBatis will can reload the xml files at runtime in your classpath`

Please consider about my suggestion. THX
