### PR TITLE
ErrorContext#store() did not store the outer context correctly.

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/ErrorContext.java
+++ b/src/main/java/org/apache/ibatis/executor/ErrorContext.java
@@ -44,8 +44,9 @@ public class ErrorContext {
   }
 
   public ErrorContext store() {
-    stored = this;
-    LOCAL.set(new ErrorContext());
+    ErrorContext newContext = new ErrorContext();
+    newContext.stored = this;
+    LOCAL.set(newContext);
     return LOCAL.get();
   }
 

--- a/src/test/java/org/apache/ibatis/binding/BoundAuthorMapper.java
+++ b/src/test/java/org/apache/ibatis/binding/BoundAuthorMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -38,6 +38,10 @@ public interface BoundAuthorMapper {
   //======================================================
 
   int insertAuthor(Author author);
+
+  int insertAuthorInvalidSelectKey(Author author);
+
+  int insertAuthorInvalidInsert(Author author);
 
   int insertAuthorDynamic(Author author);
 

--- a/src/test/java/org/apache/ibatis/binding/BoundAuthorMapper.xml
+++ b/src/test/java/org/apache/ibatis/binding/BoundAuthorMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2018 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -47,6 +47,26 @@
       select CAST(RANDOM()*1000000 as INTEGER) a from SYSIBM.SYSDUMMY1
     </selectKey>
     insert into Author (id,username,password,email,bio,favourite_section)
+    values(
+    #{id}, #{username}, #{password}, #{email}, #{bio}, #{favouriteSection:VARCHAR}
+    )
+  </insert>
+
+  <insert id="insertAuthorInvalidSelectKey">
+    <selectKey keyProperty="id" resultType="int" order="BEFORE">
+      select CCAST(RANDOM()*1000000 as INTEGER) a from SYSIBM.SYSDUMMY1
+    </selectKey>
+    insert into Author (id,username,password,email,bio,favourite_section)
+    values(
+    #{id}, #{username}, #{password}, #{email}, #{bio}, #{favouriteSection:VARCHAR}
+    )
+  </insert>
+
+  <insert id="insertAuthorInvalidInsert">
+    <selectKey keyProperty="id" resultType="int" order="BEFORE">
+      select CAST(RANDOM()*1000000 as INTEGER) a from SYSIBM.SYSDUMMY1
+    </selectKey>
+    insert into Author (id,username,password,email,bio,favourite_section_xyz)
     values(
     #{id}, #{username}, #{password}, #{email}, #{bio}, #{favouriteSection:VARCHAR}
     )

--- a/src/test/java/org/apache/ibatis/executor/ErrorContextTest.java
+++ b/src/test/java/org/apache/ibatis/executor/ErrorContextTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
  *    limitations under the License.
  */
 package org.apache.ibatis.executor;
+
+import static org.junit.Assert.*;
 
 import org.junit.Test;
 
@@ -44,4 +46,13 @@ public class ErrorContextTest {
 
   }
 
+  @Test
+  public void verifyStoreRecall() throws Exception {
+    ErrorContext outer = ErrorContext.instance();
+    ErrorContext inner = ErrorContext.instance().store();
+    assertEquals(inner, ErrorContext.instance());
+    ErrorContext recalled = ErrorContext.instance().recall();
+    assertEquals(outer, recalled);
+    assertEquals(outer, ErrorContext.instance());
+  }
 }


### PR DESCRIPTION
This makes the error message slightly inaccurate when an error occurs in `<insert />` with `<selectKey order="BEFORE" />`.