### PR TITLE
Avoid unnecessary `setAccessible()` calls.

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/invoker/GetFieldInvoker.java
+++ b/src/main/java/org/apache/ibatis/reflection/invoker/GetFieldInvoker.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.apache.ibatis.reflection.invoker;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 
+import org.apache.ibatis.reflection.Reflector;
+
 /**
  * @author Clinton Begin
  */
@@ -30,7 +32,16 @@ public class GetFieldInvoker implements Invoker {
 
   @Override
   public Object invoke(Object target, Object[] args) throws IllegalAccessException, InvocationTargetException {
-    return field.get(target);
+    try {
+      return field.get(target);
+    } catch (IllegalAccessException e) {
+      if (Reflector.canControlMemberAccessible()) {
+        field.setAccessible(true);
+        return field.get(target);
+      } else {
+        throw e;
+      }
+    }
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/reflection/invoker/MethodInvoker.java
+++ b/src/main/java/org/apache/ibatis/reflection/invoker/MethodInvoker.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package org.apache.ibatis.reflection.invoker;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+
+import org.apache.ibatis.reflection.Reflector;
 
 /**
  * @author Clinton Begin
@@ -38,7 +40,16 @@ public class MethodInvoker implements Invoker {
 
   @Override
   public Object invoke(Object target, Object[] args) throws IllegalAccessException, InvocationTargetException {
-    return method.invoke(target, args);
+    try {
+      return method.invoke(target, args);
+    } catch (IllegalAccessException e) {
+      if (Reflector.canControlMemberAccessible()) {
+        method.setAccessible(true);
+        return method.invoke(target, args);
+      } else {
+        throw e;
+      }
+    }
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/reflection/invoker/SetFieldInvoker.java
+++ b/src/main/java/org/apache/ibatis/reflection/invoker/SetFieldInvoker.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.apache.ibatis.reflection.invoker;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 
+import org.apache.ibatis.reflection.Reflector;
+
 /**
  * @author Clinton Begin
  */
@@ -30,7 +32,16 @@ public class SetFieldInvoker implements Invoker {
 
   @Override
   public Object invoke(Object target, Object[] args) throws IllegalAccessException, InvocationTargetException {
-    field.set(target, args[0]);
+    try {
+      field.set(target, args[0]);
+    } catch (IllegalAccessException e) {
+      if (Reflector.canControlMemberAccessible()) {
+        field.setAccessible(true);
+        field.set(target, args[0]);
+      } else {
+        throw e;
+      }
+    }
     return null;
   }
 

--- a/src/main/java/org/apache/ibatis/reflection/property/PropertyCopier.java
+++ b/src/main/java/org/apache/ibatis/reflection/property/PropertyCopier.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package org.apache.ibatis.reflection.property;
 
 import java.lang.reflect.Field;
 
+import org.apache.ibatis.reflection.Reflector;
+
 /**
  * @author Clinton Begin
  */
@@ -32,8 +34,16 @@ public final class PropertyCopier {
       final Field[] fields = parent.getDeclaredFields();
       for(Field field : fields) {
         try {
-          field.setAccessible(true);
-          field.set(destinationBean, field.get(sourceBean));
+          try {
+            field.set(destinationBean, field.get(sourceBean));
+          } catch (IllegalAccessException e) {
+            if (Reflector.canControlMemberAccessible()) {
+              field.setAccessible(true);
+              field.set(destinationBean, field.get(sourceBean));
+            } else {
+              throw e;
+            }
+          }
         } catch (Exception e) {
           // Nothing useful to do, will only fail on final fields, which will be ignored.
         }


### PR DESCRIPTION
As a fix for #1156 .

I used retry-on-failure approach as [isAccessible()](https://docs.oracle.com/javase/9/docs/api/java/lang/reflect/AccessibleObject.html#isAccessible--) is useless (always returns `false` on the first call).
It would be appreciated if someone can test this with named modules.