### PR TITLE
Allow specifying `columnPrefix` in constructor mapping.

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/Arg.java
+++ b/src/main/java/org/apache/ibatis/annotations/Arg.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -46,4 +46,9 @@ public @interface Arg {
   String resultMap() default "";
 
   String name() default "";
+
+  /**
+   * @since 3.5.0
+   */
+  String columnPrefix() default "";
 }

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -609,7 +609,7 @@ public class MapperAnnotationBuilder {
           nullOrEmpty(arg.select()),
           nullOrEmpty(arg.resultMap()),
           null,
-          null,
+          nullOrEmpty(arg.columnPrefix()),
           typeHandler,
           flags,
           null,

--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2017 the original author or authors.
+       Copyright 2009-2018 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -90,6 +90,7 @@ typeHandler CDATA #IMPLIED
 select CDATA #IMPLIED
 resultMap CDATA #IMPLIED
 name CDATA #IMPLIED
+columnPrefix CDATA #IMPLIED
 >
 
 <!ELEMENT arg EMPTY>
@@ -101,6 +102,7 @@ typeHandler CDATA #IMPLIED
 select CDATA #IMPLIED
 resultMap CDATA #IMPLIED
 name CDATA #IMPLIED
+columnPrefix CDATA #IMPLIED
 >
 
 <!ELEMENT collection (constructor?,id*,result*,association*,collection*, discriminator?)>

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -350,7 +350,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
     skipRows(rsw.getResultSet(), rowBounds);
     while (shouldProcessMoreRows(resultContext, rowBounds) && rsw.getResultSet().next()) {
       ResultMap discriminatedResultMap = resolveDiscriminatedResultMap(rsw.getResultSet(), resultMap, null);
-      Object rowValue = getRowValue(rsw, discriminatedResultMap);
+      Object rowValue = getRowValue(rsw, discriminatedResultMap, null);
       storeObject(resultHandler, resultContext, rowValue, parentMapping, rsw.getResultSet());
     }
   }
@@ -389,16 +389,16 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   // GET VALUE FROM ROW FOR SIMPLE RESULT MAP
   //
 
-  private Object getRowValue(ResultSetWrapper rsw, ResultMap resultMap) throws SQLException {
+  private Object getRowValue(ResultSetWrapper rsw, ResultMap resultMap, String columnPrefix) throws SQLException {
     final ResultLoaderMap lazyLoader = new ResultLoaderMap();
-    Object rowValue = createResultObject(rsw, resultMap, lazyLoader, null);
+    Object rowValue = createResultObject(rsw, resultMap, lazyLoader, columnPrefix);
     if (rowValue != null && !hasTypeHandlerForResultObject(rsw, resultMap.getType())) {
       final MetaObject metaObject = configuration.newMetaObject(rowValue);
       boolean foundValues = this.useConstructorMappings;
       if (shouldApplyAutomaticMappings(resultMap, false)) {
-        foundValues = applyAutomaticMappings(rsw, resultMap, metaObject, null) || foundValues;
+        foundValues = applyAutomaticMappings(rsw, resultMap, metaObject, columnPrefix) || foundValues;
       }
-      foundValues = applyPropertyMappings(rsw, resultMap, metaObject, lazyLoader, null) || foundValues;
+      foundValues = applyPropertyMappings(rsw, resultMap, metaObject, lazyLoader, columnPrefix) || foundValues;
       foundValues = lazyLoader.size() > 0 || foundValues;
       rowValue = foundValues || configuration.isReturnInstanceForEmptyRow() ? rowValue : null;
     }
@@ -629,7 +629,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
           value = getNestedQueryConstructorValue(rsw.getResultSet(), constructorMapping, columnPrefix);
         } else if (constructorMapping.getNestedResultMapId() != null) {
           final ResultMap resultMap = configuration.getResultMap(constructorMapping.getNestedResultMapId());
-          value = getRowValue(rsw, resultMap);
+          value = getRowValue(rsw, resultMap, constructorMapping.getColumnPrefix());
         } else {
           final TypeHandler<?> typeHandler = constructorMapping.getTypeHandler();
           value = typeHandler.getResult(rsw.getResultSet(), prependPrefix(column, columnPrefix));

--- a/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/Article.java
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/Article.java
@@ -1,0 +1,51 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.constructor_columnprefix;
+
+public class Article {
+
+  private EntityKey id;
+
+  private String name;
+
+  private Author author;
+
+  private Author coauthor;
+
+  public Article(EntityKey id, String name, Author author, Author coauthor) {
+    super();
+    this.id = id;
+    this.name = name;
+    this.author = author;
+    this.coauthor = coauthor;
+  }
+
+  public EntityKey getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Author getAuthor() {
+    return author;
+  }
+
+  public Author getCoauthor() {
+    return coauthor;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/Author.java
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/Author.java
@@ -1,0 +1,38 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.constructor_columnprefix;
+
+public class Author {
+  private Integer id;
+
+  private String name;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/ConstructorColumnPrefixTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/ConstructorColumnPrefixTest.java
@@ -1,0 +1,67 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.constructor_columnprefix;
+
+import static org.junit.Assert.*;
+
+import java.io.Reader;
+import java.util.List;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class ConstructorColumnPrefixTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/constructor_columnprefix/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+
+    // populate in-memory database
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+        "org/apache/ibatis/submitted/constructor_columnprefix/CreateDB.sql");
+  }
+
+  @Test
+  public void shouldGetArticles() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<Article> articles = mapper.getArticles();
+      assertEquals(2, articles.size());
+      Article article1 = articles.get(0);
+      assertEquals(Integer.valueOf(1), article1.getId().getId());
+      assertEquals("Article 1", article1.getName());
+      assertEquals("Mary", article1.getAuthor().getName());
+      assertEquals("Bob", article1.getCoauthor().getName());
+      Article article2 = articles.get(1);
+      assertEquals(Integer.valueOf(2), article2.getId().getId());
+      assertEquals("Article 2", article2.getName());
+      assertEquals("Jane", article2.getAuthor().getName());
+      assertEquals("Mary", article2.getCoauthor().getName());
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/ConstructorColumnPrefixTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/ConstructorColumnPrefixTest.java
@@ -50,18 +50,31 @@ public class ConstructorColumnPrefixTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       List<Article> articles = mapper.getArticles();
-      assertEquals(2, articles.size());
-      Article article1 = articles.get(0);
-      assertEquals(Integer.valueOf(1), article1.getId().getId());
-      assertEquals("Article 1", article1.getName());
-      assertEquals("Mary", article1.getAuthor().getName());
-      assertEquals("Bob", article1.getCoauthor().getName());
-      Article article2 = articles.get(1);
-      assertEquals(Integer.valueOf(2), article2.getId().getId());
-      assertEquals("Article 2", article2.getName());
-      assertEquals("Jane", article2.getAuthor().getName());
-      assertEquals("Mary", article2.getCoauthor().getName());
+      assertArticles(articles);
     }
+  }
+
+  @Test
+  public void shouldGetArticlesAnno() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<Article> articles = mapper.getArticlesAnno();
+      assertArticles(articles);
+    }
+  }
+
+  protected void assertArticles(List<Article> articles) {
+    assertEquals(2, articles.size());
+    Article article1 = articles.get(0);
+    assertEquals(Integer.valueOf(1), article1.getId().getId());
+    assertEquals("Article 1", article1.getName());
+    assertEquals("Mary", article1.getAuthor().getName());
+    assertEquals("Bob", article1.getCoauthor().getName());
+    Article article2 = articles.get(1);
+    assertEquals(Integer.valueOf(2), article2.getId().getId());
+    assertEquals("Article 2", article2.getName());
+    assertEquals("Jane", article2.getAuthor().getName());
+    assertEquals("Mary", article2.getCoauthor().getName());
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/CreateDB.sql
@@ -1,0 +1,37 @@
+--
+--    Copyright 2009-2018 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table articles if exists;
+drop table authors if exists;
+
+create table articles (
+  id int,
+  name varchar(20),
+  author_id int,
+  coauthor_id int
+);
+
+create table authors (
+  id int,
+  name varchar(20)
+);
+
+insert into articles (id, name, author_id, coauthor_id) values
+(1, 'Article 1', 1, 2),
+(2, 'Article 2', 3, 1);
+
+insert into authors (id, name) values
+(1, 'Mary'), (2, 'Bob'), (3, 'Jane');

--- a/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/EntityKey.java
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/EntityKey.java
@@ -1,0 +1,53 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.constructor_columnprefix;
+
+public class EntityKey {
+  private Integer id;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((id == null) ? 0 : id.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    EntityKey other = (EntityKey) obj;
+    if (id == null) {
+      if (other.id != null)
+        return false;
+    } else if (!id.equals(other.id))
+      return false;
+    return true;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/Mapper.java
@@ -17,8 +17,28 @@ package org.apache.ibatis.submitted.constructor_columnprefix;
 
 import java.util.List;
 
+import org.apache.ibatis.annotations.Arg;
+import org.apache.ibatis.annotations.ConstructorArgs;
+import org.apache.ibatis.annotations.Select;
+
 public interface Mapper {
 
   List<Article> getArticles();
+
+  @ConstructorArgs({
+      @Arg(id = true, resultMap = "keyRM", columnPrefix = "key_", javaType = EntityKey.class),
+      @Arg(column = "name", javaType = String.class),
+      @Arg(resultMap = "authorRM", columnPrefix = "author_", javaType = Author.class),
+      @Arg(resultMap = "authorRM", columnPrefix = "coauthor_", javaType = Author.class),
+  })
+  @Select({
+      "select id key_id, name, author.id author_id, author.name author_name,",
+      "  coauthor.id coauthor_id, coauthor.name coauthor_name",
+      "from articles",
+      "left join authors author on author.id = articles.author_id",
+      "left join authors coauthor on coauthor.id = articles.coauthor_id",
+      "order by articles.id"
+  })
+  List<Article> getArticlesAnno();
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/Mapper.java
@@ -1,0 +1,24 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.constructor_columnprefix;
+
+import java.util.List;
+
+public interface Mapper {
+
+  List<Article> getArticles();
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/Mapper.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper
+  namespace="org.apache.ibatis.submitted.constructor_columnprefix.Mapper">
+
+  <resultMap id="keyRM"
+    type="org.apache.ibatis.submitted.constructor_columnprefix.EntityKey">
+    <id property="id" column="id" />
+  </resultMap>
+
+  <resultMap id="authorRM"
+    type="org.apache.ibatis.submitted.constructor_columnprefix.Author">
+    <id property="id" column="id" />
+    <result property="name" column="name" />
+  </resultMap>
+
+  <resultMap id="articleRM"
+    type="org.apache.ibatis.submitted.constructor_columnprefix.Article">
+    <constructor>
+      <idArg resultMap="keyRM" columnPrefix="key_"
+        javaType="org.apache.ibatis.submitted.constructor_columnprefix.EntityKey" />
+      <arg column="name" javaType="string" />
+      <arg resultMap="authorRM" columnPrefix="author_"
+        javaType="org.apache.ibatis.submitted.constructor_columnprefix.Author" />
+      <arg resultMap="authorRM" columnPrefix="coauthor_"
+        javaType="org.apache.ibatis.submitted.constructor_columnprefix.Author" />
+    </constructor>
+  </resultMap>
+
+  <select id="getArticles" resultMap="articleRM"><![CDATA[
+    select id key_id, name, author.id author_id, author.name author_name,
+      coauthor.id coauthor_id, coauthor.name coauthor_name
+    from articles
+    left join authors author on author.id = articles.author_id
+    left join authors coauthor on coauthor.id = articles.coauthor_id
+    order by articles.id
+  ]]></select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/mybatis-config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url"
+          value="jdbc:hsqldb:mem:constructorcolumnprefix" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper
+      class="org.apache.ibatis.submitted.constructor_columnprefix.Mapper" />
+  </mappers>
+
+</configuration>


### PR DESCRIPTION
It's used with `resultMap` (see the attached test).

```xml
<resultMap id="authorRM" type="Author">
  <id property="id" column="id" />
  <result property="name" column="name" />
</resultMap>

<resultMap id="articleRM" type="Article">
  <constructor>
    <idArg column="id" javaType="int" />
    <arg column="name" javaType="string" />
    <arg resultMap="authorRM" columnPrefix="author_" javaType="Author" />
    <arg resultMap="authorRM" columnPrefix="coauthor_" javaType="Author" />
  </constructor>
</resultMap>
```

This should fix #968 .

@kazuki43zoo , @h3adache ,
Please let me know if there is any concern.