### PR TITLE
OffsetTimeTypeHandler should use setObject(), getObject()

### DIFF
--- a/src/main/java/org/apache/ibatis/type/OffsetTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/OffsetTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Time;
 import java.time.OffsetTime;
 
 /**
@@ -31,31 +30,22 @@ public class OffsetTimeTypeHandler extends BaseTypeHandler<OffsetTime> {
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, OffsetTime parameter, JdbcType jdbcType)
           throws SQLException {
-    ps.setTime(i, Time.valueOf(parameter.toLocalTime()));
+    ps.setObject(i, parameter);
   }
 
   @Override
   public OffsetTime getNullableResult(ResultSet rs, String columnName) throws SQLException {
-    Time time = rs.getTime(columnName);
-    return getOffsetTime(time);
+    return rs.getObject(columnName, OffsetTime.class);
   }
 
   @Override
   public OffsetTime getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
-    Time time = rs.getTime(columnIndex);
-    return getOffsetTime(time);
+    return rs.getObject(columnIndex, OffsetTime.class);
   }
 
   @Override
   public OffsetTime getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Time time = cs.getTime(columnIndex);
-    return getOffsetTime(time);
+    return cs.getObject(columnIndex, OffsetTime.class);
   }
 
-  private static OffsetTime getOffsetTime(Time time) {
-    if (time != null) {
-      return time.toLocalTime().atOffset(OffsetTime.now().getOffset());
-    }
-    return null;
-  }
 }

--- a/src/test/java/org/apache/ibatis/submitted/timestamp_with_timezone/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/timestamp_with_timezone/Mapper.java
@@ -20,10 +20,13 @@ import org.apache.ibatis.annotations.Select;
 
 public interface Mapper {
 
-  @Select("select id, odt from records where id = #{id}")
+  @Select("select id, odt, odt ot from records where id = #{id}")
   Record selectById(Integer id);
 
   @Insert("insert into records (id, odt) values (#{id}, #{odt})")
   int insertOffsetDateTime(Record record);
+
+  @Insert("insert into records (id, odt) values (#{id}, #{ot})")
+  int insertOffsetTime(Record record);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/timestamp_with_timezone/Record.java
+++ b/src/test/java/org/apache/ibatis/submitted/timestamp_with_timezone/Record.java
@@ -16,12 +16,15 @@
 package org.apache.ibatis.submitted.timestamp_with_timezone;
 
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 
 public class Record {
 
   private Integer id;
 
   private OffsetDateTime odt;
+
+  private OffsetTime ot;
 
   public Integer getId() {
     return id;
@@ -37,6 +40,14 @@ public class Record {
 
   public void setOdt(OffsetDateTime odt) {
     this.odt = odt;
+  }
+
+  public OffsetTime getOt() {
+    return ot;
+  }
+
+  public void setOt(OffsetTime ot) {
+    this.ot = ot;
   }
 
 }

--- a/src/test/java/org/apache/ibatis/type/OffsetTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/OffsetTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.apache.ibatis.type;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.sql.Time;
 import java.time.OffsetTime;
 
 import org.junit.jupiter.api.Test;
@@ -26,21 +25,20 @@ import org.junit.jupiter.api.Test;
 public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
 
   private static final TypeHandler<OffsetTime> TYPE_HANDLER = new OffsetTimeTypeHandler();
-  // java.sql.Time doesn't contain millis, so set nano to 0
-  private static final OffsetTime OFFSET_TIME = OffsetTime.now().withNano(0);
-  private static final Time TIME = Time.valueOf(OFFSET_TIME.toLocalTime());
+
+  private static final OffsetTime OFFSET_TIME = OffsetTime.now();
 
   @Override
   @Test
   public void shouldSetParameter() throws Exception {
     TYPE_HANDLER.setParameter(ps, 1, OFFSET_TIME, null);
-    verify(ps).setTime(1, TIME);
+    verify(ps).setObject(1, OFFSET_TIME);
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
-    when(rs.getTime("column")).thenReturn(TIME);
+    when(rs.getObject("column", OffsetTime.class)).thenReturn(OFFSET_TIME);
     assertEquals(OFFSET_TIME, TYPE_HANDLER.getResult(rs, "column"));
     verify(rs, never()).wasNull();
   }
@@ -48,7 +46,7 @@ public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    when(rs.getTime("column")).thenReturn(null);
+    when(rs.getObject("column", OffsetTime.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
     verify(rs, never()).wasNull();
   }
@@ -56,7 +54,7 @@ public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
-    when(rs.getTime(1)).thenReturn(TIME);
+    when(rs.getObject(1, OffsetTime.class)).thenReturn(OFFSET_TIME);
     assertEquals(OFFSET_TIME, TYPE_HANDLER.getResult(rs, 1));
     verify(rs, never()).wasNull();
   }
@@ -64,7 +62,7 @@ public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    when(rs.getTime(1)).thenReturn(null);
+    when(rs.getObject(1, OffsetTime.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
     verify(rs, never()).wasNull();
   }
@@ -72,7 +70,7 @@ public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
-    when(cs.getTime(1)).thenReturn(TIME);
+    when(cs.getObject(1, OffsetTime.class)).thenReturn(OFFSET_TIME);
     assertEquals(OFFSET_TIME, TYPE_HANDLER.getResult(cs, 1));
     verify(cs, never()).wasNull();
   }
@@ -80,7 +78,7 @@ public class OffsetTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    when(cs.getTime(1)).thenReturn(null);
+    when(cs.getObject(1, OffsetTime.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
     verify(cs, never()).wasNull();
   }


### PR DESCRIPTION
Related to #1081 and #1368 

Some DBs/drivers support storing and/or retrieving `java.sql.OffsetTime` in/from `TIMESTAMP WITH TIME ZONE` column via `PreparedStatement#setObject()`/`ResultSet#getObject()`.

The program that I used to test: https://gist.github.com/harawata/2d14ece14581089180da4708df0e074f

✅Supported
⚠️ Works, but caution is needed
❌Not supported (or does not work)

<table>
<thead>
<tr>
<th>DB</th>
<th>Driver</th>
<th>Column type</th>
<th>getObject</th>
<th>setObject</th>
</tr>
</thead>
<tbody>
<tr>
<td rowspan="2">HSQLDB 2.4.1</td>
<td rowspan="2">2.4.1</td>
<td>TIMESTAMP(9) WITH TIME ZONE</td>
<td>⚠️[1]</td>
<td>❌</td>
</tr>
<tr>
<td>TIME(9) WITH TIME ZONE</td>
<td>✅</td>
<td>✅</td>
</tr>
<tr>
<td rowspan="2">PostgreSQL 10.6</td>
<td rowspan="2">42.2.5</td>
<td>TIMESTAMP WITH TIME ZONE</td>
<td>❌</td>
<td>❌</td>
</tr>
<tr>
<td>TIME WITH TIME ZONE</td>
<td>❌</td>
<td>❌</td>
</tr>
<tr>
<td>Oracle 12c 12.2.0.1.0</td>
<td>12.2.0.1.0</td>
<td>TIMESTAMP WITH TIME ZONE</td>
<td>✅</td>
<td><g-emoji class="g-emoji" alias="warning" fallback-src="https://github.githubassets.com/images/icons/emoji/unicode/26a0.png">⚠️</g-emoji>[2]</td>
</tr>
<tr>
<td>MS SQL Server 2017 (Express Edition) 14.00.1000</td>
<td>7.1.4.0</td>
<td>DATETIMEOFFSET</td>
<td>✅</td>
<td>✅</td>
</tr>
<tr>
<td>H2 1.4.197</td>
<td>1.4.197</td>
<td>TIMESTAMP WITH TIME ZONE</td>
<td>❌</td>
<td>❌</td>
</tr>
<tr>
<td>Maria DB 10.3.12</td>
<td>2.3.0</td>
<td>TIMESTAMP(6) or DATETIME(6)</td>
<td>⚠️[3]</td>
<td>❌[4]</td>
</tr>
</tbody>
</table>

[1] Nanoseconds part gets lost i.e. always zero.
[2] Inserted data is incorrect. When inserting `00:00:00+03:00`, for example, the stored data will be `03:00:00+03:00`.
[3] The column does not hold offset info and system's default offset is added on retrieval. And the default timezone must be specified in GMT offset format (e.g. "GMT+09:00"). Otherwise, an SQLException will be thrown:  
> java.sql.SQLException: Cannot return an OffsetTime for a TIME field when default timezone is 'Asia/Tokyo' (only possible for time-zone offset from Greenwich/UTC, such as +02:00)

[4] An exception is thrown:
> java.lang.ClassCastException: Cannot cast java.time.ZoneRegion to java.time.ZoneOffset

<details><summary>See the full stack trace</summary>

```
java.lang.ClassCastException: Cannot cast java.time.ZoneRegion to java.time.ZoneOffset
	at java.lang.Class.cast(Class.java:3369)
	at org.mariadb.jdbc.internal.com.send.parameters.OffsetTimeParameter.<init>(OffsetTimeParameter.java:87)
	at org.mariadb.jdbc.BasePrepareStatement.setObject(BasePrepareStatement.java:1046)
	at test.OffsetTimeTest.insert(OffsetTimeTest.java:90)
	at test.OffsetTimeTest.execute(OffsetTimeTest.java:70)
	at test.OffsetTimeTest.testMariaDb(OffsetTimeTest.java:42)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:515)
	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:115)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$6(TestMethodTestDescriptor.java:171)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:72)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:167)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:114)
	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:59)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:105)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:72)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:71)
	at java.util.ArrayList.forEach(ArrayList.java:1249)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:110)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:72)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:71)
	at java.util.ArrayList.forEach(ArrayList.java:1249)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:110)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:72)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:95)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:71)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:220)
	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$6(DefaultLauncher.java:188)
	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:202)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:181)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:128)
	at org.eclipse.jdt.internal.junit5.runner.JUnit5TestReference.run(JUnit5TestReference.java:89)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:41)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:541)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:763)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:463)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:209)
```
</details>

