### PR TITLE
MapKey as sql column

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,8 @@
   </distributionManagement>
 
   <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
     <maven.compiler.testSource>1.8</maven.compiler.testSource>
     <maven.compiler.testCompilerArgument>-parameters</maven.compiler.testCompilerArgument>
@@ -387,6 +389,8 @@
         <jdk>1.6</jdk>
       </activation>
       <properties>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
         <maven.compiler.testTarget>1.6</maven.compiler.testTarget>
         <maven.compiler.testSource>1.6</maven.compiler.testSource>
         <maven.compiler.testCompilerArgument />
@@ -426,6 +430,8 @@
         <jdk>1.7</jdk>
       </activation>
       <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
         <maven.compiler.testTarget>1.7</maven.compiler.testTarget>
         <maven.compiler.testSource>1.7</maven.compiler.testSource>
         <maven.compiler.testCompilerArgument />

--- a/src/main/java/org/apache/ibatis/annotations/MapKeyValue.java
+++ b/src/main/java/org/apache/ibatis/annotations/MapKeyValue.java
@@ -1,0 +1,37 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.annotations;
+
+import org.apache.ibatis.mapping.Mapping;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Extended mapping.
+ * @author Anton
+ *
+ * @see MapKey
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface MapKeyValue {
+  Class<? extends Mapping> value();
+}

--- a/src/main/java/org/apache/ibatis/mapping/Mapping.java
+++ b/src/main/java/org/apache/ibatis/mapping/Mapping.java
@@ -1,0 +1,22 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.mapping;
+
+import java.util.Map;
+
+public interface Mapping {
+  <K, V> Map.Entry<K, V> apply(Object item);
+}

--- a/src/main/java/org/apache/ibatis/mapping/MappingByKey.java
+++ b/src/main/java/org/apache/ibatis/mapping/MappingByKey.java
@@ -1,0 +1,46 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.mapping;
+
+import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.reflection.ReflectorFactory;
+import org.apache.ibatis.reflection.factory.ObjectFactory;
+import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
+
+import java.util.AbstractMap;
+import java.util.Map;
+
+public class MappingByKey implements Mapping {
+
+  private final String mapKey;
+  private final ObjectFactory objectFactory;
+  private final ObjectWrapperFactory objectWrapperFactory;
+  private final ReflectorFactory reflectorFactory;
+
+  public MappingByKey(String mapKey, ObjectFactory objectFactory, ObjectWrapperFactory objectWrapperFactory, ReflectorFactory reflectorFactory) {
+    this.mapKey = mapKey;
+    this.objectFactory = objectFactory;
+    this.objectWrapperFactory = objectWrapperFactory;
+    this.reflectorFactory = reflectorFactory;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public <K, V> Map.Entry<K, V> apply(Object value) {
+    final MetaObject mo = MetaObject.forObject(value, objectFactory, objectWrapperFactory, reflectorFactory);
+    return new AbstractMap.SimpleEntry<K, V>((K)mo.getValue(mapKey), (V)value);
+  }
+}

--- a/src/main/java/org/apache/ibatis/session/SqlSession.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSession.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.BatchResult;
+import org.apache.ibatis.mapping.Mapping;
 
 /**
  * The primary Java interface for working with MyBatis.
@@ -115,6 +116,20 @@ public interface SqlSession extends Closeable {
    * @return Map containing key pair data.
    */
   <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, RowBounds rowBounds);
+
+  /**
+   * The selectMap is a special case in that it is designed to convert a list
+   * of results into a Map based on one of the properties in the resulting
+   * objects.
+   * @param <K> the returned Map keys type
+   * @param <V> the returned Map values type
+   * @param statement Unique identifier matching the statement to use.
+   * @param parameter A parameter object to pass to the statement.
+   * @param mapping Function mapping value to key-value pair.
+   * @param rowBounds  Bounds to limit object retrieval
+   * @return Map containing key pair data.
+   */
+  <K, V> Map<K, V> selectMap(String statement, Object parameter, Mapping mapping, RowBounds rowBounds);
 
   /**
    * A Cursor offers the same results as a List, except it fetches data lazily using an Iterator.

--- a/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.Properties;
 
 import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.BatchResult;
+import org.apache.ibatis.mapping.Mapping;
 import org.apache.ibatis.reflection.ExceptionUtil;
 
 /**
@@ -179,6 +180,11 @@ public class SqlSessionManager implements SqlSessionFactory, SqlSession {
   @Override
   public <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, RowBounds rowBounds) {
     return sqlSessionProxy.<K, V> selectMap(statement, parameter, mapKey, rowBounds);
+  }
+
+  @Override
+  public <K, V> Map<K, V> selectMap(String statement, Object parameter, Mapping mapping, RowBounds rowBounds) {
+    return sqlSessionProxy.<K, V> selectMap(statement, parameter, mapping, rowBounds);
   }
 
   @Override


### PR DESCRIPTION
# What is the problem
Anntotation `@MapKey` requires an object field, does not take result of sql.

# Example
For example, I have table with columns **_id, a,b_**
Example mapper:
```java
    @MapKey("id")
    @Select("SELECT id, a, b  FROM table")
    Map<String, Pojo> loadAll();
```
Example pojo without _**id**_ field
```java
@Data
public class Pojo {
    private String a;
    private String b;
}
```
It's **NOT** work (because  `Pojo` without field **_id_**)
```
Caused by: org.apache.ibatis.reflection.ReflectionException: There is no getter for property named 'id' in 'class example.Pojo'
	at org.apache.ibatis.reflection.Reflector.getGetInvoker(Reflector.java:419)
	at org.apache.ibatis.reflection.MetaClass.getGetInvoker(MetaClass.java:164)
	at org.apache.ibatis.reflection.wrapper.BeanWrapper.getBeanProperty(BeanWrapper.java:162)
	at org.apache.ibatis.reflection.wrapper.BeanWrapper.get(BeanWrapper.java:49)
	at org.apache.ibatis.reflection.MetaObject.getValue(MetaObject.java:122)
	at org.apache.ibatis.executor.result.DefaultMapResultHandler.handleResult(DefaultMapResultHandler.java:52)
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectMap(DefaultSqlSession.java:105)
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectMap(DefaultSqlSession.java:94)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:433)
```

# Expected Result
Load data as  `Map<String, Pojo>` where column **_id_** as key  and columns **a,b** as value in pojo.
I want to have the ability to apply `@MapKey` not only to the fields of the object, but also to the result sql.