### PR TITLE
if do not add type parameter,the getSuperclassTypeParameter(Class<?> …

### DIFF
--- a/src/main/java/org/apache/ibatis/type/TypeReference.java
+++ b/src/main/java/org/apache/ibatis/type/TypeReference.java
@@ -51,6 +51,12 @@ public abstract class TypeReference<T> {
       rawType = ((ParameterizedType) rawType).getRawType();
     }
 
+    if(rawType.toString().equals("T"))
+      throw new RuntimeException("'" + getClass() + "' extends TypeReference but misses the type parameter. "
+              + "Remove the extension or add a type parameter to it.");
+
+
+
     return rawType;
   }
 

--- a/src/main/java/org/txby/Test.java
+++ b/src/main/java/org/txby/Test.java
@@ -1,0 +1,8 @@
+package org.txby;
+
+/**
+ * @author chl
+ * @date 2018/9/13 19:35
+ */
+public class Test {
+}


### PR DESCRIPTION
fix: if do not add type parameter,the getSuperclassTypeParameter(Class<?> clazz) method will return String "T" and not throw TypeException,rowType is "T"
 
 