### PR TITLE
Allow custom collections return type

### DIFF
--- a/src/main/java/org/apache/ibatis/binding/MapperMethod.java
+++ b/src/main/java/org/apache/ibatis/binding/MapperMethod.java
@@ -169,8 +169,7 @@ public class MapperMethod {
   private <E> Object convertToDeclaredCollection(Configuration config, List<E> list) {
     Object collection = config.getObjectFactory().create(method.getReturnType());
     MetaObject metaObject = config.newMetaObject(collection);
-    metaObject.addAll(list);
-    return collection;
+    return metaObject.addAll(list);
   }
 
   @SuppressWarnings("unchecked")

--- a/src/main/java/org/apache/ibatis/executor/ResultExtractor.java
+++ b/src/main/java/org/apache/ibatis/executor/ResultExtractor.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public class ResultExtractor {
     } else if (targetType != null && objectFactory.isCollection(targetType)) {
       value = objectFactory.create(targetType);
       MetaObject metaObject = configuration.newMetaObject(value);
-      metaObject.addAll(list);
+      value = metaObject.addAll(list);
     } else if (targetType != null && targetType.isArray()) {
       Class<?> arrayComponentType = targetType.getComponentType();
       Object array = Array.newInstance(arrayComponentType, list.size());

--- a/src/main/java/org/apache/ibatis/reflection/MetaObject.java
+++ b/src/main/java/org/apache/ibatis/reflection/MetaObject.java
@@ -158,8 +158,7 @@ public class MetaObject {
     objectWrapper.add(element);
   }
 
-  public <E> void addAll(List<E> list) {
-    objectWrapper.addAll(list);
+  public <E> Object addAll(List<E> list) {
+    return objectWrapper.addAll(list);
   }
-
 }

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/BeanWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/BeanWrapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -197,7 +197,7 @@ public class BeanWrapper extends BaseWrapper {
   }
 
   @Override
-  public <E> void addAll(List<E> list) {
+  public <E> Object addAll(List<E> list) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/CollectionWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/CollectionWrapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -94,8 +94,8 @@ public class CollectionWrapper implements ObjectWrapper {
   }
 
   @Override
-  public <E> void addAll(List<E> element) {
+  public <E> Object addAll(List<E> element) {
     object.addAll(element);
+    return object;
   }
-
 }

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
@@ -151,8 +151,7 @@ public class MapWrapper extends BaseWrapper {
   }
 
   @Override
-  public <E> void addAll(List<E> element) {
+  public <E> Object addAll(List<E> element) {
     throw new UnsupportedOperationException();
   }
-
 }

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/ObjectWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/ObjectWrapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -50,6 +50,5 @@ public interface ObjectWrapper {
   
   void add(Object element);
   
-  <E> void addAll(List<E> element);
-
+  <E> Object addAll(List<E> element);
 }

--- a/src/test/java/org/apache/ibatis/executor/ResultExtractorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/ResultExtractorTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ public class ResultExtractorTest {
     when(objectFactory.isCollection(targetType)).thenReturn(true);
     when(objectFactory.create(targetType)).thenReturn(set);
     when(configuration.newMetaObject(set)).thenReturn(metaObject);
+    when(metaObject.addAll(anyList())).thenReturn(set);
 
     final Set result = (Set) resultExtractor.extractObjectFromList(list, targetType);
     assertThat(result).isSameAs(set);

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomCollection.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomCollection.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,8 +18,7 @@ package org.apache.ibatis.submitted.custom_collection_handling;
 import java.util.*;
 
 public class CustomCollection<T> {
-    
-    private List<T> data = new ArrayList<T>();
+    private List<T> data = new ArrayList<>();
 
     public <K> K[] toArray(K[] a) {
         return data.toArray(a);
@@ -93,7 +92,7 @@ public class CustomCollection<T> {
     @Override
     public boolean equals(Object o) {
         if (!(o instanceof CustomCollection)) return false;
-        return data.equals(((CustomCollection)o).data);
+        return data.equals(((CustomCollection) o).data);
     }
 
     public boolean containsAll(Collection<?> c) {
@@ -123,5 +122,12 @@ public class CustomCollection<T> {
     public boolean add(T e) {
         return data.add(e);
     }
-    
+
+    public List<T> getData() {
+        return data;
+    }
+
+    void setData(List<T> data) {
+        this.data = data;
+    }
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomCollectionHandlingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomCollectionHandlingTest.java
@@ -43,9 +43,12 @@ public class CustomCollectionHandlingTest {
         try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             List<Person> list = sqlSession.selectList("org.apache.ibatis.submitted.custom_collection_handling.PersonMapper.findWithResultMap");
             assertEquals(2, list.size());
-            assertEquals(2, list.get(0).getContacts().size());
+            final CustomCollection<Contact> contacts = list.get(0).getContacts();
+            assertEquals(2, contacts.size());
             assertEquals(1, list.get(1).getContacts().size());
-            assertEquals("3 Wall Street", list.get(0).getContacts().get(1).getAddress());
+            assertEquals("3 Wall Street", contacts.get(1).getAddress());
+            System.out.println(contacts.getClass());
+            assertTrue(contacts.getClass().isAssignableFrom(ImmutableCustomCollection.class));
         }
     }
 
@@ -60,6 +63,20 @@ public class CustomCollectionHandlingTest {
         SqlSessionFactory sqlSessionFactory = getSqlSessionFactoryXmlConfig(xmlConfig);
         try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             List<Person> list = sqlSession.selectList("org.apache.ibatis.submitted.custom_collection_handling.PersonMapper.findWithSelect");
+            assertEquals(2, list.size());
+            assertEquals(2, list.get(0).getContacts().size());
+            assertEquals(1, list.get(1).getContacts().size());
+            assertEquals("3 Wall Street", list.get(0).getContacts().get(1).getAddress());
+        }
+    }
+
+    @Test
+    public void testReturnsCustomList() throws Exception {
+        String xmlConfig = "org/apache/ibatis/submitted/custom_collection_handling/MapperConfig.xml";
+        SqlSessionFactory sqlSessionFactory = getSqlSessionFactoryXmlConfig(xmlConfig);
+        try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+            PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
+            ImmutableCustomCollection<Person> list = personMapper.findWithCustomList();
             assertEquals(2, list.size());
             assertEquals(2, list.get(0).getContacts().size());
             assertEquals(1, list.get(1).getContacts().size());

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectFactory.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,100 +15,21 @@
  */
 package org.apache.ibatis.submitted.custom_collection_handling;
 
-import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
+import org.apache.ibatis.reflection.factory.DefaultObjectFactory;
+
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
-import org.apache.ibatis.reflection.ReflectionException;
-import org.apache.ibatis.reflection.factory.ObjectFactory;
-
-public class CustomObjectFactory implements ObjectFactory {
-
-    @Override
-    public <T> T create(Class<T> type) {
-        return create(type, null, null);
-    }
-
+public class CustomObjectFactory extends DefaultObjectFactory {
     @Override
     public <T> T create(Class<T> type, List<Class<?>> constructorArgTypes, List<Object> constructorArgs) {
-        Class<?> classToCreate = resolveInterface(type);
-        @SuppressWarnings("unchecked") // we know types are assignable
-        T created = (T) instantiateClass(classToCreate, constructorArgTypes, constructorArgs);
-        return created;
-    }
-
-    @Override
-    public void setProperties(Properties properties) {
-        // no props for default
-    }
-
-    private <T> T instantiateClass(Class<T> type, List<Class<?>> constructorArgTypes, List<Object> constructorArgs) {
-        try {
-            Constructor<T> constructor;
-            if (constructorArgTypes == null || constructorArgs == null) {
-                constructor = type.getDeclaredConstructor();
-                if (!constructor.isAccessible()) {
-                    constructor.setAccessible(true);
-                }
-                return constructor.newInstance();
-            }
-            constructor = type.getDeclaredConstructor(constructorArgTypes.toArray(new Class[constructorArgTypes.size()]));
-            if (!constructor.isAccessible()) {
-                constructor.setAccessible(true);
-            }
-            return constructor.newInstance(constructorArgs.toArray(new Object[constructorArgs.size()]));
-        } catch (Exception e) {
-            StringBuilder argTypes = new StringBuilder();
-            if (constructorArgTypes != null) {
-                for (Class<?> argType : constructorArgTypes) {
-                    argTypes.append(argType.getSimpleName());
-                    argTypes.append(",");
-                }
-            }
-            StringBuilder argValues = new StringBuilder();
-            if (constructorArgs != null) {
-                for (Object argValue : constructorArgs) {
-                    argValues.append(String.valueOf(argValue));
-                    argValues.append(",");
-                }
-            }
-            throw new ReflectionException("Error instantiating " + type + " with invalid types (" + argTypes + ") or values (" + argValues + "). Cause: " + e, e);
+        if(CustomCollection.class.isAssignableFrom(type)) {
+            return (T) new CustomCollection();
         }
+        return super.create(type, constructorArgTypes, constructorArgs);
     }
 
-    private Class<?> resolveInterface(Class<?> type) {
-        Class<?> classToCreate;
-        if (type == List.class || type == Collection.class) {
-            classToCreate = LinkedList.class;
-        } else if (type == Map.class) {
-            classToCreate = LinkedHashMap.class;
-        } else if (type == SortedSet.class) { // issue #510 Collections Support
-            classToCreate = TreeSet.class;
-        } else if (type == Set.class) {
-            classToCreate = HashSet.class;
-        } else {
-            classToCreate = type;
-        }
-        return classToCreate;
-    }
-    
     @Override
     public <T> boolean isCollection(Class<T> type) {
-      return CustomCollection.class.isAssignableFrom(type);
+        return CustomCollection.class.isAssignableFrom(type);
     }
-
-    @SuppressWarnings("unchecked")
-    public <T> T[] createArray(Class<T> type, int size) {
-      return (T[]) Array.newInstance(type, size);
-    }
-
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectWrapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectWrapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,12 +20,12 @@ import java.util.List;
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.factory.ObjectFactory;
 import org.apache.ibatis.reflection.property.PropertyTokenizer;
+import org.apache.ibatis.reflection.wrapper.ObjectWrapper;
 
-public class CustomObjectWrapper implements org.apache.ibatis.reflection.wrapper.ObjectWrapper {
-
-  private CustomCollection collection;
+public class CustomObjectWrapper implements ObjectWrapper {
+  private CustomCollection<? super Object> collection;
   
-  public CustomObjectWrapper(CustomCollection collection){
+  CustomObjectWrapper(CustomCollection<? super Object> collection){
     this.collection = collection;
   }
   
@@ -95,12 +95,12 @@ public class CustomObjectWrapper implements org.apache.ibatis.reflection.wrapper
 
   @Override
   public void add(Object element) {
-    ((CustomCollection<Object>) collection).add(element);
+    collection.add(element);
   }
 
   @Override
-  public <E> void addAll(List<E> element) {
-    ((CustomCollection<Object>) collection).addAll(element);
+  public <E> Object addAll(List<E> element) {
+    collection.addAll(element);
+    return new ImmutableCustomCollection<>(collection.getData());
   }
-
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectWrapperFactory.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectWrapperFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,17 +17,16 @@ package org.apache.ibatis.submitted.custom_collection_handling;
 
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.wrapper.ObjectWrapper;
+import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
 
-public class CustomObjectWrapperFactory implements org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory {
-
+public class CustomObjectWrapperFactory implements ObjectWrapperFactory {
   @Override
   public boolean hasWrapperFor(Object object) {
-    return object.getClass().equals(CustomCollection.class);
+    return CustomCollection.class.isAssignableFrom(object.getClass());
   }
 
   @Override
   public ObjectWrapper getWrapperFor(MetaObject metaObject, Object object) {
-    return new org.apache.ibatis.submitted.custom_collection_handling.CustomObjectWrapper((CustomCollection) object);
+    return new CustomObjectWrapper((CustomCollection) object);
   }
-
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/ImmutableCustomCollection.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/ImmutableCustomCollection.java
@@ -1,0 +1,62 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.custom_collection_handling;
+
+import java.util.Collection;
+import java.util.List;
+
+public class ImmutableCustomCollection<T> extends CustomCollection<T> {
+    ImmutableCustomCollection() {}
+
+    ImmutableCustomCollection(List<T> data) {
+        setData(data);
+    }
+
+    @Override
+    public boolean removeAll(Collection c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public T remove(int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(int index, Collection c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean addAll(Collection c) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void add(int index, Object element) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean add(Object e) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/PersonMapper.java
@@ -15,33 +15,6 @@
  */
 package org.apache.ibatis.submitted.custom_collection_handling;
 
-public class Person {
-
-    private Integer id;
-    private String name;
-    private CustomCollection<Contact> contacts;
-
-    public Integer getId() {
-        return id;
-    }
-
-    public void setId(Integer id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public CustomCollection<Contact> getContacts() {
-        return contacts;
-    }
-
-    public void setContacts(CustomCollection<Contact> contacts) {
-        this.contacts = contacts;
-    }
+public interface PersonMapper {
+    ImmutableCustomCollection<Person> findWithCustomList();
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/PersonMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/PersonMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2018 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -65,4 +65,9 @@
         order by c.address
     </select>
 
+    <select id="findWithCustomList" resultMap="personRM2">
+        select p.id, p.name
+        from person p
+        order by p.id
+    </select>
 </mapper>


### PR DESCRIPTION
This is done in a non backwards compatible way.

The backwards compatible way to handle this would be to add a new interface method to ObjectWrapper (I had no good name for the method so I removed it lol).

This is a change that also allows languages like Scala to seamlessly use traits as mappers and still return scala List (which is immutable) so it has many different potential benefits.
