### PR TITLE
check node type and within sql of mapper file

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
@@ -110,8 +110,8 @@ public class XMLStatementBuilder extends BaseBuilder {
 
     // Validate the node type around with the sql statement head
     BoundSql boundSql = sqlSource.getBoundSql(null);
-    String sql = boundSql.getSql();
-    if (!sql.toUpperCase().startsWith(sqlCommandType.name())) {
+    String sql = boundSql.getSql().trim();
+    if (!sql.equals("") && !sql.toUpperCase().startsWith(sqlCommandType.name())) {
       String errMsg = String.format("Wrong Node Conf, NodeType:{%s}, Statement:{%s}", sqlCommandType.name(), sql);
       throw new UnCorrectNodeTypeException(errMsg);
     }

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
@@ -108,7 +108,7 @@ public class XMLStatementBuilder extends BaseBuilder {
           ? Jdbc3KeyGenerator.INSTANCE : NoKeyGenerator.INSTANCE;
     }
 
-    // Validate the node type around with the sql statement head
+    // Validate the node type against the sql statement head
     BoundSql boundSql = sqlSource.getBoundSql(null);
     String sql = boundSql.getSql().trim();
     if (!sql.equals("") && !sql.toUpperCase().startsWith(sqlCommandType.name())) {

--- a/src/main/java/org/apache/ibatis/exceptions/UnCorrectNodeTypeException.java
+++ b/src/main/java/org/apache/ibatis/exceptions/UnCorrectNodeTypeException.java
@@ -1,0 +1,21 @@
+package org.apache.ibatis.exceptions;
+
+import org.apache.ibatis.builder.BuilderException;
+
+public class UnCorrectNodeTypeException extends BuilderException {
+    public UnCorrectNodeTypeException() {
+        super();
+    }
+
+    public UnCorrectNodeTypeException(String message) {
+        super(message);
+    }
+
+    public UnCorrectNodeTypeException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public UnCorrectNodeTypeException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/apache/ibatis/exceptions/UnCorrectNodeTypeException.java
+++ b/src/main/java/org/apache/ibatis/exceptions/UnCorrectNodeTypeException.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.exceptions;
 
 import org.apache.ibatis.builder.BuilderException;

--- a/src/test/java/org/apache/ibatis/builder/UnCorrectNodeTypeMapper.xml
+++ b/src/test/java/org/apache/ibatis/builder/UnCorrectNodeTypeMapper.xml
@@ -22,8 +22,18 @@
 
 <mapper namespace="org.apache.ibatis.domain.blog.mappers.AuthorMapper">
 
-    <select id="updateAuthorName" parameterType="org.apache.ibatis.domain.blog.Author">
-		  update author set username=#{username}
-	  </select>
+  <select id="select" parameterType="org.apache.ibatis.submitted.dynsql.Parameter" resultType="map">
+    <if test="enabled">
+      <foreach collection="ids" item="id" separator="union">
+        <if test="schema != null">
+          select * from ${schema}.names where id = #{id}
+        </if>
+      </foreach>
+    </if>
+  </select>
+
+  <select id="updateAuthorName" parameterType="org.apache.ibatis.domain.blog.Author">
+    update author set username=#{username}
+  </select>
 
 </mapper>

--- a/src/test/java/org/apache/ibatis/builder/UnCorrectNodeTypeMapper.xml
+++ b/src/test/java/org/apache/ibatis/builder/UnCorrectNodeTypeMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.domain.blog.mappers.AuthorMapper">
+
+    <select id="updateAuthorName" parameterType="org.apache.ibatis.domain.blog.Author">
+		  update author set username=#{username}
+	  </select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/builder/UnCorrectNodeTypeMapper.xml
+++ b/src/test/java/org/apache/ibatis/builder/UnCorrectNodeTypeMapper.xml
@@ -22,16 +22,6 @@
 
 <mapper namespace="org.apache.ibatis.domain.blog.mappers.AuthorMapper">
 
-  <select id="select" parameterType="org.apache.ibatis.submitted.dynsql.Parameter" resultType="map">
-    <if test="enabled">
-      <foreach collection="ids" item="id" separator="union">
-        <if test="schema != null">
-          select * from ${schema}.names where id = #{id}
-        </if>
-      </foreach>
-    </if>
-  </select>
-
   <select id="updateAuthorName" parameterType="org.apache.ibatis.domain.blog.Author">
     update author set username=#{username}
   </select>

--- a/src/test/java/org/apache/ibatis/builder/XmlMapperBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlMapperBuilderTest.java
@@ -196,4 +196,16 @@ public class XmlMapperBuilderTest {
 //    builder2.parse();
 //  }
 
+    @Test
+    public void shouldFailedLoadXMLMapperFile2() throws Exception {
+        expectedEx.expect(BuilderException.class);
+        expectedEx.expectMessage("Error parsing Mapper XML. The XML location is 'org/apache/ibatis/builder/UnCorrectNodeTypeMapper.xml'");
+        Configuration configuration = new Configuration();
+        String resource = "org/apache/ibatis/builder/UnCorrectNodeTypeMapper.xml";
+        try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+            XMLMapperBuilder builder = new XMLMapperBuilder(inputStream, configuration, resource, configuration.getSqlFragments());
+            builder.parse();
+        }
+    }
+
 }


### PR DESCRIPTION
We should throw Exception when a mapper file's statement node type is incorrect,
as :
```
    // Validate the node type around with the sql statement head
    BoundSql boundSql = sqlSource.getBoundSql(null);
    String sql = boundSql.getSql();
    if (!sql.toUpperCase().startsWith(sqlCommandType.name())) {
      String errMsg = String.format("Wrong Node Conf, NodeType:{%s}, Statement:{%s}", sqlCommandType.name(), sql);
      throw new UnCorrectNodeTypeException(errMsg);
    }
```

or else in some cases it will consume us too much time to find the bug caused by the configure