### PR TITLE
Improve complex mapper element resolution

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -62,6 +62,7 @@ import org.apache.ibatis.annotations.UpdateProvider;
 import org.apache.ibatis.binding.BindingException;
 import org.apache.ibatis.binding.MapperMethod.ParamMap;
 import org.apache.ibatis.builder.BuilderException;
+import org.apache.ibatis.builder.CacheRefResolver;
 import org.apache.ibatis.builder.IncompleteElementException;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.apache.ibatis.builder.xml.XMLMapperBuilder;
@@ -217,7 +218,11 @@ public class MapperAnnotationBuilder {
         throw new BuilderException("Cannot use both value() and name() attribute in the @CacheNamespaceRef");
       }
       String namespace = (refType != void.class) ? refType.getName() : refName;
-      assistant.useCacheRef(namespace);
+      try {
+        assistant.useCacheRef(namespace);
+      } catch (IncompleteElementException e) {
+        configuration.addIncompleteCacheRef(new CacheRefResolver(assistant, namespace));
+      }
     }
   }
 

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -784,8 +784,10 @@ public class Configuration {
     }
     if (!incompleteStatements.isEmpty()) {
       synchronized (incompleteStatements) {
-        // This always throws a BuilderException.
-        incompleteStatements.iterator().next().parseStatementNode();
+        incompleteStatements.removeIf(x -> {
+          x.parseStatementNode();
+          return true;
+        });
       }
     }
     if (!incompleteMethods.isEmpty()) {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -775,8 +775,7 @@ public class Configuration {
     parsePendingResultMaps();
     if (!incompleteCacheRefs.isEmpty()) {
       synchronized (incompleteCacheRefs) {
-        // This always throws a BuilderException.
-        incompleteCacheRefs.iterator().next().resolveCacheRef();
+        incompleteCacheRefs.removeIf(x -> x.resolveCacheRef() != null);
       }
     }
     if (!incompleteStatements.isEmpty()) {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -788,8 +788,10 @@ public class Configuration {
     }
     if (!incompleteMethods.isEmpty()) {
       synchronized (incompleteMethods) {
-        // This always throws a BuilderException.
-        incompleteMethods.iterator().next().resolve();
+        incompleteMethods.removeIf(x -> {
+          x.resolve();
+          return true;
+        });
       }
     }
   }

--- a/src/test/java/org/apache/ibatis/submitted/resolution/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/CreateDB.sql
@@ -1,0 +1,26 @@
+--
+--    Copyright 2009-2018 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(20)
+);
+
+insert into users (id, name) values
+(1, 'User1'),
+(2, 'User2');

--- a/src/test/java/org/apache/ibatis/submitted/resolution/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/User.java
@@ -1,0 +1,40 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.resolution;
+
+import java.io.Serializable;
+
+public class User implements Serializable {
+  private static final long serialVersionUID = 1L;
+  private Integer id;
+  private String name;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/CacheRefFromXmlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/CacheRefFromXmlTest.java
@@ -1,0 +1,60 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.resolution.cachereffromxml;
+
+import java.io.Reader;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.submitted.resolution.User;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CacheRefFromXmlTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    try (Reader reader = Resources
+      .getResourceAsReader("org/apache/ibatis/submitted/resolution/cachereffromxml/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+
+    // populate in-memory database
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/submitted/resolution/CreateDB.sql");
+  }
+
+  @Test
+  public void shouldGetAUser() {
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    try {
+      UserMapper mapper = sqlSession.getMapper(UserMapper.class);
+      User user = mapper.getUser(1);
+      Assert.assertEquals(Integer.valueOf(1), user.getId());
+      Assert.assertEquals("User1", user.getName());
+    } finally {
+      sqlSession.close();
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/CacheRefFromXmlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/CacheRefFromXmlTest.java
@@ -46,14 +46,11 @@ public class CacheRefFromXmlTest {
 
   @Test
   public void shouldGetAUser() {
-    SqlSession sqlSession = sqlSessionFactory.openSession();
-    try {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       UserMapper mapper = sqlSession.getMapper(UserMapper.class);
       User user = mapper.getUser(1);
       Assert.assertEquals(Integer.valueOf(1), user.getId());
       Assert.assertEquals("User1", user.getName());
-    } finally {
-      sqlSession.close();
     }
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/UserMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/UserMapper.java
@@ -1,0 +1,24 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.resolution.cachereffromxml;
+
+import org.apache.ibatis.annotations.CacheNamespace;
+import org.apache.ibatis.submitted.resolution.User;
+
+@CacheNamespace
+public interface UserMapper {
+  User getUser(Integer id);
+}

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/UserMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/UserMapper.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper
+  namespace="org.apache.ibatis.submitted.resolution.cachereffromxml.UserMapper">
+
+  <cache-ref
+    namespace="org.apache.ibatis.submitted.resolution.cachereffromxml.UserMapper" />
+
+  <select id="getUser"
+    resultType="org.apache.ibatis.submitted.resolution.User">
+    select *
+    from users where id = #{id}
+  </select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/mybatis-config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url"
+          value="jdbc:hsqldb:mem:cachereffromxml" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper
+      class="org.apache.ibatis.submitted.resolution.cachereffromxml.UserMapper" />
+  </mappers>
+
+</configuration>

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/CacheRefsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/CacheRefsTest.java
@@ -1,0 +1,57 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.resolution.cacherefs;
+
+import java.io.Reader;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.submitted.resolution.User;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class CacheRefsTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    try (Reader reader = Resources
+      .getResourceAsReader("org/apache/ibatis/submitted/resolution/cacherefs/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+
+    // populate in-memory database
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/submitted/resolution/CreateDB.sql");
+  }
+
+  @Test
+  public void shouldGetAUser() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      MapperB mapper = sqlSession.getMapper(MapperB.class);
+      User user = mapper.getUser(1);
+      Assert.assertEquals(Integer.valueOf(1), user.getId());
+      Assert.assertEquals("User1", user.getName());
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/MapperA.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/MapperA.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper
+  namespace="org.apache.ibatis.submitted.resolution.cacherefs.MapperA">
+
+  <cache-ref
+    namespace="org.apache.ibatis.submitted.resolution.cacherefs.MapperB" />
+
+  <select id="getUser"
+    resultType="org.apache.ibatis.submitted.resolution.User">
+    select id, name
+    from users where id = #{id}
+  </select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/MapperB.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/MapperB.java
@@ -1,0 +1,24 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.resolution.cacherefs;
+
+import org.apache.ibatis.annotations.CacheNamespace;
+import org.apache.ibatis.submitted.resolution.User;
+
+@CacheNamespace
+public interface MapperB {
+  User getUser(Integer id);
+}

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/MapperB.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/MapperB.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper
+  namespace="org.apache.ibatis.submitted.resolution.cacherefs.MapperB">
+
+  <cache-ref
+    namespace="org.apache.ibatis.submitted.resolution.cacherefs.MapperB" />
+
+  <select id="getUser"
+    resultType="org.apache.ibatis.submitted.resolution.User">
+    select id, name
+    from users where id = #{id}
+  </select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/mybatis-config.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url"
+          value="jdbc:hsqldb:mem:cacherefs" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper
+      resource="org/apache/ibatis/submitted/resolution/cacherefs/MapperA.xml" />
+    <mapper
+      class="org.apache.ibatis.submitted.resolution.cacherefs.MapperB" />
+  </mappers>
+
+</configuration>

--- a/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/DeepResultMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/DeepResultMapTest.java
@@ -1,0 +1,57 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.resolution.deepresultmap;
+
+import java.io.Reader;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.submitted.resolution.User;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class DeepResultMapTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    try (Reader reader = Resources
+      .getResourceAsReader("org/apache/ibatis/submitted/resolution/deepresultmap/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+
+    // populate in-memory database
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/submitted/resolution/CreateDB.sql");
+  }
+
+  @Test
+  public void shouldGetAUser() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      MapperA mapper = sqlSession.getMapper(MapperA.class);
+      User user = mapper.getUser(1);
+      Assert.assertEquals(Integer.valueOf(1), user.getId());
+      Assert.assertEquals("User1", user.getName());
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/MapperA.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/MapperA.java
@@ -1,0 +1,22 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.resolution.deepresultmap;
+
+import org.apache.ibatis.submitted.resolution.User;
+
+public interface MapperA {
+  User getUser(Integer id);
+}

--- a/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/MapperA.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/MapperA.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper
+  namespace="org.apache.ibatis.submitted.resolution.deepresultmap.MapperA">
+
+  <resultMap
+    type="org.apache.ibatis.submitted.resolution.User" id="rmA"
+    extends="org.apache.ibatis.submitted.resolution.deepresultmap.MapperB.rmB">
+  </resultMap>
+
+  <select id="getUser" resultMap="rmA">
+    select id userId, name userName
+    from users where id = #{id}
+  </select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/MapperB.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/MapperB.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper
+  namespace="org.apache.ibatis.submitted.resolution.deepresultmap.MapperB">
+
+  <resultMap
+    type="org.apache.ibatis.submitted.resolution.User" id="rmB"
+    extends="org.apache.ibatis.submitted.resolution.deepresultmap.MapperC.rmC">
+  </resultMap>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/MapperC.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/MapperC.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper
+  namespace="org.apache.ibatis.submitted.resolution.deepresultmap.MapperC">
+
+  <resultMap
+    type="org.apache.ibatis.submitted.resolution.User" id="rmC"
+    extends="org.apache.ibatis.submitted.resolution.deepresultmap.MapperD.rmD">
+  </resultMap>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/MapperD.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/MapperD.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper
+  namespace="org.apache.ibatis.submitted.resolution.deepresultmap.MapperD">
+
+
+  <resultMap
+    type="org.apache.ibatis.submitted.resolution.User" id="rmD">
+    <id property="id" column="userId" />
+    <result property="name" column="userName" />
+  </resultMap>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/mybatis-config.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url"
+          value="jdbc:hsqldb:mem:deepresultmap" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper
+      class="org.apache.ibatis.submitted.resolution.deepresultmap.MapperA" />
+    <mapper
+      resource="org/apache/ibatis/submitted/resolution/deepresultmap/MapperB.xml" />
+    <mapper
+      resource="org/apache/ibatis/submitted/resolution/deepresultmap/MapperC.xml" />
+    <mapper
+      resource="org/apache/ibatis/submitted/resolution/deepresultmap/MapperD.xml" />
+  </mappers>
+
+</configuration>

--- a/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/JavaMethodsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/JavaMethodsTest.java
@@ -1,0 +1,57 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.resolution.javamethods;
+
+import java.io.Reader;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.submitted.resolution.User;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class JavaMethodsTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    try (Reader reader = Resources
+      .getResourceAsReader("org/apache/ibatis/submitted/resolution/javamethods/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+
+    // populate in-memory database
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/submitted/resolution/CreateDB.sql");
+  }
+
+  @Test
+  public void shouldGetAUser() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      MapperB mapper = sqlSession.getMapper(MapperB.class);
+      User user = mapper.getUser(1);
+      Assert.assertEquals(Integer.valueOf(1), user.getId());
+      Assert.assertEquals("User1", user.getName());
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/MapperA.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/MapperA.java
@@ -1,0 +1,28 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.resolution.javamethods;
+
+import org.apache.ibatis.annotations.CacheNamespaceRef;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.submitted.resolution.User;
+
+@CacheNamespaceRef(MapperC.class)
+public interface MapperA {
+  @ResultMap("userRM")
+  @Select("select * from users where id = #{id}")
+  User getUser(Integer id);
+}

--- a/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/MapperA.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/MapperA.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper
+  namespace="org.apache.ibatis.submitted.resolution.javamethods.MapperA">
+
+  <resultMap
+    type="org.apache.ibatis.submitted.resolution.User" id="userRM">
+    <id column="id" property="id" />
+    <result column="name" property="name" />
+  </resultMap>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/MapperB.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/MapperB.java
@@ -1,0 +1,28 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.resolution.javamethods;
+
+import org.apache.ibatis.annotations.CacheNamespaceRef;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.submitted.resolution.User;
+
+@CacheNamespaceRef(MapperC.class)
+public interface MapperB {
+  @ResultMap("org.apache.ibatis.submitted.resolution.javamethods.MapperA.userRM")
+  @Select("select * from users where id = #{id}")
+  User getUser(Integer id);
+}

--- a/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/MapperC.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/MapperC.java
@@ -1,0 +1,28 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.resolution.javamethods;
+
+import org.apache.ibatis.annotations.CacheNamespace;
+import org.apache.ibatis.annotations.ResultMap;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.submitted.resolution.User;
+
+@CacheNamespace
+public interface MapperC {
+  @ResultMap("org.apache.ibatis.submitted.resolution.javamethods.MapperA.userRM")
+  @Select("select * from users where id = #{id}")
+  User getUser(Integer id);
+}

--- a/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/mybatis-config.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2018 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url"
+          value="jdbc:hsqldb:mem:javamethods" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper
+      class="org.apache.ibatis.submitted.resolution.javamethods.MapperA" />
+    <mapper
+      class="org.apache.ibatis.submitted.resolution.javamethods.MapperB" />
+    <mapper
+      class="org.apache.ibatis.submitted.resolution.javamethods.MapperC" />
+  </mappers>
+
+</configuration>


### PR DESCRIPTION
Depending on the order of mappers being parsed, MyBatis cannot resolve mapper elements correctly.
This patch fixes the problems that have been reported and I could find.