### PR TITLE
[tests] Rework travis detection for slow running tests for clarity [see notes]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <osgi.export>org.apache.ibatis.*;version=${project.version};-noimport:=true</osgi.export>
     <osgi.import>*;resolution:=optional</osgi.import>
     <osgi.dynamicImport>*</osgi.dynamicImport>
-    <maven.surefire.excludeGroups />
+    <maven.surefire.excludeGroups>org.apache.ibatis.test.SlowTests</maven.surefire.excludeGroups>
     <module.name>org.mybatis</module.name>
   </properties>
 
@@ -382,15 +382,15 @@
 
   <profiles>
     <profile>
-        <!-- Run slow tests only on travis ci, to force run otherwise use -D"env.TRAVIS_BRANCH" -->
+        <!-- Run slow tests only on travis ci, to force run otherwise use -D"env.TRAVIS" -->
         <id>travis-ci</id>
         <activation>
             <property>
-                <name>!env.TRAVIS_BRANCH</name>
+                <name>env.TRAVIS</name>
             </property>
         </activation>
         <properties>
-            <maven.surefire.excludeGroups>org.apache.ibatis.test.SlowTests</maven.surefire.excludeGroups>
+            <maven.surefire.excludeGroups />
         </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
While this worked, it was not very intuitive in what it was doing since it checked negative condition.  While upgrading to full junit 5, I noticed that this stopped working like expected.  Travis was fine since I had not pushed there yet but my local simply ran all tests every time.  I was able to track it back to being what appears to be a defect with ~~junit 5~~ surefire not honering the parameter for exclude groups.  So at the very least, for sake of being extremely clear on what we are accomplishing here, I have made this a normal condition check.

For further insight in what runs, using 'mvn help:active-profiles' will show the following locally after this change.

```
The following profiles are active (subject to your own externals):

 - jboss (source: external)
 - sonar-remote (source: external)
 - ossrh (source: external)
 - license (source: org.mybatis:mybatis-parent:31-SNAPSHOT)
```

Previously it stated '- travis-ci' which really was misnamed profile.  It would have made more sense if '- not-travis-ci'.  But again, why run the profile that way to start with.  So now it's simply off when running outside of travis and the default behaviour is to pick up the exclude groups right away.  On the travis front, it looks now for 'TRAVIS' instead of less obvious parameter that was being used.  The 'env' in either case is necessary such that maven can see the environmental properly.