### PR TITLE
[tests] Light formatting cleanup no-op (spacing)

### DIFF
--- a/src/test/java/org/apache/ibatis/binding/MissingNamespaceMapper.java
+++ b/src/test/java/org/apache/ibatis/binding/MissingNamespaceMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.apache.ibatis.binding;
 
 public interface MissingNamespaceMapper {
-  
+
   void get();
 
 }

--- a/src/test/java/org/apache/ibatis/binding/WrongNamespaceMapper.java
+++ b/src/test/java/org/apache/ibatis/binding/WrongNamespaceMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.apache.ibatis.binding;
 
 public interface WrongNamespaceMapper {
-  
+
   void get();
 
 }

--- a/src/test/java/org/apache/ibatis/binding/WrongNamespacesTest.java
+++ b/src/test/java/org/apache/ibatis/binding/WrongNamespacesTest.java
@@ -37,5 +37,4 @@ public class WrongNamespacesTest {
     });
   }
 
-
 }

--- a/src/test/java/org/apache/ibatis/builder/ExampleObjectFactory.java
+++ b/src/test/java/org/apache/ibatis/builder/ExampleObjectFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,14 +22,15 @@ import java.util.Properties;
 
 public class ExampleObjectFactory extends DefaultObjectFactory {
   private Properties properties;
+
   @Override
   public <T> T create(Class<T> type) {
-    return super.<T>create(type);
+    return super.<T> create(type);
   }
 
   @Override
   public <T> T create(Class<T> type, List<Class<?>> constructorArgTypes, List<Object> constructorArgs) {
-    return super.<T>create(type, constructorArgTypes, constructorArgs);
+    return super.<T> create(type, constructorArgTypes, constructorArgs);
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/builder/ExamplePlugin.java
+++ b/src/test/java/org/apache/ibatis/builder/ExamplePlugin.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.Properties;
 @Intercepts({})
 public class ExamplePlugin implements Interceptor {
   private Properties properties;
+
   @Override
   public Object intercept(Invocation invocation) throws Throwable {
     return invocation.proceed();

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -58,7 +58,6 @@ import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
 import org.junit.jupiter.api.Test;
 
-
 import static com.googlecode.catchexception.apis.BDDCatchException.*;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/org/apache/ibatis/cache/SoftCacheTest.java
+++ b/src/test/java/org/apache/ibatis/cache/SoftCacheTest.java
@@ -40,7 +40,6 @@ public class SoftCacheTest {
     assertTrue(cache.getSize() < N);
   }
 
-
   @Test
   public void shouldDemonstrateCopiesAreEqual() {
     Cache cache = new SoftCache(new PerpetualCache("default"));

--- a/src/test/java/org/apache/ibatis/cache/SuperCacheTest.java
+++ b/src/test/java/org/apache/ibatis/cache/SuperCacheTest.java
@@ -32,7 +32,7 @@ public class SuperCacheTest {
     cache = new WeakCache(cache);
     cache = new ScheduledCache(cache);
     cache = new SerializedCache(cache);
-//    cache = new LoggingCache(cache);
+    // cache = new LoggingCache(cache);
     cache = new SynchronizedCache(cache);
     cache = new TransactionalCache(cache);
     for (int i = 0; i < N; i++) {
@@ -43,6 +43,5 @@ public class SuperCacheTest {
     }
     assertTrue(cache.getSize() < N);
   }
-
 
 }

--- a/src/test/java/org/apache/ibatis/cache/WeakCacheTest.java
+++ b/src/test/java/org/apache/ibatis/cache/WeakCacheTest.java
@@ -33,7 +33,7 @@ public class WeakCacheTest {
     for (int i = 0; i < N; i++) {
       cache.putObject(i, i);
       if (cache.getSize() < i + 1) {
-        //System.out.println("Cache exceeded with " + (i + 1) + " entries.");
+        // System.out.println("Cache exceeded with " + (i + 1) + " entries.");
         break;
       }
       if ((i + 1) % 100000 == 0) {
@@ -43,7 +43,6 @@ public class WeakCacheTest {
     }
     assertTrue(cache.getSize() < N);
   }
-
 
   @Test
   public void shouldDemonstrateCopiesAreEqual() {

--- a/src/test/java/org/apache/ibatis/datasource/jndi/JndiDataSourceFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/datasource/jndi/JndiDataSourceFactoryTest.java
@@ -99,5 +99,4 @@ public class JndiDataSourceFactoryTest extends BaseDataTest {
     }
   }
 
-
 }

--- a/src/test/java/org/apache/ibatis/domain/blog/mappers/AuthorMapper.java
+++ b/src/test/java/org/apache/ibatis/domain/blog/mappers/AuthorMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ public interface AuthorMapper {
   List<Author> selectAllAuthors();
 
   Set<Author> selectAllAuthorsSet();
-  
+
   Vector<Author> selectAllAuthorsVector();
 
   LinkedList<Author> selectAllAuthorsLinkedList();
@@ -42,12 +42,12 @@ public interface AuthorMapper {
   Author selectAuthor(int id);
 
   LinkedHashMap<String, Object> selectAuthorLinkedHashMap(int id);
-  
+
   void selectAuthor(int id, ResultHandler handler);
 
   @Select("select")
   void selectAuthor2(int id, ResultHandler handler);
-  
+
   void insertAuthor(Author author);
 
   int deleteAuthor(int id);

--- a/src/test/java/org/apache/ibatis/domain/blog/mappers/CopyOfAuthorMapper.java
+++ b/src/test/java/org/apache/ibatis/domain/blog/mappers/CopyOfAuthorMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,6 +37,3 @@ public interface CopyOfAuthorMapper {
   int updateAuthor(Author author);
 
 }
-
-
-

--- a/src/test/java/org/apache/ibatis/domain/jpetstore/Account.java
+++ b/src/test/java/org/apache/ibatis/domain/jpetstore/Account.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.apache.ibatis.domain.jpetstore;
 
 import java.io.Serializable;
-
 
 public class Account implements Serializable {
 

--- a/src/test/java/org/apache/ibatis/domain/jpetstore/Cart.java
+++ b/src/test/java/org/apache/ibatis/domain/jpetstore/Cart.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -54,7 +54,6 @@ public class Cart implements Serializable {
     }
     cartItem.incrementQuantity();
   }
-
 
   public Item removeItemById(String itemId) {
     CartItem cartItem = (CartItem) itemMap.remove(itemId);

--- a/src/test/java/org/apache/ibatis/domain/jpetstore/CartItem.java
+++ b/src/test/java/org/apache/ibatis/domain/jpetstore/CartItem.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.apache.ibatis.domain.jpetstore;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
-
 
 public class CartItem implements Serializable {
 

--- a/src/test/java/org/apache/ibatis/domain/jpetstore/Category.java
+++ b/src/test/java/org/apache/ibatis/domain/jpetstore/Category.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.apache.ibatis.domain.jpetstore;
 
 import java.io.Serializable;
-
 
 public class Category implements Serializable {
 

--- a/src/test/java/org/apache/ibatis/domain/jpetstore/LineItem.java
+++ b/src/test/java/org/apache/ibatis/domain/jpetstore/LineItem.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.apache.ibatis.domain.jpetstore;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
-
 
 public class LineItem implements Serializable {
 
@@ -103,6 +102,5 @@ public class LineItem implements Serializable {
       total = null;
     }
   }
-
 
 }

--- a/src/test/java/org/apache/ibatis/domain/jpetstore/Order.java
+++ b/src/test/java/org/apache/ibatis/domain/jpetstore/Order.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-
 
 public class Order implements Serializable {
 
@@ -303,7 +302,6 @@ public class Order implements Serializable {
     locale = "CA";
     status = "P";
 
-
     Iterator<CartItem> i = cart.getCartItems();
     while (i.hasNext()) {
       CartItem cartItem = (CartItem) i.next();
@@ -320,6 +318,5 @@ public class Order implements Serializable {
   public void addLineItem(LineItem lineItem) {
     lineItems.add(lineItem);
   }
-
 
 }

--- a/src/test/java/org/apache/ibatis/domain/jpetstore/Product.java
+++ b/src/test/java/org/apache/ibatis/domain/jpetstore/Product.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.apache.ibatis.domain.jpetstore;
 
 import java.io.Serializable;
-
 
 public class Product implements Serializable {
 

--- a/src/test/java/org/apache/ibatis/domain/misc/CustomBeanWrapperFactory.java
+++ b/src/test/java/org/apache/ibatis/domain/misc/CustomBeanWrapperFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ public class CustomBeanWrapperFactory implements ObjectWrapperFactory {
       return false;
     }
   }
-  
+
   @Override
   public ObjectWrapper getWrapperFor(MetaObject metaObject, Object object) {
     return new CustomBeanWrapper(metaObject, object);

--- a/src/test/java/org/apache/ibatis/domain/misc/generics/GenericAbstract.java
+++ b/src/test/java/org/apache/ibatis/domain/misc/generics/GenericAbstract.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,4 +18,3 @@ package org.apache.ibatis.domain.misc.generics;
 public abstract class GenericAbstract<K> {
   public abstract K getId();
 }
-

--- a/src/test/java/org/apache/ibatis/domain/misc/generics/GenericSubclass.java
+++ b/src/test/java/org/apache/ibatis/domain/misc/generics/GenericSubclass.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,7 +19,3 @@ public abstract class GenericSubclass extends GenericAbstract<Long> {
   @Override
   public abstract Long getId();
 }
-
-
-
-

--- a/src/test/java/org/apache/ibatis/executor/BaseExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/BaseExecutorTest.java
@@ -62,7 +62,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldInsertNewAuthorWithBeforeAutoKey() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       Author author = new Author(-1, "someone", "******", "someone@apache.org", null, Section.NEWS);
@@ -89,7 +89,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldInsertNewAuthor() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       Author author = new Author(99, "someone", "******", "someone@apache.org", null, Section.NEWS);
@@ -110,7 +110,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldSelectAllAuthorsAutoMapped() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       MappedStatement selectStatement = ExecutorTestHelper.prepareSelectAllAuthorsAutoMappedStatement(config);
@@ -132,7 +132,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldInsertNewAuthorWithAutoKey() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       Author author = new Author(-1, "someone", "******", "someone@apache.org", null, Section.NEWS);
@@ -159,7 +159,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldInsertNewAuthorByProc() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       Author author = new Author(97, "someone", "******", "someone@apache.org", null, null);
@@ -179,7 +179,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldInsertNewAuthorUsingSimpleNonPreparedStatements() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       Author author = new Author(99, "someone", "******", "someone@apache.org", null, null);
@@ -200,7 +200,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldUpdateAuthor() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       Author author = new Author(101, "someone", "******", "someone@apache.org", null, Section.NEWS);
@@ -221,7 +221,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldDeleteAuthor() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       Author author = new Author(101, null, null, null, null, null);
@@ -241,7 +241,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldSelectDiscriminatedPost() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       MappedStatement selectStatement = ExecutorTestHelper.prepareSelectDiscriminatedPost(config);
@@ -261,7 +261,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldSelect2DiscriminatedPosts() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       MappedStatement selectStatement = ExecutorTestHelper.prepareSelectDiscriminatedPost(config);
@@ -304,9 +304,9 @@ public class BaseExecutorTest extends BaseDataTest {
     }
   }
 
-  @Test 
+  @Test
   public void shouldSelectAuthorViaOutParams() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       MappedStatement selectStatement = ExecutorTestHelper.prepareSelectAuthorViaOutParams(config);
@@ -331,7 +331,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldFetchPostsForBlog() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       MappedStatement selectBlog = ExecutorTestHelper.prepareComplexSelectBlogMappedStatement(config);
@@ -353,7 +353,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldFetchOneOrphanedPostWithNoBlog() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       MappedStatement selectBlog = ExecutorTestHelper.prepareComplexSelectBlogMappedStatement(config);
@@ -374,7 +374,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldFetchPostWithBlogWithCompositeKey() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       MappedStatement selectBlog = ExecutorTestHelper.prepareSelectBlogByIdAndAuthor(config);
@@ -396,7 +396,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldFetchComplexBlogs() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       MappedStatement selectBlog = ExecutorTestHelper.prepareComplexSelectBlogMappedStatement(config);
@@ -418,7 +418,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldMapConstructorResults() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       MappedStatement selectStatement = ExecutorTestHelper.prepareSelectOneAuthorMappedStatementWithConstructorResults(config);
@@ -437,7 +437,7 @@ public class BaseExecutorTest extends BaseDataTest {
 
   @Test
   public void shouldClearDeferredLoads() throws Exception {
-    
+
     Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
     try {
       MappedStatement selectBlog = ExecutorTestHelper.prepareComplexSelectBlogMappedStatement(config);
@@ -447,7 +447,7 @@ public class BaseExecutorTest extends BaseDataTest {
       MappedStatement selectAuthor = ExecutorTestHelper.prepareSelectOneAuthorMappedStatement(config);
       MappedStatement insertAuthor = ExecutorTestHelper.prepareInsertAuthorMappedStatement(config);
 
-      //generate DeferredLoads
+      // generate DeferredLoads
       executor.query(selectPosts, 1, RowBounds.DEFAULT, Executor.NO_RESULT_HANDLER);
 
       Author author = new Author(-1, "someone", "******", "someone@apache.org", null, Section.NEWS);
@@ -462,7 +462,7 @@ public class BaseExecutorTest extends BaseDataTest {
   }
 
   protected Executor createExecutor(Transaction transaction) {
-    return new SimpleExecutor(config,transaction);
+    return new SimpleExecutor(config, transaction);
   }
 
 }

--- a/src/test/java/org/apache/ibatis/executor/BatchExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/BatchExecutorTest.java
@@ -26,6 +26,6 @@ public class BatchExecutorTest extends BaseExecutorTest {
 
   @Override
   protected Executor createExecutor(Transaction transaction) {
-    return new BatchExecutor(config,transaction);
+    return new BatchExecutor(config, transaction);
   }
 }

--- a/src/test/java/org/apache/ibatis/executor/CachingBatchExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/CachingBatchExecutorTest.java
@@ -26,7 +26,7 @@ public class CachingBatchExecutorTest extends BaseExecutorTest {
 
   @Override
   protected Executor createExecutor(Transaction transaction) {
-    return new CachingExecutor(new BatchExecutor(config,transaction));
+    return new CachingExecutor(new BatchExecutor(config, transaction));
   }
 
 }

--- a/src/test/java/org/apache/ibatis/executor/CachingSimpleExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/CachingSimpleExecutorTest.java
@@ -26,7 +26,7 @@ public class CachingSimpleExecutorTest extends BaseExecutorTest {
 
   @Override
   protected Executor createExecutor(Transaction transaction) {
-    return new CachingExecutor(new SimpleExecutor(config,transaction));
+    return new CachingExecutor(new SimpleExecutor(config, transaction));
   }
 
 }

--- a/src/test/java/org/apache/ibatis/executor/loader/SerializableProxyTest.java
+++ b/src/test/java/org/apache/ibatis/executor/loader/SerializableProxyTest.java
@@ -38,9 +38,9 @@ import org.junit.jupiter.api.Test;
 public abstract class SerializableProxyTest {
 
   protected Author author = new Author(999, "someone", "!@#@!#!@#", "someone@somewhere.com", "blah", Section.NEWS);
-  
+
   protected ProxyFactory proxyFactory;
-  
+
   @Test
   public void shouldKeepGenericTypes() throws Exception {
     for (int i = 0; i < 10000; i++) {

--- a/src/test/java/org/apache/ibatis/io/ClassLoaderWrapperTest.java
+++ b/src/test/java/org/apache/ibatis/io/ClassLoaderWrapperTest.java
@@ -31,7 +31,6 @@ public class ClassLoaderWrapperTest extends BaseDataTest {
   private final String CLASS_NOT_FOUND = "some.random.class.that.does.not.Exist";
   private final String CLASS_FOUND = "java.lang.Object";
 
-
   @BeforeEach
   public void beforeClassLoaderWrapperTest() {
     wrapper = new ClassLoaderWrapper();

--- a/src/test/java/org/apache/ibatis/jdbc/PooledDataSourceTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/PooledDataSourceTest.java
@@ -82,7 +82,7 @@ public class PooledDataSourceTest extends BaseDataTest {
     c.close();
     c.toString();
   }
-  
+
   @Test
   public void ShouldReturnRealConnection() throws Exception {
     PooledDataSource ds = createPooledDataSource(JPETSTORE_PROPERTIES);

--- a/src/test/java/org/apache/ibatis/logging/LogFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/logging/LogFactoryTest.java
@@ -55,7 +55,7 @@ public class LogFactoryTest {
     logSomething(log);
     assertEquals(log.getClass().getName(), Log4j2Impl.class.getName());
   }
-  
+
   @Test
   public void shouldUseJdKLogging() {
     LogFactory.useJdkLogging();

--- a/src/test/java/org/apache/ibatis/mapping/CacheBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/mapping/CacheBuilderTest.java
@@ -44,7 +44,7 @@ public class CacheBuilderTest {
   }
 
   @SuppressWarnings("unchecked")
-  private <T> T unwrap(Cache cache){
+  private <T> T unwrap(Cache cache) {
     Field field;
     try {
       field = cache.getClass().getDeclaredField("delegate");
@@ -53,14 +53,13 @@ public class CacheBuilderTest {
     }
     try {
       field.setAccessible(true);
-      return (T)field.get(cache);
+      return (T) field.get(cache);
     } catch (IllegalAccessException e) {
       throw new IllegalStateException(e);
     } finally {
       field.setAccessible(false);
     }
   }
-
 
   private static class InitializingCache extends PerpetualCache implements InitializingObject {
 

--- a/src/test/java/org/apache/ibatis/reflection/MetaClassTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/MetaClassTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 public class MetaClassTest {
 
   private RichType rich = new RichType();
-  Map<String,RichType> map = new HashMap<String,RichType>() {
+  Map<String, RichType> map = new HashMap<String, RichType>() {
     {
       put("richType", rich);
     }

--- a/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
@@ -50,6 +50,7 @@ public class ReflectorTest {
 
   static interface Entity<T> {
     T getId();
+
     void setId(T id);
   }
 
@@ -137,24 +138,31 @@ public class ReflectorTest {
     protected T[] array;
     private T fld;
     public T pubFld;
+
     public T getId() {
       return id;
     }
+
     public void setId(T id) {
       this.id = id;
     }
+
     public List<T> getList() {
       return list;
     }
+
     public void setList(List<T> list) {
       this.list = list;
     }
+
     public T[] getArray() {
       return array;
     }
+
     public void setArray(T[] array) {
       this.array = array;
     }
+
     public T getFld() {
       return fld;
     }

--- a/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
@@ -378,20 +378,25 @@ public class TypeParameterResolverTest {
 
   @Test
   public void testReturnParam_WildcardWithUpperBounds() throws Exception {
-    class Key {}
+    class Key {
+    }
     @SuppressWarnings("unused")
     class KeyBean<S extends Key & Cloneable, T extends Key> {
       private S key1;
       private T key2;
+
       public S getKey1() {
         return key1;
       }
+
       public void setKey1(S key1) {
         this.key1 = key1;
       }
+
       public T getKey2() {
         return key2;
       }
+
       public void setKey2(T key2) {
         this.key2 = key2;
       }

--- a/src/test/java/org/apache/ibatis/reflection/factory/DefaultObjectFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/factory/DefaultObjectFactoryTest.java
@@ -81,14 +81,12 @@ public class DefaultObjectFactoryTest {
     Assertions.assertTrue(iterable instanceof ArrayList, " iterable should be ArrayList");
   }
 
-
   @Test
   public void createTreeSet() throws Exception {
     DefaultObjectFactory defaultObjectFactory = new DefaultObjectFactory();
     SortedSet sortedSet = defaultObjectFactory.create(SortedSet.class);
     Assertions.assertTrue(sortedSet instanceof TreeSet, " sortedSet should be TreeSet");
   }
-
 
   @Test
   public void createHashSet() throws Exception {

--- a/src/test/java/org/apache/ibatis/reflection/typeparam/Level2Mapper.java
+++ b/src/test/java/org/apache/ibatis/reflection/typeparam/Level2Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,5 +18,5 @@ package org.apache.ibatis.reflection.typeparam;
 import java.io.Serializable;
 import java.util.Date;
 
-public interface Level2Mapper extends Level1Mapper<Date, Integer>, Serializable, Comparable<Integer>{
+public interface Level2Mapper extends Level1Mapper<Date, Integer>, Serializable, Comparable<Integer> {
 }

--- a/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
+++ b/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
@@ -169,7 +169,7 @@ public class SqlSessionTest extends BaseDataTest {
       });
     }
   }
-  
+
   @Test
   public void shouldSelectAllAuthorsAsMap() {
     try (SqlSession session = sqlMapper.openSession(TransactionIsolationLevel.SERIALIZABLE)) {

--- a/src/test/java/org/apache/ibatis/submitted/ancestor_ref/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/ancestor_ref/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@ package org.apache.ibatis.submitted.ancestor_ref;
 public interface Mapper {
 
   User getUserAssociation(Integer id);
+
   User getUserCollection(Integer id);
+
   Blog selectBlog(Integer id);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/associationtest/AssociationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/associationtest/AssociationTest.java
@@ -62,10 +62,10 @@ public class AssociationTest {
   public void shouldGetOneCarWithOneEngineAndBrakes() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
-      List<Car> cars = mapper.getCars2();      
+      List<Car> cars = mapper.getCars2();
       Assertions.assertEquals(1, cars.size());
       Assertions.assertNotNull(cars.get(0).getEngine());
-      Assertions.assertNotNull(cars.get(0).getBrakes());      
+      Assertions.assertNotNull(cars.get(0).getBrakes());
     }
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/associationtest/Brakes.java
+++ b/src/test/java/org/apache/ibatis/submitted/associationtest/Brakes.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.apache.ibatis.submitted.associationtest;
 
 public class Brakes {
-  
+
   private String type;
 
   public String getType() {

--- a/src/test/java/org/apache/ibatis/submitted/associationtest/Car.java
+++ b/src/test/java/org/apache/ibatis/submitted/associationtest/Car.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,28 +20,35 @@ public class Car {
   private String type;
   private Engine engine;
   private Brakes brakes;
-  
+
   public int getId() {
     return id;
   }
+
   public void setId(int id) {
     this.id = id;
   }
+
   public String getType() {
     return type;
   }
+
   public void setType(String type) {
     this.type = type;
   }
+
   public Engine getEngine() {
     return engine;
   }
+
   public void setEngine(Engine engine) {
     this.engine = engine;
   }
+
   public Brakes getBrakes() {
     return brakes;
   }
+
   public void setBrakes(Brakes brakes) {
     this.brakes = brakes;
   }

--- a/src/test/java/org/apache/ibatis/submitted/associationtest/Engine.java
+++ b/src/test/java/org/apache/ibatis/submitted/associationtest/Engine.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,15 +18,19 @@ package org.apache.ibatis.submitted.associationtest;
 public class Engine {
   private String type;
   private int cylinders;
+
   public String getType() {
     return type;
   }
+
   public void setType(String type) {
     this.type = type;
   }
+
   public int getCylinders() {
     return cylinders;
   }
+
   public void setCylinders(int cylinders) {
     this.cylinders = cylinders;
   }

--- a/src/test/java/org/apache/ibatis/submitted/associationtest/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/associationtest/Mapper.java
@@ -20,6 +20,9 @@ import java.util.List;
 public interface Mapper {
 
   List<Car> getCars();
+
   List<Car> getCars2();
+
   List<Car> getCarsAndDetectAssociationType();
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/associationtype/AssociationTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/associationtype/AssociationTypeTest.java
@@ -50,8 +50,8 @@ public class AssociationTypeTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Map> results = sqlSession.selectList("getUser");
       for (Map r : results) {
-          Assertions.assertEquals(String.class, r.get("a1").getClass());
-          Assertions.assertEquals(String.class, r.get("a2").getClass());
+        Assertions.assertEquals(String.class, r.get("a1").getClass());
+        Assertions.assertEquals(String.class, r.get("a2").getClass());
       }
     }
   }

--- a/src/test/java/org/apache/ibatis/submitted/automapping/Article.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/Article.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,5 +16,5 @@
 package org.apache.ibatis.submitted.automapping;
 
 public class Article {
-  public final Integer version=0; 
+  public final Integer version = 0;
 }

--- a/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
@@ -77,7 +77,7 @@ public class AutomappingTest {
       Assertions.assertEquals("John", user.getPets().get(0).getBreeder().getBreederName());
     }
   }
-  
+
   @Test
   public void shouldNotInheritAutoMappingInherited_ExternalNestedResultMap() {
     sqlSessionFactory.getConfiguration().setAutoMappingBehavior(AutoMappingBehavior.NONE);

--- a/src/test/java/org/apache/ibatis/submitted/awful_table/AwfulTableMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/awful_table/AwfulTableMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,15 +17,15 @@ package org.apache.ibatis.submitted.awful_table;
 
 public interface AwfulTableMapper {
 
-    int deleteByPrimaryKey(Integer customerId);
+  int deleteByPrimaryKey(Integer customerId);
 
-    int insert(AwfulTable record);
+  int insert(AwfulTable record);
 
-    int insertSelective(AwfulTable record);
+  int insertSelective(AwfulTable record);
 
-    AwfulTable selectByPrimaryKey(Integer customerId);
+  AwfulTable selectByPrimaryKey(Integer customerId);
 
-    int updateByPrimaryKeySelective(AwfulTable record);
+  int updateByPrimaryKeySelective(AwfulTable record);
 
-    int updateByPrimaryKey(AwfulTable record);
+  int updateByPrimaryKey(AwfulTable record);
 }

--- a/src/test/java/org/apache/ibatis/submitted/basetest/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/basetest/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.ibatis.submitted.basetest;
 public interface Mapper {
 
   User getUser(Integer id);
+
   void insertUser(User user);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/batch_keys/BatchKeysTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_keys/BatchKeysTest.java
@@ -90,7 +90,6 @@ public class BatchKeysTest {
     }
   }
 
-
   @Test
   public void testInsertJdbc3() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
@@ -165,5 +164,5 @@ public class BatchKeysTest {
       Assertions.assertTrue(users.size() == 1);
     }
   }
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/batch_keys/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_keys/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,8 +16,9 @@
 package org.apache.ibatis.submitted.batch_keys;
 
 public interface Mapper {
-  
+
   void insert(User user);
+
   void insertIdentity(User user);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/batch_test/BatchTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_test/BatchTest.java
@@ -27,8 +27,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class BatchTest
-{
+public class BatchTest {
 
   private static SqlSessionFactory sqlSessionFactory;
 
@@ -59,14 +58,9 @@ public class BatchTest
       } finally {
         sqlSession.commit();
       }
-    }
-    catch (Exception e)
-    {
+    } catch (Exception e) {
       Assertions.fail(e.getMessage());
-
     }
   }
-
-
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/batch_test/Dept.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_test/Dept.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,8 +15,7 @@
  */
 package org.apache.ibatis.submitted.batch_test;
 
-public class Dept
-{
+public class Dept {
 
   private Integer id;
   private String name;

--- a/src/test/java/org/apache/ibatis/submitted/batch_test/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_test/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ public interface Mapper {
 
   User getUser(Integer id);
 
-  Dept  getDept(Integer id) ;
+  Dept getDept(Integer id);
 
   void insertUser(User user);
 }

--- a/src/test/java/org/apache/ibatis/submitted/batch_test/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_test/User.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,13 +21,11 @@ public class User {
   private String name;
   private Dept dept;
 
-  public Dept getDept()
-  {
+  public Dept getDept() {
     return dept;
   }
 
-  public void setDept(Dept dept)
-  {
+  public void setDept(Dept dept) {
     this.dept = dept;
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/blobtest/BlobMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/blobtest/BlobMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@ package org.apache.ibatis.submitted.blobtest;
 import java.util.List;
 
 public interface BlobMapper {
-    int insert(BlobRecord blobRecord);
-    List<BlobRecord> selectAll();
-    List<BlobRecord> selectAllWithBlobObjects();
+  int insert(BlobRecord blobRecord);
+
+  List<BlobRecord> selectAll();
+
+  List<BlobRecord> selectAllWithBlobObjects();
 }

--- a/src/test/java/org/apache/ibatis/submitted/blocking_cache/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/blocking_cache/Person.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,39 +18,40 @@ package org.apache.ibatis.submitted.blocking_cache;
 import java.io.Serializable;
 
 public class Person implements Serializable {
-  
+
   private int id;
   private String firstname;
   private String lastname;
-  
-  public Person() {}
-  
+
+  public Person() {
+  }
+
   public Person(int id, String firstname, String lastname) {
     setId(id);
     setFirstname(firstname);
     setLastname(lastname);
   }
-  
+
   public int getId() {
     return id;
   }
-  
+
   public void setId(int id) {
     this.id = id;
   }
-  
+
   public String getFirstname() {
     return firstname;
   }
-  
+
   public void setFirstname(String firstname) {
     this.firstname = firstname;
   }
-  
+
   public String getLastname() {
     return lastname;
   }
-  
+
   public void setLastname(String lastname) {
     this.lastname = lastname;
   }

--- a/src/test/java/org/apache/ibatis/submitted/blocking_cache/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/blocking_cache/PersonMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.CacheNamespace;
 import org.apache.ibatis.annotations.Select;
 
-@CacheNamespace(blocking=true)
+@CacheNamespace(blocking = true)
 public interface PersonMapper {
 
   @Select("select id, firstname, lastname from person")

--- a/src/test/java/org/apache/ibatis/submitted/cache/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/cache/Person.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,39 +18,40 @@ package org.apache.ibatis.submitted.cache;
 import java.io.Serializable;
 
 public class Person implements Serializable {
-  
+
   private int id;
   private String firstname;
   private String lastname;
-  
-  public Person() {}
-  
+
+  public Person() {
+  }
+
   public Person(int id, String firstname, String lastname) {
     setId(id);
     setFirstname(firstname);
     setLastname(lastname);
   }
-  
+
   public int getId() {
     return id;
   }
-  
+
   public void setId(int id) {
     this.id = id;
   }
-  
+
   public String getFirstname() {
     return firstname;
   }
-  
+
   public void setFirstname(String firstname) {
     this.firstname = firstname;
   }
-  
+
   public String getLastname() {
     return lastname;
   }
-  
+
   public void setLastname(String lastname) {
     this.lastname = lastname;
   }

--- a/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/CallSettersOnNullsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/CallSettersOnNullsTest.java
@@ -89,7 +89,7 @@ public class CallSettersOnNullsTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       List<Map<String, Object>> oneColumns = mapper.getNameOnlyMapped();
-//      Assertions.assertNotNull(oneColumns.get(1));
+      // Assertions.assertNotNull(oneColumns.get(1));
       // TEST changed after fix for #307
       // When callSetterOnNull is true, setters are called with null values
       // but if all the values for an object are null
@@ -97,5 +97,5 @@ public class CallSettersOnNullsTest {
       Assertions.assertNull(oneColumns.get(1));
     }
   }
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,9 +21,13 @@ import java.util.Map;
 public interface Mapper {
 
   User getUserMapped(Integer id);
+
   User getUserUnmapped(Integer id);
+
   Map getUserInMap(Integer id);
-  List<Map<String,Object>> getNameOnly();
-  List<Map<String,Object>> getNameOnlyMapped();
+
+  List<Map<String, Object>> getNameOnly();
+
+  List<Map<String, Object>> getNameOnlyMapped();
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/User.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,7 +34,9 @@ public class User {
   }
 
   public void setName(String name) {
-    if (name == null) nullReceived = true;
+    if (name == null) {
+      nullReceived = true;
+    }
     this.name = name;
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/camelcase/Camel.java
+++ b/src/test/java/org/apache/ibatis/submitted/camelcase/Camel.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,26 +16,31 @@
 package org.apache.ibatis.submitted.camelcase;
 
 public class Camel {
-  
+
   private String id;
   private String firstName;
   private String LAST_NAME;
-  
+
   public String getId() {
     return id;
   }
+
   public void setId(String id) {
     this.id = id;
   }
+
   public String getFirstName() {
     return firstName;
   }
+
   public void setFirstName(String firstName) {
     this.firstName = firstName;
-  } 
+  }
+
   public String getLAST_NAME() {
     return LAST_NAME;
   }
+
   public void setLAST_NAME(String last_name) {
     LAST_NAME = last_name;
   }

--- a/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/Person.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ public class Person {
       return getParent().getAncestor();
     }
   }
-
 
   @Override
   public boolean equals(Object o) {

--- a/src/test/java/org/apache/ibatis/submitted/collectionparameters/CollectionParametersTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/collectionparameters/CollectionParametersTest.java
@@ -63,8 +63,8 @@ public class CollectionParametersTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       Integer[] list = new Integer[2];
-      list[0]=1;
-      list[1]=2;
+      list[0] = 1;
+      list[1] = 2;
       List<User> users = mapper.getUsersFromArray(list);
       Assertions.assertEquals(2, users.size());
     }
@@ -82,5 +82,4 @@ public class CollectionParametersTest {
     }
   }
 
-  
 }

--- a/src/test/java/org/apache/ibatis/submitted/collectionparameters/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/collectionparameters/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@ import java.util.Set;
 public interface Mapper {
 
   List<User> getUsersFromList(List<Integer> id);
+
   List<User> getUsersFromArray(Integer[] id);
+
   List<User> getUsersFromCollection(Set<Integer> id);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/column_forwarding/Group.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_forwarding/Group.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,11 +27,11 @@ public class Group {
   public void setId(Integer id) {
     this.id = id;
   }
-  
+
   public String getState() {
     return state;
   }
-  
+
   public void setState(String state) {
     this.state = state;
   }

--- a/src/test/java/org/apache/ibatis/submitted/column_prefix/ColumnPrefixTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_prefix/ColumnPrefixTest.java
@@ -70,7 +70,7 @@ public class ColumnPrefixTest {
       assertEquals("0123", person1.getBillingAddress().getPhone1().getPhone());
       assertEquals("4567", person1.getBillingAddress().getPhone2().getPhone());
       assertEquals(AddressWithCaution.class, person1.getShippingAddress().getClass());
-      assertEquals("Has a big dog.", ((AddressWithCaution)person1.getShippingAddress()).getCaution());
+      assertEquals("Has a big dog.", ((AddressWithCaution) person1.getShippingAddress()).getCaution());
       assertEquals(Integer.valueOf(11), person1.getShippingAddress().getId());
       assertEquals("CA", person1.getShippingAddress().getState());
       assertEquals("San Francisco", person1.getShippingAddress().getCity());
@@ -89,7 +89,7 @@ public class ColumnPrefixTest {
       assertEquals(Integer.valueOf(2), person2.getId());
       assertEquals(AddressWithCaution.class, person2.getBillingAddress().getClass());
       assertEquals(Integer.valueOf(12), person2.getBillingAddress().getId());
-      assertEquals("No door bell.", ((AddressWithCaution)person2.getBillingAddress()).getCaution());
+      assertEquals("No door bell.", ((AddressWithCaution) person2.getBillingAddress()).getCaution());
       assertEquals("Los Angeles", person2.getBillingAddress().getCity());
       assertEquals("California Valley Quail", person2.getBillingAddress().getStateBird());
       assertEquals("Los Angeles", person2.getBillingAddress().getZip().getCity());

--- a/src/test/java/org/apache/ibatis/submitted/complex_property/ComponentTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_property/ComponentTest.java
@@ -41,7 +41,6 @@ public class ComponentTest {
             "org/apache/ibatis/submitted/complex_property/db.sql");
   }
 
-
   @Test
   public void shouldInsertNestedPasswordFieldOfComplexType() throws Exception {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
@@ -49,12 +48,12 @@ public class ComponentTest {
       User user = new User();
       user.setId(500000L);
       user.setPassword(new EncryptedString("secret"));
-      user.setUsername("johnny" + Calendar.getInstance().getTimeInMillis());//random
+      user.setUsername("johnny" + Calendar.getInstance().getTimeInMillis());// random
       user.setAdministrator(true);
 
       sqlSession.insert("User.insert", user);
 
-      //Retrieve User
+      // Retrieve User
       user = (User) sqlSession.selectOne("User.find", user.getId());
 
       assertNotNull(user.getId());

--- a/src/test/java/org/apache/ibatis/submitted/complex_property/EncryptedString.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_property/EncryptedString.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ public class EncryptedString {
   public EncryptedString(String message) {
     this();
 
-    //encrypt the message.
+    // encrypt the message.
     setEncrypted(message);
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/complex_type/Item.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_type/Item.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,6 @@ package org.apache.ibatis.submitted.complex_type;
 import java.util.List;
 
 public class Item {
-  public int id; 
+  public int id;
   public List<Property> properties;
 }

--- a/src/test/java/org/apache/ibatis/submitted/complex_type/Property.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_type/Property.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,6 @@
 package org.apache.ibatis.submitted.complex_type;
 
 public class Property {
-  public int id; 
-  public String value; 
+  public int id;
+  public String value;
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectWrapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectWrapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,11 +24,11 @@ import org.apache.ibatis.reflection.property.PropertyTokenizer;
 public class CustomObjectWrapper implements org.apache.ibatis.reflection.wrapper.ObjectWrapper {
 
   private CustomCollection collection;
-  
-  public CustomObjectWrapper(CustomCollection collection){
+
+  public CustomObjectWrapper(CustomCollection collection) {
     this.collection = collection;
   }
-  
+
   @Override
   public Object get(PropertyTokenizer prop) {
     // Not Implemented

--- a/src/test/java/org/apache/ibatis/submitted/deferload_common_property/FatherMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/deferload_common_property/FatherMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,5 +16,5 @@
 package org.apache.ibatis.submitted.deferload_common_property;
 
 public interface FatherMapper {
-  public Father selectById(Integer id); 
+  public Father selectById(Integer id);
 }

--- a/src/test/java/org/apache/ibatis/submitted/disallowdotsonnames/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/disallowdotsonnames/PersonMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,8 +18,11 @@ package org.apache.ibatis.submitted.disallowdotsonnames;
 import java.util.List;
 
 public interface PersonMapper {
-    public Person selectByIdFlush(int id);
-    public Person selectByIdNoFlush(int id);
-    public List<Person> selectAllFlush();
-    public List<Person> selectAllNoFlush();
+  public Person selectByIdFlush(int id);
+
+  public Person selectByIdNoFlush(int id);
+
+  public List<Person> selectAllFlush();
+
+  public List<Person> selectAllNoFlush();
 }

--- a/src/test/java/org/apache/ibatis/submitted/dml_return_types/DmlMapperReturnTypesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dml_return_types/DmlMapperReturnTypesTest.java
@@ -64,7 +64,7 @@ public class DmlMapperReturnTypesTest {
 
   @Test
   public void updateShouldReturnVoid() {
-      mapper.updateReturnsVoid(new User(1, "updateShouldReturnVoid"));
+    mapper.updateReturnsVoid(new User(1, "updateShouldReturnVoid"));
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/dml_return_types/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/dml_return_types/User.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,7 +20,8 @@ public class User {
   private int id;
   private String name;
 
-  public User() {}
+  public User() {
+  }
 
   public User(int id, String name) {
     this.id = id;
@@ -42,5 +43,5 @@ public class User {
   public void setName(String name) {
     this.name = name;
   }
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/duplicate_statements/AnnotatedMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/duplicate_statements/AnnotatedMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ public interface AnnotatedMapper {
 
   @Select("select * from users")
   List<User> getAllUsers();
-  
+
   @Select("select * from users")
   List<User> getAllUsers(RowBounds rowBounds);
 }

--- a/src/test/java/org/apache/ibatis/submitted/duplicate_statements/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/duplicate_statements/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,5 +22,6 @@ import org.apache.ibatis.session.RowBounds;
 public interface Mapper {
 
   List<User> getAllUsers();
+
   List<User> getAllUsers(RowBounds rowBounds);
 }

--- a/src/test/java/org/apache/ibatis/submitted/dynsql/NumericRow.java
+++ b/src/test/java/org/apache/ibatis/submitted/dynsql/NumericRow.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.apache.ibatis.submitted.dynsql;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-
 
 public class NumericRow {
     private Integer id;

--- a/src/test/java/org/apache/ibatis/submitted/dynsql/Parameter.java
+++ b/src/test/java/org/apache/ibatis/submitted/dynsql/Parameter.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ public class Parameter {
   private String schema;
   private List<Integer> ids;
   private boolean enabled;
-  
+
   public String getFred() {
     // added this method to check for bug with DynamicContext
     // IBATIS-777

--- a/src/test/java/org/apache/ibatis/submitted/dynsql2/DynSqlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dynsql2/DynSqlTest.java
@@ -31,7 +31,6 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-
 public class DynSqlTest {
 
   protected static SqlSessionFactory sqlSessionFactory;

--- a/src/test/java/org/apache/ibatis/submitted/emptycollection/Dao.java
+++ b/src/test/java/org/apache/ibatis/submitted/emptycollection/Dao.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,9 @@ package org.apache.ibatis.submitted.emptycollection;
 import java.util.List;
 
 interface Dao {
-    List<TodoLists> selectWithEmptyList();
-    List<TodoLists> selectWithNonEmptyList();
-    List<TodoLists> selectWithNonEmptyList_noCollectionId();
+  List<TodoLists> selectWithEmptyList();
+
+  List<TodoLists> selectWithNonEmptyList();
+
+  List<TodoLists> selectWithNonEmptyList_noCollectionId();
 }

--- a/src/test/java/org/apache/ibatis/submitted/emptycollection/TodoLists.java
+++ b/src/test/java/org/apache/ibatis/submitted/emptycollection/TodoLists.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.apache.ibatis.submitted.emptycollection;
 import java.util.List;
 
 public class TodoLists {
-  
+
   @Override
   public String toString() {
     return "TodoLists [id=" + id + ", todoItems=" + todoItems + "]";
@@ -27,7 +27,7 @@ public class TodoLists {
   private int id;
 
   private List<TodoItem> todoItems;
-  
+
   public int getId() {
     return id;
   }

--- a/src/test/java/org/apache/ibatis/submitted/encoding/EncodingMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/encoding/EncodingMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,5 +17,6 @@ package org.apache.ibatis.submitted.encoding;
 
 public interface EncodingMapper {
   String select1();
+
   String select2();
 }

--- a/src/test/java/org/apache/ibatis/submitted/enum_interface_type_handler/HasValueEnumTypeHandler.java
+++ b/src/test/java/org/apache/ibatis/submitted/enum_interface_type_handler/HasValueEnumTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.apache.ibatis.submitted.enum_interface_type_handler;
 
 import java.sql.CallableStatement;

--- a/src/test/java/org/apache/ibatis/submitted/extend/ExtendMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/extend/ExtendMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,5 +17,6 @@ package org.apache.ibatis.submitted.extend;
 
 public interface ExtendMapper {
   Parent selectParent();
+
   Child selectChild();
 }

--- a/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/StudentConstructorMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/StudentConstructorMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,5 +17,6 @@ package org.apache.ibatis.submitted.extends_with_constructor;
 
 public interface StudentConstructorMapper {
   public StudentConstructor selectWithTeacherById(Integer id);
+
   public StudentConstructor selectNoNameById(Integer id);
 }

--- a/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/PersonMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.submitted.flush_statement_npe;
 
 public interface PersonMapper {
-    public Person selectById(int id);
-    public void update(Person person);
+  public Person selectById(int id);
+
+  public void update(Person person);
 }

--- a/src/test/java/org/apache/ibatis/submitted/force_flush_on_select/ForceFlushOnSelectTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/force_flush_on_select/ForceFlushOnSelectTest.java
@@ -106,7 +106,7 @@ public class ForceFlushOnSelectTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.SIMPLE)) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.selectByIdNoFlush(1);
-      person.setLastName("Perez"); //it is ignored in update
+      person.setLastName("Perez"); // it is ignored in update
       personMapper.update(person);
       Person updatedPerson = personMapper.selectByIdNoFlush(1);
       assertEquals("Smith", updatedPerson.getLastName());

--- a/src/test/java/org/apache/ibatis/submitted/foreach_map/ForEachMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/foreach_map/ForEachMapTest.java
@@ -90,7 +90,7 @@ public class ForEachMapTest {
     Assertions.assertEquals(new NestedBeanMapEntry(12345, true, 54321, false), entries.get(0));
     Assertions.assertEquals(new NestedBeanMapEntry(67890, true, 9876, false), entries.get(1));
   }
-  
+
   @Test
   public void shouldSubstituteIndexWithKey() throws Exception {
     MapParam mapParam = new MapParam();

--- a/src/test/java/org/apache/ibatis/submitted/generictyperesolution/GenericTypeResolutionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/generictyperesolution/GenericTypeResolutionTest.java
@@ -61,7 +61,7 @@ public class GenericTypeResolutionTest {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = new User();
       user.setName("User2");
-      user.fld2 =56;
+      user.fld2 = 56;
       mapper.insertUser(user);
       User result = mapper.getUserByName("User2");
       assertNotNull(result);

--- a/src/test/java/org/apache/ibatis/submitted/generictypes/Group.java
+++ b/src/test/java/org/apache/ibatis/submitted/generictypes/Group.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,18 +26,23 @@ public class Group {
   public Integer getId() {
     return id;
   }
+
   public void setId(Integer id) {
     this.id = id;
   }
+
   public User<String> getOwner() {
     return owner;
   }
+
   public void setOwner(User<String> owner) {
     this.owner = owner;
   }
+
   public List<String> getMembers() {
     return members;
   }
+
   public void setMembers(List<String> members) {
     this.members = members;
   }

--- a/src/test/java/org/apache/ibatis/submitted/global_variables/BaseTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables/BaseTest.java
@@ -70,7 +70,7 @@ public class BaseTest {
     }
   }
 
-  private CustomCache unwrap(Cache cache){
+  private CustomCache unwrap(Cache cache) {
     Field field;
     try {
       field = cache.getClass().getDeclaredField("delegate");
@@ -79,12 +79,12 @@ public class BaseTest {
     }
     try {
       field.setAccessible(true);
-      return (CustomCache)field.get(cache);
+      return (CustomCache) field.get(cache);
     } catch (IllegalAccessException e) {
       throw new IllegalStateException(e);
     } finally {
       field.setAccessible(false);
     }
   }
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/global_variables/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,5 +18,5 @@ package org.apache.ibatis.submitted.global_variables;
 public interface Mapper {
 
   User getUser(Integer id);
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/heavy_initial_load/Thing.java
+++ b/src/test/java/org/apache/ibatis/submitted/heavy_initial_load/Thing.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  *    limitations under the License.
  */
 package org.apache.ibatis.submitted.heavy_initial_load;
-
 
 public class Thing {
 

--- a/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.apache.ibatis.annotations.Param;
 public interface ImmutablePOJOMapper {
 
   public ImmutablePOJO getImmutablePOJO(@Param("pojoID") Integer pojoID);
+
   public ImmutablePOJO getImmutablePOJONoMatchingConstructor(@Param("pojoID") Integer pojoID);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOTest.java
@@ -58,7 +58,6 @@ public final class ImmutablePOJOTest {
     }
   }
 
-
   @Test
   public void shouldFailLoadingImmutablePOJO() {
     try (SqlSession session = factory.openSession()) {
@@ -68,5 +67,5 @@ public final class ImmutablePOJOTest {
       });
     }
   }
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/includes/IncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/includes/IncludeTest.java
@@ -51,13 +51,13 @@ public class IncludeTest {
       Assertions.assertEquals(Integer.valueOf(1), result);
     }
   }
-  
+
   @Test
   public void testParametrizedIncludes() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       final Map<String, Object> result = sqlSession.selectOne("org.apache.ibatis.submitted.includes.mapper.select");
-      //Assertions.assertEquals(Integer.valueOf(1), result);
+      // Assertions.assertEquals(Integer.valueOf(1), result);
     }
   }
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/inline_association_with_dot/ElementMapperUsingInline.java
+++ b/src/test/java/org/apache/ibatis/submitted/inline_association_with_dot/ElementMapperUsingInline.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,6 +15,5 @@
  */
 package org.apache.ibatis.submitted.inline_association_with_dot;
 
-public interface ElementMapperUsingInline
-extends ElementMapper {
+public interface ElementMapperUsingInline extends ElementMapper {
 }

--- a/src/test/java/org/apache/ibatis/submitted/inline_association_with_dot/ElementMapperUsingSubMap.java
+++ b/src/test/java/org/apache/ibatis/submitted/inline_association_with_dot/ElementMapperUsingSubMap.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,6 +15,5 @@
  */
 package org.apache.ibatis.submitted.inline_association_with_dot;
 
-public interface ElementMapperUsingSubMap
-extends ElementMapper {
+public interface ElementMapperUsingSubMap extends ElementMapper {
 }

--- a/src/test/java/org/apache/ibatis/submitted/javassist/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/javassist/User.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -39,11 +39,11 @@ public class User {
     this.name = name;
   }
 
-public List<Group> getGroups() {
-  return groups;
-}
+  public List<Group> getGroups() {
+    return groups;
+  }
 
-public void setGroups(List<Group> groups) {
-  this.groups = groups;
-}
+  public void setGroups(List<Group> groups) {
+    this.groups = groups;
+  }
 }

--- a/src/test/java/org/apache/ibatis/submitted/language/LanguageTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/language/LanguageTest.java
@@ -139,6 +139,7 @@ public class LanguageTest {
       }
     }
   }
+
   @Test
   public void testLangRawWithIncludeAndCData() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
@@ -150,7 +151,7 @@ public class LanguageTest {
       }
     }
   }
-  
+
   @Test
   public void testLangXmlTags() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/language/Name.java
+++ b/src/test/java/org/apache/ibatis/submitted/language/Name.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,6 +44,5 @@ public class Name {
   public void setId(int id) {
     this.id = id;
   }
-
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/lazy_immutable/ImmutablePOJOMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazy_immutable/ImmutablePOJOMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,6 +19,6 @@ import org.apache.ibatis.annotations.Param;
 
 public interface ImmutablePOJOMapper {
 
-    public ImmutablePOJO getImmutablePOJO(@Param("pojoID") Integer pojoID);
+  public ImmutablePOJO getImmutablePOJO(@Param("pojoID") Integer pojoID);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/ChildMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/ChildMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,5 +16,5 @@
 package org.apache.ibatis.submitted.lazyload_common_property;
 
 public interface ChildMapper {
-  public Child selectById(Integer id); 
+  public Child selectById(Integer id);
 }

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/FatherMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/FatherMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,5 +16,5 @@
 package org.apache.ibatis.submitted.lazyload_common_property;
 
 public interface FatherMapper {
-  public Father selectById(Integer id); 
+  public Father selectById(Integer id);
 }

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/GrandFatherMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/GrandFatherMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,5 +16,5 @@
 package org.apache.ibatis.submitted.lazyload_common_property;
 
 public interface GrandFatherMapper {
-  public GrandFather selectById(Integer id); 
+  public GrandFather selectById(Integer id);
 }

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/AbstractLazyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/AbstractLazyTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 public abstract class AbstractLazyTest {
 
   private SqlSessionFactory sqlSessionFactory;
-  private SqlSession sqlSession; 
+  private SqlSession sqlSession;
   private Mapper mapper;
 
   protected abstract String getConfiguration();

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/CglibLazyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/CglibLazyTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,9 +15,7 @@
  */
 package org.apache.ibatis.submitted.lazyload_proxyfactory_comparison;
 
-
-public class CglibLazyTest 
-extends AbstractLazyTest {
+public class CglibLazyTest extends AbstractLazyTest {
   @Override
   protected String getConfiguration() {
     return "cglib";

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/DefaultLazyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/DefaultLazyTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,9 +15,7 @@
  */
 package org.apache.ibatis.submitted.lazyload_proxyfactory_comparison;
 
-
-public class DefaultLazyTest 
-extends AbstractLazyTest {
+public class DefaultLazyTest extends AbstractLazyTest {
   @Override
   protected String getConfiguration() {
     return "default";

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/Group.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/Group.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  *    limitations under the License.
  */
 package org.apache.ibatis.submitted.lazyload_proxyfactory_comparison;
-
 
 public class Group {
 

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/Owned.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/Owned.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,5 +17,6 @@ package org.apache.ibatis.submitted.lazyload_proxyfactory_comparison;
 
 public interface Owned<OWNERTYPE> {
   OWNERTYPE getOwner();
+
   void setOwner(OWNERTYPE owner);
 }

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithGetObjectWithInterface.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithGetObjectWithInterface.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,17 +37,17 @@ implements Owned<Group> {
   public void setName(String name) {
     this.name = name;
   }
-  
+
   @Override
   public Group getOwner() {
-     return owner;
+    return owner;
   }
-  
+
   @Override
   public void setOwner(Group owner) {
     this.owner = owner;
   }
-  
+
   public Object getObject() {
     return null;
   }

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithGetObjectWithoutInterface.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithGetObjectWithoutInterface.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,15 +36,15 @@ public class UserWithGetObjectWithoutInterface {
   public void setName(String name) {
     this.name = name;
   }
-  
+
   public Group getOwner() {
-     return owner;
+    return owner;
   }
-  
+
   public void setOwner(Group owner) {
     this.owner = owner;
   }
-  
+
   public Object getObject() {
     return null;
   }

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithGetXxxWithInterface.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithGetXxxWithInterface.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,17 +37,17 @@ implements Owned<Group> {
   public void setName(String name) {
     this.name = name;
   }
-  
+
   @Override
   public Group getOwner() {
-     return owner;
+    return owner;
   }
-  
+
   @Override
   public void setOwner(Group owner) {
     this.owner = owner;
   }
-  
+
   public Object getXxx() {
     return null;
   }

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithGetXxxWithoutInterface.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithGetXxxWithoutInterface.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,11 +36,11 @@ public class UserWithGetXxxWithoutInterface {
   public void setName(String name) {
     this.name = name;
   }
-  
+
   public Group getOwner() {
-     return owner;
+    return owner;
   }
-  
+
   public void setOwner(Group owner) {
     this.owner = owner;
   }

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithNothingWithInterface.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithNothingWithInterface.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,12 +37,12 @@ implements Owned<Group> {
   public void setName(String name) {
     this.name = name;
   }
-  
+
   @Override
   public Group getOwner() {
-     return owner;
+    return owner;
   }
-  
+
   @Override
   public void setOwner(Group owner) {
     this.owner = owner;

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithNothingWithoutInterface.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithNothingWithoutInterface.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,11 +36,11 @@ public class UserWithNothingWithoutInterface {
   public void setName(String name) {
     this.name = name;
   }
-  
+
   public Group getOwner() {
-     return owner;
+    return owner;
   }
-  
+
   public void setOwner(Group owner) {
     this.owner = owner;
   }

--- a/src/test/java/org/apache/ibatis/submitted/map_class_name_conflict/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/map_class_name_conflict/PersonMapper.java
@@ -15,7 +15,6 @@
  */
 package org.apache.ibatis.submitted.map_class_name_conflict;
 
-
 public interface PersonMapper {
 
   public Person get(Long id);

--- a/src/test/java/org/apache/ibatis/submitted/mapper_extend/MapperExtendTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/mapper_extend/MapperExtendTest.java
@@ -55,7 +55,6 @@ public class MapperExtendTest {
     }
   }
 
-
   @Test
   public void shouldGetAUserWithAnExtendedAnnotatedMethod() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/mapper_extend/MapperOverload.java
+++ b/src/test/java/org/apache/ibatis/submitted/mapper_extend/MapperOverload.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ public interface MapperOverload extends ParentMapper {
 
   @Override
   User getUserXML();
-  
+
   @Override
   @Select("select * from users where id = 2")
   User getUserAnnotated();
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/mapper_extend/ParentMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/mapper_extend/ParentMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,9 +18,9 @@ package org.apache.ibatis.submitted.mapper_extend;
 import org.apache.ibatis.annotations.Select;
 
 public interface ParentMapper extends GrandpaMapper {
-  
+
   User getUserXML();
-  
+
   @Select("select * from users where id = 1")
   User getUserAnnotated();
 

--- a/src/test/java/org/apache/ibatis/submitted/maptypehandler/MapTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/maptypehandler/MapTypeHandlerTest.java
@@ -70,5 +70,5 @@ public class MapTypeHandlerTest {
       });
     }
   }
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/maptypehandler/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/maptypehandler/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,5 +29,5 @@ public interface Mapper {
   User getUserFromAMap(Map<String, Object> params);
 
   User getUserXML(Map<String, Object> params);
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/missing_id_property/Car.java
+++ b/src/test/java/org/apache/ibatis/submitted/missing_id_property/Car.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import java.util.List;
 
 public class Car {
   // the result class doesn't need id for further processing
-  private String name ;
-  private List<Part> carParts ;
+  private String name;
+  private List<Part> carParts;
 
   public String getName() {
     return name;

--- a/src/test/java/org/apache/ibatis/submitted/missing_id_property/CarMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/missing_id_property/CarMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  *    limitations under the License.
  */
 package org.apache.ibatis.submitted.missing_id_property;
-
 
 public interface CarMapper {
   Car getCarsInfo(Long id);

--- a/src/test/java/org/apache/ibatis/submitted/missing_id_property/Part.java
+++ b/src/test/java/org/apache/ibatis/submitted/missing_id_property/Part.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,10 +18,11 @@ package org.apache.ibatis.submitted.missing_id_property;
 public class Part {
 
   private String name;
-  
+
   public Part(String name) {
     this.name = name;
   }
+
   public String getName() {
     return name;
   }

--- a/src/test/java/org/apache/ibatis/submitted/multidb/DummyDatabaseIdProvider.java
+++ b/src/test/java/org/apache/ibatis/submitted/multidb/DummyDatabaseIdProvider.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.apache.ibatis.mapping.DatabaseIdProvider;
 public class DummyDatabaseIdProvider implements DatabaseIdProvider {
 
   private Properties properties;
-  
+
   @Override
   public String getDatabaseId(DataSource dataSource) {
     return properties.getProperty("name");

--- a/src/test/java/org/apache/ibatis/submitted/multidb/MultiDbMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/multidb/MultiDbMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,9 +17,14 @@ package org.apache.ibatis.submitted.multidb;
 
 public interface MultiDbMapper {
   String select1(int id);
+
   String select2(int id);
+
   String select3(int id);
+
   String select4(int id);
+
   void insert(User user);
+
   void insert2(User user);
 }

--- a/src/test/java/org/apache/ibatis/submitted/multidb/MultiDbTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multidb/MultiDbTest.java
@@ -59,7 +59,7 @@ public class MultiDbTest {
       assertEquals("common", answer);
     }
   }
-  
+
   @Test
   public void shouldExecuteHsqlQueryWithDynamicIf() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
@@ -86,8 +86,8 @@ public class MultiDbTest {
       String answer = mapper.select2(1);
       assertEquals("common", answer);
     }
-  }  
-  
+  }
+
   @Test
   public void shouldInsertInCommonWithSelectKey2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
@@ -96,6 +96,6 @@ public class MultiDbTest {
       String answer = mapper.select2(1);
       assertEquals("common", answer);
     }
-  }  
+  }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/PersonMapper.java
@@ -16,8 +16,10 @@
 package org.apache.ibatis.submitted.multiple_discriminator;
 
 public interface PersonMapper {
-    
-    public Person get(Long id);
-    public Person get2(Long id);
-    public Person getLoop();
+
+  public Person get(Long id);
+
+  public Person get2(Long id);
+
+  public Person getLoop();
 }

--- a/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ public interface Mapper {
 
   @Select(value = "{ call GetOrderDetailsAndHeaders() }")
   @ResultMap("orderDetailResultMap")
-  @Options(statementType= StatementType.CALLABLE, resultSets="orderDetailResultSet,orderHeaderResultSet")
+  @Options(statementType = StatementType.CALLABLE, resultSets = "orderDetailResultSet,orderHeaderResultSet")
   List<OrderDetail> getOrderDetailsWithHeadersAnnotationBased();
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/OrderDetail.java
+++ b/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/OrderDetail.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ public class OrderDetail {
   private int lineNumber;
   private int quantity;
   private String itemDescription;
-  
+
   private OrderHeader orderHeader;
 
   public int getOrderId() {
@@ -57,10 +57,10 @@ public class OrderDetail {
   }
 
   public OrderHeader getOrderHeader() {
-      return orderHeader;
+    return orderHeader;
   }
 
   public void setOrderHeader(OrderHeader orderHeader) {
-      this.orderHeader = orderHeader;
+    this.orderHeader = orderHeader;
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/nested/NestedForEachTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested/NestedForEachTest.java
@@ -81,7 +81,7 @@ public class NestedForEachTest {
       assertEquals(3, answer.size());
     }
   }
-  
+
   @Test
   public void testNestedSelect() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/nested_query_cache/NestedQueryCacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested_query_cache/NestedQueryCacheTest.java
@@ -49,7 +49,7 @@ public class NestedQueryCacheTest extends BaseDataTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       final AuthorMapper authorMapper = sqlSession.getMapper(AuthorMapper.class);
       author = authorMapper.selectAuthor(101);
-      
+
       // ensure that author is cached
       final Author cachedAuthor = authorMapper.selectAuthor(101);
       assertThat(author).isSameAs(cachedAuthor);
@@ -64,14 +64,14 @@ public class NestedQueryCacheTest extends BaseDataTest {
       assertThat(blogMapper.selectBlogUsingConstructor(1).getAuthor()).isSameAs(author);
     }
   }
-  
+
   @Test
   public void testThatNestedQueryItemsAreRetrievedIfNotInCache() throws Exception {
     Author author;
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       final BlogMapper blogMapper = sqlSession.getMapper(BlogMapper.class);
       author = blogMapper.selectBlog(1).getAuthor();
-      
+
       // ensure that nested author within blog is cached
       assertNotNull(blogMapper.selectBlog(1).getAuthor(), "blog author");
       assertNotNull(blogMapper.selectBlogUsingConstructor(1).getAuthor(), "blog author");
@@ -85,6 +85,6 @@ public class NestedQueryCacheTest extends BaseDataTest {
       // ensure that nested author within blog is cached
       assertThat(cachedAuthor).isSameAs(author);
     }
-    
-  }  
+
+  }
 }

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ import java.util.List;
 
 public interface Mapper {
   List<Person> getPersons();
+
   List<Person> getPersonsWithItemsOrdered();
+
   List<PersonItemPair> getPersonItemPairs();
 }

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/Person.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class Person {
   public Collection<Item> getItems() {
     return items;
   }
-  
+
   public boolean owns(String name) {
     for (Item item : getItems()) {
       if (item.getName().equals(name))

--- a/src/test/java/org/apache/ibatis/submitted/not_null_column/Base.java
+++ b/src/test/java/org/apache/ibatis/submitted/not_null_column/Base.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,15 +20,19 @@ import java.util.Date;
 public abstract class Base {
   private int tempIntField;
   private Date tempDateField;
+
   public int getTempIntField() {
     return tempIntField;
   }
+
   public void setTempIntField(int tempIntField) {
     this.tempIntField = tempIntField;
   }
+
   public Date getTempDateField() {
     return tempDateField;
   }
+
   public void setTempDateField(Date tempDateField) {
     this.tempDateField = tempDateField;
   }

--- a/src/test/java/org/apache/ibatis/submitted/not_null_column/FatherMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/not_null_column/FatherMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,10 +17,16 @@ package org.apache.ibatis.submitted.not_null_column;
 
 public interface FatherMapper {
   public Father selectByIdNoFid(Integer id);
+
   public Father selectByIdFid(Integer id);
+
   public Father selectByIdWithInternalResultMap(Integer id);
+
   public Father selectByIdWithRefResultMap(Integer id);
+
   public Father selectByIdFidMultipleNullColumns(Integer id);
+
   public Father selectByIdFidMultipleNullColumnsAndBrackets(Integer id);
+
   public Father selectByIdFidWorkaround(Integer id);
 }

--- a/src/test/java/org/apache/ibatis/submitted/ognlstatic/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognlstatic/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.ibatis.submitted.ognlstatic;
 public interface Mapper {
 
   User getUserStatic(Integer id);
+
   User getUserIfNode(String id);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/ognlstatic/OgnlStaticTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognlstatic/OgnlStaticTest.java
@@ -67,5 +67,5 @@ public class OgnlStaticTest {
       Assertions.assertEquals("User1", user.getName());
     }
   }
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/OrderPrefixRemoved.java
+++ b/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/OrderPrefixRemoved.java
@@ -50,7 +50,7 @@ public class OrderPrefixRemoved {
       Person person = personMapper.select(new String("slow"));
 
       assertNotNull(person);
-      
+
       sqlSession.commit();
     }
   }

--- a/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/PersonMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,5 +16,5 @@
 package org.apache.ibatis.submitted.order_prefix_removed;
 
 public interface PersonMapper {
-    public Person select(String orderType);
+  public Person select(String orderType);
 }

--- a/src/test/java/org/apache/ibatis/submitted/overwritingproperties/FooMapperTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/overwritingproperties/FooMapperTest.java
@@ -63,7 +63,7 @@ public class FooMapperTest {
     mapper.insertFoo(inserted);
 
     final Foo selected = mapper.selectFoo();
-    
+
     // field1 is explicitly mapped properly
     // <result property="field1" column="field1" jdbcType="INTEGER"/>
     Assertions.assertEquals(inserted.getField1(), selected.getField1());
@@ -79,7 +79,7 @@ public class FooMapperTest {
     // is automapped from the only column that matches... which is Field1
     // probably not the intention, but it's working correctly given the code
     // <association property="field2" javaType="Bar">
-    //  <result property="field1" column="bar_field1" jdbcType="INTEGER"/>
+    // <result property="field1" column="bar_field1" jdbcType="INTEGER"/>
     // </association>
     Assertions.assertEquals(inserted.getField2().getField1(), selected.getField2().getField1());
   }

--- a/src/test/java/org/apache/ibatis/submitted/parametrizedlist/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/parametrizedlist/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,5 +35,5 @@ public interface Mapper {
 
   @Select("select id, name from users")
   List<Map<String, Object>> getAListOfMaps();
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/parent_childs/Child.java
+++ b/src/test/java/org/apache/ibatis/submitted/parent_childs/Child.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,24 +25,31 @@ public class Child {
   public int getId() {
     return id;
   }
+
   public void setId(int id) {
     this.id = id;
   }
+
   public String getName() {
     return name;
   }
+
   public void setName(String name) {
     this.name = name;
   }
+
   public String getSurName() {
     return surName;
   }
+
   public void setSurName(String surName) {
     this.surName = surName;
   }
+
   public int getAge() {
     return age;
   }
+
   public void setAge(int age) {
     this.age = age;
   }

--- a/src/test/java/org/apache/ibatis/submitted/parent_childs/Parent.java
+++ b/src/test/java/org/apache/ibatis/submitted/parent_childs/Parent.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,24 +27,31 @@ public class Parent {
   public int getId() {
     return id;
   }
+
   public void setId(int id) {
     this.id = id;
   }
+
   public String getName() {
     return name;
   }
+
   public void setName(String name) {
     this.name = name;
   }
+
   public String getSurName() {
     return surName;
   }
+
   public void setSurName(String surName) {
     this.surName = surName;
   }
+
   public List<Child> getChilds() {
     return childs;
   }
+
   public void setChilds(List<Child> childs) {
     this.childs = childs;
   }

--- a/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/Blog.java
+++ b/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/Blog.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ public class Blog {
     return id;
   }
 
-  public void setId(int id) {    
+  public void setId(int id) {
     this.id = id;
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/Comment.java
+++ b/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/Comment.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ public class Comment {
   public void setComment(String comment) {
     if (this.comment != null) {
       throw new RuntimeException("Setter called twice");
-    }    
+    }
     this.comment = comment;
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/Post.java
+++ b/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/Post.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ public class Post {
   public void setBlog(Blog blog) {
     if (this.blog != null) {
       throw new RuntimeException("Setter called twice");
-    }    
+    }
     this.blog = blog;
   }
 
@@ -50,7 +50,7 @@ public class Post {
   public void setBody(String body) {
     if (this.body != null) {
       throw new RuntimeException("Setter called twice");
-    }    
+    }
     this.body = body;
   }
 
@@ -61,7 +61,7 @@ public class Post {
   public void setComments(List<Comment> comments) {
     if (this.comments != null) {
       throw new RuntimeException("Setter called twice");
-    }    
+    }
     this.comments = comments;
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/permissions/Permission.java
+++ b/src/test/java/org/apache/ibatis/submitted/permissions/Permission.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,18 +19,21 @@ public class Permission {
 
   private String permission;
   private Resource resource;
-  
+
   public String getPermission() {
     return permission;
   }
+
   public void setPermission(String permission) {
     this.permission = permission;
   }
+
   public Resource getResource() {
     return resource;
   }
+
   public void setResource(Resource resource) {
     this.resource = resource;
   }
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/permissions/PermissionsMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/permissions/PermissionsMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.List;
 public interface PermissionsMapper {
 
   List<Resource> getResources();
+
   List<Resource> getResource(String permission);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/permissions/PermissionsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/permissions/PermissionsTest.java
@@ -58,7 +58,7 @@ public class PermissionsTest {
       final Principal firstPrincipal = principalPermissions.get(0);
       final List<Permission> permissions = firstPrincipal.getPermissions();
       Assertions.assertEquals(2, permissions.size());
-      
+
       final Permission firstPermission = firstPrincipal.getPermissions().get(0);
       Assertions.assertSame(firstResource, firstPermission.getResource());
       final Permission secondPermission = firstPrincipal.getPermissions().get(1);
@@ -89,11 +89,11 @@ public class PermissionsTest {
           readFound = true;
         }
       }
-      
+
       if (!readFound) {
         Assertions.fail();
       }
     }
   }
-  
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/permissions/Principal.java
+++ b/src/test/java/org/apache/ibatis/submitted/permissions/Principal.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,16 +22,19 @@ public class Principal {
 
   private String principalName;
   private List<Permission> permissions = new ArrayList<Permission>();
-  
+
   public String getPrincipalName() {
     return principalName;
   }
+
   public void setPrincipalName(String principalName) {
     this.principalName = principalName;
   }
+
   public List<Permission> getPermissions() {
     return permissions;
   }
+
   public void setPermissions(List<Permission> permissions) {
     this.permissions = permissions;
   }

--- a/src/test/java/org/apache/ibatis/submitted/permissions/Resource.java
+++ b/src/test/java/org/apache/ibatis/submitted/permissions/Resource.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,12 +25,15 @@ public class Resource {
   public String getName() {
     return name;
   }
+
   public void setName(String name) {
     this.name = name;
   }
+
   public List<Principal> getPrincipals() {
     return Principals;
   }
+
   public void setPrincipals(List<Principal> principals) {
     this.Principals = principals;
   }

--- a/src/test/java/org/apache/ibatis/submitted/primitive_result_type/ProductMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitive_result_type/ProductMapper.java
@@ -25,6 +25,6 @@ public interface ProductMapper {
   List<Long> selectProductCodesL();
 
   List<BigDecimal> selectProductCodesB();
-  
+
   List<Product> selectAllProducts();
 }

--- a/src/test/java/org/apache/ibatis/submitted/primitives/PrimitivesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitives/PrimitivesTest.java
@@ -52,5 +52,4 @@ public class PrimitivesTest {
     }
   }
 
-
 }

--- a/src/test/java/org/apache/ibatis/submitted/propertiesinmapperfiles/PropertiesInMappersTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/propertiesinmapperfiles/PropertiesInMappersTest.java
@@ -33,11 +33,11 @@ public class PropertiesInMappersTest {
 
   @BeforeAll
   public static void setUp() throws Exception {
-    
+
     // this property value should be replaced on all mapper files
     Properties p = new Properties();
     p.put("property", "id");
-    
+
     // create a SqlSessionFactory
     try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/propertiesinmapperfiles/mybatis-config.xml")) {
       sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader, p);

--- a/src/test/java/org/apache/ibatis/submitted/result_handler/UserResultHandler.java
+++ b/src/test/java/org/apache/ibatis/submitted/result_handler/UserResultHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import org.apache.ibatis.session.ResultHandler;
 
 public class UserResultHandler implements ResultHandler {
   private List<User> users;
-  
+
   public UserResultHandler() {
     super();
     users = new ArrayList<User>();

--- a/src/test/java/org/apache/ibatis/submitted/result_handler_type/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/result_handler_type/Person.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,29 +15,24 @@
  */
 package org.apache.ibatis.submitted.result_handler_type;
 
-public class Person
-{
+public class Person {
   private Integer id;
 
   private String name;
 
-  public Integer getId()
-  {
+  public Integer getId() {
     return id;
   }
 
-  public void setId(Integer id)
-  {
+  public void setId(Integer id) {
     this.id = id;
   }
 
-  public String getName()
-  {
+  public String getName() {
     return name;
   }
 
-  public void setName(String name)
-  {
+  public void setName(String name) {
     this.name = name;
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/resultmapwithassociationstest/Address.java
+++ b/src/test/java/org/apache/ibatis/submitted/resultmapwithassociationstest/Address.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@ package org.apache.ibatis.submitted.resultmapwithassociationstest;
  *
  */
 public class Address {
-    private int id;
+  private int id;
 
-    public int getId() {
-        return id;
-    }
+  public int getId() {
+    return id;
+  }
 
-    public void setId(final int id) {
-        this.id = id;
-    }
+  public void setId(final int id) {
+    this.id = id;
+  }
 }

--- a/src/test/java/org/apache/ibatis/submitted/resultmapwithassociationstest/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/resultmapwithassociationstest/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,5 +18,5 @@ package org.apache.ibatis.submitted.resultmapwithassociationstest;
 import java.util.List;
 
 public interface Mapper {
-    List<Person> findAll();
+  List<Person> findAll();
 }

--- a/src/test/java/org/apache/ibatis/submitted/rounding/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/rounding/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,8 +18,11 @@ package org.apache.ibatis.submitted.rounding;
 public interface Mapper {
 
   User getUser(Integer id);
+
   void insert(User user);
+
   User getUser2(Integer id);
+
   void insert2(User user);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/rounding/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/rounding/User.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -40,19 +40,19 @@ public class User {
   public void setName(String name) {
     this.name = name;
   }
-  
+
   public BigDecimal getFunkyNumber() {
     return funkyNumber;
   }
-  
+
   public void setFunkyNumber(BigDecimal big) {
-    funkyNumber = big;  
+    funkyNumber = big;
   }
-  
+
   public RoundingMode getRoundingMode() {
     return roundingMode;
   }
-  
+
   public void setRoundingMode(RoundingMode mode) {
     roundingMode = mode;
   }

--- a/src/test/java/org/apache/ibatis/submitted/selectkey/SqlProvider.java
+++ b/src/test/java/org/apache/ibatis/submitted/selectkey/SqlProvider.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.apache.ibatis.submitted.selectkey;
 
 public class SqlProvider {
 
-    public String insertTable3_2(Name name) {
-        return "insert into table3 (id, name) values(#{nameId}, #{name})";
-    }
+  public String insertTable3_2(Name name) {
+    return "insert into table3 (id, name) values(#{nameId}, #{name})";
+  }
 }

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/Attribute.java
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/Attribute.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import java.io.Serializable;
 
 public class Attribute implements Serializable {
   private static final long serialVersionUID = 1L;
-  
+
   private Integer id;
 
   public Integer getId() {

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/AttributeMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/AttributeMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,4 +18,3 @@ package org.apache.ibatis.submitted.serializecircular;
 public interface AttributeMapper {
   public Attribute getById(Integer anId);
 }
-

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/Department.java
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/Department.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.apache.ibatis.submitted.serializecircular;
 
 import java.io.Serializable;
 
-public class Department implements Serializable{
+public class Department implements Serializable {
 
   private static final long serialVersionUID = 1L;
 

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/Person.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -31,13 +31,11 @@ public class Person implements Serializable {
     this.department = department;
   }
 
-  public Integer getId()
-  {
+  public Integer getId() {
     return id;
   }
 
-  public void setId(Integer id)
-  {
+  public void setId(Integer id) {
     this.id = id;
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/PersonMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,5 +19,6 @@ import java.util.List;
 
 public interface PersonMapper {
   public Person getById(Integer anId);
+
   public List<Person> getByDepartment(Integer anDepartmentId);
 }

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/SerializeCircularTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/SerializeCircularTest.java
@@ -34,7 +34,7 @@ public class SerializeCircularTest {
       testSerializeWithoutPreloadingAttribute(sqlSession);
     }
   }
-  
+
   @Test
   public void serializeAndDeserializeObjectsWithAggressiveLazyLoadingWithPreloadingAttribute() 
   throws Exception {

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/UtilityTester.java
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/UtilityTester.java
@@ -22,8 +22,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 public class UtilityTester {
-  
-  public static void serializeAndDeserializeObject(Object myObject){
+
+  public static void serializeAndDeserializeObject(Object myObject) {
 
     try {
       deserialzeObject(serializeObject(myObject));

--- a/src/test/java/org/apache/ibatis/submitted/simplelistparameter/SimpleListParameterTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/simplelistparameter/SimpleListParameterTest.java
@@ -49,7 +49,7 @@ public class SimpleListParameterTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       CarMapper carMapper = sqlSession.getMapper(CarMapper.class);
       Car car = new Car();
-      car.setDoors(Arrays.asList(new String[] {"2", "4"}));
+      car.setDoors(Arrays.asList(new String[] { "2", "4" }));
       List<Car> cars = carMapper.getCar(car);
       Assertions.assertNotNull(cars);
     }
@@ -60,7 +60,7 @@ public class SimpleListParameterTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       CarMapper carMapper = sqlSession.getMapper(CarMapper.class);
       Rv rv = new Rv();
-      rv.doors1 = Arrays.asList(new String[] {"2", "4"});
+      rv.doors1 = Arrays.asList(new String[] { "2", "4" });
       List<Rv> rvs = carMapper.getRv1(rv);
       Assertions.assertNotNull(rvs);
     }
@@ -71,7 +71,7 @@ public class SimpleListParameterTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       CarMapper carMapper = sqlSession.getMapper(CarMapper.class);
       Rv rv = new Rv();
-      rv.setDoors2(Arrays.asList(new String[] {"2", "4"}));
+      rv.setDoors2(Arrays.asList(new String[] { "2", "4" }));
       List<Rv> rvs = carMapper.getRv2(rv);
       Assertions.assertNotNull(rvs);
     }

--- a/src/test/java/org/apache/ibatis/submitted/sptests/SPMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/sptests/SPMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public interface SPMapper {
   Object adderAsSelect(Parameter parameter);
 
   void adderAsUpdate(Parameter parameter);
-  
+
   void adderWithParameterMap(Map<String, Object> parameter);
 
   Name getName(Integer id);
@@ -44,11 +44,11 @@ public interface SPMapper {
   List<List<?>> getNamesAndItems();
 
   List<Name> getNamesAndItemsLinked();
-  
+
   List<Name> getNamesAndItemsLinkedById(int id);
 
   Object echoDate(Map<String, Object> parameter);  // issue #145
-  
+
   // annotated
   @Select({ "{call sptest.adder(", "#{addend1,jdbcType=INTEGER,mode=IN},", "#{addend2,jdbcType=INTEGER,mode=IN},", "#{sum,jdbcType=INTEGER,mode=OUT})}" })
   @Options(statementType = StatementType.CALLABLE)
@@ -97,7 +97,7 @@ public interface SPMapper {
   @ResultMap("nameResult,itemResult")
   @Options(statementType = StatementType.CALLABLE)
   List<List<?>> getNamesAndItemsAnnotatedWithXMLResultMap();
-  
+
   @Select("{call sptest.getnamesanditems()}")
   @ResultMap({"nameResult","itemResult"})
   @Options(statementType = StatementType.CALLABLE)

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/BaseMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/BaseMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,32 +26,32 @@ import java.util.List;
 
 public interface BaseMapper<T> {
 
-  @SelectProvider(type= OurSqlBuilder.class, method= "buildSelectByIdProviderContextOnly")
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildSelectByIdProviderContextOnly")
   @ContainsLogicalDelete
   T selectById(Integer id);
 
-  @SelectProvider(type= OurSqlBuilder.class, method= "buildSelectByIdProviderContextOnly")
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildSelectByIdProviderContextOnly")
   T selectActiveById(Integer id);
 
-  @SelectProvider(type= OurSqlBuilder.class, method= "buildSelectByNameOneParamAndProviderContext")
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildSelectByNameOneParamAndProviderContext")
   @ContainsLogicalDelete
   List<T> selectByName(String name);
 
-  @SelectProvider(type= OurSqlBuilder.class, method= "buildSelectByNameOneParamAndProviderContext")
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildSelectByNameOneParamAndProviderContext")
   List<T> selectActiveByName(String name);
 
-  @SelectProvider(type= OurSqlBuilder.class, method= "buildSelectByIdAndNameMultipleParamAndProviderContextWithAtParam")
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildSelectByIdAndNameMultipleParamAndProviderContextWithAtParam")
   @ContainsLogicalDelete
   List<T> selectByIdAndNameWithAtParam(@Param("id") Integer id, @Param("name") String name);
 
-  @SelectProvider(type= OurSqlBuilder.class, method= "buildSelectByIdAndNameMultipleParamAndProviderContextWithAtParam")
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildSelectByIdAndNameMultipleParamAndProviderContextWithAtParam")
   List<T> selectActiveByIdAndNameWithAtParam(@Param("id") Integer id, @Param("name") String name);
 
-  @SelectProvider(type= OurSqlBuilder.class, method= "buildSelectByIdAndNameMultipleParamAndProviderContext")
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildSelectByIdAndNameMultipleParamAndProviderContext")
   @ContainsLogicalDelete
   List<T> selectByIdAndName(Integer id, String name);
 
-  @SelectProvider(type= OurSqlBuilder.class, method= "buildSelectByIdAndNameMultipleParamAndProviderContext")
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildSelectByIdAndNameMultipleParamAndProviderContext")
   List<T> selectActiveByIdAndName(Integer id, String name);
 
   @Retention(RetentionPolicy.RUNTIME)

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ public interface Mapper extends BaseMapper<User> {
 
   @SelectProvider(type = OurSqlBuilder.class, method = "buildGetUserQuery")
   User getUser(Integer userId);
- 
+
   @SelectProvider(type = OurSqlBuilder.class, method = "buildGetAllUsersQuery")
   List<User> getAllUsers();
 

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/OurSqlBuilder.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/OurSqlBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ public class OurSqlBuilder {
     // so it is passed as is from the mapper
     return "select * from users where id = #{value}";
   }
+
   public String buildGetAllUsersQuery() {
     return "select * from users order by id";
   }

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
@@ -235,7 +235,7 @@ public class SqlProviderTest {
       }
     }
   }
-  
+
   @Test
   public void methodNotFound() throws NoSuchMethodException {
     try {

--- a/src/test/java/org/apache/ibatis/submitted/substitution_in_annots/SubstitutionInAnnotsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/substitution_in_annots/SubstitutionInAnnotsTest.java
@@ -28,7 +28,6 @@ import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-
 public class SubstitutionInAnnotsTest {
 
   protected static SqlSessionFactory sqlSessionFactory;
@@ -60,7 +59,7 @@ public class SubstitutionInAnnotsTest {
       assertEquals("Barney", mapper.getPersonNameByIdWithAnnotsValue(4));
     }
   }
-  
+
   @Test
   public void testSubstitutionWithAnnotsParameter() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/typehandlerinjection/UserStateTypeHandler.java
+++ b/src/test/java/org/apache/ibatis/submitted/typehandlerinjection/UserStateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ public class UserStateTypeHandler<E> implements TypeHandler<Object> {
     lookup.put("0", "INACTIVE");
     lookup.put("1", "ACTIVE");
   }
-  
+
   UserStateTypeHandler() {
     // can only be constructed from this package
   }

--- a/src/test/java/org/apache/ibatis/submitted/uuid_test/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/uuid_test/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.UUID;
 public interface Mapper {
 
   User getUser(UUID id);
+
   void insertUser(User user);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/uuid_test/UUIDTypeHandler.java
+++ b/src/test/java/org/apache/ibatis/submitted/uuid_test/UUIDTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,21 +34,27 @@ public class UUIDTypeHandler extends BaseTypeHandler<UUID> {
   @Override
   public UUID getNullableResult(ResultSet rs, String columnName) throws SQLException {
     String value = rs.getString(columnName);
-    if (value != null) return UUID.fromString(value);
+    if (value != null) {
+      return UUID.fromString(value);
+    }
     return null;
   }
 
   @Override
   public UUID getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
     String value = rs.getString(columnIndex);
-    if (value != null) return UUID.fromString(value);
+    if (value != null) {
+      return UUID.fromString(value);
+    }
     return null;
   }
 
   @Override
   public UUID getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
     String value = cs.getString(columnIndex);
-    if (value != null) return UUID.fromString(value);
+    if (value != null) {
+      return UUID.fromString(value);
+    }
     return null;
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/InvalidWithInsertMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/InvalidWithInsertMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2018 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,5 +19,6 @@ import java.util.Map;
 
 public interface InvalidWithInsertMapper {
   Map<?, ?> selectAll();
+
   void insert(Person person);
 }

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeTest.java
@@ -66,9 +66,9 @@ public class MultipleCrossIncludeTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       MultipleCrossIncludePersonMapper personMapper = sqlSession.getMapper(MultipleCrossIncludePersonMapper.class);
       Person person = personMapper.select(1);
-      assertEquals((Integer)1, person.getId());
+      assertEquals((Integer) 1, person.getId());
       assertEquals(2, person.getPets().size());
-      assertEquals((Integer)2, person.getPets().get(1).getId());
+      assertEquals((Integer) 2, person.getPets().get(1).getId());
 
       Pet pet = personMapper.selectPet(1);
       assertEquals(Integer.valueOf(1), pet.getId());

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleIncludeTest.java
@@ -49,7 +49,7 @@ public class MultipleIncludeTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       MultipleIncludePersonMapper personMapper = sqlSession.getMapper(MultipleIncludePersonMapper.class);
       Person person = personMapper.select(1);
-      assertEquals((Integer)1, person.getId());
+      assertEquals((Integer) 1, person.getId());
       assertEquals("John", person.getName());
     }
   }

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleReverseIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleReverseIncludeTest.java
@@ -48,7 +48,7 @@ public class MultipleReverseIncludeTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       MultipleReverseIncludePersonMapper personMapper = sqlSession.getMapper(MultipleReverseIncludePersonMapper.class);
       Person person = personMapper.select(1);
-      assertEquals((Integer)1, person.getId());
+      assertEquals((Integer) 1, person.getId());
       assertEquals("John", person.getName());
     }
   }

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ReverseIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ReverseIncludeTest.java
@@ -48,7 +48,7 @@ public class ReverseIncludeTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       ReverseIncludePersonMapper personMapper = sqlSession.getMapper(ReverseIncludePersonMapper.class);
       Person person = personMapper.select(1);
-      assertEquals((Integer)1, person.getId());
+      assertEquals((Integer) 1, person.getId());
       assertEquals("John", person.getName());
     }
   }

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/SameIdTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/SameIdTest.java
@@ -48,9 +48,9 @@ public class SameIdTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SameIdPersonMapper personMapper = sqlSession.getMapper(SameIdPersonMapper.class);
       Person person = personMapper.select(1);
-      assertEquals((Integer)1, person.getId());
+      assertEquals((Integer) 1, person.getId());
       assertEquals(2, person.getPets().size());
-      assertEquals((Integer)2, person.getPets().get(1).getId());
+      assertEquals((Integer) 2, person.getPets().get(1).getId());
 
       Pet pet = personMapper.selectPet(1);
       assertEquals(Integer.valueOf(1), pet.getId());

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/XmlExternalRefTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/XmlExternalRefTest.java
@@ -95,9 +95,9 @@ public class XmlExternalRefTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.select(1);
-      assertEquals((Integer)1, person.getId());
+      assertEquals((Integer) 1, person.getId());
       assertEquals(2, person.getPets().size());
-      assertEquals((Integer)2, person.getPets().get(1).getId());
+      assertEquals((Integer) 2, person.getPets().get(1).getId());
 
       Pet pet = personMapper.selectPet(1);
       assertEquals(Integer.valueOf(1), pet.getId());

--- a/src/test/java/org/apache/ibatis/type/BlobByteObjectArrayTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/BlobByteObjectArrayTypeHandlerTest.java
@@ -40,7 +40,7 @@ public class BlobByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
     final ArgumentCaptor<ByteArrayInputStream> byteArrayCaptor = ArgumentCaptor.forClass(ByteArrayInputStream.class);
     final ArgumentCaptor<Integer> lengthCaptor = ArgumentCaptor.forClass(Integer.class);
     doNothing().when(ps).setBinaryStream(positionCaptor.capture(), byteArrayCaptor.capture(), lengthCaptor.capture());
-    TYPE_HANDLER.setParameter(ps, 1, new Byte[]{1, 2}, null);
+    TYPE_HANDLER.setParameter(ps, 1, new Byte[] { 1, 2 }, null);
     ByteArrayInputStream actualIn = byteArrayCaptor.getValue();
     assertThat(positionCaptor.getValue()).isEqualTo(1);
     assertThat(actualIn.read()).isEqualTo(1);
@@ -52,11 +52,11 @@ public class BlobByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
-    byte[] byteArray = new byte[]{1, 2};
+    byte[] byteArray = new byte[] { 1, 2 };
     when(rs.getBlob("column")).thenReturn(blob);
     when(blob.length()).thenReturn((long)byteArray.length);
     when(blob.getBytes(1, 2)).thenReturn(byteArray);
-    assertThat(TYPE_HANDLER.getResult(rs, "column")).isEqualTo(new Byte[]{1, 2});
+    assertThat(TYPE_HANDLER.getResult(rs, "column")).isEqualTo(new Byte[] { 1, 2 });
 
   }
 
@@ -70,11 +70,11 @@ public class BlobByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
-    byte[] byteArray = new byte[]{1, 2};
+    byte[] byteArray = new byte[] { 1, 2 };
     when(rs.getBlob(1)).thenReturn(blob);
     when(blob.length()).thenReturn((long)byteArray.length);
     when(blob.getBytes(1, 2)).thenReturn(byteArray);
-    assertThat(TYPE_HANDLER.getResult(rs, 1)).isEqualTo(new Byte[]{1, 2});
+    assertThat(TYPE_HANDLER.getResult(rs, 1)).isEqualTo(new Byte[] { 1, 2 });
   }
 
   @Override
@@ -87,11 +87,11 @@ public class BlobByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
-    byte[] byteArray = new byte[]{1, 2};
+    byte[] byteArray = new byte[] { 1, 2 };
     when(cs.getBlob(1)).thenReturn(blob);
     when(blob.length()).thenReturn((long)byteArray.length);
     when(blob.getBytes(1, 2)).thenReturn(byteArray);
-    assertThat(TYPE_HANDLER.getResult(cs, 1)).isEqualTo(new Byte[]{1, 2});
+    assertThat(TYPE_HANDLER.getResult(cs, 1)).isEqualTo(new Byte[] { 1, 2 });
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/ByteArrayTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ByteArrayTypeHandlerTest.java
@@ -70,6 +70,6 @@ public class ByteArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     // Unnecessary
- }
+  }
 
 }

--- a/src/test/java/org/apache/ibatis/type/ByteObjectArrayTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ByteObjectArrayTypeHandlerTest.java
@@ -36,7 +36,7 @@ public class ByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
-    byte[] byteArray = new byte[]{1, 2};
+    byte[] byteArray = new byte[] { 1, 2 };
     when(rs.getBytes("column")).thenReturn(byteArray);
     assertThat(TYPE_HANDLER.getResult(rs, "column")).isEqualTo(new Byte[]{1, 2});
     verify(rs, never()).wasNull();
@@ -53,7 +53,7 @@ public class ByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
-    byte[] byteArray = new byte[]{1, 2};
+    byte[] byteArray = new byte[] { 1, 2 };
     when(rs.getBytes(1)).thenReturn(byteArray);
     assertThat(TYPE_HANDLER.getResult(rs, 1)).isEqualTo(new Byte[]{1, 2});
     verify(rs, never()).wasNull();
@@ -70,7 +70,7 @@ public class ByteObjectArrayTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
-    byte[] byteArray = new byte[]{1, 2};
+    byte[] byteArray = new byte[] { 1, 2 };
     when(cs.getBytes(1)).thenReturn(byteArray);
     assertThat(TYPE_HANDLER.getResult(cs, 1)).isEqualTo(new Byte[]{1, 2});
     verify(cs, never()).wasNull();

--- a/src/test/java/org/apache/ibatis/type/ClobReaderTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ClobReaderTypeHandlerTest.java
@@ -121,7 +121,6 @@ public class ClobReaderTypeHandlerTest extends BaseTypeHandlerTest {
     assertNull(TYPE_HANDLER.getResult(cs, 1));
   }
 
-
   @Test
   public void integrationTest() throws IOException {
     try (SqlSession session = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/type/TypeHandlerRegistryTest.java
+++ b/src/test/java/org/apache/ibatis/type/TypeHandlerRegistryTest.java
@@ -159,17 +159,22 @@ public class TypeHandlerRegistryTest {
 
   interface SomeInterface {
   }
+
   interface ExtendingSomeInterface extends SomeInterface {
   }
+
   interface NoTypeHandlerInterface {
   }
 
   enum SomeEnum implements SomeInterface {
   }
+
   enum ExtendingSomeEnum implements ExtendingSomeInterface {
   }
+
   enum ImplementingMultiInterfaceSomeEnum implements NoTypeHandlerInterface, ExtendingSomeInterface {
   }
+
   enum NoTypeHandlerInterfaceEnum implements NoTypeHandlerInterface {
   }
 
@@ -182,14 +187,17 @@ public class TypeHandlerRegistryTest {
     public void setNonNullParameter(PreparedStatement ps, int i, E parameter, JdbcType jdbcType)
         throws SQLException {
     }
+
     @Override
     public E getNullableResult(ResultSet rs, String columnName) throws SQLException {
       return null;
     }
+
     @Override
     public E getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
       return null;
     }
+
     @Override
     public E getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
       return null;
@@ -209,7 +217,8 @@ public class TypeHandlerRegistryTest {
 
   @Test
   public void shouldRegisterReplaceNullMap() {
-    class Address {}
+    class Address {
+    }
     assertFalse(typeHandlerRegistry.hasTypeHandler(Address.class));
     typeHandlerRegistry.register(Address.class, StringTypeHandler.class);
     assertTrue(typeHandlerRegistry.hasTypeHandler(Address.class));

--- a/src/test/java/org/apache/ibatis/type/UnknownTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/UnknownTypeHandlerTest.java
@@ -115,7 +115,7 @@ public class UnknownTypeHandlerTest extends BaseTypeHandlerTest {
 
   @Test
   public void getResultWithResultSetAndColumnNameThrowsException() throws SQLException {
-    doThrow(new SQLException("invalid column")).when((UnknownTypeHandler)TYPE_HANDLER).getNullableResult(rs, "foo");
+    doThrow(new SQLException("invalid column")).when((UnknownTypeHandler) TYPE_HANDLER).getNullableResult(rs, "foo");
     try {
       TYPE_HANDLER.getResult(rs, "foo");
       Assertions.fail("Should have thrown a ResultMapException");
@@ -127,7 +127,7 @@ public class UnknownTypeHandlerTest extends BaseTypeHandlerTest {
 
   @Test
   public void getResultWithResultSetAndColumnIndexThrowsException() throws SQLException {
-    doThrow(new SQLException("invalid column")).when((UnknownTypeHandler)TYPE_HANDLER).getNullableResult(rs, 1);
+    doThrow(new SQLException("invalid column")).when((UnknownTypeHandler) TYPE_HANDLER).getNullableResult(rs, 1);
     try {
       TYPE_HANDLER.getResult(rs, 1);
       Assertions.fail("Should have thrown a ResultMapException");
@@ -139,7 +139,7 @@ public class UnknownTypeHandlerTest extends BaseTypeHandlerTest {
 
   @Test
   public void getResultWithCallableStatementAndColumnIndexThrowsException() throws SQLException {
-    doThrow(new SQLException("invalid column")).when((UnknownTypeHandler)TYPE_HANDLER).getNullableResult(cs, 1);
+    doThrow(new SQLException("invalid column")).when((UnknownTypeHandler) TYPE_HANDLER).getNullableResult(cs, 1);
     try {
       TYPE_HANDLER.getResult(cs, 1);
       Assertions.fail("Should have thrown a ResultMapException");


### PR DESCRIPTION
Reviewing potential of formatting enforcement to make all classes comply with 2 character spacing rules.  While that is too much in one go, this is a light attempt at applying some of this on the test packages only where it's easier to read and digest the overall changes.

Note: This was originally done in 2017 and overtime some classes were dropped from the first round due to changes throughout the year.  No additional checks on formatting were done since so there is likely more to be found throughout testing.  These are all spacing related, line related, or adding missing brackets.  Ultimately this will in some way reduce some checkstyle related problems but not many.  As there was likely never a good time to merge this, upon full junit 5, the time is right given the file content is roughly the same and otherwise same impacts.