### PR TITLE
ZonedDateTimeTypeHandler should use setObject(), getObject()

### DIFF
--- a/src/main/java/org/apache/ibatis/type/ZonedDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ZonedDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@ import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 /**
@@ -32,31 +30,21 @@ public class ZonedDateTimeTypeHandler extends BaseTypeHandler<ZonedDateTime> {
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, ZonedDateTime parameter, JdbcType jdbcType)
           throws SQLException {
-    ps.setTimestamp(i, Timestamp.from(parameter.toInstant()));
+    ps.setObject(i, parameter);
   }
 
   @Override
   public ZonedDateTime getNullableResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName);
-    return getZonedDateTime(timestamp);
+    return rs.getObject(columnName, ZonedDateTime.class);
   }
 
   @Override
   public ZonedDateTime getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex);
-    return getZonedDateTime(timestamp);
+    return rs.getObject(columnIndex, ZonedDateTime.class);
   }
 
   @Override
   public ZonedDateTime getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp timestamp = cs.getTimestamp(columnIndex);
-    return getZonedDateTime(timestamp);
-  }
-
-  private static ZonedDateTime getZonedDateTime(Timestamp timestamp) {
-    if (timestamp != null) {
-      return ZonedDateTime.ofInstant(timestamp.toInstant(), ZoneId.systemDefault());
-    }
-    return null;
+    return cs.getObject(columnIndex, ZonedDateTime.class);
   }
 }

--- a/src/test/java/org/apache/ibatis/type/ZonedDateTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ZonedDateTimeTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.apache.ibatis.type;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.sql.Timestamp;
 import java.time.ZonedDateTime;
 
 import org.junit.jupiter.api.Test;
@@ -27,19 +26,18 @@ public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
 
   private static final TypeHandler<ZonedDateTime> TYPE_HANDLER = new ZonedDateTimeTypeHandler();
   private static final ZonedDateTime ZONED_DATE_TIME = ZonedDateTime.now();
-  private static final Timestamp TIMESTAMP = Timestamp.from(ZONED_DATE_TIME.toInstant());
 
   @Override
   @Test
   public void shouldSetParameter() throws Exception {
     TYPE_HANDLER.setParameter(ps, 1, ZONED_DATE_TIME, null);
-    verify(ps).setTimestamp(1, TIMESTAMP);
+    verify(ps).setObject(1, ZONED_DATE_TIME);
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
-    when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
+    when(rs.getObject("column", ZonedDateTime.class)).thenReturn(ZONED_DATE_TIME);
     assertEquals(ZONED_DATE_TIME, TYPE_HANDLER.getResult(rs, "column"));
     verify(rs, never()).wasNull();
   }
@@ -47,7 +45,7 @@ public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    when(rs.getTimestamp("column")).thenReturn(null);
+    when(rs.getObject("column", ZonedDateTime.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
     verify(rs, never()).wasNull();
   }
@@ -55,7 +53,7 @@ public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
-    when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
+    when(rs.getObject(1, ZonedDateTime.class)).thenReturn(ZONED_DATE_TIME);
     assertEquals(ZONED_DATE_TIME, TYPE_HANDLER.getResult(rs, 1));
     verify(rs, never()).wasNull();
   }
@@ -63,7 +61,7 @@ public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    when(rs.getTimestamp(1)).thenReturn(null);
+    when(rs.getObject(1, ZonedDateTime.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
     verify(rs, never()).wasNull();
   }
@@ -71,7 +69,7 @@ public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
-    when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
+    when(cs.getObject(1, ZonedDateTime.class)).thenReturn(ZONED_DATE_TIME);
     assertEquals(ZONED_DATE_TIME, TYPE_HANDLER.getResult(cs, 1));
     verify(cs, never()).wasNull();
   }
@@ -79,7 +77,7 @@ public class ZonedDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    when(cs.getTimestamp(1)).thenReturn(null);
+    when(cs.getObject(1, ZonedDateTime.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
     verify(cs, never()).wasNull();
   }


### PR DESCRIPTION
Related to #1081

Only Oracle supports ZonedDateTime, I think.
See the JDBC test program for how it works : https://gist.github.com/harawata/2d14ece14581089180da4708df0e074f#file-zoneddatetimetest-java

It might be possible for other DBs to support ZonedDateTime with offset ZoneId, but it does not seem to be useful very much.