### PR TITLE
Enable Void return type mapper methods

### DIFF
--- a/src/main/java/org/apache/ibatis/binding/MapperMethod.java
+++ b/src/main/java/org/apache/ibatis/binding/MapperMethod.java
@@ -291,7 +291,7 @@ public class MapperMethod {
       } else {
         this.returnType = method.getReturnType();
       }
-      this.returnsVoid = void.class.equals(this.returnType);
+      this.returnsVoid = void.class.equals(this.returnType) || Void.class.equals(this.returnType);
       this.returnsMany = configuration.getObjectFactory().isCollection(this.returnType) || this.returnType.isArray();
       this.returnsCursor = Cursor.class.equals(this.returnType);
       this.returnsOptional = Optional.class.equals(this.returnType);

--- a/src/test/java/org/apache/ibatis/submitted/insert_with_Void/Foo.java
+++ b/src/test/java/org/apache/ibatis/submitted/insert_with_Void/Foo.java
@@ -1,0 +1,49 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.insert_with_Void;
+
+import java.io.Serializable;
+
+public class Foo implements Serializable {
+
+  private Long field1;
+  private Integer field2;
+
+  public Foo() {
+    super();
+  }
+
+  public Foo(Long field1, Integer field2) {
+    this.field1 = field1;
+    this.field2 = field2;
+  }
+
+  public Long getField1() {
+    return field1;
+  }
+
+  public void setField1(Long field1) {
+    this.field1 = field1;
+  }
+
+  public Integer getField2() {
+    return field2;
+  }
+
+  public void setField2(Integer field2) {
+    this.field2 = field2;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/insert_with_Void/FooMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/insert_with_Void/FooMapper.java
@@ -1,0 +1,26 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.insert_with_Void;
+
+public interface FooMapper {
+
+  Void insertFoo(Foo foo);
+
+  Foo selectFoo();
+
+  int deleteAllFoo();
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/insert_with_Void/FooMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/insert_with_Void/FooMapper.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.insert_with_Void.FooMapper">
+
+  <resultMap type="Foo" id="fooResult">
+    <result property="field1" column="field1" jdbcType="INTEGER"/>
+    <result property="field2" column="field2" jdbcType="INTEGER"/>
+  </resultMap>
+
+  <insert id="insertFoo" parameterType="Foo">
+    insert into FOO
+    (
+    field1,
+    field2
+    )
+    values
+    (
+    #{field1,jdbcType=INTEGER},
+    #{field2,jdbcType=INTEGER}
+    )
+  </insert>
+
+  <select id="selectFoo" resultMap="fooResult">
+    select
+    field1,
+    field2
+    from FOO;
+  </select>
+
+  <delete id="deleteAllFoo">
+    delete from FOO;
+  </delete>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/insert_with_Void/InsertWithVoidReturnTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/insert_with_Void/InsertWithVoidReturnTypeTest.java
@@ -1,0 +1,81 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.insert_with_Void;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/*
+ * @author johhud1
+ */
+public class InsertWithVoidReturnTypeTest {
+
+    private final static String SQL_MAP_CONFIG = "org/apache/ibatis/submitted/insert_with_Void/sqlmap.xml";
+    private static SqlSession session;
+    private static Connection conn;
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        final SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(Resources.getResourceAsReader(SQL_MAP_CONFIG));
+        session = factory.openSession();
+        conn = session.getConnection();
+
+        BaseDataTest.runScript(factory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/insert_with_Void/create-schema-mysql.sql");
+    }
+
+    @Before
+    public void setUp() {
+        final FooMapper mapper = session.getMapper(FooMapper.class);
+        mapper.deleteAllFoo();
+        session.commit();
+    }
+
+    @Test
+    public void testInsertWithVoidResturnType() {
+        final FooMapper mapper = session.getMapper(FooMapper.class);
+        final Foo inserted = new Foo(1L, 3);
+        mapper.insertFoo(inserted);
+
+        final Foo selected = mapper.selectFoo();
+
+        Assert.assertEquals(inserted.getField1(), selected.getField1());
+        Assert.assertEquals(inserted.getField2(), selected.getField2());
+
+    }
+
+    @AfterClass
+    public static void tearDownAfterClass() {
+        try {
+            conn.close();
+        } catch (SQLException e) {
+            Assert.fail(e.getMessage());
+        }
+        session.close();
+    }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/insert_with_Void/create-schema-mysql.sql
+++ b/src/test/java/org/apache/ibatis/submitted/insert_with_Void/create-schema-mysql.sql
@@ -1,0 +1,21 @@
+--
+--    Copyright 2009-2018 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+CREATE TABLE FOO
+(
+field1 integer,
+field2 integer
+);

--- a/src/test/java/org/apache/ibatis/submitted/insert_with_Void/sqlmap.xml
+++ b/src/test/java/org/apache/ibatis/submitted/insert_with_Void/sqlmap.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+<configuration>
+  <settings>
+    <setting name="cacheEnabled" value="true"/>
+    <setting name="lazyLoadingEnabled" value="true"/>
+    <setting name="multipleResultSetsEnabled" value="true"/>
+    <setting name="useColumnLabel" value="true"/>
+    <setting name="useGeneratedKeys" value="false"/>
+    <setting name="defaultExecutorType" value="BATCH"/>
+    <setting name="defaultStatementTimeout" value="25"/>
+  </settings>
+  <typeAliases>
+    <typeAlias type="org.apache.ibatis.submitted.insert_with_Void.Foo" alias="Foo"/>
+  </typeAliases>
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value=""/>
+      </transactionManager>
+      <dataSource type="POOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver"/>
+        <property name="url" value="jdbc:hsqldb:mem:overprops"/>
+        <property name="username" value="sa"/>
+      </dataSource>
+    </environment>
+  </environments>
+  <mappers>
+    <mapper resource="org/apache/ibatis/submitted/insert_with_Void/FooMapper.xml"/>
+  </mappers>
+</configuration>


### PR DESCRIPTION
Expanding 'returnsVoid' boolean to include 'Void' return type method signatures would allow mybatis methods to be passed as implementations of java 8 Function interface. Otherwise, as master is now, Void return type methods cause a BindingException throw on line 115 of MapperMethod. 

Please let me know if I've made any mistakes, or should make any changes or corrections. Thanks!