### PR TITLE
Fixes #1345 - Workaround for an issue when using mybatis cursor on DB2

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -846,9 +846,11 @@ public class DefaultResultSetHandler implements ResultSetHandler {
 
   private void handleRowValuesForNestedResultMap(ResultSetWrapper rsw, ResultMap resultMap, ResultHandler<?> resultHandler, RowBounds rowBounds, ResultMapping parentMapping) throws SQLException {
     final DefaultResultContext<Object> resultContext = new DefaultResultContext<>();
-    skipRows(rsw.getResultSet(), rowBounds);
+    if ( ! rsw.getResultSet().isClosed()) {
+        skipRows(rsw.getResultSet(), rowBounds);
+    }
     Object rowValue = previousRowValue;
-    while (shouldProcessMoreRows(resultContext, rowBounds) && rsw.getResultSet().next()) {
+    while (shouldProcessMoreRows(resultContext, rowBounds) && ! rsw.getResultSet().isClosed() && rsw.getResultSet().next()) {
       final ResultMap discriminatedResultMap = resolveDiscriminatedResultMap(rsw.getResultSet(), resultMap, null);
       final CacheKey rowKey = createRowKey(discriminatedResultMap, rsw, null);
       Object partialObject = nestedResultObjects.get(rowKey);


### PR DESCRIPTION
When using a Mybatis Cursor the DefaultResultSetHandler would interact with the ResultSet after it was closed automatically by the DB2 driver when we reached the end, this causes SqlExceptions. This commit implements a workaround that checks if the result set is already closed.

I also added a unit test with a mocked ResultSet that replicates the behavior of DB2. With my fix the SQLException is avoided, whereas the old code triggers the exception.

It would be nice if someone with a better knowledge of the Mybatis code base could have a look and see if there are better ways to fix it. I'm under the impression that the code in `DefaultResultSetHandler#handleRowValues` was never intended to be called multiple times like the DefaultCursor does. Maybe the code in DefaultResultSetHandler would be better off being split into two implementations: a list-based handler and a iterator-based handler.