### PR TITLE
avoid an unnecessary judgement

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/MetaObject.java
+++ b/src/main/java/org/apache/ibatis/reflection/MetaObject.java
@@ -128,7 +128,7 @@ public class MetaObject {
     if (prop.hasNext()) {
       MetaObject metaValue = metaObjectForProperty(prop.getIndexedName());
       if (metaValue == SystemMetaObject.NULL_META_OBJECT) {
-        if (value == null && prop.getChildren() != null) {
+        if (value == null) {
           // don't instantiate child path if value is null
           return;
         } else {


### PR DESCRIPTION
in method setValue of MetaObject  ,  when prop.hasNext() already is true ，it is unnecessary to judge  prop.getChildren() != null.