### PR TITLE
Avoid unnecessarily creation of new object

### DIFF
--- a/src/main/java/org/apache/ibatis/cache/decorators/BlockingCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/BlockingCache.java
@@ -25,12 +25,12 @@ import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.cache.CacheException;
 
 /**
- * Simple blocking decorator 
- * 
+ * Simple blocking decorator
+ *
  * Simple and inefficient version of EhCache's BlockingCache decorator.
  * It sets a lock over a cache key when the element is not found in cache.
  * This way, other threads will wait until this element is filled instead of hitting the database.
- * 
+ *
  * @author Eduardo Macarron
  *
  */
@@ -70,7 +70,7 @@ public class BlockingCache implements Cache {
     Object value = delegate.getObject(key);
     if (value != null) {
       releaseLock(key);
-    }        
+    }
     return value;
   }
 
@@ -90,20 +90,20 @@ public class BlockingCache implements Cache {
   public ReadWriteLock getReadWriteLock() {
     return null;
   }
-  
+
   private ReentrantLock getLockForKey(Object key) {
-    ReentrantLock lock = new ReentrantLock();
+    ReentrantLock lock = locks.getOrDefault(key, new ReentrantLock());
     ReentrantLock previous = locks.putIfAbsent(key, lock);
     return previous == null ? lock : previous;
   }
-  
+
   private void acquireLock(Object key) {
     Lock lock = getLockForKey(key);
     if (timeout > 0) {
       try {
         boolean acquired = lock.tryLock(timeout, TimeUnit.MILLISECONDS);
         if (!acquired) {
-          throw new CacheException("Couldn't get a lock in " + timeout + " for the key " +  key + " at the cache " + delegate.getId());  
+          throw new CacheException("Couldn't get a lock in " + timeout + " for the key " +  key + " at the cache " + delegate.getId());
         }
       } catch (InterruptedException e) {
         throw new CacheException("Got interrupted while trying to acquire lock for key " + key, e);
@@ -112,7 +112,7 @@ public class BlockingCache implements Cache {
       lock.lock();
     }
   }
-  
+
   private void releaseLock(Object key) {
     ReentrantLock lock = locks.get(key);
     if (lock.isHeldByCurrentThread()) {
@@ -126,5 +126,5 @@ public class BlockingCache implements Cache {
 
   public void setTimeout(long timeout) {
     this.timeout = timeout;
-  }  
+  }
 }


### PR DESCRIPTION
I found that the method `org.apache.ibatis.cache.decorators.BlockingCache#getLockForKey` can be optimized:
```java
  private ReentrantLock getLockForKey(Object key) {
    ReentrantLock lock = new ReentrantLock();
    ReentrantLock previous = locks.putIfAbsent(key, lock);
    return previous == null ? lock : previous;
  }
```
this method creates a new `ReentrantLock`  object no matter whether there is already one mapped to the key or not, if there are many threads that access the same key, a lot of `ReentrantLock` will be created, which is unnecessary.
