### PR TITLE
[ci] Run whitespace-maven-plugin to trim excessive space

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/CacheNamespace.java
+++ b/src/main/java/org/apache/ibatis/annotations/CacheNamespace.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ public @interface CacheNamespace {
   int size() default 1024;
 
   boolean readWrite() default true;
-  
+
   boolean blocking() default false;
 
   /**
@@ -49,5 +49,5 @@ public @interface CacheNamespace {
    * @since 3.4.2
    */
   Property[] properties() default {};
-  
+
 }

--- a/src/main/java/org/apache/ibatis/annotations/Mapper.java
+++ b/src/main/java/org/apache/ibatis/annotations/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 
 /**
  * Marker interface for MyBatis mappers
- * 
+ *
  * @author Frank David Martínez
  */
 @Documented

--- a/src/main/java/org/apache/ibatis/annotations/Options.java
+++ b/src/main/java/org/apache/ibatis/annotations/Options.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -61,6 +61,6 @@ public @interface Options {
   String keyProperty() default "";
 
   String keyColumn() default "";
-  
+
   String resultSets() default "";
 }

--- a/src/main/java/org/apache/ibatis/annotations/ResultType.java
+++ b/src/main/java/org/apache/ibatis/annotations/ResultType.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * ResultHandler.  Those methods must have void return type, so
  * this annotation can be used to tell MyBatis what kind of object
  * it should build for each row.
- * 
+ *
  * @since 3.2.0
  * @author Jeff Butler
  */

--- a/src/main/java/org/apache/ibatis/binding/MapperMethod.java
+++ b/src/main/java/org/apache/ibatis/binding/MapperMethod.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ public class MapperMethod {
         throw new BindingException("Unknown execution method for: " + command.getName());
     }
     if (result == null && method.getReturnType().isPrimitive() && !method.returnsVoid()) {
-      throw new BindingException("Mapper method '" + command.getName() 
+      throw new BindingException("Mapper method '" + command.getName()
           + " attempted to return null from a method with a primitive return type (" + method.getReturnType() + ").");
     }
     return result;
@@ -121,8 +121,8 @@ public class MapperMethod {
     MappedStatement ms = sqlSession.getConfiguration().getMappedStatement(command.getName());
     if (!StatementType.CALLABLE.equals(ms.getStatementType())
         && void.class.equals(ms.getResultMaps().get(0).getType())) {
-      throw new BindingException("method " + command.getName() 
-          + " needs either a @ResultMap annotation, a @ResultType annotation," 
+      throw new BindingException("method " + command.getName()
+          + " needs either a @ResultMap annotation, a @ResultType annotation,"
           + " or a resultType attribute in XML so a ResultHandler can be used as a parameter.");
     }
     Object param = method.convertArgsToSqlCommandParam(args);

--- a/src/main/java/org/apache/ibatis/binding/MapperRegistry.java
+++ b/src/main/java/org/apache/ibatis/binding/MapperRegistry.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class MapperRegistry {
       throw new BindingException("Error getting mapper instance. Cause: " + e, e);
     }
   }
-  
+
   public <T> boolean hasMapper(Class<T> type) {
     return knownMappers.containsKey(type);
   }
@@ -104,5 +104,5 @@ public class MapperRegistry {
   public void addMappers(String packageName) {
     addMappers(packageName, Object.class);
   }
-  
+
 }

--- a/src/main/java/org/apache/ibatis/builder/ParameterExpression.java
+++ b/src/main/java/org/apache/ibatis/builder/ParameterExpression.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import java.util.HashMap;
 
 /**
  * Inline parameter expression parser. Supported grammar (simplified):
- * 
+ *
  * <pre>
  * inline-parameter = (propertyName | expression) oldJdbcType attributes
  * propertyName = /expression language's property navigation path/

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -170,7 +170,7 @@ public class MapperAnnotationBuilder {
       // #1347
       InputStream inputStream = type.getResourceAsStream("/" + xmlResource);
       if (inputStream == null) {
-        // Search XML mapper that is not in the module but in the classpath. 
+        // Search XML mapper that is not in the module but in the classpath.
         try {
           inputStream = Resources.getResourceAsStream(type.getClassLoader(), xmlResource);
         } catch (IOException e2) {
@@ -388,7 +388,7 @@ public class MapperAnnotationBuilder {
           options != null ? nullOrEmpty(options.resultSets()) : null);
     }
   }
-  
+
   private LanguageDriver getLanguageDriver(Method method) {
     Lang lang = method.getAnnotation(Lang.class);
     Class<? extends LanguageDriver> langClass = null;
@@ -570,7 +570,7 @@ public class MapperAnnotationBuilder {
       resultMappings.add(resultMapping);
     }
   }
-  
+
   private String nestedSelectId(Result result) {
     String nestedSelect = result.one().select();
     if (nestedSelect.length() < 1) {
@@ -591,12 +591,12 @@ public class MapperAnnotationBuilder {
     }
     return isLazy;
   }
-  
+
   private boolean hasNestedSelect(Result result) {
     if (result.one().select().length() > 0 && result.many().select().length() > 0) {
       throw new BuilderException("Cannot use both @One and @Many annotations in the same @Result");
     }
-    return result.one().select().length() > 0 || result.many().select().length() > 0;  
+    return result.one().select().length() > 0 || result.many().select().length() > 0;
   }
 
   private void applyConstructorArgs(Arg[] args, Class<?> resultType, List<ResultMapping> resultMappings) {

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLIncludeTransformer.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLIncludeTransformer.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -105,7 +105,7 @@ public class XMLIncludeTransformer {
   }
 
   /**
-   * Read placeholders and their values from include node definition. 
+   * Read placeholders and their values from include node definition.
    * @param node Include node instance
    * @param inheritedVariablesContext Current context used for replace variables in new variables values
    * @return variables context from include instance (no inherited values)

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
@@ -352,7 +352,7 @@ public class XMLMapperBuilder extends BaseBuilder {
       }
     }
   }
-  
+
   private boolean databaseIdMatchesCurrent(String id, String databaseId, String requiredDatabaseId) {
     if (requiredDatabaseId != null) {
       if (!requiredDatabaseId.equals(databaseId)) {

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLMapperEntityResolver.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLMapperEntityResolver.java
@@ -26,7 +26,7 @@ import org.xml.sax.SAXException;
 
 /**
  * Offline entity resolver for the MyBatis DTDs
- * 
+ *
  * @author Clinton Begin
  * @author Eduardo Macarron
  */
@@ -42,11 +42,11 @@ public class XMLMapperEntityResolver implements EntityResolver {
 
   /**
    * Converts a public DTD into a local one
-   * 
+   *
    * @param publicId The public id that is what comes after "PUBLIC"
    * @param systemId The system id that is what comes after the public id.
    * @return The InputSource for the DTD
-   * 
+   *
    * @throws org.xml.sax.SAXException If anything goes wrong
    */
   @Override

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
@@ -89,7 +89,7 @@ public class XMLStatementBuilder extends BaseBuilder {
 
     // Parse selectKey after includes and remove them.
     processSelectKeyNodes(id, parameterTypeClass, langDriver);
-    
+
     // Parse the SQL (pre: <selectKey> and <include> were parsed and removed)
     SqlSource sqlSource = langDriver.createSqlSource(configuration, context, parameterTypeClass);
     String resultSets = context.getStringAttribute("resultSets");
@@ -108,7 +108,7 @@ public class XMLStatementBuilder extends BaseBuilder {
 
     builderAssistant.addMappedStatement(id, sqlSource, statementType, sqlCommandType,
         fetchSize, timeout, parameterMap, parameterTypeClass, resultMap, resultTypeClass,
-        resultSetTypeEnum, flushCache, useCache, resultOrdered, 
+        resultSetTypeEnum, flushCache, useCache, resultOrdered,
         keyGenerator, keyProperty, keyColumn, databaseId, langDriver, resultSets);
   }
 

--- a/src/main/java/org/apache/ibatis/cache/Cache.java
+++ b/src/main/java/org/apache/ibatis/cache/Cache.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,13 +19,13 @@ import java.util.concurrent.locks.ReadWriteLock;
 
 /**
  * SPI for cache providers.
- * 
+ *
  * One instance of cache will be created for each namespace.
- * 
+ *
  * The cache implementation must have a constructor that receives the cache id as an String parameter.
- * 
+ *
  * MyBatis will pass the namespace as id to the constructor.
- * 
+ *
  * <pre>
  * public MyCache(final String id) {
  *  if (id == null) {
@@ -59,16 +59,16 @@ public interface Cache {
   Object getObject(Object key);
 
   /**
-   * As of 3.3.0 this method is only called during a rollback 
+   * As of 3.3.0 this method is only called during a rollback
    * for any previous value that was missing in the cache.
-   * This lets any blocking cache to release the lock that 
+   * This lets any blocking cache to release the lock that
    * may have previously put on the key.
-   * A blocking cache puts a lock when a value is null 
+   * A blocking cache puts a lock when a value is null
    * and releases it when the value is back again.
-   * This way other threads will wait for the value to be 
+   * This way other threads will wait for the value to be
    * available instead of hitting the database.
    *
-   * 
+   *
    * @param key The key
    * @return Not used
    */
@@ -76,22 +76,22 @@ public interface Cache {
 
   /**
    * Clears this cache instance
-   */  
+   */
   void clear();
 
   /**
    * Optional. This method is not called by the core.
-   * 
+   *
    * @return The number of elements stored in the cache (not its capacity).
    */
   int getSize();
-  
-  /** 
+
+  /**
    * Optional. As of 3.2.6 this method is no longer called by the core.
-   *  
+   *
    * Any locking needed by the cache must be provided internally by the cache provider.
-   * 
-   * @return A ReadWriteLock 
+   *
+   * @return A ReadWriteLock
    */
   ReadWriteLock getReadWriteLock();
 

--- a/src/main/java/org/apache/ibatis/cache/CacheKey.java
+++ b/src/main/java/org/apache/ibatis/cache/CacheKey.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public class CacheKey implements Cloneable, Serializable {
   }
 
   public void update(Object object) {
-    int baseHashCode = object == null ? 1 : ArrayUtil.hashCode(object); 
+    int baseHashCode = object == null ? 1 : ArrayUtil.hashCode(object);
 
     count++;
     checksum += baseHashCode;

--- a/src/main/java/org/apache/ibatis/cache/TransactionalCacheManager.java
+++ b/src/main/java/org/apache/ibatis/cache/TransactionalCacheManager.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class TransactionalCacheManager {
   public Object getObject(Cache cache, CacheKey key) {
     return getTransactionalCache(cache).getObject(key);
   }
-  
+
   public void putObject(Cache cache, CacheKey key, Object value) {
     getTransactionalCache(cache).putObject(key, value);
   }

--- a/src/main/java/org/apache/ibatis/cache/decorators/SerializedCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/SerializedCache.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ public class SerializedCache implements Cache {
     protected Class<?> resolveClass(ObjectStreamClass desc) throws ClassNotFoundException {
       return Resources.classForName(desc.getName());
     }
-    
+
   }
 
 }

--- a/src/main/java/org/apache/ibatis/cache/decorators/SoftCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/SoftCache.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@ public class SoftCache implements Cache {
       if (result == null) {
         delegate.removeObject(key);
       } else {
-        // See #586 (and #335) modifications need more than a read lock 
+        // See #586 (and #335) modifications need more than a read lock
         synchronized (hardLinksToAvoidGarbageCollection) {
           hardLinksToAvoidGarbageCollection.addFirst(result);
           if (hardLinksToAvoidGarbageCollection.size() > numberOfHardLinks) {

--- a/src/main/java/org/apache/ibatis/cache/decorators/SynchronizedCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/SynchronizedCache.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.apache.ibatis.cache.Cache;
 public class SynchronizedCache implements Cache {
 
   private final Cache delegate;
-  
+
   public SynchronizedCache(Cache delegate) {
     this.delegate = delegate;
   }

--- a/src/main/java/org/apache/ibatis/cache/decorators/TransactionalCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/TransactionalCache.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,12 +27,12 @@ import org.apache.ibatis.logging.LogFactory;
 
 /**
  * The 2nd level cache transactional buffer.
- * 
+ *
  * This class holds all cache entries that are to be added to the 2nd level cache during a Session.
- * Entries are sent to the cache when commit is called or discarded if the Session is rolled back. 
- * Blocking cache support has been added. Therefore any get() that returns a cache miss 
- * will be followed by a put() so any lock associated with the key can be released. 
- * 
+ * Entries are sent to the cache when commit is called or discarded if the Session is rolled back.
+ * Blocking cache support has been added. Therefore any get() that returns a cache miss
+ * will be followed by a put() so any lock associated with the key can be released.
+ *
  * @author Clinton Begin
  * @author Eduardo Macarron
  */

--- a/src/main/java/org/apache/ibatis/cache/decorators/WeakCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/WeakCache.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import org.apache.ibatis.cache.Cache;
 /**
  * Weak Reference cache decorator.
  * Thanks to Dr. Heinz Kabutz for his guidance here.
- * 
+ *
  * @author Clinton Begin
  */
 public class WeakCache implements Cache {

--- a/src/main/java/org/apache/ibatis/datasource/pooled/PooledConnection.java
+++ b/src/main/java/org/apache/ibatis/datasource/pooled/PooledConnection.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -246,7 +246,7 @@ class PooledConnection implements InvocationHandler {
     } catch (Throwable t) {
       throw ExceptionUtil.unwrapThrowable(t);
     }
-    
+
   }
 
   private void checkConnection() throws SQLException {

--- a/src/main/java/org/apache/ibatis/datasource/pooled/PooledDataSource.java
+++ b/src/main/java/org/apache/ibatis/datasource/pooled/PooledDataSource.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -427,7 +427,7 @@ public class PooledDataSource implements DataSource {
                      connection. At the end of this loop, bad {@link @conn} will be set as null.
                    */
                   log.debug("Bad connection. Could not roll back");
-                }  
+                }
               }
               conn = new PooledConnection(oldestActiveConnection.getRealConnection(), this);
               conn.setCreatedTimestamp(oldestActiveConnection.getCreatedTimestamp());

--- a/src/main/java/org/apache/ibatis/datasource/unpooled/UnpooledDataSource.java
+++ b/src/main/java/org/apache/ibatis/datasource/unpooled/UnpooledDataSource.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.apache.ibatis.io.Resources;
  * @author Eduardo Macarron
  */
 public class UnpooledDataSource implements DataSource {
-  
+
   private ClassLoader driverClassLoader;
   private Properties driverProperties;
   private static Map<String, Driver> registeredDrivers = new ConcurrentHashMap<>();

--- a/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -345,7 +345,7 @@ public abstract class BaseExecutor implements Executor {
   public void setExecutorWrapper(Executor wrapper) {
     this.wrapper = wrapper;
   }
-  
+
   private static class DeferredLoad {
 
     private final MetaObject resultObject;

--- a/src/main/java/org/apache/ibatis/executor/BatchExecutorException.java
+++ b/src/main/java/org/apache/ibatis/executor/BatchExecutorException.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,8 +22,8 @@ import java.util.List;
  * This exception is thrown if a <code>java.sql.BatchUpdateException</code> is caught
  * during the execution of any nested batch.  The exception contains the
  * java.sql.BatchUpdateException that is the root cause, as well as
- * the results from any prior nested batch that executed successfully.  
- * 
+ * the results from any prior nested batch that executed successfully.
+ *
  * @author Jeff Butler
  */
 public class BatchExecutorException extends ExecutorException {
@@ -33,8 +33,8 @@ public class BatchExecutorException extends ExecutorException {
   private final BatchUpdateException batchUpdateException;
   private final BatchResult batchResult;
 
-  public BatchExecutorException(String message, 
-                                BatchUpdateException cause, 
+  public BatchExecutorException(String message,
+                                BatchUpdateException cause,
                                 List<BatchResult> successfulBatchResults,
                                 BatchResult batchResult) {
     super(message + " Cause: " + cause, cause);

--- a/src/main/java/org/apache/ibatis/executor/CachingExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/CachingExecutor.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class CachingExecutor implements Executor {
   public void close(boolean forceRollback) {
     try {
       //issues #499, #524 and #573
-      if (forceRollback) { 
+      if (forceRollback) {
         tcm.rollback();
       } else {
         tcm.commit();
@@ -163,7 +163,7 @@ public class CachingExecutor implements Executor {
 
   private void flushCacheIfRequired(MappedStatement ms) {
     Cache cache = ms.getCache();
-    if (cache != null && ms.isFlushCacheRequired()) {      
+    if (cache != null && ms.isFlushCacheRequired()) {
       tcm.clear(cache);
     }
   }

--- a/src/main/java/org/apache/ibatis/executor/keygen/SelectKeyGenerator.java
+++ b/src/main/java/org/apache/ibatis/executor/keygen/SelectKeyGenerator.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.apache.ibatis.session.RowBounds;
  * @author Jeff Butler
  */
 public class SelectKeyGenerator implements KeyGenerator {
-  
+
   public static final String SELECT_KEY_SUFFIX = "!selectKey";
   private final boolean executeBefore;
   private final MappedStatement keyStatement;
@@ -67,7 +67,7 @@ public class SelectKeyGenerator implements KeyGenerator {
           Executor keyExecutor = configuration.newExecutor(executor.getTransaction(), ExecutorType.SIMPLE);
           List<Object> values = keyExecutor.query(keyStatement, parameter, RowBounds.DEFAULT, Executor.NO_RESULT_HANDLER);
           if (values.size() == 0) {
-            throw new ExecutorException("SelectKey returned no data.");            
+            throw new ExecutorException("SelectKey returned no data.");
           } else if (values.size() > 1) {
             throw new ExecutorException("SelectKey returned more than one value.");
           } else {
@@ -96,7 +96,7 @@ public class SelectKeyGenerator implements KeyGenerator {
   private void handleMultipleProperties(String[] keyProperties,
       MetaObject metaParam, MetaObject metaResult) {
     String[] keyColumns = keyStatement.getKeyColumns();
-      
+
     if (keyColumns == null || keyColumns.length == 0) {
       // no key columns specified, just use the property names
       for (String keyProperty : keyProperties) {

--- a/src/main/java/org/apache/ibatis/executor/loader/ProxyFactory.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/ProxyFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,5 +29,5 @@ public interface ProxyFactory {
   void setProperties(Properties properties);
 
   Object createProxy(Object target, ResultLoaderMap lazyLoader, Configuration configuration, ObjectFactory objectFactory, List<Class<?>> constructorArgTypes, List<Object> constructorArgs);
-  
+
 }

--- a/src/main/java/org/apache/ibatis/executor/loader/ResultLoader.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/ResultLoader.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -49,10 +49,10 @@ public class ResultLoader {
   protected final BoundSql boundSql;
   protected final ResultExtractor resultExtractor;
   protected final long creatorThreadId;
-  
+
   protected boolean loaded;
   protected Object resultObject;
-  
+
   public ResultLoader(Configuration config, Executor executor, MappedStatement mappedStatement, Object parameterObject, Class<?> targetType, CacheKey cacheKey, BoundSql boundSql) {
     this.configuration = config;
     this.executor = executor;

--- a/src/main/java/org/apache/ibatis/executor/resultset/ResultSetWrapper.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/ResultSetWrapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -91,7 +91,7 @@ public class ResultSetWrapper {
    * Gets the type handler to use when reading the result set.
    * Tries to get from the TypeHandlerRegistry by searching for the property type.
    * If not found it gets the column JDBC type and tries to get a handler for it.
-   * 
+   *
    * @param propertyType
    * @param columnName
    * @return
@@ -190,5 +190,5 @@ public class ResultSetWrapper {
     }
     return prefixed;
   }
-  
+
 }

--- a/src/main/java/org/apache/ibatis/io/ClassLoaderWrapper.java
+++ b/src/main/java/org/apache/ibatis/io/ClassLoaderWrapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@ public class ClassLoaderWrapper {
     try {
       systemClassLoader = ClassLoader.getSystemClassLoader();
     } catch (SecurityException ignored) {
-      // AccessControlException on Google App Engine   
+      // AccessControlException on Google App Engine
     }
   }
-  
+
   /**
    * Get a resource as a URL using the current class path
    *

--- a/src/main/java/org/apache/ibatis/io/DefaultVFS.java
+++ b/src/main/java/org/apache/ibatis/io/DefaultVFS.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.apache.ibatis.logging.LogFactory;
 
 /**
  * A default implementation of {@link VFS} that works for most application servers.
- * 
+ *
  * @author Ben Gunter
  */
 public class DefaultVFS extends VFS {
@@ -169,7 +169,7 @@ public class DefaultVFS extends VFS {
   /**
    * List the names of the entries in the given {@link JarInputStream} that begin with the
    * specified {@code path}. Entries will match with or without a leading slash.
-   * 
+   *
    * @param jar The JAR input stream
    * @param path The leading path to match
    * @return The names of all the matching entries
@@ -212,7 +212,7 @@ public class DefaultVFS extends VFS {
    * by the URL. That is, assuming the URL references a JAR entry, this method will return a URL
    * that references the JAR file containing the entry. If the JAR cannot be located, then this
    * method returns null.
-   * 
+   *
    * @param url The URL of the JAR entry.
    * @return The URL of the JAR file, if one is found. Null if not.
    * @throws MalformedURLException
@@ -296,7 +296,7 @@ public class DefaultVFS extends VFS {
   /**
    * Converts a Java package name to a path that can be looked up with a call to
    * {@link ClassLoader#getResources(String)}.
-   * 
+   *
    * @param packageName The Java package name to convert to a path
    */
   protected String getPackagePath(String packageName) {
@@ -305,7 +305,7 @@ public class DefaultVFS extends VFS {
 
   /**
    * Returns true if the resource located at the given URL is a JAR file.
-   * 
+   *
    * @param url The URL of the resource to test.
    */
   protected boolean isJar(URL url) {
@@ -314,7 +314,7 @@ public class DefaultVFS extends VFS {
 
   /**
    * Returns true if the resource located at the given URL is a JAR file.
-   * 
+   *
    * @param url The URL of the resource to test.
    * @param buffer A buffer into which the first few bytes of the resource are read. The buffer
    *            must be at least the size of {@link #JAR_MAGIC}. (The same buffer may be reused

--- a/src/main/java/org/apache/ibatis/io/JBoss6VFS.java
+++ b/src/main/java/org/apache/ibatis/io/JBoss6VFS.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.apache.ibatis.logging.LogFactory;
 
 /**
  * A {@link VFS} implementation that works with the VFS API provided by JBoss 6.
- * 
+ *
  * @author Ben Gunter
  */
 public class JBoss6VFS extends VFS {
@@ -109,7 +109,7 @@ public class JBoss6VFS extends VFS {
   /**
    * Verifies that the provided object reference is null. If it is null, then this VFS is marked
    * as invalid for the current environment.
-   * 
+   *
    * @param object The object reference to check for null.
    */
   protected static <T> T checkNotNull(T object) {
@@ -122,7 +122,7 @@ public class JBoss6VFS extends VFS {
   /**
    * Verifies that the return type of a method is what it is expected to be. If it is not, then
    * this VFS is marked as invalid for the current environment.
-   * 
+   *
    * @param method The method whose return type is to be checked.
    * @param expected A type to which the method's return type must be assignable.
    * @see Class#isAssignableFrom(Class)

--- a/src/main/java/org/apache/ibatis/io/ResolverUtil.java
+++ b/src/main/java/org/apache/ibatis/io/ResolverUtil.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -233,7 +233,7 @@ public class ResolverUtil<T> {
   /**
    * Converts a Java package name to a path that can be looked up with a call to
    * {@link ClassLoader#getResources(String)}.
-   * 
+   *
    * @param packageName The Java package name to convert to a path
    */
   protected String getPackagePath(String packageName) {

--- a/src/main/java/org/apache/ibatis/io/VFS.java
+++ b/src/main/java/org/apache/ibatis/io/VFS.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.logging.LogFactory;
 
 /**
  * Provides a very simple API for accessing resources within an application server.
- * 
+ *
  * @author Ben Gunter
  */
 public abstract class VFS {
@@ -92,7 +92,7 @@ public abstract class VFS {
   /**
    * Adds the specified class to the list of {@link VFS} implementations. Classes added in this
    * manner are tried in the order they are added and before any of the built-in implementations.
-   * 
+   *
    * @param clazz The {@link VFS} implementation class to add.
    */
   public static void addImplClass(Class<? extends VFS> clazz) {
@@ -116,7 +116,7 @@ public abstract class VFS {
 
   /**
    * Get a method by name and parameter types. If the method is not found then return null.
-   * 
+   *
    * @param clazz The class to which the method belongs.
    * @param methodName The name of the method.
    * @param parameterTypes The types of the parameters accepted by the method.
@@ -138,7 +138,7 @@ public abstract class VFS {
 
   /**
    * Invoke a method on an object and return whatever it returns.
-   * 
+   *
    * @param method The method to invoke.
    * @param object The instance or class (for static methods) on which to invoke the method.
    * @param parameters The parameters to pass to the method.
@@ -165,7 +165,7 @@ public abstract class VFS {
   /**
    * Get a list of {@link URL}s from the context classloader for all the resources found at the
    * specified path.
-   * 
+   *
    * @param path The resource path.
    * @return A list of {@link URL}s, as returned by {@link ClassLoader#getResources(String)}.
    * @throws IOException If I/O errors occur
@@ -180,7 +180,7 @@ public abstract class VFS {
   /**
    * Recursively list the full resource path of all the resources that are children of the
    * resource identified by a URL.
-   * 
+   *
    * @param url The URL that identifies the resource to list.
    * @param forPath The path to the resource that is identified by the URL. Generally, this is the
    *            value passed to {@link #getResources(String)} to get the resource URL.
@@ -192,7 +192,7 @@ public abstract class VFS {
   /**
    * Recursively list the full resource path of all the resources that are children of all the
    * resources found at the specified path.
-   * 
+   *
    * @param path The path of the resource(s) to list.
    * @return A list containing the names of the child resources.
    * @throws IOException If I/O errors occur

--- a/src/main/java/org/apache/ibatis/jdbc/SelectBuilder.java
+++ b/src/main/java/org/apache/ibatis/jdbc/SelectBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.apache.ibatis.jdbc;
 
 /**
  * @deprecated Use the {@link SQL} Class
- * 
+ *
  * @author Clinton Begin
  */
 @Deprecated

--- a/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.apache.ibatis.reflection.ArrayUtil;
 
 /**
  * Base class for proxies to do logging
- * 
+ *
  * @author Clinton Begin
  * @author Eduardo Macarron
  */

--- a/src/main/java/org/apache/ibatis/logging/jdbc/ConnectionLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/ConnectionLogger.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,10 +27,10 @@ import org.apache.ibatis.reflection.ExceptionUtil;
 
 /**
  * Connection proxy to add logging
- * 
+ *
  * @author Clinton Begin
  * @author Eduardo Macarron
- * 
+ *
  */
 public final class ConnectionLogger extends BaseJdbcLogger implements InvocationHandler {
 
@@ -47,18 +47,18 @@ public final class ConnectionLogger extends BaseJdbcLogger implements Invocation
     try {
       if (Object.class.equals(method.getDeclaringClass())) {
         return method.invoke(this, params);
-      }    
+      }
       if ("prepareStatement".equals(method.getName())) {
         if (isDebugEnabled()) {
           debug(" Preparing: " + removeBreakingWhitespace((String) params[0]), true);
-        }        
+        }
         PreparedStatement stmt = (PreparedStatement) method.invoke(connection, params);
         stmt = PreparedStatementLogger.newInstance(stmt, statementLog, queryStack);
         return stmt;
       } else if ("prepareCall".equals(method.getName())) {
         if (isDebugEnabled()) {
           debug(" Preparing: " + removeBreakingWhitespace((String) params[0]), true);
-        }        
+        }
         PreparedStatement stmt = (PreparedStatement) method.invoke(connection, params);
         stmt = PreparedStatementLogger.newInstance(stmt, statementLog, queryStack);
         return stmt;

--- a/src/main/java/org/apache/ibatis/logging/jdbc/PreparedStatementLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/PreparedStatementLogger.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,10 +27,10 @@ import org.apache.ibatis.reflection.ExceptionUtil;
 
 /**
  * PreparedStatement proxy to add logging
- * 
+ *
  * @author Clinton Begin
  * @author Eduardo Macarron
- * 
+ *
  */
 public final class PreparedStatementLogger extends BaseJdbcLogger implements InvocationHandler {
 
@@ -46,7 +46,7 @@ public final class PreparedStatementLogger extends BaseJdbcLogger implements Inv
     try {
       if (Object.class.equals(method.getDeclaringClass())) {
         return method.invoke(this, params);
-      }          
+      }
       if (EXECUTE_METHODS.contains(method.getName())) {
         if (isDebugEnabled()) {
           debug("Parameters: " + getParameterValueString(), true);

--- a/src/main/java/org/apache/ibatis/logging/jdbc/ResultSetLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/ResultSetLogger.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,10 +30,10 @@ import org.apache.ibatis.reflection.ExceptionUtil;
 
 /**
  * ResultSet proxy to add logging
- * 
+ *
  * @author Clinton Begin
  * @author Eduardo Macarron
- * 
+ *
  */
 public final class ResultSetLogger extends BaseJdbcLogger implements InvocationHandler {
 
@@ -53,7 +53,7 @@ public final class ResultSetLogger extends BaseJdbcLogger implements InvocationH
     BLOB_TYPES.add(Types.NCLOB);
     BLOB_TYPES.add(Types.VARBINARY);
   }
-  
+
   private ResultSetLogger(ResultSet rs, Log statementLog, int queryStack) {
     super(statementLog, queryStack);
     this.rs = rs;
@@ -64,7 +64,7 @@ public final class ResultSetLogger extends BaseJdbcLogger implements InvocationH
     try {
       if (Object.class.equals(method.getDeclaringClass())) {
         return method.invoke(this, params);
-      }    
+      }
       Object o = method.invoke(rs, params);
       if ("next".equals(method.getName())) {
         if ((Boolean) o) {

--- a/src/main/java/org/apache/ibatis/logging/jdbc/StatementLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/StatementLogger.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,10 +26,10 @@ import org.apache.ibatis.reflection.ExceptionUtil;
 
 /**
  * Statement proxy to add logging
- * 
+ *
  * @author Clinton Begin
  * @author Eduardo Macarron
- * 
+ *
  */
 public final class StatementLogger extends BaseJdbcLogger implements InvocationHandler {
 
@@ -45,7 +45,7 @@ public final class StatementLogger extends BaseJdbcLogger implements InvocationH
     try {
       if (Object.class.equals(method.getDeclaringClass())) {
         return method.invoke(this, params);
-      }    
+      }
       if (EXECUTE_METHODS.contains(method.getName())) {
         if (isDebugEnabled()) {
           debug(" Executing: " + removeBreakingWhitespace((String) params[0]), true);

--- a/src/main/java/org/apache/ibatis/logging/log4j/Log4jImpl.java
+++ b/src/main/java/org/apache/ibatis/logging/log4j/Log4jImpl.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import org.apache.log4j.Logger;
  * @author Eduardo Macarron
  */
 public class Log4jImpl implements Log {
-  
+
   private static final String FQCN = Log4jImpl.class.getName();
 
   private final Logger log;

--- a/src/main/java/org/apache/ibatis/logging/log4j2/Log4j2LoggerImpl.java
+++ b/src/main/java/org/apache/ibatis/logging/log4j2/Log4j2LoggerImpl.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.MarkerManager;
  * @author Eduardo Macarron
  */
 public class Log4j2LoggerImpl implements Log {
-  
+
   private static final Marker MARKER = MarkerManager.getMarker(LogFactory.MARKER);
 
   private final Logger log;

--- a/src/main/java/org/apache/ibatis/logging/slf4j/Slf4jLocationAwareLoggerImpl.java
+++ b/src/main/java/org/apache/ibatis/logging/slf4j/Slf4jLocationAwareLoggerImpl.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.slf4j.spi.LocationAwareLogger;
  * @author Eduardo Macarron
  */
 class Slf4jLocationAwareLoggerImpl implements Log {
-  
+
   private static final Marker MARKER = MarkerFactory.getMarker(LogFactory.MARKER);
 
   private static final String FQCN = Slf4jImpl.class.getName();

--- a/src/main/java/org/apache/ibatis/mapping/BoundSql.java
+++ b/src/main/java/org/apache/ibatis/mapping/BoundSql.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import org.apache.ibatis.session.Configuration;
 
 /**
  * An actual SQL String got from an {@link SqlSource} after having processed any dynamic content.
- * The SQL may have SQL placeholders "?" and an list (ordered) of an parameter mappings 
- * with the additional information for each parameter (at least the property name of the input object to read 
+ * The SQL may have SQL placeholders "?" and an list (ordered) of an parameter mappings
+ * with the additional information for each parameter (at least the property name of the input object to read
  * the value from).
  * <p>
  * Can also have additional parameters that are created by the dynamic language (for loops, bind...).

--- a/src/main/java/org/apache/ibatis/mapping/CacheBuilder.java
+++ b/src/main/java/org/apache/ibatis/mapping/CacheBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -83,7 +83,7 @@ public class CacheBuilder {
     this.blocking = blocking;
     return this;
   }
-  
+
   public CacheBuilder properties(Properties properties) {
     this.properties = properties;
     return this;

--- a/src/main/java/org/apache/ibatis/mapping/DatabaseIdProvider.java
+++ b/src/main/java/org/apache/ibatis/mapping/DatabaseIdProvider.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import javax.sql.DataSource;
  * Should return an id to identify the type of this database.
  * That id can be used later on to build different queries for each database type
  * This mechanism enables supporting multiple vendors or versions
- * 
+ *
  * @author Eduardo Macarron
  */
 public interface DatabaseIdProvider {

--- a/src/main/java/org/apache/ibatis/mapping/MappedStatement.java
+++ b/src/main/java/org/apache/ibatis/mapping/MappedStatement.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -180,7 +180,7 @@ public final class MappedStatement {
       mappedStatement.resultSets = delimitedStringToArray(resultSet);
       return this;
     }
-    
+
     public MappedStatement build() {
       assert mappedStatement.configuration != null;
       assert mappedStatement.id != null;
@@ -288,7 +288,7 @@ public final class MappedStatement {
   public String[] getResulSets() {
     return resultSets;
   }
-  
+
   public BoundSql getBoundSql(Object parameterObject) {
     BoundSql boundSql = sqlSource.getBoundSql(parameterObject);
     List<ParameterMapping> parameterMappings = boundSql.getParameterMappings();

--- a/src/main/java/org/apache/ibatis/mapping/ParameterMapping.java
+++ b/src/main/java/org/apache/ibatis/mapping/ParameterMapping.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -107,13 +107,13 @@ public class ParameterMapping {
 
     private void validate() {
       if (ResultSet.class.equals(parameterMapping.javaType)) {
-        if (parameterMapping.resultMapId == null) { 
-          throw new IllegalStateException("Missing resultmap in property '"  
-              + parameterMapping.property + "'.  " 
+        if (parameterMapping.resultMapId == null) {
+          throw new IllegalStateException("Missing resultmap in property '"
+              + parameterMapping.property + "'.  "
               + "Parameters of type java.sql.ResultSet require a resultmap.");
-        }            
+        }
       } else {
-        if (parameterMapping.typeHandler == null) { 
+        if (parameterMapping.typeHandler == null) {
           throw new IllegalStateException("Type handler was null on parameter mapping for property '"
             + parameterMapping.property + "'. It was either not specified and/or could not be found for the javaType ("
             + parameterMapping.javaType.getName() + ") : jdbcType (" + parameterMapping.jdbcType + ") combination.");

--- a/src/main/java/org/apache/ibatis/mapping/ResultMap.java
+++ b/src/main/java/org/apache/ibatis/mapping/ResultMap.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -253,7 +253,7 @@ public class ResultMap {
   public void forceNestedResultMaps() {
     hasNestedResultMaps = true;
   }
-  
+
   public Boolean getAutoMapping() {
     return autoMapping;
   }

--- a/src/main/java/org/apache/ibatis/mapping/ResultMapping.java
+++ b/src/main/java/org/apache/ibatis/mapping/ResultMapping.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -131,7 +131,7 @@ public class ResultMapping {
       resultMapping.lazy = lazy;
       return this;
     }
-    
+
     public ResultMapping build() {
       // lock down collections
       resultMapping.flags = Collections.unmodifiableList(resultMapping.flags);
@@ -168,7 +168,7 @@ public class ResultMapping {
         }
       }
     }
-    
+
     private void resolveTypeHandler() {
       if (resultMapping.typeHandler == null && resultMapping.javaType != null) {
         Configuration configuration = resultMapping.configuration;
@@ -250,7 +250,7 @@ public class ResultMapping {
   public void setLazy(boolean lazy) {
     this.lazy = lazy;
   }
-  
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/src/main/java/org/apache/ibatis/mapping/SqlSource.java
+++ b/src/main/java/org/apache/ibatis/mapping/SqlSource.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.apache.ibatis.mapping;
 
 /**
- * Represents the content of a mapped statement read from an XML file or an annotation. 
+ * Represents the content of a mapped statement read from an XML file or an annotation.
  * It creates the SQL that will be passed to the database out of the input parameter received from the user.
  *
  * @author Clinton Begin

--- a/src/main/java/org/apache/ibatis/mapping/VendorDatabaseIdProvider.java
+++ b/src/main/java/org/apache/ibatis/mapping/VendorDatabaseIdProvider.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,17 +28,17 @@ import org.apache.ibatis.logging.LogFactory;
 
 /**
  * Vendor DatabaseId provider
- * 
+ *
  * It returns database product name as a databaseId
  * If the user provides a properties it uses it to translate database product name
- * key="Microsoft SQL Server", value="ms" will return "ms" 
- * It can return null, if no database product name or 
- * a properties was specified and no translation was found 
- * 
+ * key="Microsoft SQL Server", value="ms" will return "ms"
+ * It can return null, if no database product name or
+ * a properties was specified and no translation was found
+ *
  * @author Eduardo Macarron
  */
 public class VendorDatabaseIdProvider implements DatabaseIdProvider {
-  
+
   private Properties properties;
 
   @Override

--- a/src/main/java/org/apache/ibatis/plugin/InterceptorChain.java
+++ b/src/main/java/org/apache/ibatis/plugin/InterceptorChain.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class InterceptorChain {
   public void addInterceptor(Interceptor interceptor) {
     interceptors.add(interceptor);
   }
-  
+
   public List<Interceptor> getInterceptors() {
     return Collections.unmodifiableList(interceptors);
   }

--- a/src/main/java/org/apache/ibatis/plugin/Plugin.java
+++ b/src/main/java/org/apache/ibatis/plugin/Plugin.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public class Plugin implements InvocationHandler {
     Intercepts interceptsAnnotation = interceptor.getClass().getAnnotation(Intercepts.class);
     // issue #251
     if (interceptsAnnotation == null) {
-      throw new PluginException("No @Intercepts annotation was found in interceptor " + interceptor.getClass().getName());      
+      throw new PluginException("No @Intercepts annotation was found in interceptor " + interceptor.getClass().getName());
     }
     Signature[] sigs = interceptsAnnotation.value();
     Map<Class<?>, Set<Method>> signatureMap = new HashMap<>();

--- a/src/main/java/org/apache/ibatis/reflection/ArrayUtil.java
+++ b/src/main/java/org/apache/ibatis/reflection/ArrayUtil.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.apache.ibatis.reflection;
 
 import java.util.Arrays;
@@ -25,7 +24,7 @@ public class ArrayUtil {
 
   /**
    * Returns a hash code for {@code obj}.
-   * 
+   *
    * @param obj
    *          The object to get a hash code for. May be an array or <code>null</code>.
    * @return A hash code of {@code obj} or 0 if {@code obj} is <code>null</code>
@@ -70,7 +69,7 @@ public class ArrayUtil {
    * <li>{@code thisObj} and {@code thatObj} are arrays with the same component type and
    * equals() method of {@link Arrays} returns <code>true</code> (not deepEquals())</li>
    * </ul>
-   * 
+   *
    * @param thisObj
    *          The left hand object to compare. May be an array or <code>null</code>
    * @param thatObj
@@ -115,7 +114,7 @@ public class ArrayUtil {
   /**
    * If the {@code obj} is an array, toString() method of {@link Arrays} is called. Otherwise
    * {@link Object#toString()} is called. Returns "null" if {@code obj} is <code>null</code>.
-   * 
+   *
    * @param obj
    *          An object. May be an array or <code>null</code>.
    * @return String representation of the {@code obj}.

--- a/src/main/java/org/apache/ibatis/reflection/factory/ObjectFactory.java
+++ b/src/main/java/org/apache/ibatis/reflection/factory/ObjectFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.util.Properties;
 
 /**
  * MyBatis uses an ObjectFactory to create all needed new Objects.
- * 
+ *
  * @author Clinton Begin
  */
 public interface ObjectFactory {
@@ -32,7 +32,7 @@ public interface ObjectFactory {
   void setProperties(Properties properties);
 
   /**
-   * Creates a new object with default constructor. 
+   * Creates a new object with default constructor.
    * @param type Object type
    * @return
    */
@@ -46,11 +46,11 @@ public interface ObjectFactory {
    * @return
    */
   <T> T create(Class<T> type, List<Class<?>> constructorArgTypes, List<Object> constructorArgs);
-  
+
   /**
    * Returns true if this object can have a set of other objects.
    * It's main purpose is to support non-java.util.Collection objects like Scala collections.
-   * 
+   *
    * @param type Object type
    * @return whether it is a collection or not
    * @since 3.1.0

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/ObjectWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/ObjectWrapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,11 +45,11 @@ public interface ObjectWrapper {
   boolean hasGetter(String name);
 
   MetaObject instantiatePropertyValue(String name, PropertyTokenizer prop, ObjectFactory objectFactory);
-  
+
   boolean isCollection();
-  
+
   void add(Object element);
-  
+
   <E> void addAll(List<E> element);
 
 }

--- a/src/main/java/org/apache/ibatis/scripting/LanguageDriver.java
+++ b/src/main/java/org/apache/ibatis/scripting/LanguageDriver.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,9 +27,9 @@ public interface LanguageDriver {
 
   /**
    * Creates a {@link ParameterHandler} that passes the actual parameters to the the JDBC statement.
-   * 
+   *
    * @param mappedStatement The mapped statement that is being executed
-   * @param parameterObject The input parameter object (can be null) 
+   * @param parameterObject The input parameter object (can be null)
    * @param boundSql The resulting SQL once the dynamic language has been executed.
    * @return
    * @author Frank D. Martinez [mnesarco]
@@ -38,9 +38,9 @@ public interface LanguageDriver {
   ParameterHandler createParameterHandler(MappedStatement mappedStatement, Object parameterObject, BoundSql boundSql);
 
   /**
-   * Creates an {@link SqlSource} that will hold the statement read from a mapper xml file. 
+   * Creates an {@link SqlSource} that will hold the statement read from a mapper xml file.
    * It is called during startup, when the mapped statement is read from a class or an xml file.
-   * 
+   *
    * @param configuration The MyBatis configuration
    * @param script XNode parsed from a XML file
    * @param parameterType input parameter type got from a mapper method or specified in the parameterType xml attribute. Can be null.
@@ -51,11 +51,11 @@ public interface LanguageDriver {
   /**
    * Creates an {@link SqlSource} that will hold the statement read from an annotation.
    * It is called during startup, when the mapped statement is read from a class or an xml file.
-   * 
+   *
    * @param configuration The MyBatis configuration
    * @param script The content of the annotation
    * @param parameterType input parameter type got from a mapper method or specified in the parameterType xml attribute. Can be null.
-   * @return 
+   * @return
    */
   SqlSource createSqlSource(Configuration configuration, String script, Class<?> parameterType);
 

--- a/src/main/java/org/apache/ibatis/scripting/LanguageDriverRegistry.java
+++ b/src/main/java/org/apache/ibatis/scripting/LanguageDriverRegistry.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public class LanguageDriverRegistry {
       LANGUAGE_DRIVER_MAP.put(cls, instance);
     }
   }
-  
+
   public LanguageDriver getDriver(Class<? extends LanguageDriver> cls) {
     return LANGUAGE_DRIVER_MAP.get(cls);
   }

--- a/src/main/java/org/apache/ibatis/scripting/defaults/RawLanguageDriver.java
+++ b/src/main/java/org/apache/ibatis/scripting/defaults/RawLanguageDriver.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.apache.ibatis.session.Configuration;
  * As of 3.2.4 the default XML language is able to identify static statements
  * and create a {@link RawSqlSource}. So there is no need to use RAW unless you
  * want to make sure that there is not any dynamic tag for any reason.
- * 
+ *
  * @since 3.2.0
  * @author Eduardo Macarron
  */

--- a/src/main/java/org/apache/ibatis/scripting/defaults/RawSqlSource.java
+++ b/src/main/java/org/apache/ibatis/scripting/defaults/RawSqlSource.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,9 +26,9 @@ import org.apache.ibatis.scripting.xmltags.SqlNode;
 import org.apache.ibatis.session.Configuration;
 
 /**
- * Static SqlSource. It is faster than {@link DynamicSqlSource} because mappings are 
+ * Static SqlSource. It is faster than {@link DynamicSqlSource} because mappings are
  * calculated during startup.
- * 
+ *
  * @since 3.2.0
  * @author Eduardo Macarron
  */

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/ForEachSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/ForEachSqlNode.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -66,9 +66,9 @@ public class ForEachSqlNode implements SqlNode {
         context = new PrefixedContext(context, separator);
       }
       int uniqueNumber = context.getUniqueNumber();
-      // Issue #709 
+      // Issue #709
       if (o instanceof Map.Entry) {
-        @SuppressWarnings("unchecked") 
+        @SuppressWarnings("unchecked")
         Map.Entry<Object, Object> mapEntry = (Map.Entry<Object, Object>) o;
         applyIndex(context, mapEntry.getKey(), uniqueNumber);
         applyItem(context, mapEntry.getValue(), uniqueNumber);

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/OgnlClassResolver.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/OgnlClassResolver.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import org.apache.ibatis.io.Resources;
 /**
  * Custom ognl {@code ClassResolver} which behaves same like ognl's
  * {@code DefaultClassResolver}. But uses the {@code Resources}
- * utility class to find the target class instead of {@code Class#forName(String)}. 
+ * utility class to find the target class instead of {@code Class#forName(String)}.
  *
- * @author Daniel Guggi 
+ * @author Daniel Guggi
  *
  * @see <a href='https://github.com/mybatis/mybatis-3/issues/161'>Issue 161</a>
  */

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/TextSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/TextSqlNode.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -32,12 +32,12 @@ public class TextSqlNode implements SqlNode {
   public TextSqlNode(String text) {
     this(text, null);
   }
-  
+
   public TextSqlNode(String text, Pattern injectionFilter) {
     this.text = text;
     this.injectionFilter = injectionFilter;
   }
-  
+
   public boolean isDynamic() {
     DynamicCheckerTokenParser checker = new DynamicCheckerTokenParser();
     GenericTokenParser parser = createParser(checker);
@@ -51,7 +51,7 @@ public class TextSqlNode implements SqlNode {
     context.appendSql(parser.parse(text));
     return true;
   }
-  
+
   private GenericTokenParser createParser(TokenHandler handler) {
     return new GenericTokenParser("${", "}", handler);
   }
@@ -86,7 +86,7 @@ public class TextSqlNode implements SqlNode {
       }
     }
   }
-  
+
   private static class DynamicCheckerTokenParser implements TokenHandler {
 
     private boolean isDynamic;
@@ -105,5 +105,5 @@ public class TextSqlNode implements SqlNode {
       return null;
     }
   }
-  
+
 }

--- a/src/main/java/org/apache/ibatis/session/AutoMappingBehavior.java
+++ b/src/main/java/org/apache/ibatis/session/AutoMappingBehavior.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.apache.ibatis.session;
 
 /**
  * Specifies if and how MyBatis should automatically map columns to fields/properties.
- * 
+ *
  * @author Eduardo Macarron
  */
 public enum AutoMappingBehavior {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -820,7 +820,7 @@ public class Configuration {
         }
       } while (resolved);
       if (!incompleteResultMaps.isEmpty() && ex != null) {
-        // At least one result map is unresolvable. 
+        // At least one result map is unresolvable.
         throw ex;
       }
     }

--- a/src/main/java/org/apache/ibatis/session/SqlSessionFactory.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSessionFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import java.sql.Connection;
 
 /**
  * Creates an {@link SqlSession} out of a connection or a DataSource
- * 
+ *
  * @author Clinton Begin
  */
 public interface SqlSessionFactory {

--- a/src/main/java/org/apache/ibatis/session/SqlSessionFactoryBuilder.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSessionFactoryBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ public class SqlSessionFactoryBuilder {
       }
     }
   }
-    
+
   public SqlSessionFactory build(Configuration config) {
     return new DefaultSqlSessionFactory(config);
   }

--- a/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSessionFactory.java
+++ b/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSessionFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ public class DefaultSqlSessionFactory implements SqlSessionFactory {
         // Failover to true, as most poor drivers
         // or databases won't support transactions
         autoCommit = true;
-      }      
+      }
       final Environment environment = configuration.getEnvironment();
       final TransactionFactory transactionFactory = getTransactionFactoryFromEnvironment(environment);
       final Transaction tx = transactionFactory.newTransaction(connection);

--- a/src/main/java/org/apache/ibatis/transaction/Transaction.java
+++ b/src/main/java/org/apache/ibatis/transaction/Transaction.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import java.sql.SQLException;
 
 /**
  * Wraps a database connection.
- * Handles the connection lifecycle that comprises: its creation, preparation, commit/rollback and close. 
+ * Handles the connection lifecycle that comprises: its creation, preparation, commit/rollback and close.
  *
  * @author Clinton Begin
  */
@@ -56,5 +56,5 @@ public interface Transaction {
    * @throws SQLException
    */
   Integer getTimeout() throws SQLException;
-  
+
 }

--- a/src/main/java/org/apache/ibatis/transaction/TransactionFactory.java
+++ b/src/main/java/org/apache/ibatis/transaction/TransactionFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ public interface TransactionFactory {
    * @since 3.1.0
    */
   Transaction newTransaction(Connection conn);
-  
+
   /**
    * Creates a {@link Transaction} out of a datasource.
    * @param dataSource DataSource to take the connection from

--- a/src/main/java/org/apache/ibatis/transaction/jdbc/JdbcTransaction.java
+++ b/src/main/java/org/apache/ibatis/transaction/jdbc/JdbcTransaction.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -146,5 +146,5 @@ public class JdbcTransaction implements Transaction {
   public Integer getTimeout() throws SQLException {
     return null;
   }
-  
+
 }

--- a/src/main/java/org/apache/ibatis/type/BaseTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BaseTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.apache.ibatis.session.Configuration;
  * {@link CallableStatement#wasNull()} method for handling the SQL {@code NULL} value.
  * In other words, {@code null} value handling should be performed on subclass.
  * </p>
- * 
+ *
  * @author Clinton Begin
  * @author Simone Tripodi
  * @author Kzuki Shimizu

--- a/src/main/java/org/apache/ibatis/type/EnumOrdinalTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/EnumOrdinalTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -85,5 +85,5 @@ public class EnumOrdinalTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E
       }
     }
   }
-  
+
 }

--- a/src/main/java/org/apache/ibatis/type/MonthTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/MonthTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import java.time.Month;
  * @author Björn Raupach
  */
 public class MonthTypeHandler extends BaseTypeHandler<Month> {
-    
+
     @Override
     public void setNonNullParameter(PreparedStatement ps, int i, Month month, JdbcType type) throws SQLException {
         ps.setInt(i, month.getValue());
@@ -50,5 +50,5 @@ public class MonthTypeHandler extends BaseTypeHandler<Month> {
         int month = cs.getInt(columnIndex);
         return month == 0 && cs.wasNull() ? null : Month.of(month);
     }
-    
+
 }

--- a/src/main/java/org/apache/ibatis/type/SqlxmlTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/SqlxmlTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-
 package org.apache.ibatis.type;
 
 import java.sql.CallableStatement;
@@ -24,7 +23,7 @@ import java.sql.SQLXML;
 
 /**
  * Convert <code>String</code> to/from <code>SQLXML</code>.
- * 
+ *
  * @since 3.5.0
  * @author Iwao AVE!
  */

--- a/src/main/java/org/apache/ibatis/type/TypeAliasRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeAliasRegistry.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -143,7 +143,7 @@ public class TypeAliasRegistry {
     Alias aliasAnnotation = type.getAnnotation(Alias.class);
     if (aliasAnnotation != null) {
       alias = aliasAnnotation.value();
-    } 
+    }
     registerAlias(alias, type);
   }
 
@@ -166,7 +166,7 @@ public class TypeAliasRegistry {
       throw new TypeException("Error registering type alias "+alias+" for "+value+". Cause: " + e, e);
     }
   }
-  
+
   /**
    * @since 3.2.2
    */

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -452,14 +452,14 @@ public final class TypeHandlerRegistry {
       }
     }
   }
-  
+
   // get information
-  
+
   /**
    * @since 3.2.2
    */
   public Collection<TypeHandler<?>> getTypeHandlers() {
     return Collections.unmodifiableCollection(ALL_TYPE_HANDLERS_MAP.values());
   }
-  
+
 }

--- a/src/main/java/org/apache/ibatis/type/YearTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/YearTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.time.Year;
  * @author Björn Raupach
  */
 public class YearTypeHandler extends BaseTypeHandler<Year> {
-    
+
     @Override
     public void setNonNullParameter(PreparedStatement ps, int i, Year year, JdbcType type) throws SQLException {
         ps.setInt(i, year.getValue());
@@ -49,5 +49,5 @@ public class YearTypeHandler extends BaseTypeHandler<Year> {
         int year = cs.getInt(columnIndex);
         return year == 0 && cs.wasNull() ? null : Year.of(year);
     }
-    
+
 }

--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@
   <property name="username" value="${username}"/>
   <property name="password" value="${password}"/>
 </dataSource>]]></source>
-        <p>El usuario y password de este ejemplo se reemplazarán por los valores de los elementos de tipo property. El driver y la url se reemplazarán por los valores contenidos en el fichero config.properties.  Esto aumenta mucho las posibilidades de configuración. 
+        <p>El usuario y password de este ejemplo se reemplazarán por los valores de los elementos de tipo property. El driver y la url se reemplazarán por los valores contenidos en el fichero config.properties.  Esto aumenta mucho las posibilidades de configuración.
         </p>
         <p>Las propiedades también pueden pasarse como parámetro al método SqlSessionFactoryBuilder.build(). Por ejemplo:
         </p>
@@ -228,7 +228,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               <td>
                 autoMappingBehavior
               </td>
-              <td>Especifica cómo deben mapearse de forma automática las columnas a los campos/propiedades. NONE desactiva el mapeo automático. PARTIAL sólo mapea automáticamente los resultados que no contienen result maps anidados en su interior. FULL mapea resultados de cualquier complejidad (contengan anidados o no). 
+              <td>Especifica cómo deben mapearse de forma automática las columnas a los campos/propiedades. NONE desactiva el mapeo automático. PARTIAL sólo mapea automáticamente los resultados que no contienen result maps anidados en su interior. FULL mapea resultados de cualquier complejidad (contengan anidados o no).
               </td>
               <td>
                 NONE, PARTIAL, FULL
@@ -346,7 +346,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
               	MyBatis usa una cache local para evitar dependencias circulares y acelerar ejecuciones repeticas de queries anidadas.
-              	Por defecto (SESSION) todas las queries ejecutadas en una sesión se cachean. Si localCacheScope=STATEMENT 
+              	Por defecto (SESSION) todas las queries ejecutadas en una sesión se cachean. Si localCacheScope=STATEMENT
               	la sesión local solo se usará durante la ejecución de un statement, no se comparten datos entre distintas llamadas
               	a SqlSession.
               </td>
@@ -362,7 +362,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 jdbcTypeForNull
               </td>
               <td>
-                Permite especificar el tipo JDBC que 
+                Permite especificar el tipo JDBC que
                 Especifica el tipo JDBC para valores nulos cuando no se ha especificado un tipo concreto para el parámetro.
                 Algunos drivers requieren que se indique el tipo JDBC de la columna pero otros permite valores genéricos como NULL, VARCHAR or OTHER.
               </td>
@@ -582,7 +582,7 @@ A continuación se muestra un ejemplo del elemento settings al completo:
         <p>
         Cada bean encontrado en <code>domain.blog</code>, en caso de que no contenga ninguna anotación,
         se registrará como alias usando su nombre no cualificado en minúsculas. Es decir, <code>domain.blog.Author</code>
-        se registrará como will be registered as <code>author</code>. 
+        se registrará como will be registered as <code>author</code>.
         Si se encuentra la anotación <code>@Alias</code> se usará su valor como alias. Mira el ejemplo a continuación:
         </p>
         <source><![CDATA[@Alias("author")
@@ -1106,7 +1106,7 @@ public class Author {
                 Enumeration Type
               </td>
               <td>
-                <code>VARCHAR</code> Cualquiera compatible con string porque se guarda el código (no el índice).       
+                <code>VARCHAR</code> Cualquiera compatible con string porque se guarda el código (no el índice).
               </td>
             </tr>
             <tr>
@@ -1255,9 +1255,9 @@ public class Author {
           </tbody>
         </table>
         <p>
-        Es posible sobrescribir los TypeHanders o crear TypeHanders personalizados para tratar tipos no soportados o no estándares. 
-        Para ello, debes implementar la interfaz <code>org.apache.ibatis.type.TypeHandler</code> o extender 
-        la clase de ayuda <code>org.apache.ibatis.type.BaseTypeHandler</code> y opcionalmente mapear el TypeHandler a un tipo JDBC. 
+        Es posible sobrescribir los TypeHanders o crear TypeHanders personalizados para tratar tipos no soportados o no estándares.
+        Para ello, debes implementar la interfaz <code>org.apache.ibatis.type.TypeHandler</code> o extender
+        la clase de ayuda <code>org.apache.ibatis.type.BaseTypeHandler</code> y opcionalmente mapear el TypeHandler a un tipo JDBC.
         Por ejemplo:
         </p>
 
@@ -1299,7 +1299,7 @@ public class ExampleTypeHandler extends BaseTypeHandler<String> {
         </p>
         <ul>
           <li>Añadir un atributo <code>javaType</code> al elemento typeHandler (por ejemplo: <code>javaType="String"</code>)
-          </li> 
+          </li>
           <li>Añadir una anotación <code>@MappedTypes</code> a tu clase TypeHandler especificando la lista de tipos java a la que asociarlo.
           Esta anotación será ignorada si se ha especificado también un atributo <code>javaType</code>.
           </li>
@@ -1311,7 +1311,7 @@ public class ExampleTypeHandler extends BaseTypeHandler<String> {
           <li>
            Añadiendo un atributo <code>jdbcType</code> al lemento typeHandler (por ejemplo: <code>jdbcType="VARCHAR"</code>).
           </li>
-          <li>Añadiendo una anotación <code>@MappedJdbcTypes</code> a tu clase TypeHandler especificando la lista de tipos JDBC a la que asociarlo. 
+          <li>Añadiendo una anotación <code>@MappedJdbcTypes</code> a tu clase TypeHandler especificando la lista de tipos JDBC a la que asociarlo.
 		   Esta anotación será ignorada si se ha especificado también un atributo <code>jdbcType</code>.
           </li>
         </ul>
@@ -1325,7 +1325,7 @@ public class ExampleTypeHandler extends BaseTypeHandler<String> {
           TypeHandler available for use in a <code>ResultMap</code>, set <code>includeNullJdbcType=true</code>
           on the <code>@MappedJdbcTypes</code> annotation. Since Mybatis 3.4.0 however, if a <b>single</b>
           TypeHandler is registered to handle a Java type, it will be used by default in <code>ResultMap</code>s
-          using this Java type (i.e. even without <code>includeNullJdbcType=true</code>). 
+          using this Java type (i.e. even without <code>includeNullJdbcType=true</code>).
         </p>
 
         <p>Y finalmente puedes hacer que MyBatis busque tus TypeHandlers:</p>
@@ -1357,30 +1357,30 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
   ...
 ]]></source>
 
-		<p><code>EnumTypeHandler</code> y <code>EnumOrdinalTypeHandler</code> son TypeHandlers genéricos. 
-		Conoceremos más sobre ellos en la próxima sección. 
+		<p><code>EnumTypeHandler</code> y <code>EnumOrdinalTypeHandler</code> son TypeHandlers genéricos.
+		Conoceremos más sobre ellos en la próxima sección.
 		</p>
 
       </subsection>
-      
+
       <subsection name="Handling Enums">
       	<p>
-      	Si quires mapear un <code>Enum</code>, debes usar bien un 
-      	<code>EnumTypeHandler</code> o un <code>EnumOrdinalTypeHandler</code>. 
+      	Si quires mapear un <code>Enum</code>, debes usar bien un
+      	<code>EnumTypeHandler</code> o un <code>EnumOrdinalTypeHandler</code>.
       	</p>
-      	
+
       	<p>Por ejemplo, digamos que quieres guardar el modo de reondeo que debe
       	usarse con un número determinado que debe redondearse. Por defecto MyBatis
       	usa un <code>EnumTypeHandler</code> para comvertir los valores del  <code>Enum</code>
       	a sus nombres.
       	</p>
-      	
-      	<b>Observa que el <code>EnumTypeHandler</code> es un handler especial en el sentido de que 
-      	no maneja una clase específica, como los demás handlers sino cualquier clase que extiende 
+
+      	<b>Observa que el <code>EnumTypeHandler</code> es un handler especial en el sentido de que
+      	no maneja una clase específica, como los demás handlers sino cualquier clase que extiende
       	de <code>Enum</code></b>
 
       	<p>
-      	Sin embargo, puede que no queramos guardar nombres. Nuestro DBA puede insistir en que 
+      	Sin embargo, puede que no queramos guardar nombres. Nuestro DBA puede insistir en que
       	usemos un entero en su lugar. Muy sencillo: añade un <code>EnumOrdinalTypeHandler</code>
       	a las sección de <code>typeHandlers</code> de tu fichero de configuración y ahora todos los
       	<code>RoundingMode</code> se mapearán a un entero usando su valor ordinal.
@@ -1391,12 +1391,12 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
 </typeHandlers>
 ]]></source>
 		<p>
-		  Pero ¿y si quieres mapear el mismo <code>Enum</code> a un string en un sitio pero a un entero en otro? 
+		  Pero ¿y si quieres mapear el mismo <code>Enum</code> a un string en un sitio pero a un entero en otro?
 		</p>
       	<p>
       	  El mapeo automático siempre usará <code>EnumOrdinalTypeHandler</code>,
-      	  así que si queremos usar el clásico <code>EnumTypeHandler</code>, 
-      	  debemos indicarlo establiencidolo esplícitamente su uso en los statements. 
+      	  así que si queremos usar el clásico <code>EnumTypeHandler</code>,
+      	  debemos indicarlo establiencidolo esplícitamente su uso en los statements.
       	</p>
       	<p>
       	  Los mappers no se tratarán hasta la sección siguiente asi que si esta es tu primera lectura de
@@ -1422,7 +1422,7 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
 	    	#{id}, #{name}, #{funkyNumber}, #{roundingMode}
 	    )
 	</insert>
-	
+
 	<resultMap type="org.apache.ibatis.submitted.rounding.User" id="usermap2">
 		<id column="id" property="id"/>
 		<result column="name" property="name"/>
@@ -1441,7 +1441,7 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
 </mapper>
 ]]></source>
 		<p>
-		  Observa que esto nos fuerza a usar un <code>resultMap</code> 
+		  Observa que esto nos fuerza a usar un <code>resultMap</code>
 		  en lugar de un <code>resultType</code> en nuestros statements tipo select.
 		</p>
       </subsection>
@@ -1579,7 +1579,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
           <li>La configuración del TransactionManager (ej. type=”JDBC”)</li>
           <li>La configuración del DataSource (ej. type=”POOLED”)</li>
         </ul>
-        <p>El ID del entorno por defecto y de los entornos existentes son auto-explicativos. Puedes nombrarlos como más te guste, tan sólo asegúrate de que el valor por defecto coincide con un entorno existente. 
+        <p>El ID del entorno por defecto y de los entornos existentes son auto-explicativos. Puedes nombrarlos como más te guste, tan sólo asegúrate de que el valor por defecto coincide con un entorno existente.
         </p>
         <p>
           <strong>transactionManager</strong>
@@ -1587,9 +1587,9 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
         <p>MyBatis incluye dos tipos de TransactionManager (ej. type=”[JDBC|MANAGED]”):
         </p>
         <ul>
-          <li>JDBC – Este TransactionManager simplemente hace uso del las capacidades de commit y rollback de JDBC.  Utiliza la conexión obtenida del DataSource para gestionar la transacción.  
+          <li>JDBC – Este TransactionManager simplemente hace uso del las capacidades de commit y rollback de JDBC.  Utiliza la conexión obtenida del DataSource para gestionar la transacción.
           </li>
-          <li>MANAGED  – Este TransactionManager no hace nada. No hace commit ni rollback sobre la conexión. En su lugar, permite que el contenedor gestione el ciclo de vida completo de la transacción (ej. Spring o un servidor de aplicaciones JEE).  Por defecto cierra la conexión. Sin embargo, algunos contenedores no esperan que la conexión se cierre y por tanto, si necesitas cambiar este comportamiento, informa la propiedad closeConnection a false. Por ejemplo: 
+          <li>MANAGED  – Este TransactionManager no hace nada. No hace commit ni rollback sobre la conexión. En su lugar, permite que el contenedor gestione el ciclo de vida completo de la transacción (ej. Spring o un servidor de aplicaciones JEE).  Por defecto cierra la conexión. Sin embargo, algunos contenedores no esperan que la conexión se cierre y por tanto, si necesitas cambiar este comportamiento, informa la propiedad closeConnection a false. Por ejemplo:
 <source><![CDATA[<transactionManager type="MANAGED">
   <property name="closeConnection" value="false"/>
 </transactionManager>]]></source>
@@ -1603,9 +1603,9 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
         <p>Ninguno de estos TransactionManagers necesita ninguna propiedad. Sin embargo ambos son Type Aliases, es decir, en lugar de usarlos puedes informar el nombre totalmente cualificado o el Type Alias de tu propia implementación del interfaz TransactionFactory:
         </p>
         <source><![CDATA[public interface TransactionFactory {
-  void setProperties(Properties props);  
+  void setProperties(Properties props);
   Transaction newTransaction(Connection conn);
-  Transaction newTransaction(DataSource dataSource, TransactionIsolationLevel level, boolean autoCommit);  
+  Transaction newTransaction(DataSource dataSource, TransactionIsolationLevel level, boolean autoCommit);
 }]]></source>
         <p>Todas las propiedades que configures en el XML se pasarán al método setProperties() tras la instanciación de la clase. Tu implementación debe crear una implementación de Transaction, que a su vez es también un interfaz muy sencillo:
         </p>
@@ -1646,7 +1646,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
           <li><code>driver.encoding=UTF8</code></li>
         </ul>
         <p>
-          Esto pasaría la propiedad “encoding” con el valor “UTF8” al driver de base datos mediante el método DriverManager.getConnection(url, driverProperties).  
+          Esto pasaría la propiedad “encoding” con el valor “UTF8” al driver de base datos mediante el método DriverManager.getConnection(url, driverProperties).
         </p>
         <p>
           <strong>POOLED</strong> – Esta implementación de DataSource hace usa un pool de conexiones para evitar el tiempo necesario en realizar la conexión y autenticación cada vez que se solicita una nueva instancia de conexión. Este es un enfoque habitual en aplicaciones Web concurrentes para obtener el mejor tiempo de respuesta posible.</p>
@@ -1705,13 +1705,13 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
 }]]></source>
 
         <p>
-		  The <code>org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory</code> puede extenderse para crear nuevos 
-		  adaptadores. Por ejemplo, este es el código necesario para integrar C3P0: 
+		  The <code>org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory</code> puede extenderse para crear nuevos
+		  adaptadores. Por ejemplo, este es el código necesario para integrar C3P0:
 		</p>
 
         <source><![CDATA[import org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
-        
+
 public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
 
   public C3P0DataSourceFactory() {
@@ -1720,7 +1720,7 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
 }]]></source>
 
         <p>Para configurarlo, añade una propiedad por cada método al que quieres que llame MyBatis.
-        A continuación se muestra una configuración de ejemplo para conectar con una base de datos PostgresSQL:</p>        
+        A continuación se muestra una configuración de ejemplo para conectar con una base de datos PostgresSQL:</p>
 
         <source><![CDATA[<dataSource type="org.myproject.C3P0DataSourceFactory">
   <property name="driver" value="org.postgresql.Driver"/>
@@ -1729,42 +1729,42 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
   <property name="password" value="root"/>
 </dataSource>
 ]]></source>
-        
+
       </subsection>
-      
+
       <subsection name="databaseIdProvider">
         <p>
           MyBatis puede ejeutar sentencias distintas en función del fabricante (vendor) de tu base de datos.
           El soporte de múltiples bases de datos se basa en el atributo de <code>databaseId</code> de los mapped statements.
-          MyBatis cargará todos los statements que no tengan atributo <code>databaseId</code> attribute o aquellos 
-          cuyo <code>databaseId</code> coincida con el valor en curso. Si se encuentra un statement con y sin atributo 
-          <code>databaseId</code> el último se descartará.  
+          MyBatis cargará todos los statements que no tengan atributo <code>databaseId</code> attribute o aquellos
+          cuyo <code>databaseId</code> coincida con el valor en curso. Si se encuentra un statement con y sin atributo
+          <code>databaseId</code> el último se descartará.
           Para activar el soporte de multi vendor añade un <code>databaseIdProvider</code>
           al fichero mybatis-config.xml file de la siguiente forma:
         </p>
-        
+
         <source><![CDATA[<databaseIdProvider type="DB_VENDOR" />
 ]]></source>
 
-		<p> 
-		  La implementación DB_VENDOR del databaseIdProvider establece como databaseId el String devuelto por 
-		  <code>DatabaseMetaData#getDatabaseProductName()</code>. 
+		<p>
+		  La implementación DB_VENDOR del databaseIdProvider establece como databaseId el String devuelto por
+		  <code>DatabaseMetaData#getDatabaseProductName()</code>.
 		  Como normalmente este string es demasiado largo, y además, distintas versiones del mismo producto devuelven valores
 		  similares, puedes traducirlo a un valor más corto añadiendo propiedades de la siguente forma:
 		</p>
-		
+
         <source><![CDATA[<databaseIdProvider type="DB_VENDOR">
   <property name="SQL Server" value="sqlserver"/>
-  <property name="DB2" value="db2"/>        
+  <property name="DB2" value="db2"/>
   <property name="Oracle" value="oracle" />
 </databaseIdProvider>]]></source>
 
-		<p> 
+		<p>
 		  Cuando se añaden propiedades, el databaseIdProvider DB_VENDOR devuelve el primer valor que corresponde a la primera clave
 		  encontrada en el nombre devuelto por <code>DatabaseMetaData#getDatabaseProductName()</code> o "null" si no se encuentra ninguna.
-		  En este caso, si <code>getDatabaseProductName()</code> devuelve "Oracle (DataDirect)" el databaseId se informará con "oracle".  
+		  En este caso, si <code>getDatabaseProductName()</code> devuelve "Oracle (DataDirect)" el databaseId se informará con "oracle".
 		</p>
-		
+
 		<p>
 		  Puedes construir tu propio DatabaseIdProvider implementando la interfaz <code>org.apache.ibatis.mapping.DatabaseIdProvider</code>
 		  y registrandolo en el fichero mybatis-config.xml:
@@ -1776,7 +1776,7 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
 }]]></source>
 
       </subsection>
-      
+
       <subsection name="mappers">
         <p>
           Ahora que se ha configurado el comportamiento de MyBatis con todos los elementos de configuración comentados estamos listos para definir los SQL mapped statements (sentencias SQL mapeadas). Primeramente necesitaremos indicarle a MyBatis dónde encontrarlos. Java no ofrece muchas posibilidades de auto-descubrimiento así que la mejor forma es simplemente decirle a MyBatis donde encontrar los ficheros de mapeo. Puedes utilizar referencias tipo classpath, o tipo path o referencias url completamente cualificadas (incluyendo file:///) . Por ejemplo:

--- a/src/site/es/xdoc/dynamic-sql.xml
+++ b/src/site/es/xdoc/dynamic-sql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
   <section name="SQL dinámico">
   <p>Una de las características más potentes de MyBatis ha sido siempre sus capacidades de SQL dinámico. Si tienes experiencia con JDBC o algún framework similar, entenderás que doloroso es concatenar strings de SQL, asegurándose de que no olvidas espacios u omitir una coma al final de la lista de columnas. El SQL dinámico puede ser realmente doloroso de usar.</p>
   <p>Aunque trabajar con SQL dinámico no va a ser nunca una fiesta, MyBatis ciertamente mejora la situación con un lenguaje de SQL dinámico potente que puede usarse en cualquier mapped statement.</p>
-  <p>Los elementos de SQL dinámico deberían ser familiares a aquel que haya usado JSTL o algún procesador de texto basado en XML. En versiones anteriores de MyBatis había un montón de elementos que conocer y comprender. MyBatis 3 mejora esto y ahora hay algo menos de la mitad de esos elementos con los que trabajar. MyBatis emplea potentes expresiones OGNL para eliminar la necesidad del resto de los elementos:</p>  
+  <p>Los elementos de SQL dinámico deberían ser familiares a aquel que haya usado JSTL o algún procesador de texto basado en XML. En versiones anteriores de MyBatis había un montón de elementos que conocer y comprender. MyBatis 3 mejora esto y ahora hay algo menos de la mitad de esos elementos con los que trabajar. MyBatis emplea potentes expresiones OGNL para eliminar la necesidad del resto de los elementos:</p>
   <ul>
     <li>if</li>
     <li>choose (when, otherwise)</li>
@@ -38,19 +38,19 @@
   </ul>
   <subsection name="if" id="if">
   <p>La tarea más frecuente en SQL dinámico es incluir un trozo de la clausula where condicionalmente. Por ejemplo:</p>
-  <source><![CDATA[<select id="findActiveBlogWithTitleLike" 
+  <source><![CDATA[<select id="findActiveBlogWithTitleLike"
      resultType="Blog">
-  SELECT * FROM BLOG 
-  WHERE state = ‘ACTIVE’ 
+  SELECT * FROM BLOG
+  WHERE state = ‘ACTIVE’
   <if test="title != null">
     AND title like #{title}
   </if>
-</select>]]></source>  
+</select>]]></source>
   <p>Este statement proporciona una funcionalidad de búsqueda de texto. Si no se pasa ningún título, entonces se retornan todos los Blogs activos. Pero si se pasa un título se buscará un título como el pasado (para los perspicaces, sí, en este caso tu parámetro debe incluir el carácter de comodín).</p>
   <p>¿Y cómo hacemos si debemos buscar opcionalmente por título o autor? Primeramente, yo cambiaría el nombre del statement para que tenga algo más de sentido. Y luego añadir otra condición.</p>
-  <source><![CDATA[<select id="findActiveBlogLike" 
+  <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG WHERE state = ‘ACTIVE’ 
+  SELECT * FROM BLOG WHERE state = ‘ACTIVE’
   <if test="title != null">
     AND title like #{title}
   </if>
@@ -62,7 +62,7 @@
   <subsection name="choose, when, otherwise" id="chooseWhenOtherwise">
   <p>En ocasiones no queremos usar una condición sino elegir una de entre varias opciones. De forma similar al switch  de Java, MyBatis ofrece el elemento choose.</p>
   <p>Usemos el ejemplo anterior, pero ahora vamos a buscar solamente por título si se ha proporcionado un título y por autor si se ha proporcionado un autor. Si  no se proporciona ninguno devolvemos una lista de Blogs destacados (quizá una lista seleccionada por los administradores en lugar de una gran lista de blogs sin sentido).</p>
-  <source><![CDATA[<select id="findActiveBlogLike" 
+  <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
   SELECT * FROM BLOG WHERE state = ‘ACTIVE’
   <choose>
@@ -80,13 +80,13 @@
   </subsection>
   <subsection name="trim, where, set" id="trimWhereSet">
   <p>En los ejemplos anteriores se ha sorteado intencionadamente un notorio problema del SQL dinámico. Imagina lo que sucedería si volvemos a nuestro ejemplo del “if”, pero esta vez, hacemos que “ACTIVE = 1” sea también una condición dinámica.</p>
-  <source><![CDATA[<select id="findActiveBlogLike" 
+  <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG 
-  WHERE 
+  SELECT * FROM BLOG
+  WHERE
   <if test="state != null">
     state = #{state}
-  </if> 
+  </if>
   <if test="title != null">
     AND title like #{title}
   </if>
@@ -95,21 +95,21 @@
   </if>
 </select>]]></source>
   <p>¿Qué sucede si no se cumple ninguna condición? Acabarías con una sentencia SQL con este aspecto:</p>
-  <source><![CDATA[SELECT * FROM BLOG 
+  <source><![CDATA[SELECT * FROM BLOG
 WHERE]]></source>
   <p>Y eso fallará. ¿Y qué sucede si se cumple la segunda condición? Acabarías con una sentencia SQL con este aspecto:</p>
-  <source><![CDATA[SELECT * FROM BLOG 
-WHERE 
+  <source><![CDATA[SELECT * FROM BLOG
+WHERE
 AND title like ‘someTitle’]]></source>
   <p>Y eso también fallará. Este problema no se resuelve fácil con condicionales, y si alguna vez tienes que hacerlo, posiblemente no quieras repetirlo nunca más.</p>
   <p>MyBatis tiene una respuesta sencilla que funcionará en el 90% de los casos. Y en los casos en los que no funciona puedes personalizarlo para hacerlo funcionar. Con un cambio simple, todo funciona correctamente:</p>
-  <source><![CDATA[<select id="findActiveBlogLike" 
+  <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG 
-  <where> 
+  SELECT * FROM BLOG
+  <where>
     <if test="state != null">
          state = #{state}
-    </if> 
+    </if>
     <if test="title != null">
         AND title like #{title}
     </if>
@@ -117,12 +117,12 @@ AND title like ‘someTitle’]]></source>
         AND author_name like #{author.name}
     </if>
   </where>
-</select>]]></source> 
+</select>]]></source>
   <p>El elemento where sabe que debe insertar la “WHERE” solo si los tags internos devuelven algún contenido. Más aun, si el contenido comienza con “AND” o “OR”, sabe cómo eliminarlo.</p>
   <p>Si el elemento where no se comporta exactamente como te gustaría, lo puedes personalizar definiendo tu propio elemento trim. Por ejemplo, el trim equivalente al elemento where es:</p>
   <source><![CDATA[<trim prefix="WHERE" prefixOverrides="AND |OR ">
-  ... 
-</trim>]]></source>  
+  ...
+</trim>]]></source>
   <p>El atributo prefixOverrides acepta una lista de textos delimitados pro el carácter “| “ donde el espacio en blanco es relevante. El resultado es que se elimina cualquier cosa que se haya especificado en el atributo prefixOverrides, y que se inserta todo lo incluido en el atributo with.</p>
   <p>Hay una solución similar para updates dinámicos llamada set. El elemento set se pude usar para incluir dinámicamente columnas para modificar y dejar fuera las demás. Por ejemplo:</p>
   <source><![CDATA[<update id="updateAuthorIfNecessary">
@@ -135,7 +135,7 @@ AND title like ‘someTitle’]]></source>
     </set>
   where id=#{id}
 </update>]]></source>
-  <p>En este caso, el elemento set  prefijará dinámicamente el valor SET y además eliminará todas las comas sobrantes que pudieran quedar tras las asignaciones de valor después de que se hayan aplicado las condiciones.</p>  
+  <p>En este caso, el elemento set  prefijará dinámicamente el valor SET y además eliminará todas las comas sobrantes que pudieran quedar tras las asignaciones de valor después de que se hayan aplicado las condiciones.</p>
   <p>Si tienes curiosidad de qué aspecto tendría el elemento trim equivalente, aquí lo tienes:</p>
   <source><![CDATA[<trim prefix="SET" suffixOverrides=",">
   ...
@@ -156,7 +156,7 @@ AND title like ‘someTitle’]]></source>
   <p>El elemento foreach es muy potente, permite especificar una colección y declarar variables elemento e índice que pueden usarse dentro del cuerpo del elemento. Permite también abrir y cerrar strings y añadir un separador entre las iteraciones. Este elemento es inteligente en tanto en cuanto no añade separadores extra accidentalmente.</p>
   <p><span class="label important">NOTA</span> You can pass any Iterable object (for example List, Set, etc.), as well as any Map or Array object to foreach as collection parameter. When using an Iterable or Array, index will be the number of current iteration and value item will be the element retrieved in this iteration. When using a Map (or Collection of Map.Entry objects), index will be the key object and item will be the value object.</p>
   <p>Esto finaliza la discusión sobre la configuración XML y los ficheros de mapeo XML. En la sección siguiente hablaremos del API Java en detalle, de forma que puedas obtener el máximo rendimiento de los mapeos que has creado.</p>
-  </subsection>  
+  </subsection>
   <subsection name="bind">
   <p>El elemento <code>bind</code> te permite crear una variable a partir de una expresion OGNL y asociarla al contexto. Por ejemplo:</p>
   <source><![CDATA[
@@ -190,7 +190,7 @@ AND title like ‘someTitle’]]></source>
   ParameterHandler createParameterHandler(MappedStatement mappedStatement, Object parameterObject, BoundSql boundSql);
   SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType);
   SqlSource createSqlSource(Configuration configuration, String script, Class<?> parameterType);
-}]]></source>    
+}]]></source>
     <p>Una vez tienes tu driver de lenguaje puedes puede hacer que sea el de uso por defecto estableciéndolo en el fichero mybatis-config.xml:</p>
   <source><![CDATA[<typeAliases>
   <typeAlias type="org.sample.MyLanguageDriver" alias="myLanguage"/>
@@ -198,8 +198,8 @@ AND title like ‘someTitle’]]></source>
 <settings>
   <setting name="defaultScriptingLanguage" value="myLanguage"/>
 </settings>
-]]></source>    
-    <p>En lugar de cambiar el valor por defecto, puedes indicar el lenguaje para un statement específico 
+]]></source>
+    <p>En lugar de cambiar el valor por defecto, puedes indicar el lenguaje para un statement específico
     añadiendo el atributo <code>lang</code> de la siguiente forma:
     </p>
   <source><![CDATA[<select id="selectBlog" lang="myLanguage">
@@ -214,7 +214,7 @@ AND title like ‘someTitle’]]></source>
 
     <p><span class="label important">NOTA</span> Puedes utilizar Apache Velocity como lenguaje dinámico. Echa un vistazo al proyecto MyBatis-Velocity para conocer los detalles.</p>
 
-    <p>Todos los tags que has visto en las secciones previas se proporcionan por el lenguaje por defecto de MyBatis cuyo driver es 
+    <p>Todos los tags que has visto en las secciones previas se proporcionan por el lenguaje por defecto de MyBatis cuyo driver es
     <code>org.apache.ibatis.scripting.xmltags.XmlLanguageDriver</code> que tiene un alias llamado <code>xml</code>.</p>
 	</subsection>
   </section>

--- a/src/site/es/xdoc/getting-started.xml
+++ b/src/site/es/xdoc/getting-started.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@
 
 	<body>
 		<section name="Primeros pasos">
-		
-    
+
+
     <subsection name="Instalación">
       <p>
         Para usar MyBatis sólo tienes que incluir el fichero
@@ -44,10 +44,10 @@
   <artifactId>mybatis</artifactId>
   <version>x.x.x</version>
 </dependency>]]></source>
-    </subsection>    
-    
+    </subsection>
+
 			<subsection name="Cómo crear un SqlSessionFactory a partir de XML">
-		
+
 			<p>
 				Una aplicación que usa MyBatis debe utilizar una instancia de
 				SqlSessionFactory. Se puede obtener una instancia de

--- a/src/site/es/xdoc/java-api.xml
+++ b/src/site/es/xdoc/java-api.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@
       /web.xml</pre>
   <p>Recuerda, esto son prefierncias no requisitos, pero habrá otros que te agradecerán que uses una estructura de directorios conún.</p>
   <p>Los ejemplos restantes en esta sección asumen que estás utilizando esta estructura de directorios.</p>
-  </subsection>  
+  </subsection>
 
   <subsection name="SqlSessions" id="sqlSessions">
   <p>El interfaz principal para trabajar con MyBatis es el SqlSession. A través de este interfaz puedes ejecutar comandos, obtener mappers y gestionar transacciones. Hablaremos más sobre el propio SqlSession en breve, pero primero veamos cómo obtener una instancia de SqlSession. Las SqlSessions se crean por una instancia de SqlSessionFactory. La SqlSessionFactory contiene métodos para crear instancias de SqlSessions de distintas formas. La SqlSessionFactory en si misma se crea por la SqlSessionFactoryBuilder que puede crear una SqlSessionFactory a partir de XML, anotaciones o un objeto Configuration creado por código.</p>
@@ -71,7 +71,7 @@
 SqlSessionFactory build(InputStream inputStream, String environment)
 SqlSessionFactory build(InputStream inputStream, Properties properties)
 SqlSessionFactory build(InputStream inputStream, String env, Properties props)
-SqlSessionFactory build(Configuration config)</source>  
+SqlSessionFactory build(Configuration config)</source>
 
   <p>Los primeros cuatro métodos son los más comunes, dado que reciben una instancia de InputStream que referencia a un documento XML, o más específicamente, al fichero SqlMapConfig.xml comentado anteriormente. Los parámetros opcionales son environment y properties. Environment determina qué entorno cargar, incluyendo el datasource y el gestor de transacciones. Por ejemplo:</p>
 
@@ -88,8 +88,8 @@ SqlSessionFactory build(Configuration config)</source>
     <dataSource type="JNDI">
         ...
   </environment>
-</environments>]]></source>  
-  <p>Si llamas al método build que recibe el parámetro environment, entonces MyBatis usará la configuración de dicho entorno. Por supuesto, si especificas un entorno inválido, recibirás un error. Si llamas a alguno de los métodos que no reciben el parámetro environment, entonces se utilizará el entorno por defecto (que es el especificado como default=”development” en el ejemplo anterior).</p>  
+</environments>]]></source>
+  <p>Si llamas al método build que recibe el parámetro environment, entonces MyBatis usará la configuración de dicho entorno. Por supuesto, si especificas un entorno inválido, recibirás un error. Si llamas a alguno de los métodos que no reciben el parámetro environment, entonces se utilizará el entorno por defecto (que es el especificado como default=”development” en el ejemplo anterior).</p>
   <p>Si llamas a un método que recibe una instancia de properties, MyBatis cargará dichas properties y las hará accesibles desde tu configuración. Estas propiedades pueden usarse en lugar de la gran mayoría de los valores utilizando al sintaxis: ${propName}</p>
   <p>Recuerda que las propiedades pueden también referenciarse desde el fichero SqlMapConfig.xml, o especificarse directamente en él. Por lo tanto es importante conocer las prioridades. Lo mencionamos anteriormente en este documento, pero lo volvemos a mencionar para facilitar la referencia.</p>
 
@@ -102,14 +102,14 @@ SqlSessionFactory build(Configuration config)</source>
   </ul>
   <p>Por lo tanto la prioridad mayor es la de las propiedades pasadas como parámetro, seguidas por las especificadas en el atributo resource/url y finalmente las propiedades especificadas en el cuerpo del elemento properties.</p>
   <hr/>
-  
-  <p>Por tanto, para resumir, los primeros cuatro métodos son casi iguales pero te permiten opcionalmente especificar el environment y/o las propiedades. Aquí hay un ejemplo de cómo se construye un SqlSessionFactory desde un fichero mybatis-config.xml.</p>  
+
+  <p>Por tanto, para resumir, los primeros cuatro métodos son casi iguales pero te permiten opcionalmente especificar el environment y/o las propiedades. Aquí hay un ejemplo de cómo se construye un SqlSessionFactory desde un fichero mybatis-config.xml.</p>
 
   <source>String <strong>resource</strong> = "org/mybatis/builder/mybatis-config.xml";
 InputStream <strong>inputStream</strong> = Resources.getResourceAsStream(resource);
 SqlSessionFactoryBuilder <strong>builder</strong> = new SqlSessionFactoryBuilder();
-SqlSessionFactory <strong>factory</strong> = builder.build(inputStream);</source>  
-  
+SqlSessionFactory <strong>factory</strong> = builder.build(inputStream);</source>
+
   <p>Observa que estamos usando la clase de utilidad Resources, que está ubicada en el paquete org.mybatis.io. La clase Resources, tal y como su nombre indica, te ayuda a cargar recursos desde el classpath, el sistema de ficheros o desde una web o URL. Con un vistazo rápido al código fuente en tu IDE descubrirás un conjunto bastante obvio de métodos. Rápidamente:</p>
   <source>URL getResourceURL(String resource)
 URL getResourceURL(ClassLoader loader, String resource)
@@ -217,7 +217,7 @@ int delete(String statement)]]></source>
 void select (String statement, Object parameter, ResultHandler<T> handler)
 void select (String statement, Object parameter, RowBounds rowBounds, ResultHandler<T> handler)]]></source>
 
-  <p>El parámetro RowBounds hace que MyBatis salte los registros especificados y que limite los resultados devueltos a cierto número. La clase RowBounds tiene un constructor que recibe ambos el offset y el limit, y es inmutable.</p> 
+  <p>El parámetro RowBounds hace que MyBatis salte los registros especificados y que limite los resultados devueltos a cierto número. La clase RowBounds tiene un constructor que recibe ambos el offset y el limit, y es inmutable.</p>
   <source>int offset = 100;
 int limit = 25;
 RowBounds rowBounds = new RowBounds(offset, limit);</source>
@@ -225,7 +225,7 @@ RowBounds rowBounds = new RowBounds(offset, limit);</source>
   <p>El rendimiento de algunos drivers puede variar mucho en este aspecto. Para un rendimiento optimo, usa tipos de ResultSet SCROLL_SENSITIVE o SCROLL_INSENSITIVE (es decir, no FORWARD_ONLY)</p>
   <p>El parámetro ResultHandler te permite manejar cada fila como tú quieras. Puedes añadirla a una lista, crear un Map, un Set, o descartar cada resultado y guardar solo cálculos. Puedes hacer casi todo lo que quieras con un ResultHandler, de hecho, es lo que MyBatis usa internamente para construir listas de ResultSets.</p>
   <p>Since 3.4.6, ResultHandler passed to a CALLABLE statement is used on every REFCURSOR output parameter of the stored procedure if there is any.</p>
-  <p>La interfaz es muy sencilla:</p>  
+  <p>La interfaz es muy sencilla:</p>
   <source><![CDATA[package org.apache.ibatis.session;
 public interface ResultHandler<T> {
   void handleResult(ResultContext<? extends T> context);
@@ -234,7 +234,7 @@ public interface ResultHandler<T> {
   <p>El parámetro ResultContext te da acceso al objeto resultado en sí mismo, un contador del número de objetos creados y un método booleano stop() que te permite indicar a MyBatis que pare la carga de datos.</p>
 
   <p>Using a ResultHandler has two limitations that you should be aware of:</p>
-  
+
   <ul>
   <li>Data got from an method called with a ResultHandler will not be cached.</li>
   <li>When using advanced resultmaps MyBatis will probably require several rows to build an object. If a ResultHandler is used you may be given an object whose associations or collections are not yet filled.</li>
@@ -287,12 +287,12 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
   <source>Configuration getConfiguration()</source>
 
   <h5>Uso de Mappers</h5>
-  <source><![CDATA[<T> T getMapper(Class<T> type)]]></source>  
+  <source><![CDATA[<T> T getMapper(Class<T> type)]]></source>
   <p>Aunque los métodos insert, update, delete y select son potentes, también son muy verbosos, no hay seguridad de tipos (type safety) y no son tan apropiados para tu IDE o tus pruebas unitarias como pudieran ser. Ya hemos visto un ejemplo de uso de mappers en la sección de primeros pasos.</p>
   <p>Por lo tanto, una forma más común de ejecutar mapped statements es utilizar clases Mapper. Un mapper es simplemente una interfaz con definiciones de métodos que se hacen encajar con métodos de SqlSession. El ejemplo siguiente demuestra algunas firmas de método y como se asignan a una SqlSession.</p>
   <source><![CDATA[public interface AuthorMapper {
   // (Author) selectOne("selectAuthor",5);
-  Author selectAuthor(int id); 
+  Author selectAuthor(int id);
   // (List<Author>) selectList(“selectAuthors”)
   List<Author> selectAuthors();
   // (Map<Integer,Author>) selectMap("selectAuthors", "id")
@@ -305,7 +305,7 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
   // delete("deleteAuthor",5)
   int deleteAuthor(int id);
 }]]></source>
-  <p>En resumen, cada firma de método de mapper se asigna al método de la SqlSession al que está asociado pero sin parámetro ID. En su lugar el nombre del método debe ser el mismo que el ID del mapped statement.</p> 
+  <p>En resumen, cada firma de método de mapper se asigna al método de la SqlSession al que está asociado pero sin parámetro ID. En su lugar el nombre del método debe ser el mismo que el ID del mapped statement.</p>
   <p>Además, el tipo devuelto debe ser igual que el result type del mapped statement. Todos los tipos habituales se soportan, incluyendo primitivas, mapas, POJOs y JavaBeans.</p>
   <p><span class="label important">NOTA</span> Los mappers no necesitan implementar ninguna interfaz o extender ninguna clase. Sólo es necesario que la firma de método pueda usarse para identificar unívocamente el mapped statement correspondiente.</p>
   <p><span class="label important">NOTA</span> Los mappers pueden extender otras interfaces. Asegúrate que tienes tus statements en los namespaces adecuados en tu fichero XML. Además, la única limitación es que no puedes tener el mismo método, con la misma firma, en dos interfaces de la jerarquía (una mala idea en cualquier caso).</p>
@@ -400,16 +400,16 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td>N/A</td>
         <td><code>&lt;association&gt;</code></td>
         <td>
-        Un mapeo a una propiedad que contiene un tipo complejo. Atributos: select, que contiene el nombre completamente cualificado de un mapped statement (o un método de mapper) que puede cargar la instancia del tipo indicado, 
-        <code>fetchType</code>, que sobrescribe el parámetro global de configuración <code>lazyLoadingEnabled</code> para este mapeo. 
+        Un mapeo a una propiedad que contiene un tipo complejo. Atributos: select, que contiene el nombre completamente cualificado de un mapped statement (o un método de mapper) que puede cargar la instancia del tipo indicado,
+        <code>fetchType</code>, que sobrescribe el parámetro global de configuración <code>lazyLoadingEnabled</code> para este mapeo.
         Nota: Habrás visto que el mapeo de tipo join no se soporta mediante el API de anotaciones. Esto es debido a las limitaciones de las anotaciones en Java que no permiten referencias circulares.</td>
       </tr>
       <tr>
         <td><code>@Many</code></td>
         <td>N/A</td>
         <td><code>&lt;collection&gt;</code></td>
-        <td>Un mapeo a una propiedad que contiene una colección de tipos complejos. Atributos: select, que contiene el nombre completamente cualificado de un mapped statement (o un método de mapper) que puede cargar la instancia del tipo indicado, 
-        <code>fetchType</code>, que sobrescribe el parámetro global de configuración <code>lazyLoadingEnabled</code> para este mapeo. 
+        <td>Un mapeo a una propiedad que contiene una colección de tipos complejos. Atributos: select, que contiene el nombre completamente cualificado de un mapped statement (o un método de mapper) que puede cargar la instancia del tipo indicado,
+        <code>fetchType</code>, que sobrescribe el parámetro global de configuración <code>lazyLoadingEnabled</code> para este mapeo.
         Nota: Habrás visto que el mapeo de tipo join no se soporta mediante el API de anotaciones. Esto es debido a las limitaciones de las anotaciones en Java que no permiten referencias circulares.</td>
       </tr>
       <tr>
@@ -489,9 +489,9 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td><code>Method</code></td>
         <td>N/A</td>
         <td>Esta anotación se usa cuando se utiliza un result handler. En ese caso, el tipo devuelto por el método es void y
-        MyBatis no puede determinar el tipo del objeto que debe construir para cada fila. 
-        Si hay un result map XML entonces se utiliza la anotación @ResultMap. Si el tipo de retorno se especifica en el 
-        elemento <code>&lt;select&gt;</code> del XML entonces no es necesaria ninguna otra anotación.  
+        MyBatis no puede determinar el tipo del objeto que debe construir para cada fila.
+        Si hay un result map XML entonces se utiliza la anotación @ResultMap. Si el tipo de retorno se especifica en el
+        elemento <code>&lt;select&gt;</code> del XML entonces no es necesaria ninguna otra anotación.
         En el resto de casos, usa esta anotación. Por ejemplo en un método anotado con @Select con un result handler
         el valor de retorno será void y por tanto se requiere incluir esta anotación (o @ResultMap).
         La anotación se ignora si el tipo devuelto por el méotdo no es void.</td>

--- a/src/site/es/xdoc/logging.xml
+++ b/src/site/es/xdoc/logging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@
       un string como parametro de constructor.
       </p>
       <p>Tambien puedes seleccionar el método de logging llamando a uno de los siguientes métodos:
-      </p>      
+      </p>
       <source><![CDATA[org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
 org.apache.ibatis.logging.LogFactory.useLog4JLogging();
 org.apache.ibatis.logging.LogFactory.useLog4J2Logging();
@@ -108,7 +108,7 @@ public interface BlogMapper {
   @Select("SELECT * FROM blog WHERE id = #{id}")
   Blog selectBlog(int id);
 }]]></source>
-        <p>Crea un fichero con nombre <code>log4j.properties</code> 
+        <p>Crea un fichero con nombre <code>log4j.properties</code>
         como el que se muestra a continuación y colocalo en tu classpath:
         </p>
         <source><![CDATA[# Global logging configuration
@@ -123,15 +123,15 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
         <p>Si quieres activar un nivel más fino de logging puedes activar el logging para statements específicos en lugar de para todo un mapper. La siguiente línea activa el logging sólo para el statement <code>selectBlog</code>:</p>
 
         <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
-        
+
         <p>Si por el contrario quieres activar el log para un grupo de mappers debes añadir un logger para el paquete raiz donde residen tus mappers:</p>
 
         <source>log4j.logger.org.mybatis.example=TRACE</source>
-        
+
         <p>Hay consultas que pueden devolver una gran cantidad de datos. En esos casos puedes querer ver las sentencias SQL pero no los datos. Para conseguirlo las sentencias se loguean con nivel DEBUG (FINE en JDK) y los resultados con TRACE (FINER en JDK), por tanto si quieres ver la sentencia pero no el resultado establece el nivel a DEBUG</p>
 
         <source>log4j.logger.org.mybatis.example=DEBUG</source>
-        
+
         <p>Y si estás usando ficheros XML como este?</p>
 
       <source><![CDATA[<?xml version="1.0" encoding="UTF-8" ?>

--- a/src/site/es/xdoc/statement-builders.xml
+++ b/src/site/es/xdoc/statement-builders.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ String sql = "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FULL_NAME, "
   <subsection name="La Solución">
   <p>MyBatis 3 introduce un concepto un tanto distinto para tratar con el problema.
     Con la clase SQL, puecdes crear una sentencia SQL en un sólo paso invocando a sus métodos.
-    El ejemplo anterior tendría este aspecto si se rescribe con la clase SQL:  
+    El ejemplo anterior tendría este aspecto si se rescribe con la clase SQL:
   </p>
 
       <source><![CDATA[
@@ -72,7 +72,7 @@ private String selectPersonSql() {
   }}.toString();
 }
 ]]></source>
-    <p>¿Qué hay de especial en este ejemplo? 
+    <p>¿Qué hay de especial en este ejemplo?
       Bien, si lo miras detenidamente, verás que no hay que preocuparse de duplicar “AND”s, o elegir entre “WHERE” o “AND”, o ninguno de ambos!
       La clase SQL se ocupa de colocar el "WHERE" donde debe de ir, si debe usarse "AND" o no y de realizar todas las concatenaciones de Strings.
     </p>
@@ -378,9 +378,9 @@ public String updatePersonSql() {
 
       <subsection name="SqlBuilder y SelectBuilder (DEPRECADAS)">
         <p>
-          En versiones anteriores a la 3.2 optamos por una solución distinta, usando una variable ThreadLocal para 
+          En versiones anteriores a la 3.2 optamos por una solución distinta, usando una variable ThreadLocal para
           resolver algunas limitaciones de las que hacen los DSLs Java algo incomodos. Sin embargo, esta solución está ahora
-          desprecada porque los frameworks actuales están mas orientados a usar patrones builder-type y clases anónimas 
+          desprecada porque los frameworks actuales están mas orientados a usar patrones builder-type y clases anónimas
           interas para este tipo de cosas. Por lo tanto las clases SelectBuilder y SqlBuilder están ahora deprecadas.
         </p>
         <p>
@@ -409,8 +409,8 @@ public String updatePersonSql() {
         </tbody>
         </table>
 
-  <p>La clase SelectBuilder no es mágica, pero es importante que conozcas cómo funcionan. 
-  SelectBuilder y SqlBuilder usan una combinación de imports estáticos y una variable ThreadLocal para permitir una sintaxis más limpia más fácilmente usabe con condicionales. 
+  <p>La clase SelectBuilder no es mágica, pero es importante que conozcas cómo funcionan.
+  SelectBuilder y SqlBuilder usan una combinación de imports estáticos y una variable ThreadLocal para permitir una sintaxis más limpia más fácilmente usabe con condicionales.
   Para usarlas debes importar estáticamente métodos de las siguientes clases (uno u otro, no ambos):</p>
 
         <source>import static org.apache.ibatis.jdbc.SelectBuilder.*;</source>

--- a/src/site/ja/xdoc/configuration.xml
+++ b/src/site/ja/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -1402,16 +1402,16 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
         </p>
 
       </subsection>
-      
+
       <subsection name="Handling Enums">
         <p>
           <code>Enum</code> （列挙型）をマップする場合、
           <code>EnumTypeHandler</code> または <code>EnumOrdinalTypeHandler</code> のどちらかを使うことになります。
         </p>
-        
+
         <p>例えば数値の丸めモード（java.math.RoundingMode）を格納する場合、デフォルトでは <code>EnumTypeHandler</code> が使われ、各 <code>Enum</code> は名前の文字列（DOWN, HALF_UP, etc.）に変換されます。
         </p>
-        
+
         <b>他の TypeHandler が特定のクラスを対象としているのに対し、<code>EnumTypeHandler</code> は <code>Enum</code> を継承した任意のクラスを対象とする特別な TypeHandler です。</b>
 
         <p>では名前以外の値を格納したい場合、例えばデータベース管理者が数値で格納して欲しいと言ってきた場合はどうすれば良いのでしょうか。
@@ -1452,7 +1452,7 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
 	    	#{id}, #{name}, #{funkyNumber}, #{roundingMode}
 	    )
 	</insert>
-	
+
 	<resultMap type="org.apache.ibatis.submitted.rounding.User" id="usermap2">
 		<id column="id" property="id"/>
 		<result column="name" property="name"/>
@@ -1805,7 +1805,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
         <p>
           上記のように指定すると、"encoding=UTF8" というプロパティが InitialContext のインスタンス生成時にコンストラクタに渡されます。
         </p>
-        
+
         <p>
           上記以外の DataSource を利用する場合は <code>org.apache.ibatis.datasource.DataSourceFactory</code> インターフェイスを実装したアダプタを作成します。
         </p>
@@ -1822,7 +1822,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
 
         <source><![CDATA[import org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
-        
+
 public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
 
   public C3P0DataSourceFactory() {
@@ -1842,7 +1842,7 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
   <property name="password" value="root"/>
 </dataSource>
 ]]></source>
-        
+
       </subsection>
 
       <subsection name="databaseIdProvider">

--- a/src/site/ja/xdoc/dynamic-sql.xml
+++ b/src/site/ja/xdoc/dynamic-sql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -41,22 +41,22 @@
   </ul>
   <subsection name="if" id="if">
   <p>動的 SQL で最も良く行うのが、次のように条件に応じて where 句に検索条件を追加する処理でしょう。</p>
-  <source><![CDATA[<select id="findActiveBlogWithTitleLike" 
+  <source><![CDATA[<select id="findActiveBlogWithTitleLike"
      resultType="Blog">
-  SELECT * FROM BLOG 
-  WHERE state = ‘ACTIVE’ 
+  SELECT * FROM BLOG
+  WHERE state = ‘ACTIVE’
   <if test="title != null">
     AND title like #{title}
   </if>
-</select>]]></source>  
+</select>]]></source>
   <p>このステートメントによって「任意の検索項目」を実現することができます。title を指定しなければ全ての ACTIVE な Blog が返されますが、title を指定した場合は指定したタイトルを持った Blog が返されます（このステートメントでは like 演算子を使っているので、渡された title にワイルドカードを使うこともできます）。</p>
   <p>
     タイトルと著者の両方を任意の条件としたい場合はどうすれば良いのでしょうか。<br />
     ステートメント名を分かりやすいものに変更したら、あとは条件をもう一つ追加するだけです。
   </p>
-  <source><![CDATA[<select id="findActiveBlogLike" 
+  <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG WHERE state = ‘ACTIVE’ 
+  SELECT * FROM BLOG WHERE state = ‘ACTIVE’
   <if test="title != null">
     AND title like #{title}
   </if>
@@ -68,7 +68,7 @@
   <subsection name="choose, when, otherwise" id="chooseWhenOtherwise">
   <p>全ての条件を適用する代わりに、多くの選択肢の中から一つを選んで適用したいという場合があります。</p>
   <p>引き続き上の例を使って、タイトルが指定されたらタイトルのみを条件として検索し、著者が指定されたら著者のみを条件として検索するようにしてみましょう。どちらも指定されなかった場合は注目のブログのみを返すようにしてみましょう（ランダムに選ばれた無意味なリストではなく、管理者が戦略的に選んだリストを返したいという要件があるのでしょう）。</p>
-  <source><![CDATA[<select id="findActiveBlogLike" 
+  <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
   SELECT * FROM BLOG WHERE state = ‘ACTIVE’
   <choose>
@@ -86,13 +86,13 @@
   </subsection>
   <subsection name="trim, where, set" id="trimWhereSet">
   <p>ここまでの例題は動的 SQL の厄介な問題点を都合よく避けていました。もう一度 if の例に戻って、今度は "ACTIVE = 1" も動的な条件に変更してみましょう。</p>
-  <source><![CDATA[<select id="findActiveBlogLike" 
+  <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG 
-  WHERE 
+  SELECT * FROM BLOG
+  WHERE
   <if test="state != null">
     state = #{state}
-  </if> 
+  </if>
   <if test="title != null">
     AND title like #{title}
   </if>
@@ -101,21 +101,21 @@
   </if>
 </select>]]></source>
   <p>どの条件にも一致しない場合はどうなるのでしょうか？その場合は次のような SQL が実行されることになります。</p>
-  <source><![CDATA[SELECT * FROM BLOG 
+  <source><![CDATA[SELECT * FROM BLOG
 WHERE]]></source>
   <p>この SQL は構文エラーで失敗するでしょう。もし２番目の条件だけが一致したらどうなるのでしょうか？今度は次の SQL になります。</p>
-  <source><![CDATA[SELECT * FROM BLOG 
-WHERE 
+  <source><![CDATA[SELECT * FROM BLOG
+WHERE
 AND title like ‘someTitle’]]></source>
   <p>これまた構文エラーで失敗するでしょう。動的 SQL の問題は単なる条件分岐だけで解決できるものではありません。自分で書いたことがある方なら、もう二度と書きたくないと思うはずです。</p>
   <p>MyBatis は約 90% のケースをうまく処理できる簡単な解決策を提供します。残りの 10% についても、カスタマイズすることで処理できるようになります。上記の例は、一箇所修正するだけで期待通りに動作するようになります。</p>
-  <source><![CDATA[<select id="findActiveBlogLike" 
+  <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG 
-  <where> 
+  SELECT * FROM BLOG
+  <where>
     <if test="state != null">
          state = #{state}
-    </if> 
+    </if>
     <if test="title != null">
         AND title like #{title}
     </if>
@@ -123,12 +123,12 @@ AND title like ‘someTitle’]]></source>
         AND author_name like #{author.name}
     </if>
   </where>
-</select>]]></source> 
+</select>]]></source>
   <p><em>where</em> 要素は、内包するタグのどれかが結果を返すときだけ "WHERE" を挿入します。更に、内包するタグから返された結果が "AND" または "OR" で始まっていた場合はこれを削除します。</p>
   <p><em>where</em> 要素の動作が期待と異なる場合は、trim 要素を定義することで処理内容をカスタマイズすることができます。</p>
   <source><![CDATA[<trim prefix="WHERE" prefixOverrides="AND |OR ">
-  ... 
-</trim>]]></source>  
+  ...
+</trim>]]></source>
   <p><em>prefixOverrides</em> 属性にはパイプで区切られたオーバーライド対象の文字列を指定します。ここではスペースにも意味があります。trim 要素の <em>prefixOverrides</em> 属性のリストに含まれる文字列が先頭にあった場合は削除され、<em>prefix</em> 属性で指定された文字列は結果が空でない場合先頭に挿入されます。</p>
   <p>動的な update ステートメントのために同じような要素 <em>set</em> が用意されています。<em>set</em> 要素を使うと、アップデート対象の列を動的に追加することができます。例：</p>
   <source><![CDATA[<update id="updateAuthorIfNecessary">
@@ -141,7 +141,7 @@ AND title like ‘someTitle’]]></source>
     </set>
   where id=#{id}
 </update>]]></source>
-  <p><em>set</em> 要素は、動的に SET キーワードを付加し、余分な末尾のカンマを削除します。</p>  
+  <p><em>set</em> 要素は、動的に SET キーワードを付加し、余分な末尾のカンマを削除します。</p>
   <p>疑問に思った方のために、これと同じ処理を行う trim 要素は次のようになります。</p>
   <source><![CDATA[<trim prefix="SET" suffixOverrides=",">
   ...
@@ -162,14 +162,14 @@ AND title like ‘someTitle’]]></source>
   <p><em>foreach</em> 要素は非常に強力で、イテレーション処理の対象となるコレクションを指定する collection と、ループ内で要素を格納する変数 item、ループ回数を格納する index 変数を宣言することができます。また、開始・終了の文字列とイテレーションの合間に出力する区切り文字を指定することもできます。foreach タグは賢いので、余分な区切り文字を出力することはありません。</p>
   <p><span class="label important">NOTE</span> collection には Iterable を実装したオブジェクト（List や Set など）の他に Map や Array を指定することもできます。collection に Iterable または Array を指定した場合、 index で指定した変数にはインデックスの数値、 item で指定した変数にはコレクション、配列の要素が格納されます。Map あるいは Map.Entry のコレクションを指定した場合は index にマップのキー、item にマップの値が格納されます。</p>
   <p>XML 設定ファイルと XML Mapper ファイルについての説明はここまでになります。次の章では、Java API について詳しく見ていきます。</p>
-  </subsection>  
+  </subsection>
   <subsection name="bind">
   <p><code>bind</code> 要素を使うと、OGNL 式の結果を変数に格納し、その変数を SQL 文中で使用することができます。</p>
   <source><![CDATA[
 <select id="selectBlogsLike" resultType="Blog">
   <bind name="pattern" value="'%' + _parameter.getTitle() + '%'" />
   SELECT * FROM BLOG
-  WHERE title LIKE #{pattern} 
+  WHERE title LIKE #{pattern}
 </select>]]></source>
   </subsection>
   <subsection name="複数データベースのサポート">
@@ -194,7 +194,7 @@ AND title like ‘someTitle’]]></source>
   ParameterHandler createParameterHandler(MappedStatement mappedStatement, Object parameterObject, BoundSql boundSql);
   SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType);
   SqlSource createSqlSource(Configuration configuration, String script, Class<?> parameterType);
-}]]></source>    
+}]]></source>
     <p>作成した言語ドライバーをデフォルトとして使用する場合は、mybatis-config.xml に次のような設定を追加します（typeAlias の使用は必須ではありません）。</p>
     <source><![CDATA[<typeAliases>
   <typeAlias type="org.sample.MyLanguageDriver" alias="myLanguage"/>

--- a/src/site/ja/xdoc/getting-started.xml
+++ b/src/site/ja/xdoc/getting-started.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 
   <body>
     <section name="スタートガイド">
-    
+
     <subsection name="Installation">
       <p>
         MyBatis を使うためには、ダウンロードした
@@ -43,8 +43,8 @@
   <artifactId>mybatis</artifactId>
   <version>x.x.x</version>
 </dependency>]]></source>
-    </subsection>    
-     
+    </subsection>
+
       <subsection name="XML 形式の設定ファイルを使って SqlSessionFactory を生成する">
         <p>
           MyBatis アプリケーションは、SqlSessionFactory のインスタンスを中心に構成されています。<br />

--- a/src/site/ja/xdoc/java-api.xml
+++ b/src/site/ja/xdoc/java-api.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@
       /web.xml</pre>
   <p>これは推奨されるディレクトリ構造であって必須ではありませんが、一般的なディレクトリ構造を使っておけば他の開発者からは感謝されるはずです。</p>
   <p>尚、この章のサンプルでは、上記のディレクトリ構造を前提にしています。</p>
-  </subsection>  
+  </subsection>
 
   <subsection name="SqlSessions" id="sqlSessions">
   <p>MyBatis の最も良く使う Java インターフェイスは SqlSession です。コマンドの実行、Mapper の取得、トランザクション管理はこのインターフェイスを通して行うことができます。SqlSession については、後で詳しく説明しますが、その前に SqlSession のインスタンスを取得する方法について学ばなくてはなりません。SqlSession は SqlSessionFactory のインスタンスによって作成されます。SqlSessionFactory には、様々な方法で SqlSession を作成するメソッドが含まれています。SqlSessionFactory 自身は SqlSessionFactoryBuilder によって作られますが、作成される SqlSessionFactory は XML、アノテーション、ハードコードされた Java コンフィグレーションのいずれかの方法で設定することができます。</p>
@@ -71,7 +71,7 @@
 SqlSessionFactory build(InputStream inputStream, String environment)
 SqlSessionFactory build(InputStream inputStream, Properties properties)
 SqlSessionFactory build(InputStream inputStream, String env, Properties props)
-SqlSessionFactory build(Configuration config)</source>  
+SqlSessionFactory build(Configuration config)</source>
 
   <p>
 良く使うのは、InputStream のインスタンスを引数に取って XML ファイル（具体的には mybatis-config.xml ファイル）を読み込む最初の４つのメソッドです。オプションの引数は environment と properties です。environment は、データソースやトランザクションマネージャーも含めて、どの environment を読み込むかを決定します。例：</p>
@@ -89,7 +89,7 @@ SqlSessionFactory build(Configuration config)</source>
     <dataSource type="JNDI">
         ...
   </environment>
-</environments>]]></source>  
+</environments>]]></source>
   <p>引数として environment を取る build メソッドを呼び出した場合、MyBatis はその environment の設定を使ってビルドを実行します。未定義の environment を指定した場合はエラーが発生します。引数に environment を取らない build メソッドを呼び出した場合はデフォルトの environment が使用されます（上記の例では default="development" と指定されています）。</p>
   <p>引数に properties のインスタンスを取る build メソッドを実行した場合、これらのプロパティは設定内でアクセスできるように読み込まれます。設定内では ${propName} のように記述することでプロパティを参照することができます。</p>
   <p>このドキュメントの前の方で説明しましたが、プロパティは mybatis-config.xml ファイルからも参照される可能性があるので、優先順位について理解しておくことが重要です。再掲しておきます。</p>
@@ -104,13 +104,13 @@ SqlSessionFactory build(Configuration config)</source>
   <p>従って、メソッド引数として渡されたプロパティが最も優先度が高く、次に resource/url 属性、最も優先度が低いのは properties 要素のボディで指定された値ということになります。</p>
   <hr/>
 
-  <p>まとめると、最初の４つの build メソッドはだいたい同じで、必要に応じて environment と properties をオーバーライドできるメソッドを選択することができます。mybatis-config.xml ファイルから SqlSessionFactory をビルドする例を挙げておきます。</p>  
+  <p>まとめると、最初の４つの build メソッドはだいたい同じで、必要に応じて environment と properties をオーバーライドできるメソッドを選択することができます。mybatis-config.xml ファイルから SqlSessionFactory をビルドする例を挙げておきます。</p>
 
   <source>String <strong>resource</strong> = "org/mybatis/builder/mybatis-config.xml";
 InputStream <strong>inputStream</strong> = Resources.getResourceAsStream(resource);
 SqlSessionFactoryBuilder <strong>builder</strong> = new SqlSessionFactoryBuilder();
-SqlSessionFactory <strong>factory</strong> = builder.build(inputStream);</source>  
-  
+SqlSessionFactory <strong>factory</strong> = builder.build(inputStream);</source>
+
   <p>ここでは org.apache.ibatis.io パッケージに含まれている Resources ユーティリティクラスを利用しています。このクラスは名前からも分かるように、クラスパスやファイルシステムあるいはウェブ上の URL からリソースを読み込むためのメソッドを提供します。分かりやすい実装なので、ソースを読めばどのようなメソッドが用意されているか分かると思いますが、シグネチャだけリストアップしておきます。</p>
   <source>URL getResourceURL(String resource)
 URL getResourceURL(ClassLoader loader, String resource)
@@ -226,16 +226,16 @@ RowBounds rowBounds = new RowBounds(offset, limit);</source>
   <p>ドライバーによって得られる効果は異なります。SCROLL_SENSITIVE または SCROLL_INSENSITIVE （つまり FORWARD_ONLY 以外）の結果セットタイプを使った時、最も良いパフォーマンスが得られます。</p>
   <p>ResultHandler を渡すと、各行を自由に処理することができます。List に追加したり、Map や Set を作成することもできますし、結果を捨てて合計値のみを返すこともできます。ResultHandler を使えば好きな処理を行うことも可能で、MyBatis 自身も内部的に結果リストを構築するために ResultHandler を利用しています。</p>
   <p>3.4.6 以降では、CALLABLE ステートメントに渡された ResultHandler は、指定されたストアド・プロシージャで宣言されている REFCURSOR 型の OUT 引数全てに対して適用されます。</p>
-  <p>ResultHandler インターフェイスは非常にシンプルです。</p>  
+  <p>ResultHandler インターフェイスは非常にシンプルです。</p>
   <source><![CDATA[package org.mybatis.executor.result;
 public interface ResultHandler<T> {
   void handleResult(ResultContext<? extends T> context);
 }]]></source>
 
   <p>引数 ResultContext を介して結果オブジェクトにアクセスすることができます。ResultContext#getResultCount() メソッドは作成された結果オブジェクトの数を返します。ResultContext#stop() メソッドを呼び出すと、それ以上結果を読み込まないよう MyBatis に指示します。</p>
-  
+
   <p>ResultHandler を使用する場合に注意すべき点が２つあります。</p>
-  
+
   <ul>
   <li>ResultHandler を引数に取るメソッドから返されるデータはキャッシュされません。</li>
   <li>複雑な ResultMap では複数行のデータがひとつのオブジェクトにマッピングされることもあります。こうした ResultMap を ResultHandler と併用する際、association や collection のデータがマッピングされる前の状態のオブジェクトが渡される場合があります。</li>
@@ -288,12 +288,12 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
   <source>Configuration getConfiguration()</source>
 
   <h5>Mapper を使う</h5>
-  <source><![CDATA[<T> T getMapper(Class<T> type)]]></source>  
+  <source><![CDATA[<T> T getMapper(Class<T> type)]]></source>
   <p>SqlSession に用意されている insert, update, delete, select などのメソッドは確かに強力ですが、かなり冗長で、型に安全でないため IDE やユニットテストの機能をフルに活用することができません。既にスタートガイドの章で Mapper を使う例が出てきました。</p>
   <p>マップドステートメントを実行する際は Mapper クラスを使った方法がより一般的です。Mapper クラスは SqlSession のメソッドに対応したメソッド定義を持つインターフェイスです。次の例は、Mapper クラスで定義されているメソッドが SqlSession のメソッドとどのように対応しているかを表しています。</p>
   <source><![CDATA[public interface AuthorMapper {
   // (Author) selectOne("selectAuthor",5);
-  Author selectAuthor(int id); 
+  Author selectAuthor(int id);
   // (List<Author>) selectList(“selectAuthors”)
   List<Author> selectAuthors();
   // (Map<Integer,Author>) selectMap("selectAuthors", "id")
@@ -306,7 +306,7 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
   // delete("deleteAuthor",5)
   int deleteAuthor(int id);
 }]]></source>
-  <p>基本的に、それぞれの Mapper メソッドのシグネチャは、対応する SqlSession のメソッドのシグネチャからステートメントの ID を指定する String 型の引数を除いたものになっています。ステートメントの ID は引数で指定するのではなくメソッド名から取得されます。</p> 
+  <p>基本的に、それぞれの Mapper メソッドのシグネチャは、対応する SqlSession のメソッドのシグネチャからステートメントの ID を指定する String 型の引数を除いたものになっています。ステートメントの ID は引数で指定するのではなくメソッド名から取得されます。</p>
   <p>戻り値の型について補足しておくと、クエリの結果が単一オブジェクトの場合はその型と一致している必要があり、複数の場合は配列またはコレクションになります。プリミティブ、Map, POJO, JavaBean など通常の型は一通り指定可能です。</p>
   <p><span class="label important">NOTE</span> Mapper インターフェイスは、他のインターフェイスを実装したり、他のクラスを継承する必要はありません。定義されているメソッドのシグネチャから対応するステートメントを識別できるようになっていれば OK です。</p>
   <p><span class="label important">NOTE</span> Mapper インターフェイスは他のインターフェイスを継承することができます。Mapper インターフェイスを XML と組み合わせて使う場合は、ステートメントが正しいネームスペースに含まれるように注意してください。また唯一の制限として、継承関係にある複数のインターフェイスに同じシグネチャを持つメソッドを定義することはできません（そもそも良い考えではありません）。</p>

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -94,7 +94,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
 </dataSource>]]></source>
 
         <p>
-          이 기능은 기본적으로 비활성화되어 있다. placeholder 에 기본값을 지정한다면, 
+          이 기능은 기본적으로 비활성화되어 있다. placeholder 에 기본값을 지정한다면,
           이 기능을 활성화하려면 다음과 같이 특별한 속성을 추가해주어야 한다.
         </p>
 
@@ -105,9 +105,9 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
 </properties>]]></source>
 
         <p>
-          <span class="label important">NOTE</span> 
-          또한 이미 property key (예 : <code>db : username</code>)로 <code>":"</code>를 사용하거나 
-          SQL 정의에서 OGNL 표현식의 삼항 연산자 (예 : <code>${tableName != null ? tableName : 'global_constants'}</code>)를 사용하는 경우 
+          <span class="label important">NOTE</span>
+          또한 이미 property key (예 : <code>db : username</code>)로 <code>":"</code>를 사용하거나
+          SQL 정의에서 OGNL 표현식의 삼항 연산자 (예 : <code>${tableName != null ? tableName : 'global_constants'}</code>)를 사용하는 경우
           다음과 같이 특별한 속성을 추가하여 키와 기본값을 구분하는 문자를 변경해야한다.
         </p>
 
@@ -154,7 +154,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
                 지연로딩을 사용할지에 대한 여부. 사용하지 않는다면 모두 즉시 로딩할 것이다.
-                이 값은 <code>fetchType</code> 속성을 사용해서 대체할 수 있다.  
+                이 값은 <code>fetchType</code> 속성을 사용해서 대체할 수 있다.
               </td>
               <td>
                 true | false
@@ -193,8 +193,8 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               <td>
                 useColumnLabel
               </td>
-              <td>칼럼명 대신에 칼럼라벨을 사용. 
-			  드라이버마다 조금 다르게 작동한다. 
+              <td>칼럼명 대신에 칼럼라벨을 사용.
+			  드라이버마다 조금 다르게 작동한다.
 			  문서와 간단한 테스트를 통해 실제 기대하는 것처럼 작동하는지 확인해야 한다.</td>
               <td>
                 true | false
@@ -207,8 +207,8 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               <td>
                 useGeneratedKeys
               </td>
-              <td>생성키에 대한 JDBC 지원을 허용. 지원하는 드라이버가 필요하다. 
-			  true로 설정하면 생성키를 강제로 생성한다. 
+              <td>생성키에 대한 JDBC 지원을 허용. 지원하는 드라이버가 필요하다.
+			  true로 설정하면 생성키를 강제로 생성한다.
 			  일부 드라이버(예를들면, Derby)에서는 이 설정을 무시한다.</td>
               <td>
                 true | false
@@ -221,8 +221,8 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               <td>
                 autoMappingBehavior
               </td>
-              <td>마이바티스가 칼럼을 필드/프로퍼티에 자동으로 매핑할지와 방법에 대해 명시. 
-			  PARTIAL은 간단한 자동매핑만 할뿐 내포된 결과에 대해서는 처리하지 않는다. 
+              <td>마이바티스가 칼럼을 필드/프로퍼티에 자동으로 매핑할지와 방법에 대해 명시.
+			  PARTIAL은 간단한 자동매핑만 할뿐 내포된 결과에 대해서는 처리하지 않는다.
 			  FULL은 처리가능한 모든 자동매핑을 처리한다.</td>
               <td>
                 NONE, PARTIAL, FULL
@@ -254,9 +254,9 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               <td>
                 defaultExecutorType
               </td>
-              <td>디폴트 실행자(executor) 설정. 
-			  SIMPLE 실행자는 특별히 하는 것이 없다. 
-			  REUSE 실행자는 PreparedStatement를 재사용한다. 
+              <td>디폴트 실행자(executor) 설정.
+			  SIMPLE 실행자는 특별히 하는 것이 없다.
+			  REUSE 실행자는 PreparedStatement를 재사용한다.
 			  BATCH 실행자는 구문을 재사용하고 수정을 배치처리한다.</td>
               <td>
                 SIMPLE
@@ -273,7 +273,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>데이터베이스로의 응답을 얼마나 오래 기다릴지를 판단하는 타임아웃을 설정</td>
               <td>
-				양수 
+				양수
               </td>
               <td>설정되지 않음(null)</td>
             </tr>
@@ -283,7 +283,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
                 조회결과를 가져올때 가져올 데이터 크기를 제어하는 용도로 드라이버에 힌트를 설정
-				이 파라미터값은 쿼리 설정으로 변경할 수 있다. 
+				이 파라미터값은 쿼리 설정으로 변경할 수 있다.
               </td>
               <td>
                 양수
@@ -297,8 +297,8 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 defaultFetchSize
               </td>
               <td>
-                결과를 가져오는 크기를 제어하는 힌트처럼 드라이버에 설정한다. 
-				이 파라미터는 쿼리설정으로 변경할 수 있다. 
+                결과를 가져오는 크기를 제어하는 힌트처럼 드라이버에 설정한다.
+				이 파라미터는 쿼리설정으로 변경할 수 있다.
               </td>
               <td>
                 양수
@@ -313,7 +313,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
                 중첩구문내 RowBound사용을 허용
-                허용한다면 false로 설정 
+                허용한다면 false로 설정
               </td>
               <td>
                 true | false
@@ -328,7 +328,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
                 중첩구문내 ResultHandler사용을 허용
-                허용한다면 false로 설정 
+                허용한다면 false로 설정
               </td>
               <td>
                 true | false
@@ -356,9 +356,9 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 localCacheScope
               </td>
               <td>
-                마이바티스는 순환참조를 막거나 반복된 쿼리의 속도를 높히기 위해 로컬캐시를 사용한다. 
-                디폴트 설정인 SESSION을 사용해서 동일 세션의 모든 쿼리를 캐시한다. 
-                localCacheScope=STATEMENT 로 설정하면 로컬 세션은 구문 실행할때만 사용하고 같은 SqlSession에서 두개의 다른 호출사이에는 데이터를 공유하지 않는다. 
+                마이바티스는 순환참조를 막거나 반복된 쿼리의 속도를 높히기 위해 로컬캐시를 사용한다.
+                디폴트 설정인 SESSION을 사용해서 동일 세션의 모든 쿼리를 캐시한다.
+                localCacheScope=STATEMENT 로 설정하면 로컬 세션은 구문 실행할때만 사용하고 같은 SqlSession에서 두개의 다른 호출사이에는 데이터를 공유하지 않는다.
               </td>
               <td>
                 SESSION | STATEMENT
@@ -372,11 +372,11 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 jdbcTypeForNull
               </td>
               <td>
-                JDBC타입을 파라미터에 제공하지 않을때 null값을 처리한 JDBC타입을 명시한다. 
-                일부 드라이버는 칼럼의 JDBC타입을 정의하도록 요구하지만 대부분은 NULL, VARCHAR 나 OTHER 처럼 일반적인 값을 사용해서 동작한다. 
+                JDBC타입을 파라미터에 제공하지 않을때 null값을 처리한 JDBC타입을 명시한다.
+                일부 드라이버는 칼럼의 JDBC타입을 정의하도록 요구하지만 대부분은 NULL, VARCHAR 나 OTHER 처럼 일반적인 값을 사용해서 동작한다.
               </td>
               <td>
-                JdbcType 이늄. 대부분은 NULL, VARCHAR 나 OTHER 를 공통적으로 사용한다. 
+                JdbcType 이늄. 대부분은 NULL, VARCHAR 나 OTHER 를 공통적으로 사용한다.
               </td>
               <td>
                 OTHER
@@ -430,8 +430,8 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
                 가져온 값이 null일때 setter나 맵의 put 메소드를 호출할지를 명시
-                Map.keySet() 이나 null값을 초기화할때 유용하다. 
-                int, boolean 등과 같은 원시타입은 null을 설정할 수 없다는 점은 알아두면 좋다.  
+                Map.keySet() 이나 null값을 초기화할때 유용하다.
+                int, boolean 등과 같은 원시타입은 null을 설정할 수 없다는 점은 알아두면 좋다.
               </td>
               <td>
                 true | false
@@ -461,7 +461,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 logPrefix
               </td>
               <td>
-                마이바티스가 로거(logger) 이름에 추가할 접두사 문자열을 명시 
+                마이바티스가 로거(logger) 이름에 추가할 접두사 문자열을 명시
               </td>
               <td>
                 문자열
@@ -476,7 +476,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
                 마이바티스가 사용할 로깅 구현체를 명시
-                이 설정을 사용하지 않으면 마이바티스가 사용할 로깅 구현체를 자동으로 찾는다.  
+                이 설정을 사용하지 않으면 마이바티스가 사용할 로깅 구현체를 자동으로 찾는다.
               </td>
               <td>
                 SLF4J | LOG4J | LOG4J2 | JDK_LOGGING | COMMONS_LOGGING | STDOUT_LOGGING | NO_LOGGING
@@ -564,8 +564,8 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
 
       </subsection>
       <subsection name="typeAliases">
-        <p>타입 별칭은 자바 타입에 대한 짧은 이름이다. 
-		오직 XML 설정에서만 사용되며, 타이핑을 줄이기 위해 존재한다. 
+        <p>타입 별칭은 자바 타입에 대한 짧은 이름이다.
+		오직 XML 설정에서만 사용되며, 타이핑을 줄이기 위해 존재한다.
 		예를들면:</p>
         <source><![CDATA[<typeAliases>
   <typeAlias alias="Author" type="domain.blog.Author"/>
@@ -584,10 +584,10 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
 </typeAliases>
 ]]></source>
         <p>
-          <code>domain.blog</code> 에서 빈을 검색하고 애노테이션이 없을 경우 빈의 이름이 소문자로 변환된 형태의 별칭으로 등록할 것이다. 
-		  이때 빈의 패키지정보도 제거하고 등록된다. 
-          이를테면 <code>domain.blog.Author</code>는 <code>author</code>로 등록될 것이다. 
-		  만약에 <code>@Alias</code> 애노테이션을 사용한다면 이 애노테이션에서 지정한 값이 별칭으로 사용될 것이다. 
+          <code>domain.blog</code> 에서 빈을 검색하고 애노테이션이 없을 경우 빈의 이름이 소문자로 변환된 형태의 별칭으로 등록할 것이다.
+		  이때 빈의 패키지정보도 제거하고 등록된다.
+          이를테면 <code>domain.blog.Author</code>는 <code>author</code>로 등록될 것이다.
+		  만약에 <code>@Alias</code> 애노테이션을 사용한다면 이 애노테이션에서 지정한 값이 별칭으로 사용될 것이다.
           아래의 예를 보라:
         </p>
         <source><![CDATA[@Alias("author")
@@ -595,13 +595,13 @@ public class Author {
     ...
 }
 ]]></source>
-        <p>공통의 자바타입에 대해서는 내장된 타입 별칭이 있다. 
+        <p>공통의 자바타입에 대해서는 내장된 타입 별칭이 있다.
 		이 모두 대소문자를 가린다.</p>
         <table>
           <thead>
             <tr>
               <th>
-                별칭 
+                별칭
               </th>
               <th>
                 매핑된 타입
@@ -829,7 +829,7 @@ public class Author {
         </table>
       </subsection>
       <subsection name="typeHandlers">
-        <p>마이바티스가 PreparedStatement에 파라미터를 설정하고 ResultSet에서 값을 가져올때마다 TypeHandler는 적절한 자바 타입의 값을 가져오기 위해 사용된다. 
+        <p>마이바티스가 PreparedStatement에 파라미터를 설정하고 ResultSet에서 값을 가져올때마다 TypeHandler는 적절한 자바 타입의 값을 가져오기 위해 사용된다.
         다음의 표는 디폴트 TypeHandlers를 설명한다.</p>
         <p>
           <span class="label important">NOTE</span>
@@ -839,10 +839,10 @@ public class Author {
           <thead>
             <tr>
               <th>
-              타입 핸들러 
+              타입 핸들러
               </th>
               <th>
-              자바 타입 
+              자바 타입
               </th>
               <th>
               JDBC 타입
@@ -1233,8 +1233,8 @@ public class Author {
             </tr>
           </tbody>
         </table>
-        <p>지원하지 않거나 비표준인 타입에 대해서는 당신 스스로 만들어서 타입핸들러를 오버라이드할 수 있다. 
-        그러기 위해서는 TypeHandler 인터페이스를 구현하고 자바 타입에 TypeHandler를 매핑하면 된다. 
+        <p>지원하지 않거나 비표준인 타입에 대해서는 당신 스스로 만들어서 타입핸들러를 오버라이드할 수 있다.
+        그러기 위해서는 TypeHandler 인터페이스를 구현하고 자바 타입에 TypeHandler를 매핑하면 된다.
 		예를들면:</p>
 
         <source><![CDATA[// ExampleTypeHandler.java
@@ -1269,17 +1269,17 @@ public class ExampleTypeHandler extends BaseTypeHandler<String> {
 </typeHandlers>
 ]]></source>
 
-        <p>이러한 TypeHandler를 사용하는 것은 자바 String프로퍼티와 VARCHAR파라미터 및 결과를 위해 이미 존재하는 핸들러를 오버라이드하게 될 것이다. 
-        마이바티스는 타입을 판단하기 위해 데이터베이스의 메타데이터를 보지 않는다. 
-		그래서 파라미터와 결과에 정확한 타입 핸들러를 매핑해야 한다. 
+        <p>이러한 TypeHandler를 사용하는 것은 자바 String프로퍼티와 VARCHAR파라미터 및 결과를 위해 이미 존재하는 핸들러를 오버라이드하게 될 것이다.
+        마이바티스는 타입을 판단하기 위해 데이터베이스의 메타데이터를 보지 않는다.
+		그래서 파라미터와 결과에 정확한 타입 핸들러를 매핑해야 한다.
         마이바티스가 구문이 실행될때까지는 데이터 타입에 대해 모르기 때문이다.</p>
-        <p>마이바티스는 제네릭타입을 체크해서 TypeHandler로 다루고자 하는 자바타입을 알것이다. 
+        <p>마이바티스는 제네릭타입을 체크해서 TypeHandler로 다루고자 하는 자바타입을 알것이다.
 		하지만 두가지 방법으로 이 행위를 재정의할 수 있다:
         </p>
         <ul>
-          <li>typeHandler 엘리먼트의 <code>javaType</code> 속성 추가(예제: <code>javaType="String"</code>)          
-          </li> 
-          <li>TypeHandler클래스에 관련된 자바타입의 목록을 정의하는 <code>@MappedTypes</code> 애노테이션 추가. 
+          <li>typeHandler 엘리먼트의 <code>javaType</code> 속성 추가(예제: <code>javaType="String"</code>)
+          </li>
+          <li>TypeHandler클래스에 관련된 자바타입의 목록을 정의하는 <code>@MappedTypes</code> 애노테이션 추가.
           <code>javaType</code> 속성도 함께 정의되어 있다면 <code>@MappedTypes</code>는 무시된다.</li>
         </ul>
 
@@ -1287,17 +1287,17 @@ public class ExampleTypeHandler extends BaseTypeHandler<String> {
         <ul>
           <li>typeHandler 엘리먼트에 <code>jdbcType</code> 속성 추가(예제: <code>jdbcType="VARCHAR"</code>).
           </li>
-          <li>TypeHandler클래스에 관련된 JDBC타입의 목록을 정의하는 <code>@MappedJdbcTypes</code> 애노테이션 추가. 
+          <li>TypeHandler클래스에 관련된 JDBC타입의 목록을 정의하는 <code>@MappedJdbcTypes</code> 애노테이션 추가.
           <code>jdbcType</code> 속성도 함께 정의되어 있다면 <code>@MappedJdbcTypes</code>는 무시된다.</li>
         </ul>
 
         <p>
-          <code>ResultMap</code>에서 타입핸들러를 사용한다고 결정하면 마이바티스가 자바타입은 잘 처리하지만 JDBC타입은 잘 처리하지 못할 수 있다. 
-		  그래서 마이바티스는 타입핸들러를 선택하기 위해 <code>javaType=[TheJavaType], jdbcType=null</code>조합을 사용한다. 
-		  <code>@MappedJdbcTypes</code> 애노테이션의 사용은 타입핸들러의  범위를 <i>제한</i>하고 명시적으로 설정하지 않는한 <code>결과매핑</code>을 사용하지 못하도록 만든다. 
-		  <code>결과매핑</code>에서 타입핸들러를 사용할수 있도록 하려면 <code>@MappedJdbcTypes</code>애노테이션에 <code>includeNullJdbcType=true</code>를 설정하자. 
-		  자바타입을 다루기 위해 <b>한개의</b> 타입핸들러만 등록한다면 <code>결과매핑</code>에서 자바타입을 다루기 위해 이 타입핸들러를 기본적으로 사용할 것이다. 
-		  한개의 타입핸들러만 등록할 경우 <code>includeNullJdbcType=true</code>를 설정하지 않아도 동일하게 동작한다. 
+          <code>ResultMap</code>에서 타입핸들러를 사용한다고 결정하면 마이바티스가 자바타입은 잘 처리하지만 JDBC타입은 잘 처리하지 못할 수 있다.
+		  그래서 마이바티스는 타입핸들러를 선택하기 위해 <code>javaType=[TheJavaType], jdbcType=null</code>조합을 사용한다.
+		  <code>@MappedJdbcTypes</code> 애노테이션의 사용은 타입핸들러의  범위를 <i>제한</i>하고 명시적으로 설정하지 않는한 <code>결과매핑</code>을 사용하지 못하도록 만든다.
+		  <code>결과매핑</code>에서 타입핸들러를 사용할수 있도록 하려면 <code>@MappedJdbcTypes</code>애노테이션에 <code>includeNullJdbcType=true</code>를 설정하자.
+		  자바타입을 다루기 위해 <b>한개의</b> 타입핸들러만 등록한다면 <code>결과매핑</code>에서 자바타입을 다루기 위해 이 타입핸들러를 기본적으로 사용할 것이다.
+		  한개의 타입핸들러만 등록할 경우 <code>includeNullJdbcType=true</code>를 설정하지 않아도 동일하게 동작한다.
         </p>
 
         <p>마지막으로 마이바티스로 하여금 TypeHandler를 찾도록 할수 있다:</p>
@@ -1309,7 +1309,7 @@ public class ExampleTypeHandler extends BaseTypeHandler<String> {
 
         <p>JDBC타입에 대한 자동검색 기능은 애노테이션을 명시한 경우에만 가능하다는 것을 알아둘 필요가 있다. </p>
         <p>
-          한개 이상의 클래스를 다루는 제네릭 TypeHandler를 만들수 있다. 
+          한개 이상의 클래스를 다루는 제네릭 TypeHandler를 만들수 있다.
           파라미터로 클래스를 가져오는 생성자를 추가하고 마이바티스는 TypeHandler를 만들때 실제 클래스를 전달할 것이다.
         </p>
 
@@ -1325,28 +1325,28 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
   ...
 ]]></source>
 
-		<p><code>EnumTypeHandler</code> 와 <code>EnumOrdinalTypeHandler</code> 는 제네릭 TypeHandler이다. 
-		이어서 각각을 다룬다.  
+		<p><code>EnumTypeHandler</code> 와 <code>EnumOrdinalTypeHandler</code> 는 제네릭 TypeHandler이다.
+		이어서 각각을 다룬다.
 		</p>
 
       </subsection>
-      
+
       <subsection name="Handling Enums">
       	<p>
-      	<code>Enum</code>을 매핑하고자 한다면 <code>EnumTypeHandler</code> 나 <code>EnumOrdinalTypeHandler</code> 를 사용할 필요가 있을것이다.  
+      	<code>Enum</code>을 매핑하고자 한다면 <code>EnumTypeHandler</code> 나 <code>EnumOrdinalTypeHandler</code> 를 사용할 필요가 있을것이다.
       	</p>
-      	
-      	<p>예를들어 순환 방식으로 몇개의 숫자를 사용하는 순환모드를 저장할 필요가 있다고 해보자. 
+
+      	<p>예를들어 순환 방식으로 몇개의 숫자를 사용하는 순환모드를 저장할 필요가 있다고 해보자.
       	기본적으로 마이바티스는 <code>Enum</code> 값을 각각의 이름으로 변환하기 위해 <code>EnumTypeHandler</code> 를 사용한다.
       	</p>
-      	
-      	<b><code>EnumTypeHandler</code>는 특히 다른 핸들러와 차이가 있다. 
+
+      	<b><code>EnumTypeHandler</code>는 특히 다른 핸들러와 차이가 있다.
       	어떤 하나의 특정 클래스를 다루지 않고 <code>Enum</code> 을 확장하는 모든 클래스를 다룬다. </b>
 
-      	<p>아무리 이름을 저장하려해도 DBA는 숫자코드를 고집할수 있다. 
-		이름대신 숫자코드를 저장하는 방법은 쉽다. 
-      	설정파일의 <code>typeHandlers</code>에 <code>EnumOrdinalTypeHandler</code> 를 추가하자. 
-      	그러면 각각의 <code>RoundingMode</code>는 순서값을 사용해서 숫자를 매핑할 것이다.     	
+      	<p>아무리 이름을 저장하려해도 DBA는 숫자코드를 고집할수 있다.
+		이름대신 숫자코드를 저장하는 방법은 쉽다.
+      	설정파일의 <code>typeHandlers</code>에 <code>EnumOrdinalTypeHandler</code> 를 추가하자.
+      	그러면 각각의 <code>RoundingMode</code>는 순서값을 사용해서 숫자를 매핑할 것이다.
       	</p>
        <source><![CDATA[<!-- mybatis-config.xml -->
 <typeHandlers>
@@ -1357,11 +1357,11 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
 		  같은 <code>Enum</code>을 사용해서 어떤곳에는 문자열로 매핑하고 다른곳에는 숫자로 매핑해야 한다면 무엇을 해야 하나?
 		</p>
       	<p>
-      	  자동매퍼는 <code>EnumOrdinalTypeHandler</code> 를 자동으로 사용할 것이다. 
-      	  그래서 평범한 순서를 나타내는 <code>EnumTypeHandler</code> 를 사용하고자 한다면 SQL구문에 사용할 타입핸들러를 몀시적으로 설정한다. 
+      	  자동매퍼는 <code>EnumOrdinalTypeHandler</code> 를 자동으로 사용할 것이다.
+      	  그래서 평범한 순서를 나타내는 <code>EnumTypeHandler</code> 를 사용하고자 한다면 SQL구문에 사용할 타입핸들러를 몀시적으로 설정한다.
       	</p>
       	<p>
-      	  (매퍼 파일은 다음절까지는 다루지 않는다. 
+      	  (매퍼 파일은 다음절까지는 다루지 않는다.
       	  그래서 문서를 보면서 처음 봤다면 일단 이부분은 건너띄고 다음에 다시 볼수도 있다. )
       	</p>
       	<source><![CDATA[<!DOCTYPE mapper
@@ -1384,7 +1384,7 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
 	    	#{id}, #{name}, #{funkyNumber}, #{roundingMode}
 	    )
 	</insert>
-	
+
 	<resultMap type="org.apache.ibatis.submitted.rounding.User" id="usermap2">
 		<id column="id" property="id"/>
 		<result column="name" property="name"/>
@@ -1403,14 +1403,14 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
 </mapper>
 ]]></source>
 		<p>
-		  여기서 사용한 select구문에서는 <code>resultType</code> 대신에 <code>resultMap</code>을 사용해야 한다는 점을 알아두자. 
+		  여기서 사용한 select구문에서는 <code>resultType</code> 대신에 <code>resultMap</code>을 사용해야 한다는 점을 알아두자.
 		</p>
       </subsection>
 
       <subsection name="objectFactory">
-        <p>매번 마이바티스는 결과 객체의 인스턴스를 만들기 위해 ObjectFactory를 사용한다. 
-		디폴트 ObjectFactory 는 디폴트 생성자를 가진 대상 클래스를 인스턴스화하는 것보다 조금 더 많은 작업을 한다. 
-		ObjectFactory 의 디폴트 행위를 오버라이드하고자 한다면 만들 수 있다. 
+        <p>매번 마이바티스는 결과 객체의 인스턴스를 만들기 위해 ObjectFactory를 사용한다.
+		디폴트 ObjectFactory 는 디폴트 생성자를 가진 대상 클래스를 인스턴스화하는 것보다 조금 더 많은 작업을 한다.
+		ObjectFactory 의 디폴트 행위를 오버라이드하고자 한다면 만들 수 있다.
 		예를들면:</p>
         <source><![CDATA[// ExampleObjectFactory.java
 public class ExampleObjectFactory extends DefaultObjectFactory {
@@ -1432,14 +1432,14 @@ public class ExampleObjectFactory extends DefaultObjectFactory {
 <objectFactory type="org.mybatis.example.ExampleObjectFactory">
   <property name="someProperty" value="100"/>
 </objectFactory>]]></source>
-        <p>ObjectFactory인터페이스는 매우 간단한다. 
-		두개의 create메소드를 가지고 있으며 하나는 디폴트 생성자를 처리하고 다른 하나는 파라미터를 가진 생성자를 처리한다. 
-		마지막으로 setProperties 메소드는 ObjectFactory를 설정하기 위해 사용될 수 있다. 
+        <p>ObjectFactory인터페이스는 매우 간단한다.
+		두개의 create메소드를 가지고 있으며 하나는 디폴트 생성자를 처리하고 다른 하나는 파라미터를 가진 생성자를 처리한다.
+		마지막으로 setProperties 메소드는 ObjectFactory를 설정하기 위해 사용될 수 있다.
 		objectFactory엘리먼트에 정의된 프로퍼티는 ObjectFactory인스턴스가 초기화된 후 setProperties에 전달될 것이다.</p>
 
       </subsection>
       <subsection name="plugins">
-        <p>마이바티스는 매핑 구문을 실행하는 어떤 시점에 호출을 가로챈다. 
+        <p>마이바티스는 매핑 구문을 실행하는 어떤 시점에 호출을 가로챈다.
 		기본적으로 마이바티스는 메소드 호출을 가로채기 위한 플러그인을 허용한다.</p>
         <ul>
           <li>
@@ -1461,11 +1461,11 @@ public class ExampleObjectFactory extends DefaultObjectFactory {
             (prepare, parameterize, batch, update, query)
           </li>
         </ul>
-        <p>이 클래스들의 메소드는 각각 메소드 시그니처를 통해 찾을 수 있고 소스코드는 마이바티스 릴리즈 파일에서 찾을 수 있다. 
-		오버라이드할 메소드의 행위를 이해해야만 한다. 
-		주어진 메소드의 행위를 변경하거나 오버라이드하고자 한다면 마이바티스의 핵심기능에 악영향을 줄수도 있다. 
+        <p>이 클래스들의 메소드는 각각 메소드 시그니처를 통해 찾을 수 있고 소스코드는 마이바티스 릴리즈 파일에서 찾을 수 있다.
+		오버라이드할 메소드의 행위를 이해해야만 한다.
+		주어진 메소드의 행위를 변경하거나 오버라이드하고자 한다면 마이바티스의 핵심기능에 악영향을 줄수도 있다.
 		이러한 로우레벨 클래스와 메소드들은 주의를 해서 사용해야 한다.</p>
-        <p>플러그인을 사용하도록 처리하는 방법은 간단하다. 
+        <p>플러그인을 사용하도록 처리하는 방법은 간단하다.
 		Interceptor인터페이스를 구현해서 가로채고(intercept) 싶은 시그니처를 명시해야 한다.</p>
 
         <source><![CDATA[// ExamplePlugin.java
@@ -1494,27 +1494,27 @@ public class ExamplePlugin implements Interceptor {
         <p><span class="label important">참고</span>
           <strong>설정파일 오버라이드하기</strong>
         </p>
-        <p>플러그인을 사용해서 마이바티스 핵심 행위를 변경하기 위해 Configuration클래스 전체를 오버라이드 할 수 있다. 
+        <p>플러그인을 사용해서 마이바티스 핵심 행위를 변경하기 위해 Configuration클래스 전체를 오버라이드 할 수 있다.
 		이 클래스를 확장하고 내부 메소드를 오버라이드하고 SqlSessionFactoryBuilder.build(myConfig)메소드에 그 객체를 넣어주면 된다.
 		다시 얘기하지만 이 작업은 마이바티스에 큰 영향을 줄수 있으니 주의해서 해야 한다.</p>
       </subsection>
       <subsection name="environments">
-        <p>마이바티스는 여러개의 환경으로 설정할 수 있다. 
-		여러가지 이유로 여러개의 데이터베이스에 SQL Map을 적용하는데 도움이 된다. 
-		예를들어, 개발, 테스트, 리얼 환경을 위해 별도의 설정을 가지거나 같은 스키마를 여러개의 DBMS 제품을 사용할 경우들이다. 
+        <p>마이바티스는 여러개의 환경으로 설정할 수 있다.
+		여러가지 이유로 여러개의 데이터베이스에 SQL Map을 적용하는데 도움이 된다.
+		예를들어, 개발, 테스트, 리얼 환경을 위해 별도의 설정을 가지거나 같은 스키마를 여러개의 DBMS 제품을 사용할 경우들이다.
 		그외에도 많은 경우가 있을 수 있다.</p>
         <p>
           <strong>중요하게 기억해야 할 것은 다중 환경을 설정할 수는 있지만 SqlSessionFactory 인스턴스마다 한개만 사용할 수 있다는 것이다.</strong>
         </p>
-        <p>두개의 데이터베이스에 연결하고 싶다면 SqlSessionFactory 인스턴스를 두개 만들 필요가 있다. 
-		세개의 데이터베이스를 사용한다면 역시 세개의 인스턴스를 필요로 한다. 
+        <p>두개의 데이터베이스에 연결하고 싶다면 SqlSessionFactory 인스턴스를 두개 만들 필요가 있다.
+		세개의 데이터베이스를 사용한다면 역시 세개의 인스턴스를 필요로 한다.
 		기억하기 쉽게</p>
         <ul>
           <li>
             <strong>데이터베이스별로 하나의 SqlSessionFactory</strong>
           </li>
         </ul>
-        <p>환경을 명시하기 위해 SqlSessionFactoryBuilder에 옵션으로 추가 파라미터를 주면 된다. 
+        <p>환경을 명시하기 위해 SqlSessionFactoryBuilder에 옵션으로 추가 파라미터를 주면 된다.
 		환경을 선택하는 두가지 시그니처는</p>
 
         <source><![CDATA[SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environment);
@@ -1553,13 +1553,13 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
         </p>
         <p>마이바티스는 두가지 타입의 TransactionManager를 제공한다.</p>
         <ul>
-          <li>JDBC - 이 설정은 간단하게 JDBC 커밋과 롤백을 처리하기 위해 사용된다. 
+          <li>JDBC - 이 설정은 간단하게 JDBC 커밋과 롤백을 처리하기 위해 사용된다.
 		  트랜잭션의 스코프를 관리하기 위해 dataSource 로 부터 커넥션을 가져온다. </li>
-          <li>MANAGED - 이 설정은 어떤것도 하지 않는다. 
-		  결코 커밋이나 롤백을 하지 않는다. 
-		  대신 컨테이너가 트랜잭션의 모든 생명주기를 관리한다. 
-		  디플트로 커넥션을 닫긴 한다. 
-		  하지만 몇몇 컨테이너는 커넥션을 닫는 것 또한 기대하지 않기 때문에 커넥션 닫는 것으로 멈추고자 한다면 “closeConnection”프로퍼티를 false로 설정하라. 
+          <li>MANAGED - 이 설정은 어떤것도 하지 않는다.
+		  결코 커밋이나 롤백을 하지 않는다.
+		  대신 컨테이너가 트랜잭션의 모든 생명주기를 관리한다.
+		  디플트로 커넥션을 닫긴 한다.
+		  하지만 몇몇 컨테이너는 커넥션을 닫는 것 또한 기대하지 않기 때문에 커넥션 닫는 것으로 멈추고자 한다면 “closeConnection”프로퍼티를 false로 설정하라.
 		  예를들면:
             <source><![CDATA[<transactionManager type="MANAGED">
   <property name="closeConnection" value="false"/>
@@ -1569,15 +1569,15 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
         <p>
           <span class="label important">참고</span>당신은 마이바티스를 스프링과 함께 사용하는 경우에는 구성할 필요가 없습니다
           스프링 모듈 자체의 설정 때문에 어떤 TransactionManager 이전에 설정된 구성을 무시합니다.</p>
-        <p>TransactionManager 타입은 어떠한 프로퍼티도 필요하지 않다. 
-		어쨌든 둘다 타입 별칭이 있다. 
+        <p>TransactionManager 타입은 어떠한 프로퍼티도 필요하지 않다.
+		어쨌든 둘다 타입 별칭이 있다.
 		즉 TransactionFactory를 위한 클래스 명이나 타입 별칭 중 하나를 사용할 수 있다.</p>
         <source><![CDATA[public interface TransactionFactory {
-  void setProperties(Properties props);  
+  void setProperties(Properties props);
   Transaction newTransaction(Connection conn);
-  Transaction newTransaction(DataSource dataSource, TransactionIsolationLevel level, boolean autoCommit);  
+  Transaction newTransaction(DataSource dataSource, TransactionIsolationLevel level, boolean autoCommit);
 }]]></source>
-        <p>XML에 설정된 프로퍼티는 인스턴스를 만든 뒤 setProperties()메소드에 전달할 것이다. 
+        <p>XML에 설정된 프로퍼티는 인스턴스를 만든 뒤 setProperties()메소드에 전달할 것이다.
 		당신의 구현체가 Transaction구현체를 만들 필요가 있을 것이다.:</p>
         <source><![CDATA[public interface Transaction {
   Connection getConnection() throws SQLException;
@@ -1596,8 +1596,8 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
         </ul>
         <p>여기엔 3 가지의 내장된 dataSource타입이 있다.</p>
         <p>
-          <strong>UNPOOLED</strong> - 이 구현체는 매번 요청에 대해 커넥션을 열고 닫는 간단한 DataSource이다. 
-		  조금 늦긴 하지만 성능을 크게 필요로 하지 않는 간단한 애플리케이션을 위해서는 괜찮은 선택이다. 
+          <strong>UNPOOLED</strong> - 이 구현체는 매번 요청에 대해 커넥션을 열고 닫는 간단한 DataSource이다.
+		  조금 늦긴 하지만 성능을 크게 필요로 하지 않는 간단한 애플리케이션을 위해서는 괜찮은 선택이다.
 		  UNPOOLED DataSource는 5 개의 프로퍼티만으로 설정한다.</p>
         <ul>
           <li><code>driver</code> - JDBC드라이버의 패키지 경로를 포함한 결제 자바 클래스명</li>
@@ -1606,51 +1606,51 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
           <li><code>password</code> - 데이터베이스에 로그인 할 때 사용할 패스워드</li>
           <li><code>defaultTransactionIsolationLevel</code> - 커넥션에 대한 디폴트 트랜잭션 격리 레벨</li>
         </ul>
-        <p>필수는 아니지만 선택적으로 데이터베이스 드라이버에 프로퍼티를 전달할 수도 있다. 
+        <p>필수는 아니지만 선택적으로 데이터베이스 드라이버에 프로퍼티를 전달할 수도 있다.
 		그러기 위해서는 다음 예제처럼 “driver.” 로 시작하는 접두어로 프로퍼티를 명시하면 된다.</p>
         <ul>
           <li><code>driver.encoding=UTF8</code></li>
         </ul>
-        <p>이 설정은 “encoding” 프로퍼티를 “UTF8”로 설정하게 된다. 
+        <p>이 설정은 “encoding” 프로퍼티를 “UTF8”로 설정하게 된다.
 		이 방법외에도 DriverManager.getConnection(url, driverProperties)메소드를 통해서도 프로퍼티를 설정할 수 있다.</p>
         <p>
-          <strong>POOLED</strong> - DataSource에 풀링이 적용된 JDBC 커넥션을 위한 구현체이다. 
-		  이는 새로운 Connection 인스턴스를 생성하기 위해 매번 초기화하는 것을 피하게 해준다. 
+          <strong>POOLED</strong> - DataSource에 풀링이 적용된 JDBC 커넥션을 위한 구현체이다.
+		  이는 새로운 Connection 인스턴스를 생성하기 위해 매번 초기화하는 것을 피하게 해준다.
 		  그래서 빠른 응답을 요구하는 웹 애플리케이션에서는 가장 흔히 사용되고 있다.</p>
         <p>UNPOOLED DataSource에 비해 많은 프로퍼티를 설정할 수 있다.</p>
         <ul>
-          <li><code>poolMaximumActiveConnections</code> - 주어진 시간에 존재할 수 있는 활성화된(사용중인) 커넥션의 수. 
+          <li><code>poolMaximumActiveConnections</code> - 주어진 시간에 존재할 수 있는 활성화된(사용중인) 커넥션의 수.
 		  디폴트는 10이다.</li>
           <li><code>poolMaximumIdleConnections</code> - 주어진 시간에 존재할 수 있는 유휴 커넥션의 수</li>
-          <li>강제로 리턴되기 전에 풀에서 “체크아웃” 될 수 있는 커넥션의 시간. 
+          <li>강제로 리턴되기 전에 풀에서 “체크아웃” 될 수 있는 커넥션의 시간.
 		  디폴트는 20000ms(20 초)</li>
-          <li><code>poolTimeToWait</code> - 풀이 로그 상태를 출력하고 비정상적으로 긴 경우 커넥션을 다시 얻을려고 시도하는 로우 레벨 설정. 
+          <li><code>poolTimeToWait</code> - 풀이 로그 상태를 출력하고 비정상적으로 긴 경우 커넥션을 다시 얻을려고 시도하는 로우 레벨 설정.
 		  디폴트는 20000ms(20 초)</li>
           <li><code>poolMaximumLocalBadConnectionTolerance</code> – 이것은 모든 쓰레드에 대해 bad Connection이 허용되는 정도에 대한 낮은 수준의 설정입니다.
             만약 쓰레드가 bad connection 을 얻게 되어도 유효한 또 다른 connection 을 다시 받을 수 있습니다.
             하지만 재시도 횟수는 <code>poolMaximumIdleConnections</code> 과 <code>poolMaximumLocalBadConnectionTolerance</code> 의 합보다 많아야 합니다.
             디폴트는 3이다. (3.4.5 부터)
           </li>
-          <li><code>poolPingQuery</code> - 커넥션이 작업하기 좋은 상태이고 요청을 받아서 처리할 준비가 되었는지 체크하기 위해 데이터베이스에 던지는 핑쿼리(Ping Query). 
-		  디폴트는 “핑 쿼리가 없음” 이다. 
+          <li><code>poolPingQuery</code> - 커넥션이 작업하기 좋은 상태이고 요청을 받아서 처리할 준비가 되었는지 체크하기 위해 데이터베이스에 던지는 핑쿼리(Ping Query).
+		  디폴트는 “핑 쿼리가 없음” 이다.
 		  이 설정은 대부분의 데이터베이스로 하여금 에러메시지를 보게 할수도 있다.</li>
-          <li><code>poolPingEnabled</code> - 핑쿼리를 사용할지 말지를 결정. 
-		  사용한다면 오류가 없는(그리고 빠른) SQL 을 사용하여 poolPingQuery 프로퍼티를 설정해야 한다. 
+          <li><code>poolPingEnabled</code> - 핑쿼리를 사용할지 말지를 결정.
+		  사용한다면 오류가 없는(그리고 빠른) SQL 을 사용하여 poolPingQuery 프로퍼티를 설정해야 한다.
 		  디폴트는 false 이다.</li>
-          <li><code>poolPingConnectionsNotUsedFor</code> - poolPingQuery가 얼마나 자주 사용될지 설정한다. 
-		  필요이상의 핑을 피하기 위해 데이터베이스의 타임아웃 값과 같을 수 있다. 
-		  디폴트는 0이다. 
+          <li><code>poolPingConnectionsNotUsedFor</code> - poolPingQuery가 얼마나 자주 사용될지 설정한다.
+		  필요이상의 핑을 피하기 위해 데이터베이스의 타임아웃 값과 같을 수 있다.
+		  디폴트는 0이다.
 		  디폴트 값은 poolPingEnabled가 true일 경우에만 모든 커넥션이 매번 핑을 던지는 값이다.</li>
         </ul>
         <p>
-          <strong>JNDI</strong> - 이 DataSource 구현체는 컨테이너에 따라 설정이 변경되며 JNDI 컨텍스트를 참조한다. 
+          <strong>JNDI</strong> - 이 DataSource 구현체는 컨테이너에 따라 설정이 변경되며 JNDI 컨텍스트를 참조한다.
 		  이 DataSource 는 오직 두개의 프로퍼티만을 요구한다.</p>
         <ul>
-          <li><code>initial_context</code> - 이 프로퍼티는 InitialContext 에서 컨텍스트를 찾기(예를 들어 initialContext.lookup(initial_context))위해 사용된다. 
-		  이 프로퍼티는 선택적인 값이다. 
+          <li><code>initial_context</code> - 이 프로퍼티는 InitialContext 에서 컨텍스트를 찾기(예를 들어 initialContext.lookup(initial_context))위해 사용된다.
+		  이 프로퍼티는 선택적인 값이다.
 		  이 설정을 생략하면 data_source프로퍼티가 InitialContext에서 직접 찾을 것이다.</li>
-          <li><code>data_source</code> - DataSource인스턴스의 참조를 찾을 수 있는 컨텍스트 경로이다. 
-		  initial_context 룩업을 통해 리턴된 컨텍스트에서 찾을 것이다. 
+          <li><code>data_source</code> - DataSource인스턴스의 참조를 찾을 수 있는 컨텍스트 경로이다.
+		  initial_context 룩업을 통해 리턴된 컨텍스트에서 찾을 것이다.
 		  initial_context 가 지원되지 않는다면 InitialContext 에서 직접 찾을 것이다.</li>
         </ul>
         <p>다른 DataSource설정과 유사하게 다음처럼 “env.”를 접두어로 프로퍼티를 전달할 수 있다.</p>
@@ -1660,7 +1660,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
         <p>이 설정은 인스턴스화할 때 InitialContext생성자에 “encoding”프로퍼티를 “UTF8”로 전달한다.</p>
 
 		<p>
-		  <code>org.apache.ibatis.datasource.DataSourceFactory</code> 인터페이스를 구현해서 또다른 DataSource구현체를 만들수 있다. 
+		  <code>org.apache.ibatis.datasource.DataSourceFactory</code> 인터페이스를 구현해서 또다른 DataSource구현체를 만들수 있다.
 		</p>
 
         <source><![CDATA[public interface DataSourceFactory {
@@ -1669,13 +1669,13 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
 }]]></source>
 
         <p>
-		  <code>org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory</code>는 새로운 데이터소스를 만들기 위한 상위 클래스처럼 사용할 수 있다. 
-		  예를들면 다음의 코드를 사용해서 C3P0를 사용할 수 있다.   
+		  <code>org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory</code>는 새로운 데이터소스를 만들기 위한 상위 클래스처럼 사용할 수 있다.
+		  예를들면 다음의 코드를 사용해서 C3P0를 사용할 수 있다.
 		</p>
 
         <source><![CDATA[import org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
-        
+
 public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
 
   public C3P0DataSourceFactory() {
@@ -1683,8 +1683,8 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
   }
 }]]></source>
 
-        <p>마이바티스가 호출할 setter메소드가 사용하는 프로퍼티를 추가해서 설정한다. 
-        다음의 설정은 PostgreSQL데이터베이스에 연결할때 사용한 샘플 설정이다. </p>        
+        <p>마이바티스가 호출할 setter메소드가 사용하는 프로퍼티를 추가해서 설정한다.
+        다음의 설정은 PostgreSQL데이터베이스에 연결할때 사용한 샘플 설정이다. </p>
 
         <source><![CDATA[<dataSource type="org.myproject.C3P0DataSourceFactory">
   <property name="driver" value="org.postgresql.Driver"/>
@@ -1693,33 +1693,33 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
   <property name="password" value="root"/>
 </dataSource>
 ]]></source>
-        
+
       </subsection>
-      
+
       <subsection name="databaseIdProvider">
-        <p>마이바티스는 데이터베이스 제품마다 다른 구문을 실행할 수 있다. 
-		여러개의 데이터베이스 제품을 가진 업체 제품은 <code>databaseId</code> 속성을 사용한 매핑된 구문을 기반으로 지원한다. 
-        마이바티스는 <code>databaseId</code>속성이 없거나 <code>databaseId</code>속성을 가진 모든 구문을 로드한다. 
-        같은 구문인데 하나는 <code>databaseId</code>속성이 있고 하나는 <code>databaseId</code>속성이 없을때 뒤에 나온 것이 무시된다. 
+        <p>마이바티스는 데이터베이스 제품마다 다른 구문을 실행할 수 있다.
+		여러개의 데이터베이스 제품을 가진 업체 제품은 <code>databaseId</code> 속성을 사용한 매핑된 구문을 기반으로 지원한다.
+        마이바티스는 <code>databaseId</code>속성이 없거나 <code>databaseId</code>속성을 가진 모든 구문을 로드한다.
+        같은 구문인데 하나는 <code>databaseId</code>속성이 있고 하나는 <code>databaseId</code>속성이 없을때 뒤에 나온 것이 무시된다.
         다중 지원을 사용하기 위해서는 mybatis-config.xml파일에 다음처럼 <code>databaseIdProvider</code>를 추가하라:
         </p>
-        
+
         <source><![CDATA[<databaseIdProvider type="DB_VENDOR" />
 ]]></source>
 
-    <p>DB_VENDOR구현체 databaseIdProvider는 <code>DatabaseMetaData#getDatabaseProductName()</code>에 의해 리턴된 문자열로 databaseId를 설정한다. 
+    <p>DB_VENDOR구현체 databaseIdProvider는 <code>DatabaseMetaData#getDatabaseProductName()</code>에 의해 리턴된 문자열로 databaseId를 설정한다.
     이때 리턴되는 문자열이 너무 길거나 같은 제품의 서로다른 버전으로 다른 값을 리턴하는 경우 다음처럼 프로퍼티를 추가해서 짧게 처리할 수도 있다:
     </p>
-    
+
         <source><![CDATA[<databaseIdProvider type="DB_VENDOR">
   <property name="SQL Server" value="sqlserver"/>
-  <property name="DB2" value="db2"/>        
+  <property name="DB2" value="db2"/>
   <property name="Oracle" value="oracle" />
 </databaseIdProvider>]]></source>
 
-    <p>프로퍼터가 제공되면 DB_VENDOR databaseIdProvider는 리턴된 데이터베이스 제품명에서 찾은 첫번째 프로퍼티값이나 일치하는 프로퍼티가 없다면 "null" 을 찾을 것이다. 
+    <p>프로퍼터가 제공되면 DB_VENDOR databaseIdProvider는 리턴된 데이터베이스 제품명에서 찾은 첫번째 프로퍼티값이나 일치하는 프로퍼티가 없다면 "null" 을 찾을 것이다.
     이 경우 <code>getDatabaseProductName()</code>가 "Oracle (DataDirect)"를 리턴한다면 databaseId는 "oracle"로 설정될 것이다. </p>
-    
+
     <p><code>org.apache.ibatis.mapping.DatabaseIdProvider</code> 인터페이스를 구현해서 자신만의 DatabaseIdProvider를 빌드하고 mybatis-config.xml파일에 등록할 수 있다:
     </p>
 
@@ -1729,13 +1729,13 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
 }]]></source>
 
       </subsection>
-      
+
       <subsection name="mappers">
-        <p>이제 우리는 매핑된 SQL 구문을 정의할 시간이다. 
-		하지만 먼저 설정을 어디에 둘지 결정해야 한다. 
-		자바는 자동으로 리소스를 찾기 위한 좋은 방법을 제공하지 않는다. 
-		그래서 가장 좋은 건 어디서 찾으라고 지정하는 것이다. 
-		클래스패스에 상대적으로 리소스를 지정할 수도 있고 url 을 통해서 지정할 수 도 있다. 
+        <p>이제 우리는 매핑된 SQL 구문을 정의할 시간이다.
+		하지만 먼저 설정을 어디에 둘지 결정해야 한다.
+		자바는 자동으로 리소스를 찾기 위한 좋은 방법을 제공하지 않는다.
+		그래서 가장 좋은 건 어디서 찾으라고 지정하는 것이다.
+		클래스패스에 상대적으로 리소스를 지정할 수도 있고 url 을 통해서 지정할 수 도 있다.
 		예를들면</p>
         <source><![CDATA[<!-- 클래스패스의 상대경로의 리소스 사용 -->
 <mappers>

--- a/src/site/ko/xdoc/dynamic-sql.xml
+++ b/src/site/ko/xdoc/dynamic-sql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -27,15 +27,15 @@
 
   <body>
     <section name="동적 SQL">
-      <p>마이바티스의 가장 강력한 기능 중 하나는 동적 SQL을 처리하는 방법이다. 
-	  JDBC나 다른 유사한 프레임워크를 사용해본 경험이 있다면 동적으로 SQL 을 구성하는 것이 얼마나 힘든 작업인지 이해할 것이다. 
-	  간혹 공백이나 콤마를 붙이는 것을 잊어본 적도 있을 것이다. 
+      <p>마이바티스의 가장 강력한 기능 중 하나는 동적 SQL을 처리하는 방법이다.
+	  JDBC나 다른 유사한 프레임워크를 사용해본 경험이 있다면 동적으로 SQL 을 구성하는 것이 얼마나 힘든 작업인지 이해할 것이다.
+	  간혹 공백이나 콤마를 붙이는 것을 잊어본 적도 있을 것이다.
 	  동적 SQL 은 그만큼 어려운 것이다.</p>
-      <p>동적 SQL 을 사용하는 것은 결코 파티가 될 수 없을 것이다. 
+      <p>동적 SQL 을 사용하는 것은 결코 파티가 될 수 없을 것이다.
 	  마이바티스는 강력한 동적 SQL 언어로 이 상황은 개선한다.</p>
-      <p>동적 SQL 엘리먼트들은 JSTL이나 XML기반의 텍스트 프로세서를 사용해 본 사람에게는 친숙할 것이다. 
-	  마이바티스의 이전 버전에서는 알고 이해해야 할 엘리먼트가 많았다. 
-	  마이바티스 3 에서는 이를 크게 개선했고 실제 사용해야 할 엘리먼트가 반 이하로 줄었다. 
+      <p>동적 SQL 엘리먼트들은 JSTL이나 XML기반의 텍스트 프로세서를 사용해 본 사람에게는 친숙할 것이다.
+	  마이바티스의 이전 버전에서는 알고 이해해야 할 엘리먼트가 많았다.
+	  마이바티스 3 에서는 이를 크게 개선했고 실제 사용해야 할 엘리먼트가 반 이하로 줄었다.
 	  마이바티스의 다른 엘리먼트의 사용을 최대한 제거하기 위해 OGNL 기반의 표현식을 가져왔다.</p>
       <ul>
         <li>if</li>
@@ -44,25 +44,25 @@
         <li>foreach</li>
       </ul>
       <subsection name="if" id="if">
-        <p>동적 SQL 에서 가장 공통적으로 사용되는 것으로 where의 일부로 포함될 수 있다. 
+        <p>동적 SQL 에서 가장 공통적으로 사용되는 것으로 where의 일부로 포함될 수 있다.
 		예를 들면:</p>
-        <source><![CDATA[<select id="findActiveBlogWithTitleLike" 
+        <source><![CDATA[<select id="findActiveBlogWithTitleLike"
      resultType="Blog">
-  SELECT * FROM BLOG 
-  WHERE state = ‘ACTIVE’ 
+  SELECT * FROM BLOG
+  WHERE state = ‘ACTIVE’
   <if test="title != null">
     AND title like #{title}
   </if>
 </select>]]></source>
-        <p>이 구문은 선택적으로 문자열 검색 기능을 제공할 것이다. 
-		만약에 title 값이 없다면 모든 active 상태의 Blog 가 리턴될 것이다. 
+        <p>이 구문은 선택적으로 문자열 검색 기능을 제공할 것이다.
+		만약에 title 값이 없다면 모든 active 상태의 Blog 가 리턴될 것이다.
 		하지만 title 값이 있다면 그 값과 비슷한 데이터를 찾게 될 것이다.</p>
-        <p>title과 author를 사용하여 검색하고 싶다면? 
-		먼저 의미가 좀더 잘 전달되도록 구문의 이름을 변경할 것이다. 
+        <p>title과 author를 사용하여 검색하고 싶다면?
+		먼저 의미가 좀더 잘 전달되도록 구문의 이름을 변경할 것이다.
 		그리고 다른 조건을 추가한다.</p>
-        <source><![CDATA[<select id="findActiveBlogLike" 
+        <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG WHERE state = ‘ACTIVE’ 
+  SELECT * FROM BLOG WHERE state = ‘ACTIVE’
   <if test="title != null">
     AND title like #{title}
   </if>
@@ -72,12 +72,12 @@
 </select>]]></source>
       </subsection>
       <subsection name="choose, when, otherwise" id="chooseWhenOtherwise">
-        <p>우리는 종종 적용 할 모든 조건을 원하는 대신에 한가지 경우만을 원할 수 있다. 
+        <p>우리는 종종 적용 할 모든 조건을 원하는 대신에 한가지 경우만을 원할 수 있다.
 		자바에서는 switch 구문과 유사하며 마이바티스에서는 choose 엘리먼트를 제공한다.</p>
-        <p>위 예제를 다시 사용해보자. 
-		지금은 title만으로 검색하고 author가 있다면 그 값으로 검색된다. 
+        <p>위 예제를 다시 사용해보자.
+		지금은 title만으로 검색하고 author가 있다면 그 값으로 검색된다.
 		둘다 제공하지 않는다면 featured 상태의 blog가 리턴된다.</p>
-        <source><![CDATA[<select id="findActiveBlogLike" 
+        <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
   SELECT * FROM BLOG WHERE state = ‘ACTIVE’
   <choose>
@@ -94,15 +94,15 @@
 </select>]]></source>
       </subsection>
       <subsection name="trim, where, set" id="trimWhereSet">
-        <p>앞서 예제는 악명높게 다양한 엘리먼트가 사용된 동적 SQL 이다. 
+        <p>앞서 예제는 악명높게 다양한 엘리먼트가 사용된 동적 SQL 이다.
 		“if” 예제를 사용해보자.</p>
-        <source><![CDATA[<select id="findActiveBlogLike" 
+        <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG 
-  WHERE 
+  SELECT * FROM BLOG
+  WHERE
   <if test="state != null">
     state = #{state}
-  </if> 
+  </if>
   <if test="title != null">
     AND title like #{title}
   </if>
@@ -110,28 +110,28 @@
     AND author_name like #{author.name}
   </if>
 </select>]]></source>
-        <p>어떤 조건에도 해당되지 않는다면 어떤 일이 벌어질까? 
+        <p>어떤 조건에도 해당되지 않는다면 어떤 일이 벌어질까?
 		아마도 다음과 같은 SQL 이 만들어질 것이다.</p>
-        <source><![CDATA[SELECT * FROM BLOG 
+        <source><![CDATA[SELECT * FROM BLOG
 WHERE]]></source>
-        <p>아마도 이건 실패할 것이다. 
-		두번째 조건에만 해당된다면 무슨 일이 벌어질까? 
+        <p>아마도 이건 실패할 것이다.
+		두번째 조건에만 해당된다면 무슨 일이 벌어질까?
 		아마도 다음과 같은 SQL이 만들어질 것이다.</p>
-        <source><![CDATA[SELECT * FROM BLOG 
-WHERE 
+        <source><![CDATA[SELECT * FROM BLOG
+WHERE
 AND title like ‘someTitle’]]></source>
-        <p>이것도 아마 실패할 것이다. 
-		이 문제는 조건만 가지고는 해결되지 않았다. 
+        <p>이것도 아마 실패할 것이다.
+		이 문제는 조건만 가지고는 해결되지 않았다.
 		이렇게 작성했다면 다시는 이렇게 작성하지 않게 될 것이다.</p>
-        <p>실패하지 않기 위해서 조금 수정해야 한다. 
+        <p>실패하지 않기 위해서 조금 수정해야 한다.
 		조금 수정하면 아마도 다음과 같을 것이다.</p>
-        <source><![CDATA[<select id="findActiveBlogLike" 
+        <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG 
-  <where> 
+  SELECT * FROM BLOG
+  <where>
     <if test="state != null">
          state = #{state}
-    </if> 
+    </if>
     <if test="title != null">
         AND title like #{title}
     </if>
@@ -140,17 +140,17 @@ AND title like ‘someTitle’]]></source>
     </if>
   </where>
 </select>]]></source>
-        <p>where 엘리먼트는 태그에 의해 컨텐츠가 리턴되면 단순히 “WHERE”만을 추가한다. 
+        <p>where 엘리먼트는 태그에 의해 컨텐츠가 리턴되면 단순히 “WHERE”만을 추가한다.
 		게다가 컨텐츠가 “AND”나 “OR”로 시작한다면 그 “AND”나 “OR”를 지워버린다.</p>
-        <p>만약에 where 엘리먼트가 기대한 것처럼 작동하지 않는다면 trim 엘리먼트를 사용자 정의할 수도 있다. 
+        <p>만약에 where 엘리먼트가 기대한 것처럼 작동하지 않는다면 trim 엘리먼트를 사용자 정의할 수도 있다.
 		예를들어 다음은 where 엘리먼트에 대한 trim 기능과 동일하다.</p>
         <source><![CDATA[<trim prefix="WHERE" prefixOverrides="AND |OR ">
-  ... 
+  ...
 </trim>]]></source>
-        <p>override 속성은 오버라이드하는 텍스트의 목록을 제한한다. 
+        <p>override 속성은 오버라이드하는 텍스트의 목록을 제한한다.
 		결과는 override 속성에 명시된 것들을 지우고 with 속성에 명시된 것을 추가한다.</p>
-        <p>다음 예제는 동적인 update 구문의 유사한 경우이다. 
-		set 엘리먼트는 update 하고자 하는 칼럼을 동적으로 포함시키기 위해 사용될 수 있다. 
+        <p>다음 예제는 동적인 update 구문의 유사한 경우이다.
+		set 엘리먼트는 update 하고자 하는 칼럼을 동적으로 포함시키기 위해 사용될 수 있다.
 		예를 들어:</p>
         <source><![CDATA[<update id="updateAuthorIfNecessary">
   update Author
@@ -170,8 +170,8 @@ AND title like ‘someTitle’]]></source>
         <p>이 경우 접두사는 추가하고 접미사를 오버라이딩 한다.</p>
       </subsection>
       <subsection name="foreach">
-        <p>동적 SQL 에서 공통적으로 필요한 것은 collection 에 대해 반복처리를 하는 것이다. 
-		종종 IN 조건을 사용하게 된다. 
+        <p>동적 SQL 에서 공통적으로 필요한 것은 collection 에 대해 반복처리를 하는 것이다.
+		종종 IN 조건을 사용하게 된다.
 		예를들면</p>
         <source><![CDATA[<select id="selectPostIn" resultType="domain.blog.Post">
   SELECT *
@@ -182,14 +182,14 @@ AND title like ‘someTitle’]]></source>
         #{item}
   </foreach>
 </select>]]></source>
-        <p>foreach엘리먼트는 매우 강력하고 collection 을 명시하는 것을 허용한다. 
-		엘리먼트 내부에서 사용할 수 있는 item, index두가지 변수를 선언한다. 
+        <p>foreach엘리먼트는 매우 강력하고 collection 을 명시하는 것을 허용한다.
+		엘리먼트 내부에서 사용할 수 있는 item, index두가지 변수를 선언한다.
 		이 엘리먼트는 또한 열고 닫는 문자열로 명시할 수 있고 반복간에 둘 수 있는 구분자도 추가할 수 있다.</p>
         <p><span class="label important">참고</span> 컬렉션 파라미터로 Map이나 배열객체와 더불어 List, Set등과 같은 반복가능한 객체를 전달할 수 있다. 반복가능하거나 배열을 사용할때 index값은 현재 몇번째 반복인지를 나타내고 value항목은 반복과정에서 가져오는 요소를 나타낸다. Map을 사용할때 index는 key객체가 되고 항목은 value객체가 된다. </p>
         <p>XML설정 파일과 XML 매핑 파일에 대해서는 이 정도에서 정리하고 다음 섹션에서는 Java API 에 대해 좀더 상세하게 살펴볼 것이다.</p>
       </subsection>
   <subsection name="bind">
-  <p><code>bind</code> 엘리먼트는 OGNL표현을 사용해서 변수를 만든 뒤 컨텍스트에 바인딩한다. 
+  <p><code>bind</code> 엘리먼트는 OGNL표현을 사용해서 변수를 만든 뒤 컨텍스트에 바인딩한다.
   예를들면 </p>
   <source><![CDATA[
 <select id="selectBlogsLike" resultType="Blog">
@@ -199,7 +199,7 @@ AND title like ‘someTitle’]]></source>
 </select>]]></source>
   </subsection>
       <subsection name="Multi-db vendor support">
-        <p>"_databaseId" 변수로 설정된 databaseIdProvider가 동적인 코드에도 사용가능하다면 데이터베이스 제품별로 서로다른 구문을 사용할 수 있다. 
+        <p>"_databaseId" 변수로 설정된 databaseIdProvider가 동적인 코드에도 사용가능하다면 데이터베이스 제품별로 서로다른 구문을 사용할 수 있다.
 		다음의 예제를 보라:</p>
         <source><![CDATA[<insert id="insert">
   <selectKey keyProperty="id" resultType="int" order="BEFORE">
@@ -215,20 +215,20 @@ AND title like ‘someTitle’]]></source>
 ]]></source>
       </subsection>
   <subsection name="Pluggable Scripting Languages For Dynamic SQL">
-    <p>마이바티스 3.2부터는 플러그인 형태로 스크립트 언어를 사용할 수 있다. 
+    <p>마이바티스 3.2부터는 플러그인 형태로 스크립트 언어를 사용할 수 있다.
     그래서 언어별 드라이버를 장착하고 동적 SQL쿼리를 작성할때 그 언어를 사용할 수 있다. </p>
     <p>두개의 내장된 언어가 있다. </p>
     <ul>
     <li>xml</li>
     <li>raw</li>
     </ul>
-    <p><code>xml</code> 언어는 설정하지 않을때 기본으로 사용하는 값이다. 
+    <p><code>xml</code> 언어는 설정하지 않을때 기본으로 사용하는 값이다.
     <code>xml</code>을 사용하면 이전에 다룬 모든 동적태그를 실행할 수 있다. </p>
-    <p><code>raw</code> 언어는 사실 기능이 조금 부족하다. 
-    <code>raw</code>설정을 사용하면 마이바티스는 파라미터를 치환해서 데이터베이스 드라이버에 구문을 전달한다. 
-    짐작하는 것처럼 <code>raw</code> 언어는 <code>xml</code> 언어보다 조금더 빠르다. 
+    <p><code>raw</code> 언어는 사실 기능이 조금 부족하다.
+    <code>raw</code>설정을 사용하면 마이바티스는 파라미터를 치환해서 데이터베이스 드라이버에 구문을 전달한다.
+    짐작하는 것처럼 <code>raw</code> 언어는 <code>xml</code> 언어보다 조금더 빠르다.
     </p>
-    <p>다음처럼 <code>lang</code> 속성을 추가해서 구문에서 사용할 언어를 명시할 수 있다. 
+    <p>다음처럼 <code>lang</code> 속성을 추가해서 구문에서 사용할 언어를 명시할 수 있다.
     </p>
   <source><![CDATA[<select id="selectBlog" lang="raw">
   SELECT * FROM BLOG
@@ -244,7 +244,7 @@ AND title like ‘someTitle’]]></source>
   ParameterHandler createParameterHandler(MappedStatement mappedStatement, Object parameterObject, BoundSql boundSql);
   SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType);
   SqlSource createSqlSource(Configuration configuration, String script, Class<?> parameterType);
-}]]></source>    
+}]]></source>
 	</subsection>
     </section>
   </body>

--- a/src/site/ko/xdoc/getting-started.xml
+++ b/src/site/ko/xdoc/getting-started.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -27,15 +27,15 @@
 
   <body>
     <section name="시작하기">
-    
+
     <subsection name="설치">
       <p>
-        마이바티스를 사용하기 위해 
+        마이바티스를 사용하기 위해
         <a href="https://github.com/mybatis/mybatis-3/releases">mybatis-x.x.x.jar</a>
-        파일을 클래스패스에 두어야 한다. 
+        파일을 클래스패스에 두어야 한다.
       </p>
       <p>
-        메이븐을 사용한다면 pom.xml에 다음의 설정을 추가하자. 
+        메이븐을 사용한다면 pom.xml에 다음의 설정을 추가하자.
       </p>
         <source><![CDATA[
 <dependency>
@@ -43,22 +43,22 @@
   <artifactId>mybatis</artifactId>
   <version>x.x.x</version>
 </dependency>]]></source>
-    </subsection>    
-    
+    </subsection>
+
     <subsection name="XML에서 SqlSessionFactory 빌드하기">
-      <p>모든 마이바티스 애플리케이션은 SqlSessionFactory 인스턴스를 사용한다. 
-	  SqlSessionFactory인스턴스는 SqlSessionFactoryBuilder를 사용하여 만들수 있다. 
+      <p>모든 마이바티스 애플리케이션은 SqlSessionFactory 인스턴스를 사용한다.
+	  SqlSessionFactory인스턴스는 SqlSessionFactoryBuilder를 사용하여 만들수 있다.
 	  SqlSessionFactoryBuilder는 XML설정파일에서 SqlSessionFactory인스턴스를 빌드할 수 있다.
       </p>
-      <p>XML파일에서 SqlSessionFactory인스턴스를 빌드하는 것은 매우 간단한다. 
-	  설정을 위해 클래스패스 자원을 사용하는 것을 추천하나 파일 경로나 file:// URL로부터 만들어진 InputStream인스턴스를 사용할 수도 있다. 
+      <p>XML파일에서 SqlSessionFactory인스턴스를 빌드하는 것은 매우 간단한다.
+	  설정을 위해 클래스패스 자원을 사용하는 것을 추천하나 파일 경로나 file:// URL로부터 만들어진 InputStream인스턴스를 사용할 수도 있다.
 	  마이바티스는 클래스패스와 다른 위치에서 자원을 로드하는 것으로 좀더 쉽게 해주는 Resources 라는 유틸성 클래스를 가지고 있다.</p>
       <source><![CDATA[
 String resource = "org/mybatis/example/mybatis-config.xml";
 InputStream inputStream = Resources.getResourceAsStream(resource);
 SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream);]]></source>
-      <p>XML설정파일에서 지정하는 마이바티스의 핵심이 되는 설정은 
-	  트랜잭션을 제어하기 위한 TransactionManager과 함께 데이터베이스 Connection인스턴스를 가져오기 위한 DataSource 를 포함한다. 
+      <p>XML설정파일에서 지정하는 마이바티스의 핵심이 되는 설정은
+	  트랜잭션을 제어하기 위한 TransactionManager과 함께 데이터베이스 Connection인스턴스를 가져오기 위한 DataSource 를 포함한다.
 	  세부적인 설정은 조금 뒤에 보고 간단한 예제를 먼저보자.</p>
       <source><![CDATA[<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE configuration
@@ -80,9 +80,9 @@ SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(input
     <mapper resource="org/mybatis/example/BlogMapper.xml"/>
   </mappers>
 </configuration>]]></source>
-      <p>좀 더 많은 XML 설정방법이 있지만 위 예제에서는 가장 핵심적인 부분만을 보여주고 있다. 
-	  XML 가장 위부분에서는 XML 문서의 유효성체크를 위해 필요하다. 
-	  environment엘리먼트는 트랜잭션 관리와 커넥션 풀링을 위한 환경적인 설정을 나타낸다. 
+      <p>좀 더 많은 XML 설정방법이 있지만 위 예제에서는 가장 핵심적인 부분만을 보여주고 있다.
+	  XML 가장 위부분에서는 XML 문서의 유효성체크를 위해 필요하다.
+	  environment엘리먼트는 트랜잭션 관리와 커넥션 풀링을 위한 환경적인 설정을 나타낸다.
 	  mappers엘리먼트는 SQL 코드와 매핑 정의를 가지는 XML 파일인 mapper 의 목록을 지정한다.</p>
     </subsection>
     <subsection name="XML 을 사용하지 않고 SqlSessionFactory 빌드하기">
@@ -93,15 +93,15 @@ Environment environment = new Environment("development", transactionFactory, dat
 Configuration configuration = new Configuration(environment);
 configuration.addMapper(BlogMapper.class);
 SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);]]></source>
-      <p>이 설정에서 추가로 해야 할 일은 Mapper클래스를 추가하는 것이다. 
-	  Mapper클래스는 SQL 매핑 애노테이션을 가진 자바 클래스이다. 
-	  어쨌든 자바 애노테이션의 몇가지 제약과 몇가지 설정방법의 목잡함에도 불구하고 XML 매핑은 세부적인 매핑을 위해 언제든 필요하다. 
+      <p>이 설정에서 추가로 해야 할 일은 Mapper클래스를 추가하는 것이다.
+	  Mapper클래스는 SQL 매핑 애노테이션을 가진 자바 클래스이다.
+	  어쨌든 자바 애노테이션의 몇가지 제약과 몇가지 설정방법의 목잡함에도 불구하고 XML 매핑은 세부적인 매핑을 위해 언제든 필요하다.
 	  좀더 세부적인 내용은 조금 뒤 다시 보도록 하자.</p>
     </subsection>
     <subsection name="SqlSessionFactory 에서 SqlSession 만들기">
-      <p>SqlSessionFactory 이름에서 보듯이 SqlSession 인스턴스를 만들수 있다. 
-	  SqlSession 은 데이터베이스에 대해 SQL명령어를 실행하기 위해 필요한 모든 메소드를 가지고 있다. 
-	  그래서 SqlSession 인스턴스를 통해 직접 SQL 구문을 실행할 수 있다. 
+      <p>SqlSessionFactory 이름에서 보듯이 SqlSession 인스턴스를 만들수 있다.
+	  SqlSession 은 데이터베이스에 대해 SQL명령어를 실행하기 위해 필요한 모든 메소드를 가지고 있다.
+	  그래서 SqlSession 인스턴스를 통해 직접 SQL 구문을 실행할 수 있다.
 	  예를 들면 :</p>
       <source><![CDATA[SqlSession session = sqlSessionFactory.openSession();
 try {
@@ -109,9 +109,9 @@ try {
 } finally {
   session.close();
 }]]></source>
-      <p>이 방법이 마이바티스의 이전버전을 사용한 사람이라면 굉장히 친숙할 것이다. 
-	  하지만 좀더 좋은 방법이 생겼다. 
-	  주어진 SQL 구문의 파라미터와 리턴값을 설명하는 인터페이스(예를 들면, BlogMapper.class )를 사용하여 
+      <p>이 방법이 마이바티스의 이전버전을 사용한 사람이라면 굉장히 친숙할 것이다.
+	  하지만 좀더 좋은 방법이 생겼다.
+	  주어진 SQL 구문의 파라미터와 리턴값을 설명하는 인터페이스(예를 들면, BlogMapper.class )를 사용하여
 	  문자열 처리 오류나 타입 캐스팅 오류 없이 좀더 타입에 안전하고 깔끔하게 실행할 수 있다.</p>
       <p>예를들면:</p>
       <source><![CDATA[SqlSession session = sqlSessionFactory.openSession();
@@ -124,14 +124,14 @@ try {
       <p>그럼 자세히 살펴보자.</p>
     </subsection>
     <subsection name="매핑된 SQL 구문 살펴보기">
-      <p>이 시점에 SqlSession이나 Mapper클래스가 정확히 어떻게 실행되는지 궁금할 것이다. 
-	  매핑된 SQL 구문에 대한 내용이 가장 중요하다. 
-	  그래서 이 문서 전반에서 가장 자주 다루어진다. 
+      <p>이 시점에 SqlSession이나 Mapper클래스가 정확히 어떻게 실행되는지 궁금할 것이다.
+	  매핑된 SQL 구문에 대한 내용이 가장 중요하다.
+	  그래서 이 문서 전반에서 가장 자주 다루어진다.
 	  하지만 다음의 두가지 예제를 통해 정확히 어떻게 작동하는지에 대해서는 충분히 이해하게 될 것이다.</p>
-      <p>위 예제처럼 구문은 XML이나 애노테이션을 사용해서 정의할 수 있다. 
-	  그럼 먼저 XML 을 보자. 
-	  마이바티스가 제공하는 대부분의 기능은 XML을 통해 매핑 기법을 사용한다. 
-	  이전에 마이바티스를 사용했었다면 쉽게 이해되겠지만 XML 매핑 문서에 이전보다 많은 기능이 추가되었다. 
+      <p>위 예제처럼 구문은 XML이나 애노테이션을 사용해서 정의할 수 있다.
+	  그럼 먼저 XML 을 보자.
+	  마이바티스가 제공하는 대부분의 기능은 XML을 통해 매핑 기법을 사용한다.
+	  이전에 마이바티스를 사용했었다면 쉽게 이해되겠지만 XML 매핑 문서에 이전보다 많은 기능이 추가되었다.
 	  SqlSession을 호출하는 XML 기반의 매핑 구문이다.</p>
       <source><![CDATA[<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
@@ -142,24 +142,24 @@ try {
     select * from Blog where id = #{id}
   </select>
 </mapper>]]></source>
-      <p>간단한 예제치고는 조금 복잡해 보이지만 실제로는 굉장히 간단하다. 
-	  한 개의 매퍼 XML 파일에는 많은 수의 매핑 구문을 정의할 수 있다. 
-	  XML 도입무의 헤더와 doctype 을 제외하면 나머지는 쉽게 이해되는 구문의 형태이다. 
-	  여기선 org.mybatis.example.BlogMapper 네임스페이스에서 selectBlog라는 매핑 구문을 정의했고 
-	  이는 결과적으로 org.mybatis.example.BlogMapper.selectBlog형태로 실제 명시되게 된다. 
+      <p>간단한 예제치고는 조금 복잡해 보이지만 실제로는 굉장히 간단하다.
+	  한 개의 매퍼 XML 파일에는 많은 수의 매핑 구문을 정의할 수 있다.
+	  XML 도입무의 헤더와 doctype 을 제외하면 나머지는 쉽게 이해되는 구문의 형태이다.
+	  여기선 org.mybatis.example.BlogMapper 네임스페이스에서 selectBlog라는 매핑 구문을 정의했고
+	  이는 결과적으로 org.mybatis.example.BlogMapper.selectBlog형태로 실제 명시되게 된다.
 	  그래서 다음처럼 사용하게 되는 셈이다.</p>
       <source><![CDATA[Blog blog = (Blog) session.selectOne("org.mybatis.example.BlogMapper.selectBlog", 101);]]></source>
-      <p>이건 마치 패키지를 포함한 전체 경로의 클래스내 메소드를 호출하는 것과 비슷한 형태이다. 
-	  이 이름은 매핑된 select구문의 이름과 파라미터 그리고 리턴타입을 가진 네임스페이스과 같은 이름의 Mapper 클래스와 직접 매핑될 수 있다. 
-	  이건 위에서 본것과 같은 Mapper 인터페이스의 메소드를 간단히 호출하도록 허용한다. 
+      <p>이건 마치 패키지를 포함한 전체 경로의 클래스내 메소드를 호출하는 것과 비슷한 형태이다.
+	  이 이름은 매핑된 select구문의 이름과 파라미터 그리고 리턴타입을 가진 네임스페이스과 같은 이름의 Mapper 클래스와 직접 매핑될 수 있다.
+	  이건 위에서 본것과 같은 Mapper 인터페이스의 메소드를 간단히 호출하도록 허용한다.
 	  위 예제에 대응되는 형태는 아래와 같다.</p>
       <source><![CDATA[BlogMapper mapper = session.getMapper(BlogMapper.class);
 Blog blog = mapper.selectBlog(101);]]></source>
-      <p>두번째 방법은 많은 장점을 가진다. 
-	  먼저 문자열에 의존하지 않는다는 것이다. 
-	  이는 애플리케이션을 좀더 안전하게 만든다. 
-	  두번째는 개발자가 IDE 를 사용할 때 매핑된 SQL 구문을 사용할때의 수고를 덜어준다. 
-	  세번째는 리턴타입에 대해 타입 캐스팅을 하지 않아도 된다. 
+      <p>두번째 방법은 많은 장점을 가진다.
+	  먼저 문자열에 의존하지 않는다는 것이다.
+	  이는 애플리케이션을 좀더 안전하게 만든다.
+	  두번째는 개발자가 IDE 를 사용할 때 매핑된 SQL 구문을 사용할때의 수고를 덜어준다.
+	  세번째는 리턴타입에 대해 타입 캐스팅을 하지 않아도 된다.
 	  그래서 BlogMapper 인터페이스는 깔끔하고 리턴 타입에 대해 타입에 안전하며 이는 파라미터에도 그대로 적용된다.</p>
       <hr/>
       <p>
@@ -167,72 +167,72 @@ Blog blog = mapper.selectBlog(101);]]></source>
         <strong>네임스페이스(Namespaces)에 대한 설명</strong>
       </p>
       <p>
-        <strong>네임스페이스(Namespaces)</strong>가 이전버전에서는 사실 선택사항이었다. 
+        <strong>네임스페이스(Namespaces)</strong>가 이전버전에서는 사실 선택사항이었다.
 		하지만 이제는 패키지경로를 포함한 전체 이름을 가진 구문을 구분하기 위해 필수로 사용해야 한다.</p>
-      <p>네임스페이스은 인터페이스 바인딩을 가능하게 한다. 
+      <p>네임스페이스은 인터페이스 바인딩을 가능하게 한다.
 	  네임스페이스을 사용하고 자바 패키지의 네임스페이스을 두면 코드가 깔끔해지고 마이바티스의 사용성이 크게 향상될 것이다.</p>
       <p>
         <strong>이름 분석(Name Resolution):</strong> 타이핑을 줄이기 위해 마이바티스는 구문과 결과매핑, 캐시등의 모든 설정엘리먼트를 위한 이름 분석 규칙을 사용한다.</p>
       <ul>
         <li>“com.mypackage.MyMapper.selectAllThings”과 같은 패키지를 포함한 전체 경로명(Fully qualified names)은 같은 형태의 경로가 있다면 그 경로내에서 직접 찾는다.</li>
-        <li>“selectAllThings”과 같은 짧은 형태의 이름은 모호하지 않은 엔트리를 참고하기 위해 사용될 수 있다. 
+        <li>“selectAllThings”과 같은 짧은 형태의 이름은 모호하지 않은 엔트리를 참고하기 위해 사용될 수 있다.
 		그래서 짧은 이름은 모호해서 에러를 자주 보게 되니 되도록 이면 전체 경로를 사용해야 할 것이다.</li>
       </ul>
       <hr/>
-      <p>BlogMapper와 같은 Mapper클래스에는 몇가지 트릭이 있다. 
-	  매핑된 구문은 XML 에 전혀 매핑될 필요가 없다. 
-	  대신 자바 애노테이션을 사용할 수 있다. 
+      <p>BlogMapper와 같은 Mapper클래스에는 몇가지 트릭이 있다.
+	  매핑된 구문은 XML 에 전혀 매핑될 필요가 없다.
+	  대신 자바 애노테이션을 사용할 수 있다.
 	  예를들어 위 XML 예제는 다음과 같은 형태로 대체될 수 있다.</p>
       <source><![CDATA[package org.mybatis.example;
 public interface BlogMapper {
   @Select("SELECT * FROM blog WHERE id = #{id}")
   Blog selectBlog(int id);
 }]]></source>
-      <p>간단한 구문에서는 애노테이션이 좀더 깔끔하다. 
-	  어쨌든 자바 애노테이션은 좀더 복잡한 구문에서는 제한적이고 코드를 엉망으로 만들 수 있다. 
+      <p>간단한 구문에서는 애노테이션이 좀더 깔끔하다.
+	  어쨌든 자바 애노테이션은 좀더 복잡한 구문에서는 제한적이고 코드를 엉망으로 만들 수 있다.
 	  그러므로 복잡하게 사용하고자 한다면 XML 매핑 구문을 사용하는 것이 좀더 나을 것이다.</p>
-      <p>여기서 당신과 당신의 프로젝트 팀은 어떤 방법이 좋은지 결정해야 할 것이다. 
-	  매핑된 구문을 일관된 방식으로 정의하는 것이 중요하다. 
-      앞서 언급했지만 반드시 한가지만 고집해야 하는 건 아니다. 
+      <p>여기서 당신과 당신의 프로젝트 팀은 어떤 방법이 좋은지 결정해야 할 것이다.
+	  매핑된 구문을 일관된 방식으로 정의하는 것이 중요하다.
+      앞서 언급했지만 반드시 한가지만 고집해야 하는 건 아니다.
 	  애노테이션은 XML로 쉽게 변환할 수 있고 그 반대의 형태 역시 쉽게 처리할 수 있다. </p>
     </subsection>
     <subsection name="스코프(Scope) 와 생명주기(Lifecycle)">
-      <p>이제부터 다룰 스코프와 생명주기에 대해서 이해하는 것은 매우 중요하다. 
+      <p>이제부터 다룰 스코프와 생명주기에 대해서 이해하는 것은 매우 중요하다.
 	  스코프와 생명주기를 잘못 사용하는 것은 다양한 동시성 문제를 야기할 수 있다.</p>
       <hr/>
       <p><span class="label important">참고</span>
         <strong>객체 생명주기와 의존성 삽입 프레임워크</strong>
       </p>
-      <p>의존성 삽입 프레임워크는 쓰레드에 안전하도록 해준다. 
+      <p>의존성 삽입 프레임워크는 쓰레드에 안전하도록 해준다.
 	  트랜잭션 성질을 가지는 SqlSessions과 매퍼들 그리고 그것들을 직접 빈에 삽입하면 생명주기에 대해 기억하지 않아도 되게 해준다.
-      DI프레임워크와 마이바티스를 사용하기 위해 좀더 많은 정보를 보기 위해서는 MyBatis-Spring이나 MyBatis-Guice 하위 프로젝트를 찾아보면 된다. 
+      DI프레임워크와 마이바티스를 사용하기 위해 좀더 많은 정보를 보기 위해서는 MyBatis-Spring이나 MyBatis-Guice 하위 프로젝트를 찾아보면 된다.
       </p>
       <hr/>
       <h4>SqlSessionFactoryBuilder</h4>
-        <p>이 클래스는 인스턴스회되어 사용되고 던져질 수 있다. 
-		SqlSessionFactory 를 생성한 후 유지할 필요는 없다. 
-		그러므로 SqlSessionFactoryBuilder 인스턴스의 가장 좋은 스코프는 메소드 스코프(예를들면 메소드 지역변수)이다. 
+        <p>이 클래스는 인스턴스회되어 사용되고 던져질 수 있다.
+		SqlSessionFactory 를 생성한 후 유지할 필요는 없다.
+		그러므로 SqlSessionFactoryBuilder 인스턴스의 가장 좋은 스코프는 메소드 스코프(예를들면 메소드 지역변수)이다.
 		여러개의 SqlSessionFactory 인스턴스를 빌드하기 위해 SqlSessionFactoryBuilder를 재사용할 수도 있지만 유지하지 않는 것이 가장 좋다.</p>
       <h4>SqlSessionFactory</h4>
-        <p>한번 만든뒤 SqlSessionFactory는 애플리케이션을 실행하는 동안 존재해야만 한다. 
-		그래서 삭제하거나 재생성할 필요가 없다. 
-		애플리케이션이 실행되는 동안 여러 차례 SqlSessionFactory 를 다시 빌드하지 않는 것이 가장 좋은 형태이다. 
-		재빌드하는 형태는 결과적으로 “나쁜냄새” 가 나도록 한다. 
-		그러므로 SqlSessionFactory 의 가장 좋은 스코프는 애플리케이션 스코프이다. 
-		애플리케이션 스코프로 유지하기 위한 다양한 방법이 존재한다. 
-		가장 간단한 방법은 싱글턴 패턴이나 static 싱글턴 패턴을 사용하는 것이다. 
-		또는 구글 쥬스나 스프링과 같은 의존성 삽입 컨테이너를 선호할 수도 있다. 
+        <p>한번 만든뒤 SqlSessionFactory는 애플리케이션을 실행하는 동안 존재해야만 한다.
+		그래서 삭제하거나 재생성할 필요가 없다.
+		애플리케이션이 실행되는 동안 여러 차례 SqlSessionFactory 를 다시 빌드하지 않는 것이 가장 좋은 형태이다.
+		재빌드하는 형태는 결과적으로 “나쁜냄새” 가 나도록 한다.
+		그러므로 SqlSessionFactory 의 가장 좋은 스코프는 애플리케이션 스코프이다.
+		애플리케이션 스코프로 유지하기 위한 다양한 방법이 존재한다.
+		가장 간단한 방법은 싱글턴 패턴이나 static 싱글턴 패턴을 사용하는 것이다.
+		또는 구글 쥬스나 스프링과 같은 의존성 삽입 컨테이너를 선호할 수도 있다.
 		이러한 프레임워크는 SqlSessionFactory의 생명주기를 싱글턴으로 관리할 것이다.</p>
       <h4>SqlSession</h4>
-        <p>각각의 쓰레드는 자체적으로 SqlSession인스턴스를 가져야 한다. 
-		SqlSession인스턴스는 공유되지 않고 쓰레드에 안전하지도 않다. 
-		그러므로 가장 좋은 스코프는 요청 또는 메소드 스코프이다. 
-		SqlSession 을 static 필드나 클래스의 인스턴스 필드로 지정해서는 안된다. 
+        <p>각각의 쓰레드는 자체적으로 SqlSession인스턴스를 가져야 한다.
+		SqlSession인스턴스는 공유되지 않고 쓰레드에 안전하지도 않다.
+		그러므로 가장 좋은 스코프는 요청 또는 메소드 스코프이다.
+		SqlSession 을 static 필드나 클래스의 인스턴스 필드로 지정해서는 안된다.
 		그리고 서블릿 프레임워크의 HttpSession 과 같은 관리 스코프에 둬서도 안된다.
-		어떠한 종류의 웹 프레임워크를 사용한다면 HTTP 요청과 유사한 스코프에 두는 것으로 고려해야 한다. 
-		달리 말해서 HTTP 요청을 받을때마다 만들고 응답을 리턴할때마다 SqlSession 을 닫을 수 있다. 
-		SqlSession 을 닫는 것은 중요하다. 
-		언제나 finally 블록에서 닫아야만 한다. 
+		어떠한 종류의 웹 프레임워크를 사용한다면 HTTP 요청과 유사한 스코프에 두는 것으로 고려해야 한다.
+		달리 말해서 HTTP 요청을 받을때마다 만들고 응답을 리턴할때마다 SqlSession 을 닫을 수 있다.
+		SqlSession 을 닫는 것은 중요하다.
+		언제나 finally 블록에서 닫아야만 한다.
 		다음은 SqlSession을 닫는 것을 확인하는 표준적인 형태다.</p>
         <source><![CDATA[SqlSession session = sqlSessionFactory.openSession();
 try {
@@ -240,14 +240,14 @@ try {
 } finally {
   session.close();
 }]]></source>
-        <p>코드전반에 이런 형태를 사용하는 것은 모든 데이터베이스 자원을 잘 닫는 것으로 보장하게 할 것이다. 
+        <p>코드전반에 이런 형태를 사용하는 것은 모든 데이터베이스 자원을 잘 닫는 것으로 보장하게 할 것이다.
         </p>
       <h4>Mapper 인스턴스</h4>
-        <p>Mapper는 매핑된 구문을 바인딩 하기 위해 만들어야 할 인터페이스이다. 
-		mapper 인터페이스의 인스턴스는 SqlSession 에서 생성한다. 
-		그래서 mapper 인스턴스의 가장 좋은 스코프는 SqlSession 과 동일하다. 
-		어쨌든 mapper 인스턴스의 가장 좋은 스코프는 메소드 스코프이다. 
-		사용할 메소드가 호출되면 생성되고 끝난다. 
+        <p>Mapper는 매핑된 구문을 바인딩 하기 위해 만들어야 할 인터페이스이다.
+		mapper 인터페이스의 인스턴스는 SqlSession 에서 생성한다.
+		그래서 mapper 인스턴스의 가장 좋은 스코프는 SqlSession 과 동일하다.
+		어쨌든 mapper 인스턴스의 가장 좋은 스코프는 메소드 스코프이다.
+		사용할 메소드가 호출되면 생성되고 끝난다.
 		명시적으로 닫을 필요는 없다.</p>
         <source><![CDATA[SqlSession session = sqlSessionFactory.openSession();
 try {

--- a/src/site/ko/xdoc/index.xml
+++ b/src/site/ko/xdoc/index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@
       <subsection name="마이바티스는 무엇인가?">
         <p>
 		마이바티스는 개발자가 지정한 SQL, 저장프로시저 그리고 몇가지 고급 매핑을 지원하는 퍼시스턴스 프레임워크이다.
-		마이바티스는 JDBC로 처리하는 상당부분의 코드와 파라미터 설정및 결과 매핑을 대신해준다. 
+		마이바티스는 JDBC로 처리하는 상당부분의 코드와 파라미터 설정및 결과 매핑을 대신해준다.
 		마이바티스는 데이터베이스 레코드에 원시타입과 Map 인터페이스 그리고 자바 POJO 를 설정해서 매핑하기 위해 XML과 애노테이션을 사용할 수 있다.
 		</p>
       </subsection>
@@ -40,7 +40,7 @@
 		이 문서가 일부 내용을 자세히 다루지 않거나 특정 기능에 대해 설명하지 않을 경우 마이바티스를 공부하는 가장 좋은 방법은 사용자 스스로 그 부분에 대한 문서를 작성하는 것이다!
         </p>
         <p>
-		이 문서는 xdoc포맷으로 되어 있으며 <a href="https://github.com/mybatis/mybatis-3/tree/master/src/site">프로젝트 깃허브</a>에서 볼수 있다. 
+		이 문서는 xdoc포맷으로 되어 있으며 <a href="https://github.com/mybatis/mybatis-3/tree/master/src/site">프로젝트 깃허브</a>에서 볼수 있다.
 		저장소를 포크하고 수정한 뒤 Pull request요청을 보내면 됩니다.        </p>
         <p>
 		그러면 이 문서의 가장 멋진 저자가 되고 다른 많은 사람들이 이 문서를 읽을 것이다!
@@ -53,7 +53,7 @@
         <ul class="i18n">
           <li class="en"><a href="../getting-started.html">영어</a></li>
           <li class="es"><a href="../es/index.html">스페인어</a></li>
-<!--      <li class="fr"><a href="../fr/index.html">프랑스어</a></li> -->      
+<!--      <li class="fr"><a href="../fr/index.html">프랑스어</a></li> -->
           <li class="ja"><a href="../ja/index.html">일본어</a></li>
           <li class="ko"><a href="../ko/index.html">한국어</a></li>
           <li class="zh"><a href="../zh/index.html">중국어번체</a></li>

--- a/src/site/ko/xdoc/java-api.xml
+++ b/src/site/ko/xdoc/java-api.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -27,16 +27,16 @@
 
   <body>
   <section name="자바 API" id="javaApi">
-  <p>이제 마이바티스를 설정하는 방법과 매핑을 만드는 방법을 알게 되었다. 
-  이미 충분히 잘 사용할 준비가 된 셈이다. 
-  마이바티스 자바 API 는 당신의 노력에 대한 보상을 얻게 할 것이다. 
-  JDBC 와 비교해보면 마이바티스는 코드를 굉장히 단순하게 만들고 깔끔하게 만든다. 
-  이해하기 쉬워서 유지보수도 편하게 해준다. 
+  <p>이제 마이바티스를 설정하는 방법과 매핑을 만드는 방법을 알게 되었다.
+  이미 충분히 잘 사용할 준비가 된 셈이다.
+  마이바티스 자바 API 는 당신의 노력에 대한 보상을 얻게 할 것이다.
+  JDBC 와 비교해보면 마이바티스는 코드를 굉장히 단순하게 만들고 깔끔하게 만든다.
+  이해하기 쉬워서 유지보수도 편하게 해준다.
   마이바티스 3은 SQL Map을 사용하는 많은 수의 개선 내용을 소개했다.</p>
 
   <subsection name="디렉터리 구조" id="directoryStructure">
-  <p>자바 API 를 살펴보기 전에 디렉터리 구조에 대해 전반적으로 이해하는 것이 중요하다. 
-  마이바티스는 매우 유연하고 파일을 사용해서 어떤 것도 할 수 있다. 
+  <p>자바 API 를 살펴보기 전에 디렉터리 구조에 대해 전반적으로 이해하는 것이 중요하다.
+  마이바티스는 매우 유연하고 파일을 사용해서 어떤 것도 할 수 있다.
   하지만 프레임워크이기 때문에 선호하는 방법이 있다.</p>
   <p>전형적인 애플리케이션 디렉터리 구조를 살펴보자.</p>
   <pre>/my_application
@@ -65,36 +65,36 @@
   /web
     /WEB-INF
       /web.xml</pre>
-  <p>이건 선호되는 형태이지 반드시 따라야 하는 요구사항이 아님을 기억해두라. 
+  <p>이건 선호되는 형태이지 반드시 따라야 하는 요구사항이 아님을 기억해두라.
   하지만 이러한 공통적인 형태를 사용하면 많은 사람들이 쉽게 이해할 것이다. </p>
   <p>이 섹션의 나머지 예제는 디렉터리 구조가 이렇게 되어 있다고 가정하고 설명한다.</p>
-  </subsection>  
+  </subsection>
 
   <subsection name="SqlSessions" id="sqlSessions">
-  <p>마이바티스를 사용하기 위한 기본적인 자바 인터페이스는 SqlSession이다. 
-  이 인터페이스를 통해 명령어를 실행하고 매퍼를 얻으며 트랜잭션을 관리 할 수 있다. 
-  우리는 SqlSession에 대해서 좀더 얘기해볼 것이지만 먼저 SqlSession의 인스턴스를 만드는 방법을 배워보자. 
-  SqlSession은 SqlSessionFactory인스턴스를 사용해서 만든다. 
-  SqlSessionFactory는 몇가지 방법으로 SqlSession인스턴스를 생성하기 위한 메소드를 포함하고 있다. 
+  <p>마이바티스를 사용하기 위한 기본적인 자바 인터페이스는 SqlSession이다.
+  이 인터페이스를 통해 명령어를 실행하고 매퍼를 얻으며 트랜잭션을 관리 할 수 있다.
+  우리는 SqlSession에 대해서 좀더 얘기해볼 것이지만 먼저 SqlSession의 인스턴스를 만드는 방법을 배워보자.
+  SqlSession은 SqlSessionFactory인스턴스를 사용해서 만든다.
+  SqlSessionFactory는 몇가지 방법으로 SqlSession인스턴스를 생성하기 위한 메소드를 포함하고 있다.
   SqlSessionFactory자체는 XML, 애노테이션 또는 자바 설정에서 SqlSessonFactory를 생성할 수 있는 SqlSessionFactoryBuilder를 통해 만들어진다.</p>
-  <p><span class="label important">참고</span> 
-  스프링이나 쥬스와 같은 의존성 삽입 프레임워크와 함께 사용할때 SqlSessions은 DI프레임워크에 의해 생성되고 삽입된다. 
-  그래서 SqlSessionFactoryBuilder나 SqlSessionFactory가 필요하지 않을 것이기 때문에 SqlSession섹션으로 바로 넘어가도 무방하다. 
+  <p><span class="label important">참고</span>
+  스프링이나 쥬스와 같은 의존성 삽입 프레임워크와 함께 사용할때 SqlSessions은 DI프레임워크에 의해 생성되고 삽입된다.
+  그래서 SqlSessionFactoryBuilder나 SqlSessionFactory가 필요하지 않을 것이기 때문에 SqlSession섹션으로 바로 넘어가도 무방하다.
   추가적인 정보는 MyBatis-Spring이나 MyBatis-Guice를 참고하길 바란다. </p>
   <h4>SqlSessionFactoryBuilder</h4>
-  <p>SqlSessionFactoryBuilder는 5개의 build() 메소드를 가진다. 
+  <p>SqlSessionFactoryBuilder는 5개의 build() 메소드를 가진다.
   각각은 서로 다른 소스에서 SqlSession을 빌드한다.</p>
   <source>SqlSessionFactory build(InputStream inputStream)
 SqlSessionFactory build(InputStream inputStream, String environment)
 SqlSessionFactory build(InputStream inputStream, Properties properties)
 SqlSessionFactory build(InputStream inputStream, String env, Properties props)
-SqlSessionFactory build(Configuration config)</source>  
+SqlSessionFactory build(Configuration config)</source>
 
-  <p>처음 4개의 메소드가 가장 공통적이다. 
-  XML 문서를 나타내는 Reader 인스턴스를 가진다. 
-  SqlMapConfig.xml 파일은 위에서 다루었다. 
-  선택적으로 사용가능한 프로퍼티는 environment와 properties이다. 
-  environment는 데이터소스와 트랜잭션 관리자를 포함하여 로드할 환경을 판단한다. 
+  <p>처음 4개의 메소드가 가장 공통적이다.
+  XML 문서를 나타내는 Reader 인스턴스를 가진다.
+  SqlMapConfig.xml 파일은 위에서 다루었다.
+  선택적으로 사용가능한 프로퍼티는 environment와 properties이다.
+  environment는 데이터소스와 트랜잭션 관리자를 포함하여 로드할 환경을 판단한다.
   예를들면:</p>
 
   <source><![CDATA[<environments default="development">
@@ -110,41 +110,41 @@ SqlSessionFactory build(Configuration config)</source>
     <dataSource type="JNDI">
         ...
   </environment>
-</environments>]]></source>  
-  <p>environment파라미터를 가진 메소드를 호출한다면 마이바티스는 사용할 환경을 위한 설정을 사용할 것이다. 
-  물론 잘못된 환경설정을 사용하면 에러를 보게 될 것이다. 
-  environment파라미터를 가지지 않는 메소드 중 하나를 호출한다면 디폴트 환경(위 예제에서 default=“development”)이 사용될 것이다.</p>  
-  <p>properties인스턴스를 가진 메소드를 호출하면 마이바티스는 프로퍼티들을 로드해서 설정에서 사용가능한 부분을 사용할 것이다. 
+</environments>]]></source>
+  <p>environment파라미터를 가진 메소드를 호출한다면 마이바티스는 사용할 환경을 위한 설정을 사용할 것이다.
+  물론 잘못된 환경설정을 사용하면 에러를 보게 될 것이다.
+  environment파라미터를 가지지 않는 메소드 중 하나를 호출한다면 디폴트 환경(위 예제에서 default=“development”)이 사용될 것이다.</p>
+  <p>properties인스턴스를 가진 메소드를 호출하면 마이바티스는 프로퍼티들을 로드해서 설정에서 사용가능한 부분을 사용할 것이다.
   프로퍼티들은 ${propName}와 같은 문법을 사용해서 설정의 값으로 대체될 수 있다.</p>
-  <p>프로퍼티들은 SqlMapConfig.xml파일에서 사용되거나 직접 명시할 수 있다. 
-  그러므로 프로퍼티들의 우선순위를 이해하는 것이 중요하다. 
+  <p>프로퍼티들은 SqlMapConfig.xml파일에서 사용되거나 직접 명시할 수 있다.
+  그러므로 프로퍼티들의 우선순위를 이해하는 것이 중요하다.
   우리는 앞서 언급하긴 했지만 쉽게 이해할 수 있도록 다시 보여주도록 하겠다.</p>
 
   <hr/>
   <p>프로퍼티가 한개 이상 존재한다면 마이바티스는 일정한 순서로 로드한다.</p>
   <ul>
   <li>properties엘리먼트에 명시된 속성을 가장 먼저 읽는다.</li>
-  <li>properties엘리먼트의 클래스패스 자원이나 url 속성으로 부터 로드된 속성을 두번재로 읽는다. 
+  <li>properties엘리먼트의 클래스패스 자원이나 url 속성으로 부터 로드된 속성을 두번재로 읽는다.
   그래서 이미 읽은 값이 있다면 덮어쓴다.,</li>
-  <li>마지막으로 메소드 파라미터로 전달된 속성을 읽는다. 
+  <li>마지막으로 메소드 파라미터로 전달된 속성을 읽는다.
   앞서 로드된 값을 덮어쓴다</li>
   </ul>
-  <p>그래서 가장 우선순위가 높은 속성은 메소드의 파라미터로 전달된 값이고 
+  <p>그래서 가장 우선순위가 높은 속성은 메소드의 파라미터로 전달된 값이고
   그 다음은 자원및 url 속성이고 마지막은 properties 엘리먼트에 명시된 값이다.</p>
   <hr/>
-  
-  <p>요약해보면 처음 4개의 메소드는 사실 같지만 environment 그리고/또는 properties에 명시한 값을 오버라이드한다. 
-  mybatis-config.xml파일에서 SqlSessionFactory를 빌드하는 예제이다.</p>  
+
+  <p>요약해보면 처음 4개의 메소드는 사실 같지만 environment 그리고/또는 properties에 명시한 값을 오버라이드한다.
+  mybatis-config.xml파일에서 SqlSessionFactory를 빌드하는 예제이다.</p>
 
   <source>String <strong>resource</strong> = "org/mybatis/builder/mybatis-config.xml";
 InputStream <strong>inputStream</strong> = Resources.getResourceAsStream(resource);
 SqlSessionFactoryBuilder <strong>builder</strong> = new SqlSessionFactoryBuilder();
-SqlSessionFactory <strong>factory</strong> = builder.build(inputStream);</source>  
-  
-  <p>Resources유틸리티 클래스를 사용하고 있는 것을 주의깊게 보면 된다. 
-  이 클래스는 org.apache.ibatis.io 패키지에 있다. 
-  Resources 클래스는 그 이름이 나타내는 것처럼 클래스패스나 파일 시스템 또는 웹 URL 에서 자원으로 로드하도록 해준다. 
-  IDE를 통해 클래스의 소스 코드를 보는 것으로 유용한 메소드를 보게 될 것이다. 
+SqlSessionFactory <strong>factory</strong> = builder.build(inputStream);</source>
+
+  <p>Resources유틸리티 클래스를 사용하고 있는 것을 주의깊게 보면 된다.
+  이 클래스는 org.apache.ibatis.io 패키지에 있다.
+  Resources 클래스는 그 이름이 나타내는 것처럼 클래스패스나 파일 시스템 또는 웹 URL 에서 자원으로 로드하도록 해준다.
+  IDE를 통해 클래스의 소스 코드를 보는 것으로 유용한 메소드를 보게 될 것이다.
   그 유용한 메소드 목록들이다.</p>
   <source>URL getResourceURL(String resource)
 URL getResourceURL(ClassLoader loader, String resource)
@@ -161,10 +161,10 @@ Reader getUrlAsReader(String urlString)
 Properties getUrlAsProperties(String urlString)
 Class classForName(String className)</source>
 
-  <p>마지막 build메소드는 Configuration의 인스턴스를 가진다. 
-  Configuration클래스는 SqlSessionFactory 인스턴스에 대해 알 필요가 있는 모든 것으로 가지고 있다. 
-  Configuration클래스는 SQL Map을 찾거나 관리하는 것을 포함하여 설정을 살펴보기 위해 유용하다. 
-  Configuration클래스는 앞서 봤던 모든 설정을 처리할 수 있으며 자바 API 로 나타낼 수 있다. 
+  <p>마지막 build메소드는 Configuration의 인스턴스를 가진다.
+  Configuration클래스는 SqlSessionFactory 인스턴스에 대해 알 필요가 있는 모든 것으로 가지고 있다.
+  Configuration클래스는 SQL Map을 찾거나 관리하는 것을 포함하여 설정을 살펴보기 위해 유용하다.
+  Configuration클래스는 앞서 봤던 모든 설정을 처리할 수 있으며 자바 API 로 나타낼 수 있다.
   SqlSessionFactory를 생성하기 위해 Configuration인스턴스를 build()메소드에 전달하는 예제이다.</p>
   <source>DataSource dataSource = BaseDataTest.createBlogDataSource();
 TransactionFactory transactionFactory = new JdbcTransactionFactory();
@@ -183,11 +183,11 @@ configuration.addMapper(BoundAuthorMapper.class);
 SqlSessionFactoryBuilder builder = new SqlSessionFactoryBuilder();
 SqlSessionFactory factory = builder.build(configuration);</source>
 
-  <p>이제 SqlSessionFactory를 만들었다. 
+  <p>이제 SqlSessionFactory를 만들었다.
   SqlSession인스턴스를 만들기 위해 사용해보자.</p>
 
   <h4>SqlSessionFactory</h4>
-  <p>SqlSessionFactory는 SqlSession인스턴스를 생성하기 위해 사용할 수 있는 6개의 메소드를 가지고 있다. 
+  <p>SqlSessionFactory는 SqlSession인스턴스를 생성하기 위해 사용할 수 있는 6개의 메소드를 가지고 있다.
   6개의 메소드가 선택해서 사용하는 것들을 보자.</p>
   <ul>
     <li><strong>Transaction</strong>: 세션에서 트랜잭션 스코프 또는 자동 커밋을 사용하고 싶은가?</li>
@@ -210,41 +210,41 @@ Configuration getConfiguration();</source>
     <li>트랜잭션 스코프는 시작될 것이다.</li>
     <li>Connection 객체는 활성화된 환경에 의해 설정된 DataSource인스턴스를 획득할 것이다.</li>
     <li>트랜잭션 격리 레벨은 드라이버나 데이터소스가 디폴트로 제공하는 옵션을 사용할 것이다.</li>
-    <li>PreparedStatements는 재사용되지 않을 것이다. 
+    <li>PreparedStatements는 재사용되지 않을 것이다.
 	그리고 update또한 배치처리되지 않을 것이다.</li>
   </ul>
-  <p>메소드 대부분은 그 이름과 파라미터가 그 역할을 충분히 설명한다. 
-  자동커밋을 활성화하기 위해서 autoCommit파라미터에 “true” 값을 설정하라. 
+  <p>메소드 대부분은 그 이름과 파라미터가 그 역할을 충분히 설명한다.
+  자동커밋을 활성화하기 위해서 autoCommit파라미터에 “true” 값을 설정하라.
   자체적인 커넥션을 제공하기 위해서는 connection파라미터에 Connection인스턴스를 설정하라.</p>
-  <p>Connection 과 autoCommit 둘다 설정하는 것을 오버라이드하지 않는다. 
-  왜냐하면 마이바티스는 제공된 connection 객체를 설정할때마다 현재 사용중인 것을 사용한다. 
-  마이바티스는 TransactionIsolationLevel라고 불리는 트랜잭션 격리 레벨을 위한 자바 enum 래퍼를 사용한다. 
+  <p>Connection 과 autoCommit 둘다 설정하는 것을 오버라이드하지 않는다.
+  왜냐하면 마이바티스는 제공된 connection 객체를 설정할때마다 현재 사용중인 것을 사용한다.
+  마이바티스는 TransactionIsolationLevel라고 불리는 트랜잭션 격리 레벨을 위한 자바 enum 래퍼를 사용한다.
   JDBC를 5가지를 지원한다(NONE, READ_UNCOMMITTED, READ_COMMITTED, REPEATABLE_READ, SERIALIZABLE).</p>
-  <p>새롭게 보일수 있는 하나의 파라미터는 ExecutorType이다. 
+  <p>새롭게 보일수 있는 하나의 파라미터는 ExecutorType이다.
   enum으로는 3개의 값을 정의한다.</p>
   <ul>
-    <li><code>ExecutorType.SIMPLE</code>: 이 타입의 실행자는 아무것도 하지 않는다. 
+    <li><code>ExecutorType.SIMPLE</code>: 이 타입의 실행자는 아무것도 하지 않는다.
 	구문 실행마다 새로운 PreparedStatement를 생성한다.</li>
     <li><code>ExecutorType.REUSE</code>: 이 타입의 실행자는 PreparedStatements를 재사용할 것이다.</li>
-    <li><code>ExecutorType.BATCH</code>: 이 실행자는 모든 update구문을 배치처리하고 중간에 select 가 실행될 경우 필요하다면 경계를 표시한다. 
+    <li><code>ExecutorType.BATCH</code>: 이 실행자는 모든 update구문을 배치처리하고 중간에 select 가 실행될 경우 필요하다면 경계를 표시한다.
 	이러한 과정은 행위를 좀더 이해하기 쉽게 하기 위함이다.</li>
   </ul>
-  <p><span class="label important">참고</span> SqlSessionFactory에서 언급하지 않는 한개 이상의 메소드가 있다. 
+  <p><span class="label important">참고</span> SqlSessionFactory에서 언급하지 않는 한개 이상의 메소드가 있다.
   getConfiguration() 메소드인데 이 메소드는 런타임시 마이바티스 설정을 조사하는 Configuration인스턴스를 리턴할 것이다.</p>
   <p><span class="label important">참고</span> 마이바티스 이전 버전을 사용했다면 세션, 트랜잭션 그리고 배치들을 여기저기서 찾게 될 것이다.
-  이것들은 더이상 사용되지 않는다. 
-  세가지 모두 세션의 범위에 모두 포함되었다. 
+  이것들은 더이상 사용되지 않는다.
+  세가지 모두 세션의 범위에 모두 포함되었다.
   이것들이 제공하던 모든 기능을 사용하기 위해 각각이 필요한 것 아니다.</p>
 
   <h4>SqlSession</h4>
-  <p>앞서 언급한 것처럼 SqlSession인스턴스는 마이바티스에서 굉장히 강력한 클래스이다. 
+  <p>앞서 언급한 것처럼 SqlSession인스턴스는 마이바티스에서 굉장히 강력한 클래스이다.
   구문을 실행하고 트랜잭션을 커밋하거나 롤백하는 그리고 mapper인스턴스를 습득하기 위해 필요한 모든 메소드를 찾을 수 있을 것이다.</p>
-  <p>SqlSession에는 20개 이상의 메소드가 있다. 
+  <p>SqlSession에는 20개 이상의 메소드가 있다.
   좀더 적절히 모아서 보도록 하자.</p>
 
   <h5>구문을 실행하는 메소드</h5>
-  <p>이 메소드들은 SQL 매핑 XML 파일에 정의된 SELECT, INSERT, UPDATE 그리고 DELETE 구문을 실행하기 위해 사용된다. 
-  메소드 이름 자체가 그 역할을 설명하도록 명명되었다. 
+  <p>이 메소드들은 SQL 매핑 XML 파일에 정의된 SELECT, INSERT, UPDATE 그리고 DELETE 구문을 실행하기 위해 사용된다.
+  메소드 이름 자체가 그 역할을 설명하도록 명명되었다.
   메소드 각각은 구문의 ID 와 파라미터 객체(원시타입, 자바빈, POJO 또는 Map)을 가진다.</p>
   <source><![CDATA[<T> T selectOne(String statement, Object parameter)
 <E> List<E> selectList(String statement, Object parameter)
@@ -253,12 +253,12 @@ Configuration getConfiguration();</source>
 int insert(String statement, Object parameter)
 int update(String statement, Object parameter)
 int delete(String statement, Object parameter)]]></source>
-  <p>selectOne과 selectList의 차이점은 selectOne메소드는 오직 하나의 객체만을 리턴해야 한다는 것이다. 
-  한개 이상을 리턴하거나 null 이 리턴된다면 예외가 발생할 것이다. 
-  얼마나 많은 객체가 리턴될지 모른다면 selectList를 사용하라. 
-  객체의 존재여부를 체크하고 싶다면 개수를 리턴하는 방법이 더 좋다. 
-  selectMap은 결과 목록을 Map으로 변환하기 위해 디자인된 특별한 경우이다. 
-  이 경우 결과 객체의 프로퍼티 중 하나를 키로 사용하게 된다. 
+  <p>selectOne과 selectList의 차이점은 selectOne메소드는 오직 하나의 객체만을 리턴해야 한다는 것이다.
+  한개 이상을 리턴하거나 null 이 리턴된다면 예외가 발생할 것이다.
+  얼마나 많은 객체가 리턴될지 모른다면 selectList를 사용하라.
+  객체의 존재여부를 체크하고 싶다면 개수를 리턴하는 방법이 더 좋다.
+  selectMap은 결과 목록을 Map으로 변환하기 위해 디자인된 특별한 경우이다.
+  이 경우 결과 객체의 프로퍼티 중 하나를 키로 사용하게 된다.
   모든 구문이 파라미터를 필요로 하지는 않기 때문에 파라미터 객체를 요구하지 않는 형태로 오버로드되었다.</p>
   <p>A Cursor offers the same results as a List, except it fetches data lazily using an Iterator.</p>
   <source><![CDATA[try (Cursor<MyEntity> entities = session.selectCursor(statement, param)) {
@@ -276,26 +276,26 @@ int update(String statement)
 int delete(String statement)]]></source>
 
   <p>마지막으로 리턴되는 데이터의 범위를 제한하거나 결과를 핸들링 하는 로직을 부여할 수 있는 3개의 select 메소드가 있다.</p>
-  
+
   <source><![CDATA[<E> List<E> selectList (String statement, Object parameter, RowBounds rowBounds)
 <T> Cursor<T> selectCursor(String statement, Object parameter, RowBounds rowBounds)
 <K,V> Map<K,V> selectMap(String statement, Object parameter, String mapKey, RowBounds rowbounds)
 void select (String statement, Object parameter, ResultHandler<T> handler)
 void select (String statement, Object parameter, RowBounds rowBounds, ResultHandler<T> handler)]]></source>
 
-  <p>RowBounds 파라미터는 마이바티스로 하여금 특정 개수 만큼의 레코드를 건너띄게 한다. 
+  <p>RowBounds 파라미터는 마이바티스로 하여금 특정 개수 만큼의 레코드를 건너띄게 한다.
   RowBounds클래스는 offset과 limit 둘다 가지는 생성자가 있다.</p>
- 
+
   <source>int offset = 100;
 int limit = 25;
 RowBounds rowBounds = new RowBounds(offset, limit);</source>
 
   <p>가장 좋은 성능을 위해 결과셋의 타입을 SCROLL_SENSITIVE나 SCROLL_INSENSITIVE로 사용하라.</p>
-  <p>ResultHandler파라미터는 레코드별로 다룰수 있도록 해준다. 
-  List에 추가할수도 있고 Map, Set을 만들수도 있으며 각각의 결과를 그냥 던질수도 있다. 
+  <p>ResultHandler파라미터는 레코드별로 다룰수 있도록 해준다.
+  List에 추가할수도 있고 Map, Set을 만들수도 있으며 각각의 결과를 그냥 던질수도 있다.
   ResultHandler로 많은 것을 할 수 있고 마이바티스는 결과셋을 다루기 위해 내부적으로 사용한다.</p>
   <p>Since 3.4.6, ResultHandler passed to a CALLABLE statement is used on every REFCURSOR output parameter of the stored procedure if there is any.</p>
-  <p>인터페이스는 매우 간단하다.</p>  
+  <p>인터페이스는 매우 간단하다.</p>
   <source><![CDATA[package org.apache.ibatis.session;
 public interface ResultHandler<T> {
   void handleResult(ResultContext<? extends T> context);
@@ -304,42 +304,42 @@ public interface ResultHandler<T> {
   <p>ResultContext파라미터는 결과 객체에 접근할 수 있도록 해준다.</p>
 
   <p>Using a ResultHandler has two limitations that you should be aware of:</p>
-  
+
   <ul>
   <li>Data got from an method called with a ResultHandler will not be cached.</li>
   <li>When using advanced resultmaps MyBatis will probably require several rows to build an object. If a ResultHandler is used you may be given an object whose associations or collections are not yet filled.</li>
   </ul>
 
   <h5>배치 수정시 flush메소드</h5>
-  <p>어떤 시점에 JDBC드라이버 클래스에 저장된 배치 수정구문을 지울(flushing(executing)) 방법이 있다. 
+  <p>어떤 시점에 JDBC드라이버 클래스에 저장된 배치 수정구문을 지울(flushing(executing)) 방법이 있다.
   이 방법은 <code>ExecutorType</code>을 <code>ExecutorType.BATCH</code>로 설정한 경우 사용가능하다. </p>
   <source><![CDATA[List<BatchResult> flushStatements()]]></source>
 
   <h5>트랙잭션 제어 메소드</h5>
-  <p>트랜잭션을 제어하기 위해 4개의 메소드가 있다. 
-  물론 자동커밋을 선택하였거나 외부 트랜잭션 관리자를 사용하면 영향이 없다. 
+  <p>트랜잭션을 제어하기 위해 4개의 메소드가 있다.
+  물론 자동커밋을 선택하였거나 외부 트랜잭션 관리자를 사용하면 영향이 없다.
   어쨌든 Connection인스턴스에 의해 관리되고 JDBC 트랜잭션 관리자를 사용하면 이 4개의 메소드를 사용할 수 있다.</p>
   <source>void commit()
 void commit(boolean force)
 void rollback()
 void rollback(boolean force)</source>
-  <p>기본적으로 마이바티스는 insert, update 또는 delete 를 호출하여 데이터베이스가 변경된 것으로 감지하지 않는 한 실제로 커밋하지 않는다. 
+  <p>기본적으로 마이바티스는 insert, update 또는 delete 를 호출하여 데이터베이스가 변경된 것으로 감지하지 않는 한 실제로 커밋하지 않는다.
   이러한 메소드 호출없이 변경되면 커밋된 것으로 보장하기 위해 commit 와 rollback 메소드에 true 값을 전달한다.</p>
   <p><span class="label important">참고</span> MyBatis-Spring 과 MyBatis-Guice는 선언적인 트랜잭션 관리기법을 제공한다.
   그래서 스프링이나 쥬스와 함께 마이바티스를 사용한다면 해당되는 메뉴얼을 꼭 참고하길 바란다. </p>
 
   <h5>세션 레벨의 캐시를 지우기</h5>
   <source>void clearCache()</source>
-  <p>SqlSession인스턴스는 update, commit, rollback 또는 close 할때마다 지워지는 로컬 캐시이다. 
+  <p>SqlSession인스턴스는 update, commit, rollback 또는 close 할때마다 지워지는 로컬 캐시이다.
   명시적으로 닫기 위해서는 clearCache()메소드를 호출할 수 있다.</p>
 
   <h5>SqlSession 을 반드시 닫도록 한다.</h5>
   <source>void close()</source>
-  <p>반드시 기억해야 하는 중요한 것은 당신이 열었던 세션을 닫아주는 것이다. 
+  <p>반드시 기억해야 하는 중요한 것은 당신이 열었던 세션을 닫아주는 것이다.
   확실히 하기 위해 가장 좋은 방법은 다음과 같은 형태로 개발하는 것이다.</p>
   <source>SqlSession session = sqlSessionFactory.openSession();
 try {
-    // 다음의 3줄은 "어떤 작업을 하는"을 나타낸다. 
+    // 다음의 3줄은 "어떤 작업을 하는"을 나타낸다.
     session.insert(...);
     session.update(...);
     session.delete(...);
@@ -350,7 +350,7 @@ try {
   <p>JDK 1.7이상과 마이바티스 3.2이상을 사용한다면 다음처럼 try-with-resources 구문을 사용할 수 있다. </p>
   <source>
 try (SqlSession session = sqlSessionFactory.openSession()) {
-    // 다음의 3줄은 "어떤 작업을 하는"을 나타낸다. 
+    // 다음의 3줄은 "어떤 작업을 하는"을 나타낸다.
     session.insert(...);
     session.update(...);
     session.delete(...);
@@ -360,19 +360,19 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
   <source>Configuration getConfiguration()</source>
 
   <h5>Mappers 사용하기</h5>
-  <source><![CDATA[<T> T getMapper(Class<T> type)]]></source>  
-  <p>다양한 insert, update, delete 그리고 select 메소드는 강력하지만 다소 장황하고 타입에 안전하지 않다. 
-  더군다나 IDE나 단위 테스트에 그다지 도움이 되지 않는 형태이다. 
+  <source><![CDATA[<T> T getMapper(Class<T> type)]]></source>
+  <p>다양한 insert, update, delete 그리고 select 메소드는 강력하지만 다소 장황하고 타입에 안전하지 않다.
+  더군다나 IDE나 단위 테스트에 그다지 도움이 되지 않는 형태이다.
   우리는 Mapper를 사용하는 예제는 이미 시작하기 섹션에서 봤다.</p>
-  <p>그러므로 매핑된 구문을 실행하기 위해 좀더 공통적인 방법은 Mapper클래스를 사용하는 것이다. 
-  Mapper클래스는 SqlSession 메소드에 일치하는 메소드와 간단히 연동된다. 
+  <p>그러므로 매핑된 구문을 실행하기 위해 좀더 공통적인 방법은 Mapper클래스를 사용하는 것이다.
+  Mapper클래스는 SqlSession 메소드에 일치하는 메소드와 간단히 연동된다.
   다음의 예제 클래스는 몇가지 메소드 시그니처와 SqlSession에 매핑하는 방법을 보여준다.</p>
   <source><![CDATA[public interface AuthorMapper {
   // (Author) selectOne("selectAuthor",5);
-  Author selectAuthor(int id); 
+  Author selectAuthor(int id);
   // (List<Author>) selectList(“selectAuthors”)
   List<Author> selectAuthors();
-  
+
   // (Map<Integer,Author>) selectMap("selectAuthors", "id")
   @MapKey("id")
   List<Author> selectAuthorsAsMap();
@@ -383,32 +383,32 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
   // delete("deleteAuthor",5)
   int deleteAuthor(int id);
 }]]></source>
-  <p>아주 간결하게 각각의 Mapper메소드 시그니처는 SqlSession 의 메소드 시그니처와 일치해야만 한다. 
-  String 파라미터 ID가 없지만 대신 메소드명은 매핑된 구문의 ID 와 같아야 한다.</p> 
-  <p>추가로 리턴 타입은 기대하는 결과 타입과 일치해야만 한다. 
+  <p>아주 간결하게 각각의 Mapper메소드 시그니처는 SqlSession 의 메소드 시그니처와 일치해야만 한다.
+  String 파라미터 ID가 없지만 대신 메소드명은 매핑된 구문의 ID 와 같아야 한다.</p>
+  <p>추가로 리턴 타입은 기대하는 결과 타입과 일치해야만 한다.
   원시타입과 Map, POJO 그리고 자바빈등 대부분의 타입이 지원된다.</p>
-  <p><span class="label important">참고</span> Mapper 인터페이스는 어떠한 인터페이스를 구현할 필요가 없고 어떠한 클래스를 확장할 필요도 없다. 
+  <p><span class="label important">참고</span> Mapper 인터페이스는 어떠한 인터페이스를 구현할 필요가 없고 어떠한 클래스를 확장할 필요도 없다.
   메소드 시그니처는 관련된 매핑된 구문을 유일하게 확인하기 위해 사용될 수 있다.</p>
-  <p><span class="label important">참고</span> Mapper 인터페이스는 다른 인터페이스를 확장할 수 있다. 
-  적절한 명명공간의 구문은 Mapper 인터페이스에 XML바인딩을 사용한다. 
+  <p><span class="label important">참고</span> Mapper 인터페이스는 다른 인터페이스를 확장할 수 있다.
+  적절한 명명공간의 구문은 Mapper 인터페이스에 XML바인딩을 사용한다.
   오직 하나의 제한점은 두개의 인터페이스에 같은 메소드 시그니처를 사용할 수 없다는 것이다.</p>
-  <p>mapper 메소드에 여러개의 파라미터를 전달 할 수 있다. 
-  여러개의 파라미터를 전달하면 파라미터 목록의 위치에 따라 명명될 것이다. 
-  예를 들면 #{param1}, #{param2} 기타 등등 이런 식이다. 
+  <p>mapper 메소드에 여러개의 파라미터를 전달 할 수 있다.
+  여러개의 파라미터를 전달하면 파라미터 목록의 위치에 따라 명명될 것이다.
+  예를 들면 #{param1}, #{param2} 기타 등등 이런 식이다.
   만약 파라미터의 이름을 변경하고자 한다면 파라미터의 @Param(“paramName”)애노테이션을 사용할 수 있다.</p>
   <p>쿼리 결과를 제한하기 위해 메소드에 RowBounds인스턴스를 전달 할 수 있다.</p>
 
   <h5>Mapper 애노테이션</h5>
-  <p>이 프레임워크가 만들어진 이후로 마이바티스는 XML 기반의 프레임워크이다. 
-  설정은 XML기반이고 매핑된 구문또한 XML 에 정의한다. 
-  마이바티스 3 에서는 새로운 추가 옵션이 생겼다. 
-  마이바티스 3 은 편리하고 강력한 자바 기반의 설정 API 를 제공한다. 
-  설정 API 는 XML 기반의 마이바티스 설정의 기초가 된다. 
+  <p>이 프레임워크가 만들어진 이후로 마이바티스는 XML 기반의 프레임워크이다.
+  설정은 XML기반이고 매핑된 구문또한 XML 에 정의한다.
+  마이바티스 3 에서는 새로운 추가 옵션이 생겼다.
+  마이바티스 3 은 편리하고 강력한 자바 기반의 설정 API 를 제공한다.
+  설정 API 는 XML 기반의 마이바티스 설정의 기초가 된다.
   이는 새로운 애노테이션 기반의 설정에도 그대로 적용된다.
   애노테이션은 소개하는데 많은 시간이 할애하지 않아도 될 정도로 매핑된 구문을 구현하는 간단한 방법을 제공한다.</p>
-  <p><span class="label important">참고</span> 자바 애노테이션은 복잡하고 유연해야 하는 경우에 대해서는 다소 제한적이다. 
-  조사하는데 많은 시간이 소요됨에도 불구하고 가장 강력한 마이바티스 매핑은 애노테이션으로 처리되지는 못한다. 
-  C# 속성은 이러한 제한사항이 없어서 MyBatis.NET 버전은 XML 대안으로 자바보다 다소 더 풍부한 기능을 제공한다. 
+  <p><span class="label important">참고</span> 자바 애노테이션은 복잡하고 유연해야 하는 경우에 대해서는 다소 제한적이다.
+  조사하는데 많은 시간이 소요됨에도 불구하고 가장 강력한 마이바티스 매핑은 애노테이션으로 처리되지는 못한다.
+  C# 속성은 이러한 제한사항이 없어서 MyBatis.NET 버전은 XML 대안으로 자바보다 다소 더 풍부한 기능을 제공한다.
   하지만 자바 애노테이션 기반의 설정이 장점이 없지는 않다.</p>
   <p><strong>사용가능한 애노테이션은 아래에서 설명한다.</strong></p>
   <table>
@@ -462,17 +462,17 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
             <li><code>&lt;idArg&gt;</code></li>
           </ul>
         </td>
-        <td>ConstructorArgs 의 일부로 한개의 생성자 인자 
-		사용가능한 속성들 : id, column, javaType, jdbcType, typeHandler, select 그리고 resultMap. 
+        <td>ConstructorArgs 의 일부로 한개의 생성자 인자
+		사용가능한 속성들 : id, column, javaType, jdbcType, typeHandler, select 그리고 resultMap.
 		id 속성은 비교하기 위해 사용되는 값이다.
-		XML에서는 <code>&lt;idArg&gt;</code> 엘리먼트와 유사하다.</td>  
+		XML에서는 <code>&lt;idArg&gt;</code> 엘리먼트와 유사하다.</td>
       </tr>
       <tr>
         <td><code>@TypeDiscriminator</code></td>
         <td><code>Method</code></td>
         <td><code>&lt;discriminator&gt;</code></td>
         <td>결과매핑을 할때 사용될 수 있는 경우에 대한 값들
-		사용가능한 속성들 : column, javaType, jdbcType, typeHandler, cases. 
+		사용가능한 속성들 : column, javaType, jdbcType, typeHandler, cases.
 		cases 속성은 경우(case)의 배열이다.</td>
       </tr>
       <tr>
@@ -480,7 +480,7 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td>N/A</td>
         <td><code>&lt;case&gt;</code></td>
         <td>case 의 값과 매핑
-		사용가능한 속성들 : value, type, results. 
+		사용가능한 속성들 : value, type, results.
 		results 속성은 Result 의 배열이다.
 		게다가 이 Case 애노테이션은 Results애노테이션에서 명시된 ResultMap과 유사하다.</td>
       </tr>
@@ -500,11 +500,11 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
             <li><code>&lt;id&gt;</code></li>
           </ul>
         </td>
-        <td>칼럼이 프로퍼티나 필드에 매핑되는 한개의 결과 매핑 
+        <td>칼럼이 프로퍼티나 필드에 매핑되는 한개의 결과 매핑
 		사용가능한 속성들 : id, column, property, javaType, jdbcType, typeHandler, one, many.
 		id 속성은 프로퍼티를 비교할 때 사용할지를 표시하는 boolean 값이다. (XML 에서 &lt;id&gt; 와 유사하다.)
-		one 속성은 한개의 관계(associations)이고 &lt;association&gt; 과 유사하다. 
-		many 속성은 collection이고  &lt;collection&gt; 과 유사하다. 
+		one 속성은 한개의 관계(associations)이고 &lt;association&gt; 과 유사하다.
+		many 속성은 collection이고  &lt;collection&gt; 과 유사하다.
 		클래스의 명명규칙 충돌을 피하기 위해 명명되었다.</td>
       </tr>
       <tr>
@@ -513,45 +513,45 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td><code>&lt;association&gt;</code></td>
         <td>복잡한 타입의 한개의 프로퍼티를 위한 매핑이다.
 		사용가능한 속성들 : select(매핑 구문의 이름, 예를들어 매퍼 메소드)
-		Note: 조인 매핑은 애노테이션 API 를 통해서는 지원되지 않는다는 것을 알아야 한다. 
+		Note: 조인 매핑은 애노테이션 API 를 통해서는 지원되지 않는다는 것을 알아야 한다.
 		순환(circular) 참조를 허용하지 않는 자바 애노테이션의 제약사항때문이다.</td>
       </tr>
       <tr>
         <td><code>@Many</code></td>
         <td>N/A</td>
         <td><code>&lt;collection&gt;</code></td>
-        <td>복잡한 타입의 collection 프로퍼티를 위한 매핑이다. 
+        <td>복잡한 타입의 collection 프로퍼티를 위한 매핑이다.
 		사용가능한 속성들 : select(매핑 구문의 이름, 예를들어 매퍼 메소드)
-		Note: 조인 매핑은 애노테이션 API 를 통해서는 지원되지 않는다는 것을 알아야 한다. 
+		Note: 조인 매핑은 애노테이션 API 를 통해서는 지원되지 않는다는 것을 알아야 한다.
 		순환(circular) 참조를 허용하지 않는 자바 애노테이션의 제약사항때문이다.</td>
       </tr>
       <tr>
         <td><code>@MapKey</code></td>
         <td><code>Method</code></td>
         <td> </td>
-        <td>리턴 타입이 Map 인 메소드에서 사용된다. 
+        <td>리턴 타입이 Map 인 메소드에서 사용된다.
 		결과객체의 List 를 객체의 프로퍼티에 기초한 Map으로 변환하기 위해 사용된다.</td>
       </tr>
       <tr>
         <td><code>@Options</code></td>
         <td><code>Method</code></td>
         <td>매핑 구문의  속성들 </td>
-        <td>이 애노테이션은 매핑된 구문에 속성으로 존재하는 많은 분기(switch)와 설정 옵션에 접근할 수 있다. 
+        <td>이 애노테이션은 매핑된 구문에 속성으로 존재하는 많은 분기(switch)와 설정 옵션에 접근할 수 있다.
 		각 구문을 복잡하게 만들기 보다 Options 애노테이션으로 일관되고 깔끔한 방법으로 설정 할수 있게 한다.
 		사용가능한 속성들 : useCache=true,
 		flushCache=FlushCachePolicy.DEFAULT,
 		resultSetType=DEFAULT,
-		statementType=PREPARED, 
+		statementType=PREPARED,
 		fetchSize=-1,
-		timeout=-1, 
+		timeout=-1,
 		useGeneratedKeys=false,
 		keyProperty=“”,
 		keyColumn=“”,
 		resultSets=“”.
-		자바 애노테이션을 이해하는 것이 중요하다. 
-		자바 애노테이션은 “null”을 설정 할 수 없다. 
-		그래서 일단 Options 애노테이션을 사용하면 각각의 속성은 디폴트 값을 사용하게 된다. 
-		디폴트 값이 기대하지 않은 결과를 만들지 않도록 주의해야 한다. 
+		자바 애노테이션을 이해하는 것이 중요하다.
+		자바 애노테이션은 “null”을 설정 할 수 없다.
+		그래서 일단 Options 애노테이션을 사용하면 각각의 속성은 디폴트 값을 사용하게 된다.
+		디폴트 값이 기대하지 않은 결과를 만들지 않도록 주의해야 한다.
 		keyColumn은 키 칼럼이 테이블의 첫번째 칼럼이 아닌 특정 데이터베이스에서만(PostgreSQL 같은) 필요하다.</td>
       </tr>
       <tr>
@@ -572,10 +572,10 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
             <li><code>&lt;select&gt;</code></li>
           </ul>
         </td>
-        <td>각각의 애노테이션은 실행하고자 하는 SQL을 표현한다. 
-		각각 문자열의 배열(또는 한개의 문자열)을 가진다. 
-		문자열의 배열이 전달되면, 각각 공백을 두고 하나로 합친다. 
-		자바 코드에서 SQL 을 만들때 발행할 수 있는 “공백 누락” 문제를 해결하도록 도와준다. 
+        <td>각각의 애노테이션은 실행하고자 하는 SQL을 표현한다.
+		각각 문자열의 배열(또는 한개의 문자열)을 가진다.
+		문자열의 배열이 전달되면, 각각 공백을 두고 하나로 합친다.
+		자바 코드에서 SQL 을 만들때 발행할 수 있는 “공백 누락” 문제를 해결하도록 도와준다.
 		사용가능한 속성들 : value(한개의 SQL 구문을 만들기 위한 문자열의 배열)</td>
       </tr>
       <tr>
@@ -599,7 +599,7 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td>실행시 SQL 을 리턴할 클래스 과 메소드명을 명시하도록 해주는 대체수단의 애노테이션이다 (Since 3.4.6, you can specify the <code>CharSequence</code> instead of <code>String</code> as a method return type).
 		매핑된 구문을 실행할 때 마이바티스는 클래스의 인스턴스를 만들고 메소드를 실행한다.
     Mapper 메서드의 인수인 "Mapper interface type" 과 <code>ProviderContext</code>(Mybatis 3.4.5 부터) 를 이용한 "Mapper method" 로 전달 된 객체를 메서드 매개변수로 전달할 수 있다.(마이바티스 3.4이상에서는 복수 파라미터를 허용한다.)
-		사용가능한 속성들 : type, method. 
+		사용가능한 속성들 : type, method.
 		type 속성은 클래스.
 		method 속성은 메소드명이다.
 		Note: 이 섹션은 클래스에 대한 설명으로 동적 SQL 을 좀더 깔끔하고 읽기 쉽게 만드는데 도움이 될 수 있다.</td>
@@ -608,7 +608,7 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td><code>@Param</code></td>
         <td><code>Parameter</code></td>
         <td>N/A</td>
-        <td>매퍼 메소드가 여러개의 파라미터를 가진다면 이 애노테이션은 이름에 일치하는 매퍼 메소드 파라미터에 적용된다. 
+        <td>매퍼 메소드가 여러개의 파라미터를 가진다면 이 애노테이션은 이름에 일치하는 매퍼 메소드 파라미터에 적용된다.
 		반면에 여러개의 파라미터는 순서대로 명명된다.
 		예를들어 #{param1}, #{param2} 등이 디폴트다.
 		@Param(“person”)을 사용하면 파라미터는 #{person}로 명명된다.</td>
@@ -617,34 +617,34 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td><code>@SelectKey</code></td>
         <td><code>Method</code></td>
         <td><code>&lt;selectKey&gt;</code></td>
-        <td>이 애노테이션은 @Insert, @InsertProvider, @Update 또는 @UpdateProvider 애노테이션을 사용하는 메소드에서 &lt;selectKey&gt;와 똑같다. 
-		다른 메소드에서는 무시된다. 
+        <td>이 애노테이션은 @Insert, @InsertProvider, @Update 또는 @UpdateProvider 애노테이션을 사용하는 메소드에서 &lt;selectKey&gt;와 똑같다.
+		다른 메소드에서는 무시된다.
 		@SelectKey애노테이션을 명시하면 마이바티스는 @Options애노테이션이나 설정 프로퍼티를 통해 설정된 key프로퍼티를 무시할 것이다.
-		사용가능한 속성들 : statement는 실행할 SQL 구문을 만드는 문자열의 배열이다. 
-		keyProperty는 새로운 값으로 수정될 파라미터 객체의 프로퍼티이다. 
-		SQL이 insert 전후에 실행되는 것을 나타내기 위해 true나 false가 되어야 한다. 
-		resultType은 keyProperty의 자바 타입이다. 
+		사용가능한 속성들 : statement는 실행할 SQL 구문을 만드는 문자열의 배열이다.
+		keyProperty는 새로운 값으로 수정될 파라미터 객체의 프로퍼티이다.
+		SQL이 insert 전후에 실행되는 것을 나타내기 위해 true나 false가 되어야 한다.
+		resultType은 keyProperty의 자바 타입이다.
 		statementType=PREPARED.</td>
       </tr>
       <tr>
         <td><code>@ResultMap</code></td>
         <td><code>Method</code></td>
         <td>N/A</td>
-        <td>이 애노테이션은 @Select또는 @SelectProvider애노테이션을 위해 XML 매퍼의 &lt;resultMap&gt; 엘리먼트의 id를 제공하기 위해 사용된다. 
-		XML 에 정의된 결과매핑을 재사용하도록 해준다. 
+        <td>이 애노테이션은 @Select또는 @SelectProvider애노테이션을 위해 XML 매퍼의 &lt;resultMap&gt; 엘리먼트의 id를 제공하기 위해 사용된다.
+		XML 에 정의된 결과매핑을 재사용하도록 해준다.
 		이 애노테이션은 @Results나 @ConstructorArgs를 오버라이드 할 것이다.</td>
       </tr>
       <tr>
         <td><code>@ResultType</code></td>
         <td><code>Method</code></td>
         <td>N/A</td>
-        <td>이 애노테이션은 결과 핸들러를 사용할때 사용한다. 
+        <td>이 애노테이션은 결과 핸들러를 사용할때 사용한다.
 		이 경우 리턴타입은 void이고 마이바티스는 각각의 레코드 정보를 가지는 객체의 타입을 결정하는 방법을 가져야만 한다.
 		XML 결과매핑이 있다면  @ResultMap 애노테이션을 사용하자.
-        결과타입이 XML에서 <code>&lt;select&gt;</code> 엘리먼트에 명시되어 있다면 다른 애노테이션이 필요하지 않다. 
+        결과타입이 XML에서 <code>&lt;select&gt;</code> 엘리먼트에 명시되어 있다면 다른 애노테이션이 필요하지 않다.
         결과타입이 XML에서 <code>&lt;select&gt;</code> 엘리먼트에 명시되어 있지 않은 경우에 이 애노테이션을 사용하자.
-        예를들어 @Select 애노테이션이 선언되어 있다면 메소드는 결과 핸들러를 사용할 것이다. 
-        결과 타입은 void여야만 하고 이 애노테이션(이나 @ResultMap)을 반드시 사용해야 한다. 
+        예를들어 @Select 애노테이션이 선언되어 있다면 메소드는 결과 핸들러를 사용할 것이다.
+        결과 타입은 void여야만 하고 이 애노테이션(이나 @ResultMap)을 반드시 사용해야 한다.
         이 애노테이션은 메소드 리턴타입이 void가 아니라면 무시한다. </td>
       </tr>
       <tr>
@@ -712,7 +712,7 @@ List<User> getUsersByName(
 
 class UserSqlBuilder {
 
-  // @Param애노테이션을 사용하지 않으면 매퍼 메소드와 동일한 인자를 정의해야만 한다. 
+  // @Param애노테이션을 사용하지 않으면 매퍼 메소드와 동일한 인자를 정의해야만 한다.
   public static String buildGetUsersByName(
       final String name, final String orderByColumn) {
     return new SQL(){{
@@ -723,7 +723,7 @@ class UserSqlBuilder {
     }}.toString();
   }
 
-  // @Param애노테이션을 사용한다면, 오직 사용할 인자만 정의할 수 있다. 
+  // @Param애노테이션을 사용한다면, 오직 사용할 인자만 정의할 수 있다.
   public static String buildGetUsersByName(@Param("orderByColumn") final String orderByColumn) {
     return new SQL(){{
       SELECT("*");

--- a/src/site/ko/xdoc/logging.xml
+++ b/src/site/ko/xdoc/logging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
   <body>
     <section name="Logging">
       <p></p>
-      <p>마이바티스는 내부 로그 팩토리를 사용하여 로깅 정보를 제공한다. 
+      <p>마이바티스는 내부 로그 팩토리를 사용하여 로깅 정보를 제공한다.
 	  내부 로그 팩토리는 로깅 정보를 다른 로그 구현체 중 하나에 전달한다.
       </p>
       <ul>
@@ -48,20 +48,20 @@
           JDK logging
         </li>
       </ul>
-      <p>로깅 솔루션은 내부 마이바티스 로그 팩토리의 런타임 체크를 통해 선택된다. 
-	  마이바티스 로그 팩토리는 가능하면 첫번째 구현체를 사용할 것이다(위 로깅 구현체의 나열 순서는 내부적으로 선택하는 우선순위이다). 
+      <p>로깅 솔루션은 내부 마이바티스 로그 팩토리의 런타임 체크를 통해 선택된다.
+	  마이바티스 로그 팩토리는 가능하면 첫번째 구현체를 사용할 것이다(위 로깅 구현체의 나열 순서는 내부적으로 선택하는 우선순위이다).
 	  만약 마이바티스가 위 구현체중 하나도 찾지 못한다면 로깅을 하지 않을 것이다.
       </p>
-      <p>많은 환경은 애플리케이션 서버(좋은 예는 톰캣과 웹스피어)의 클래스패스의 일부로 JCL 을 사용한다. 
-	  이러한 환경을 아는 것이 중요하다. 
-	  마이바티스는 로깅 구현체로 JCL 을 사용할 것이다. 
-	  웹스피어와 같은 환경에서 Log4J 설정은 무시될 것이다. 
-	  왜냐하면 웹스피어는 자체 JCL 구현체를 제공하기 때문이다. 
-	  이러한 사항은 불만스러울수 있다. 
-	  왜냐하면 마이바티스는 당신의 Log4J 설정을 무시하는 것처럼 보일수도 있기 때문이다. 
-	  (사실 마이바티스는 당신의 Log4J 설정을 무시한다. 
-	  왜냐하면 마이바티스는 이러한 환경에서 JCL 을 사용할 것이기 때문이다.) 
-	  만약 당신의 애플리케이션이 클래스패스에 JCL 을 포함한 환경에서 돌아가지만 다른 로깅 구현체 중 하나를 더 선호한다면 
+      <p>많은 환경은 애플리케이션 서버(좋은 예는 톰캣과 웹스피어)의 클래스패스의 일부로 JCL 을 사용한다.
+	  이러한 환경을 아는 것이 중요하다.
+	  마이바티스는 로깅 구현체로 JCL 을 사용할 것이다.
+	  웹스피어와 같은 환경에서 Log4J 설정은 무시될 것이다.
+	  왜냐하면 웹스피어는 자체 JCL 구현체를 제공하기 때문이다.
+	  이러한 사항은 불만스러울수 있다.
+	  왜냐하면 마이바티스는 당신의 Log4J 설정을 무시하는 것처럼 보일수도 있기 때문이다.
+	  (사실 마이바티스는 당신의 Log4J 설정을 무시한다.
+	  왜냐하면 마이바티스는 이러한 환경에서 JCL 을 사용할 것이기 때문이다.)
+	  만약 당신의 애플리케이션이 클래스패스에 JCL 을 포함한 환경에서 돌아가지만 다른 로깅 구현체 중 하나를 더 선호한다면
 	  다음의 메소드 중 하나를 호출하여 다른 로깅 구현체를 선택 할 수 있다.
       </p>
       <source><![CDATA[org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
@@ -69,12 +69,12 @@ org.apache.ibatis.logging.LogFactory.useLog4JLogging();
 org.apache.ibatis.logging.LogFactory.useJdkLogging();
 org.apache.ibatis.logging.LogFactory.useCommonsLogging();
 org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
-      <p>마이바티스가 메소드를 호출하기 전에 위 메소드 중 하나를 호출해야 한다. 
-	  이 메소드들은 런타임 클래스패스에 구현체가 존재하면 그 로그 구현체를 사용하게 한다. 
-	  예를들어 Log4J 로깅을 선택했지만 런타임에 Log4J 구현체가 클래스패스에 없다면 
+      <p>마이바티스가 메소드를 호출하기 전에 위 메소드 중 하나를 호출해야 한다.
+	  이 메소드들은 런타임 클래스패스에 구현체가 존재하면 그 로그 구현체를 사용하게 한다.
+	  예를들어 Log4J 로깅을 선택했지만 런타임에 Log4J 구현체가 클래스패스에 없다면
 	  마이바티스는 Log4J 구현체의 사용을 무시하고 로깅 구현체를 찾아 다시 사용할 것이다.
       </p>
-      <p>SLF4J, Jakarta Commons 로깅, Log4J 그리고 JDK 로깅 API 에 대한 설명은 이 문서의 범위를 벗어난다. 
+      <p>SLF4J, Jakarta Commons 로깅, Log4J 그리고 JDK 로깅 API 에 대한 설명은 이 문서의 범위를 벗어난다.
 	  이러한 로깅 관련 프레임워크에 대해 좀더 알고 싶다면 개별 위치에서 좀더 많은 정보를 얻을 수 있을 것이다.
       </p>
       <ul>
@@ -92,36 +92,36 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
         </li>
       </ul>
       <subsection name="Logging Configuration">
-        <p>마이바티스 로깅 구문을 보기 위해서 패키지, 매퍼의 전체 경로, 구문명의 명명공간에 대해 활성화해주어야 할것이다. 
+        <p>마이바티스 로깅 구문을 보기 위해서 패키지, 매퍼의 전체 경로, 구문명의 명명공간에 대해 활성화해주어야 할것이다.
         </p>
-        <p>다시 얘기해서 사용할 로깅 구현체에 따라야 하고 우리는 Log4J를 사용하는 방법을 보여줄 것이다. 
+        <p>다시 얘기해서 사용할 로깅 구현체에 따라야 하고 우리는 Log4J를 사용하는 방법을 보여줄 것이다.
         로깅 설정은 대부분 하나 이상의 설정파일(예를들면, log4j.properties)과 몇개의 새로운 jar파일(예륻를면, log4j.jar)을 다룬다.
-       다음의 설정예제는 Log4J를 사용하여 설정하고 2단계로 설정한다. 
+       다음의 설정예제는 Log4J를 사용하여 설정하고 2단계로 설정한다.
         </p>
         <p></p>
         <h4>
           첫번째 단계 : Log4J JAR 파일 추가하기
         </h4>
-        <p>Log4J를 사용하기 때문에 애플리케이션에 JAR 파일이 있어야 한다. 
-		Log4J 를 사용하기 위해 애플리케이션의 클래스패스에 JAR 파일을 추가할 필요가 있다. 
+        <p>Log4J를 사용하기 때문에 애플리케이션에 JAR 파일이 있어야 한다.
+		Log4J 를 사용하기 위해 애플리케이션의 클래스패스에 JAR 파일을 추가할 필요가 있다.
 		위 URL 에서 Log4J 를 다운로드 할 수 있다.
         </p>
-        <p>웹이나 기업용 애플리케이션에서는 <code>WEB-INF/lib</code> 디렉터리에 <code>log4j.jar</code> 파일을 추가할 수 있다. 
+        <p>웹이나 기업용 애플리케이션에서는 <code>WEB-INF/lib</code> 디렉터리에 <code>log4j.jar</code> 파일을 추가할 수 있다.
 		단독으로 실행되는 애플리케이션에서는 JVM의 <code>-classpath</code> 시작 파라미터에서 간단히 추가할 수 있다.
         </p>
         <p></p>
         <h4>
           두번째 단계 : Log4J 설정하기
         </h4>
-        <p>Log4J 를 설정하는 것은 간단하다. 
-		다음의 매퍼를 위한 로깅을 활성화하려고 한다고 해보자. 
+        <p>Log4J 를 설정하는 것은 간단하다.
+		다음의 매퍼를 위한 로깅을 활성화하려고 한다고 해보자.
         </p>
         <source><![CDATA[package org.mybatis.example;
 public interface BlogMapper {
   @Select("SELECT * FROM blog WHERE id = #{id}")
   Blog selectBlog(int id);
 }]]></source>
-        <p>아래처럼 <code>log4j.properties</code>파일을 만들어서 클래스패스에 두자. 
+        <p>아래처럼 <code>log4j.properties</code>파일을 만들어서 클래스패스에 두자.
         </p>
         <source><![CDATA[# Global logging configuration
 log4j.rootLogger=ERROR, stdout
@@ -132,28 +132,28 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
         <p>
-        위 파일은 <code>org.mybatis.example.BlogMapper</code>의 상세한 로그와 애플리케이션의 에러들을 출력할 것이다. 
+        위 파일은 <code>org.mybatis.example.BlogMapper</code>의 상세한 로그와 애플리케이션의 에러들을 출력할 것이다.
         </p>
         <p>
-        finer레벨로 로깅을 하고자 한다면 전체 매퍼 파일대신 특정 구문만을 로깅할 수 있다. 
-		다음 줄은 <code>selectBlog</code>구문의 로그를 출력하도록 한다. 
+        finer레벨로 로깅을 하고자 한다면 전체 매퍼 파일대신 특정 구문만을 로깅할 수 있다.
+		다음 줄은 <code>selectBlog</code>구문의 로그를 출력하도록 한다.
         </p>
 
         <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
-        
-        <p>반대로 특정 매퍼들에 대해 로깅을 원할 수 있다. 
+
+        <p>반대로 특정 매퍼들에 대해 로깅을 원할 수 있다.
 		이 경우 매퍼의 가장 상위 패키지에 로거를 추가할 수 있다. </p>
 
         <source>log4j.logger.org.mybatis.example=TRACE</source>
-        
-        <p>큰 결과를 리턴할 수 있는 쿼리가 있다. 
-		이 경우 결과가 아닌 SQL구문만을 보고자 할 수 있다. 
+
+        <p>큰 결과를 리턴할 수 있는 쿼리가 있다.
+		이 경우 결과가 아닌 SQL구문만을 보고자 할 수 있다.
         이러한 목적으로 SQL구문은 DEBUG레벨(JDK로깅에서는 FINE)로 지정하고 결과에 대해서는 TRACE레벨(JDK로깅에서는 FINER)로 지정한다.
-        결과가 아닌 구문만 보고자 하는 경우에는 DEBUG로 레벨을 설정하자. 
+        결과가 아닌 구문만 보고자 하는 경우에는 DEBUG로 레벨을 설정하자.
         </p>
 
         <source>log4j.logger.org.mybatis.example=DEBUG</source>
-        
+
         <p>다음처럼 매퍼 인터페이스가 아닌 매퍼 XML을 사용하다면 어떻게 해야 할까?
         </p>
 
@@ -177,10 +177,10 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
 
 		<p>앞서 언급한것처럼 매퍼 인터페이스와 XML매퍼 파일간의 차이는 없다. </p>
 
-        <p><code>log4j.properties</code> 파일의 나머지는 어펜더(appender)를 설정하기 위해 사용했다. 
+        <p><code>log4j.properties</code> 파일의 나머지는 어펜더(appender)를 설정하기 위해 사용했다.
 		어펜더는 이 문서의 범위를 넘어선다.
-		Log4J 웹사이트에서 좀더 많은 정보를 얻을 수 있다. 
-		설정파일간의 차이는 실행을 해보면 간단히 확인할 수 있다. 
+		Log4J 웹사이트에서 좀더 많은 정보를 얻을 수 있다.
+		설정파일간의 차이는 실행을 해보면 간단히 확인할 수 있다.
         </p>
       </subsection>
     </section>

--- a/src/site/ko/xdoc/statement-builders.xml
+++ b/src/site/ko/xdoc/statement-builders.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2017 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -28,14 +28,14 @@
   <body>
     <section name="SQL Builder 클래스">
       <subsection name="문제점">
-        <p>자바코드에서 SQL을 작성하는 작업은 자바 개발자를 가장 힘들게 하는 것중 하나이다. 
-		대개는 동적 SQL을 작성해야 하지만 종종 파일이나 저장프로시저에 작성해야 할수도 있다. 
-		이미 본것처럼 마이바티스는 XML매핑 기능으로 동적 SQL을 처리하는 강력한 기능을 제공한다. 
-		하지만 종종 자바 코드를 사용해서 SQL구문을 만들어야 할수도 있다. 
-		마이바티스는 이런 경우를 위한 기능도 제공한다. 
-		더하기 기호나 따옴표, 개행처리, 포매팅 그리고 콤마나 문자열을 합치는 등의 다양한 조건을 처리하지 않아도 되도록 해준다. 
-		정말 자바코드에서 SQL을 동적으로 만드는 것은 악몽과 같다. 
-		예를들어보자. 
+        <p>자바코드에서 SQL을 작성하는 작업은 자바 개발자를 가장 힘들게 하는 것중 하나이다.
+		대개는 동적 SQL을 작성해야 하지만 종종 파일이나 저장프로시저에 작성해야 할수도 있다.
+		이미 본것처럼 마이바티스는 XML매핑 기능으로 동적 SQL을 처리하는 강력한 기능을 제공한다.
+		하지만 종종 자바 코드를 사용해서 SQL구문을 만들어야 할수도 있다.
+		마이바티스는 이런 경우를 위한 기능도 제공한다.
+		더하기 기호나 따옴표, 개행처리, 포매팅 그리고 콤마나 문자열을 합치는 등의 다양한 조건을 처리하지 않아도 되도록 해준다.
+		정말 자바코드에서 SQL을 동적으로 만드는 것은 악몽과 같다.
+		예를들어보자.
         </p>
 
         <source><![CDATA[
@@ -53,9 +53,9 @@ String sql = "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FULL_NAME, "
 ]]></source>
       </subsection>
       <subsection name="해결방법">
-      <p>마이바티스 3은 이런 문제를 해결하기 위해 편리한 클래스를 제공한다. 
-	  SQL클래스를 사용해서 인스턴스를 만들고 SQL구문을 만드는 메소드를 호출하자. 
-	  위 문제가 되는 예제를 SQL클래스를 사용해서 재작성하면 다음과 같다. 
+      <p>마이바티스 3은 이런 문제를 해결하기 위해 편리한 클래스를 제공한다.
+	  SQL클래스를 사용해서 인스턴스를 만들고 SQL구문을 만드는 메소드를 호출하자.
+	  위 문제가 되는 예제를 SQL클래스를 사용해서 재작성하면 다음과 같다.
       </p>
 
       <source><![CDATA[
@@ -81,10 +81,10 @@ private String selectPersonSql() {
 }
 ]]></source>
 
-      <p>이 예제가 특별한게 뭘까? 자 조금더 자세히 보자. 
-	  "AND" 키워드가 중복으로 나오는 것이나 "WHERE"과 "AND"를 선택하는데 걱정할 필요가 없다. 
-	  SQL클래스는 "WHERE"가 필요한 위치를 이해하고 처리한다. 
-	  그리고 "AND"를 사용하고 문자열을 합쳐야 하는 부분에 대해서도 알고 처리한다. 
+      <p>이 예제가 특별한게 뭘까? 자 조금더 자세히 보자.
+	  "AND" 키워드가 중복으로 나오는 것이나 "WHERE"과 "AND"를 선택하는데 걱정할 필요가 없다.
+	  SQL클래스는 "WHERE"가 필요한 위치를 이해하고 처리한다.
+	  그리고 "AND"를 사용하고 문자열을 합쳐야 하는 부분에 대해서도 알고 처리한다.
         </p>
 
       </subsection>
@@ -175,7 +175,7 @@ public String updatePersonSql() {
               </td>
               <td><code>SELECT</code>절로 시작하거나 덧붙이기.
 			  한번 이상 호출할 수 있고 파라미터는 <code>SELECT</code>절에 덧붙일것이다.
-			  파라미터는 칼럼과 별칭의 목록을 콤마를 구분자로 나열하지만 드라이버에 따라 처리가 안될수도 있다. 
+			  파라미터는 칼럼과 별칭의 목록을 콤마를 구분자로 나열하지만 드라이버에 따라 처리가 안될수도 있다.
               </td>
             </tr>
             <tr>
@@ -190,9 +190,9 @@ public String updatePersonSql() {
                 </ul>
               </td>
               <td><code>SELECT</code>절로 시작하거나 덧붙이기.
-			  생성된 쿼리에 <code>DISTINCT</code>를 추가한다. 
+			  생성된 쿼리에 <code>DISTINCT</code>를 추가한다.
 			  한번 이상 호출할 수 있고 파라미터는 <code>SELECT</code>절에 덧붙일것이다.
-			  파라미터는 칼럼과 별칭의 목록을 콤마를 구분자로 나열하지만 드라이버에 따라 처리가 안될수도 있다. 
+			  파라미터는 칼럼과 별칭의 목록을 콤마를 구분자로 나열하지만 드라이버에 따라 처리가 안될수도 있다.
               </td>
             </tr>
             <tr>
@@ -208,7 +208,7 @@ public String updatePersonSql() {
               </td>
               <td><code>FROM</code>절로 시작하거나 덧붙이기.
 			  한번 이상 호출할 수 있고 파라미터는 <code>FROM</code>절에 덧붙일것이다.
-			  파라미터는 테이블명과 별칭이지만 드라이버에 따라 처리가 안될수도 있다. 
+			  파라미터는 테이블명과 별칭이지만 드라이버에 따라 처리가 안될수도 있다.
               </td>
             </tr>
             <tr>
@@ -241,8 +241,8 @@ public String updatePersonSql() {
                 </ul>
               </td>
               <td>새로운 적절한 타입의 <code>JOIN</code>절을 추가.
-			  타입은 호출하는 메소드에 따라 다르다. 
-			  파라미터는 조인을 구성하는 칼럼과 조건이다. 
+			  타입은 호출하는 메소드에 따라 다르다.
+			  파라미터는 조인을 구성하는 칼럼과 조건이다.
               </td>
             </tr>
             <tr>
@@ -256,27 +256,27 @@ public String updatePersonSql() {
                   </li>
                 </ul>
               </td>
-              <td>새로운 <code>WHERE</code>절과 <code>AND</code>로 합친 조건을 덧붙인다. 
-			  여러번 호출할 수 있고 <code>AND</code>를 사용할때마다 새로운 조건을 합친다. 
-			  <code>OR</code>로 분리하려면 <code>OR()</code>를 사용하자. 
+              <td>새로운 <code>WHERE</code>절과 <code>AND</code>로 합친 조건을 덧붙인다.
+			  여러번 호출할 수 있고 <code>AND</code>를 사용할때마다 새로운 조건을 합친다.
+			  <code>OR</code>로 분리하려면 <code>OR()</code>를 사용하자.
               </td>
             </tr>
             <tr>
               <td>
                 <code>OR()</code>
               </td>
-              <td><code>OR</code>를 사용해서 <code>WHERE</code>조건절을 분리한다. 
-			  여러번 호출할 수 있지만 한개의 로우에 여러번 호출할 경우 에러를 가진 <code>SQL</code>을 만들수도 있다. 
+              <td><code>OR</code>를 사용해서 <code>WHERE</code>조건절을 분리한다.
+			  여러번 호출할 수 있지만 한개의 로우에 여러번 호출할 경우 에러를 가진 <code>SQL</code>을 만들수도 있다.
               </td>
             </tr>
             <tr>
               <td>
                 <code>AND()</code>
               </td>
-              <td><code>AND</code>를 가진 <code>WHERE</code>절을 분리한다. 
-			  여러번 호출할 수 있지만 여러번 호출할 경우 에러를 가진 <code>SQL</code>을 만들수도 있다. 
-			  <code>WHERE</code>와 <code>HAVING</code> 두가지는 <code>AND</code>를 자동으로 붙이기 때문에 
-			  흔하게 사용하지 않고 필요할때만 사용한다. 
+              <td><code>AND</code>를 가진 <code>WHERE</code>절을 분리한다.
+			  여러번 호출할 수 있지만 여러번 호출할 경우 에러를 가진 <code>SQL</code>을 만들수도 있다.
+			  <code>WHERE</code>와 <code>HAVING</code> 두가지는 <code>AND</code>를 자동으로 붙이기 때문에
+			  흔하게 사용하지 않고 필요할때만 사용한다.
               </td>
             </tr>
             <tr>
@@ -290,8 +290,8 @@ public String updatePersonSql() {
                   </li>
                 </ul>
               </td>
-              <td>새로운 <code>GROUP BY</code>절을 콤마를 더해서 덧붙인다. 
-			  여러번 호출할 수 있고 개별 조건을 콤마를 붙여서 합칠 수 있다. 
+              <td>새로운 <code>GROUP BY</code>절을 콤마를 더해서 덧붙인다.
+			  여러번 호출할 수 있고 개별 조건을 콤마를 붙여서 합칠 수 있다.
               </td>
             </tr>
             <tr>
@@ -305,9 +305,9 @@ public String updatePersonSql() {
                   </li>
                 </ul>
               </td>
-              <td>새로운 <code>HAVING</code>절을 AND를 더해서 덧붙인다. 
-			  여러번 호출할 수 있고 개별 조건을 <code>AND</code>를 붙여서 합칠 수 있다. 
-			  <code>OR</code>로 분리하기 위해서는 <code>OR</code>를 사용하자. 
+              <td>새로운 <code>HAVING</code>절을 AND를 더해서 덧붙인다.
+			  여러번 호출할 수 있고 개별 조건을 <code>AND</code>를 붙여서 합칠 수 있다.
+			  <code>OR</code>로 분리하기 위해서는 <code>OR</code>를 사용하자.
               </td>
             </tr>
             <tr>
@@ -321,23 +321,23 @@ public String updatePersonSql() {
                   </li>
                 </ul>
               </td>
-              <td>새로운 <code>ORDER BY</code>절을 콤마를 더해서 덧붙인다. 
-			  여러번 호출할 수 있고 개별조건을 콤마를 붙여서 합칠수 있다. 
+              <td>새로운 <code>ORDER BY</code>절을 콤마를 더해서 덧붙인다.
+			  여러번 호출할 수 있고 개별조건을 콤마를 붙여서 합칠수 있다.
               </td>
             </tr>
             <tr>
               <td>
                 <code>DELETE_FROM(String)</code>
               </td>
-              <td>delete구문을 시작하고 삭제할 테이블을 명시한다. 
-			  대개는 WHERE구문이 뒤에 붙여서 삭제한 대상 조건을 명시한다. 
+              <td>delete구문을 시작하고 삭제할 테이블을 명시한다.
+			  대개는 WHERE구문이 뒤에 붙여서 삭제한 대상 조건을 명시한다.
               </td>
             </tr>
             <tr>
               <td>
                 <code>INSERT_INTO(String)</code>
               </td>
-              <td>insert구문을 시작하고 입력한 테이블을 명시한다. 
+              <td>insert구문을 시작하고 입력한 테이블을 명시한다.
 			  VALUES() or INTO_COLUMNS() and INTO_VALUES() 메소드 호출은 여러번 해서 입력한 칼럼과 값을 명시한다.
               </td>
             </tr>
@@ -358,16 +358,16 @@ public String updatePersonSql() {
               <td>
                 <code>UPDATE(String)</code>
               </td>
-              <td>update구문을 시작하고 update수정할 테이블을 명시한다. 
-			  수정할 칼럼과 값을 명시하기 위해 SET()메소드 호출을 여러번 할수 있고 대개 수정할 대상 데이터를 한정하기 위해 WHERE()메소드도 호출한다. 
+              <td>update구문을 시작하고 update수정할 테이블을 명시한다.
+			  수정할 칼럼과 값을 명시하기 위해 SET()메소드 호출을 여러번 할수 있고 대개 수정할 대상 데이터를 한정하기 위해 WHERE()메소드도 호출한다.
               </td>
             </tr>
             <tr>
               <td>
                 <code>VALUES(String, String)</code>
               </td>
-              <td>insert구문에 덧붙인다. 
-			  첫번째 파라미터는 입력한 칼럼이고 두번째 파라미터는 입력할 값이다. 
+              <td>insert구문에 덧붙인다.
+			  첫번째 파라미터는 입력한 칼럼이고 두번째 파라미터는 입력할 값이다.
               </td>
             </tr>
             <tr>
@@ -424,14 +424,14 @@ public String updatePersonSql() {
       </subsection>
 
       <subsection name="SqlBuilder 와 SelectBuilder (향후 제거예정)">
-        <p>3.2버전 이전에는 다른 방법을 사용했다. 
-		자바 DSL을 다루기 힘든 언어의 제한점을 가리기 위해 ThreadLocal변수를 사용했다. 
-		하지만 이 방법은 이제 사용하지 않길 바란다. 
-		최근에는 빌더 타입의 패턴과 익명 내부 클래스를 사용하는 추세이다. 
-		그러므로 SelectBuilder 와 SqlBuilder는 향후 제거할 예정이다. 
+        <p>3.2버전 이전에는 다른 방법을 사용했다.
+		자바 DSL을 다루기 힘든 언어의 제한점을 가리기 위해 ThreadLocal변수를 사용했다.
+		하지만 이 방법은 이제 사용하지 않길 바란다.
+		최근에는 빌더 타입의 패턴과 익명 내부 클래스를 사용하는 추세이다.
+		그러므로 SelectBuilder 와 SqlBuilder는 향후 제거할 예정이다.
         </p>
         <p>
-        다음에 나열된 메소드는 SqlBuilder 와 SelectBuilder클래스에서만 사용할 수 있다. 
+        다음에 나열된 메소드는 SqlBuilder 와 SelectBuilder클래스에서만 사용할 수 있다.
         </p>
         <table>
         <thead>
@@ -447,9 +447,9 @@ public String updatePersonSql() {
             /
             <code>RESET()</code>
           </td>
-          <td>이 메소드는 SelectBuilder클래스의 ThreadLocal상태를 지우고 새로운 구문을 만들 준비를 한다. 
-		  <code>BEGIN()</code>은 새로운 구문을 시작할때 사용하는게 좋다. 
-		  <code>RESET()</code>은 처리중인 구문의 상태를 몇가지 사유로 지워야 할때 사용하는게 좋다. 
+          <td>이 메소드는 SelectBuilder클래스의 ThreadLocal상태를 지우고 새로운 구문을 만들 준비를 한다.
+		  <code>BEGIN()</code>은 새로운 구문을 시작할때 사용하는게 좋다.
+		  <code>RESET()</code>은 처리중인 구문의 상태를 몇가지 사유로 지워야 할때 사용하는게 좋다.
 		  (아마도 몇가지 사유로 완전히 다른 구문을 실행해야 할때 사용할것이다.)
           </td>
         </tr>
@@ -457,17 +457,17 @@ public String updatePersonSql() {
           <td>
             <code>SQL()</code>
           </td>
-          <td>생성된 <code>SQL()</code>를 리턴하고 <code>SelectBuilder</code>상태를 재설정(마치 <code>BEGIN()</code>이나 <code>RESET()</code>을 호출한것처럼)한다. 
-		  이 메소드는 한번만 호출할 수 있다. 
+          <td>생성된 <code>SQL()</code>를 리턴하고 <code>SelectBuilder</code>상태를 재설정(마치 <code>BEGIN()</code>이나 <code>RESET()</code>을 호출한것처럼)한다.
+		  이 메소드는 한번만 호출할 수 있다.
           </td>
         </tr>
         </tbody>
         </table>
 
         <p>
-		SelectBuilder와 SqlBuilder클래스가 신기하지는 않지만 이 클래스가 동작하는 방식을 아는게 중요하다. 
-		SelectBuilder와 SqlBuilder는 문법을 명확히 처리하기 위해 Static Imports와 ThreadLocal변수의 조합을 사용한다. 
-		이 두가지 클래스를 사용하기 위해 다음처럼 정적인 방법으로 import할 필요가 있다. 
+		SelectBuilder와 SqlBuilder클래스가 신기하지는 않지만 이 클래스가 동작하는 방식을 아는게 중요하다.
+		SelectBuilder와 SqlBuilder는 문법을 명확히 처리하기 위해 Static Imports와 ThreadLocal변수의 조합을 사용한다.
+		이 두가지 클래스를 사용하기 위해 다음처럼 정적인 방법으로 import할 필요가 있다.
         </p>
 
         <source>import static org.apache.ibatis.jdbc.SelectBuilder.*;</source>

--- a/src/site/site_fr.xml
+++ b/src/site/site_fr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@
 <project xmlns="http://maven.apache.org/DECORATION/1.7.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/DECORATION/1.7.0 http://maven.apache.org/xsd/decoration-1.7.0.xsd"
   name="MyBatis">
-  
+
   <body>
     <menu name="Core">
       <item name="Introduction" href="index.html"/>

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -208,7 +208,7 @@ SqlSessionFactory factory =
                 lazyLoadingEnabled
               </td>
               <td>
-                Globally enables or disables lazy loading. When enabled, all relations will be lazily loaded. 
+                Globally enables or disables lazy loading. When enabled, all relations will be lazily loaded.
                 This value can be superseded for an specific relation by using the <code>fetchType</code> attribute on it.
               </td>
               <td>
@@ -508,7 +508,7 @@ SqlSessionFactory factory =
                 callSettersOnNulls
               </td>
               <td>
-                Specifies if setters or map's put method will be called when a retrieved value is null. It is useful when you rely on Map.keySet() or null value initialization. Note primitives such as (int,boolean,etc.) will not be set to null. 
+                Specifies if setters or map's put method will be called when a retrieved value is null. It is useful when you rely on Map.keySet() or null value initialization. Note primitives such as (int,boolean,etc.) will not be set to null.
               </td>
               <td>
                 true | false
@@ -538,7 +538,7 @@ SqlSessionFactory factory =
                 logPrefix
               </td>
               <td>
-                Specifies the prefix string that MyBatis will add to the logger names. 
+                Specifies the prefix string that MyBatis will add to the logger names.
               </td>
               <td>
                 Any String
@@ -552,7 +552,7 @@ SqlSessionFactory factory =
                 logImpl
               </td>
               <td>
-                Specifies which logging implementation MyBatis should use. If this setting is not present logging implementation will be autodiscovered. 
+                Specifies which logging implementation MyBatis should use. If this setting is not present logging implementation will be autodiscovered.
               </td>
               <td>
                 SLF4J | LOG4J | LOG4J2 | JDK_LOGGING | COMMONS_LOGGING | STDOUT_LOGGING | NO_LOGGING
@@ -1373,7 +1373,7 @@ public class Author {
         <p>
           You can override the type handlers or create your own to deal with
           unsupported or non-standard types. To do so, implement the interface <code>org.apache.ibatis.type.TypeHandler</code>
-          or extend the convenience class <code>org.apache.ibatis.type.BaseTypeHandler</code> 
+          or extend the convenience class <code>org.apache.ibatis.type.BaseTypeHandler</code>
           and optionally map it to a JDBC type. For example:
         </p>
 
@@ -1456,7 +1456,7 @@ public class ExampleTypeHandler extends BaseTypeHandler<String> {
           TypeHandler available for use in a <code>ResultMap</code>, set <code>includeNullJdbcType=true</code>
           on the <code>@MappedJdbcTypes</code> annotation. Since Mybatis 3.4.0 however, if a <b>single</b>
           TypeHandler is registered to handle a Java type, it will be used by default in <code>ResultMap</code>s
-          using this Java type (i.e. even without <code>includeNullJdbcType=true</code>). 
+          using this Java type (i.e. even without <code>includeNullJdbcType=true</code>).
         </p>
 
         <p>And finally you can let MyBatis search for your TypeHandlers:</p>
@@ -1472,7 +1472,7 @@ public class ExampleTypeHandler extends BaseTypeHandler<String> {
         </p>
 
         <p>
-          You can create a generic TypeHandler that is able to handle more than one class. For that purpose  
+          You can create a generic TypeHandler that is able to handle more than one class. For that purpose
           add a constructor that receives the class as a parameter and MyBatis will pass the actual class when
           constructing the TypeHandler.
         </p>
@@ -1489,31 +1489,31 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
   ...
 ]]></source>
 
-        <p><code>EnumTypeHandler</code> and <code>EnumOrdinalTypeHandler</code> are generic TypeHandlers. We will learn 
-        about them in the following section. 
+        <p><code>EnumTypeHandler</code> and <code>EnumOrdinalTypeHandler</code> are generic TypeHandlers. We will learn
+        about them in the following section.
         </p>
 
       </subsection>
-      
+
       <subsection name="Handling Enums">
           <p>
             If you want to map an <code>Enum</code>, you'll need to use either
-            <code>EnumTypeHandler</code> or <code>EnumOrdinalTypeHandler</code>. 
+            <code>EnumTypeHandler</code> or <code>EnumOrdinalTypeHandler</code>.
           </p>
-          
-          <p>For example, let's say that we need to store the rounding mode that 
+
+          <p>For example, let's say that we need to store the rounding mode that
           should be used with some number if it needs to be rounded. By default, MyBatis
           uses <code>EnumTypeHandler</code> to convert the <code>Enum</code>
           values to their names.
           </p>
-          
-          <b>Note <code>EnumTypeHandler</code> is special in the sense that unlike other handlers, 
+
+          <b>Note <code>EnumTypeHandler</code> is special in the sense that unlike other handlers,
           it does not handle just one specific class, but any class that extends <code>Enum</code></b>
 
-          <p>However, we may not want to store names. Our DBA may insist on an 
+          <p>However, we may not want to store names. Our DBA may insist on an
           integer code instead. That's just as easy: add <code>EnumOrdinalTypeHandler</code>
           to the <code>typeHandlers</code> in your config file, and now each
-          <code>RoundingMode</code> will be mapped to an integer using its ordinal value.         
+          <code>RoundingMode</code> will be mapped to an integer using its ordinal value.
           </p>
        <source><![CDATA[<!-- mybatis-config.xml -->
 <typeHandlers>
@@ -1522,14 +1522,14 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
 </typeHandlers>
 ]]></source>
         <p>
-          But what if you want to map the same <code>Enum</code> to a 
-          string in one place and to integer in another? 
+          But what if you want to map the same <code>Enum</code> to a
+          string in one place and to integer in another?
         </p>
           <p>
-            The auto-mapper will automatically use <code>EnumOrdinalTypeHandler</code>, 
+            The auto-mapper will automatically use <code>EnumOrdinalTypeHandler</code>,
             so if we want to go back to using plain old ordinary
-            <code>EnumTypeHandler</code>, we have to tell it, by explicitly setting 
-            the type handler to use for those SQL statements. 
+            <code>EnumTypeHandler</code>, we have to tell it, by explicitly setting
+            the type handler to use for those SQL statements.
           </p>
           <p>
             (Mapper files aren't covered until the next section, so if this is your first
@@ -1556,7 +1556,7 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
             #{id}, #{name}, #{funkyNumber}, #{roundingMode}
         )
     </insert>
-    
+
     <resultMap type="org.apache.ibatis.submitted.rounding.User" id="usermap2">
         <id column="id" property="id"/>
         <result column="name" property="name"/>
@@ -1576,7 +1576,7 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
 </mapper>
 ]]></source>
         <p>
-          Note that this forces us to use a <code>resultMap</code> 
+          Note that this forces us to use a <code>resultMap</code>
           instead of a <code>resultType</code> in our select statements.
         </p>
       </subsection>
@@ -2021,7 +2021,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, propert
           to the
           constructor of the InitialContext upon instantiation.
         </p>
-        
+
         <p>
           You can plug any 3rd party DataSource by implementing the interface <code>org.apache.ibatis.datasource.DataSourceFactory</code>:
         </p>
@@ -2038,7 +2038,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, propert
 
         <source><![CDATA[import org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
-        
+
 public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
 
   public C3P0DataSourceFactory() {
@@ -2046,8 +2046,8 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
   }
 }]]></source>
 
-        <p>To set it up, add a property for each setter method you want MyBatis to call. 
-        Follows below a sample configuration which connects to a PostgreSQL database:</p>        
+        <p>To set it up, add a property for each setter method you want MyBatis to call.
+        Follows below a sample configuration which connects to a PostgreSQL database:</p>
 
         <source><![CDATA[<dataSource type="org.myproject.C3P0DataSourceFactory">
   <property name="driver" value="org.postgresql.Driver"/>
@@ -2056,7 +2056,7 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
   <property name="password" value="root"/>
 </dataSource>
 ]]></source>
-        
+
       </subsection>
 
       <subsection name="databaseIdProvider">
@@ -2113,7 +2113,7 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
           this regard, so the best way to do it is to simply tell MyBatis
           where to find the mapping files. You can use classpath relative
           resource references, fully qualified url references
-          (including <code>file:///</code> URLs), class names or package names. 
+          (including <code>file:///</code> URLs), class names or package names.
           For example:
         </p>
         <source><![CDATA[<!-- Using classpath relative resources -->

--- a/src/site/xdoc/dynamic-sql.xml
+++ b/src/site/xdoc/dynamic-sql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -189,7 +189,7 @@ AND title like ‘someTitle’]]></source>
   ParameterHandler createParameterHandler(MappedStatement mappedStatement, Object parameterObject, BoundSql boundSql);
   SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType);
   SqlSource createSqlSource(Configuration configuration, String script, Class<?> parameterType);
-}]]></source>    
+}]]></source>
     <p>Once you have your custom language driver you can set it to be the default by configuring it in the mybatis-config.xml file:</p>
   <source><![CDATA[<typeAliases>
   <typeAlias type="org.sample.MyLanguageDriver" alias="myLanguage"/>
@@ -197,7 +197,7 @@ AND title like ‘someTitle’]]></source>
 <settings>
   <setting name="defaultScriptingLanguage" value="myLanguage"/>
 </settings>
-]]></source>    
+]]></source>
     <p>Instead of changing the default, you can specify the language for an specific statement by adding the <code>lang</code> attribute as follows:
     </p>
   <source><![CDATA[<select id="selectBlog" lang="myLanguage">
@@ -212,7 +212,7 @@ AND title like ‘someTitle’]]></source>
 
     <p><span class="label important">NOTE</span> You can use Apache Velocity as your dynamic language. Have a look at the MyBatis-Velocity project for the details.</p>
 
-    <p>All the xml tags you have seen in the previous sections are provided by the default MyBatis language that is provided by the driver  
+    <p>All the xml tags you have seen in the previous sections are provided by the default MyBatis language that is provided by the driver
     <code>org.apache.ibatis.scripting.xmltags.XmlLanguageDriver</code> which is aliased as <code>xml</code>.</p>
 	</subsection>
   </section>

--- a/src/site/xdoc/getting-started.xml
+++ b/src/site/xdoc/getting-started.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 
   <body>
     <section name="Getting started">
-    
+
     <subsection name="Installation">
       <p>
         To use MyBatis you just need to include the
@@ -42,9 +42,9 @@
   <artifactId>mybatis</artifactId>
   <version>x.x.x</version>
 </dependency>]]></source>
-    </subsection>    
-    
-    <subsection name="Building SqlSessionFactory from XML">    
+    </subsection>
+
+    <subsection name="Building SqlSessionFactory from XML">
       <p>
         Every MyBatis application centers around an instance of
         SqlSessionFactory. A SqlSessionFactory instance can be acquired by
@@ -304,19 +304,19 @@ public interface BlogMapper {
         classes we've discussed so far. Using them incorrectly can cause
         severe concurrency problems.
       </p>
-      
+
       <hr/>
       <p><span class="label important">NOTE</span>
         <strong>Object lifecycle and Dependency Injection Frameworks</strong>
       </p>
       <p>
-        Dependency Injection frameworks can create thread safe, transactional SqlSessions and mappers 
-        and inject them directly into your beans so you can just forget about their lifecycle. 
+        Dependency Injection frameworks can create thread safe, transactional SqlSessions and mappers
+        and inject them directly into your beans so you can just forget about their lifecycle.
         You may want to have a look at MyBatis-Spring or
         MyBatis-Guice sub-projects to know more about using MyBatis with DI frameworks.
       </p>
       <hr/>
-      
+
       <h4>SqlSessionFactoryBuilder</h4>
         <p>
           This class can be instantiated, used and thrown away. There is no need

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@
         <ul class="i18n">
           <li class="en"><a href="./getting-started.html">English</a></li>
           <li class="es"><a href="./es/index.html">Español</a></li>
-<!--      <li class="fr"><a href="./fr/index.html">Français</a></li> -->      
+<!--      <li class="fr"><a href="./fr/index.html">Français</a></li> -->
           <li class="ja"><a href="./ja/index.html">日本語</a></li>
           <li class="ko"><a href="./ko/index.html">한국어</a></li>
           <li class="zh"><a href="./zh/index.html">简体中文</a></li>

--- a/src/site/xdoc/java-api.xml
+++ b/src/site/xdoc/java-api.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@
       /web.xml</pre>
   <p>Remember, these are preferences, not requirements, but others will thank you for using a common directory structure.</p>
   <p>The rest of the examples in this section will assume you're following this directory structure.</p>
-  </subsection>  
+  </subsection>
 
   <subsection name="SqlSessions" id="sqlSessions">
   <p>The primary Java interface for working with MyBatis is the SqlSession. Through this interface you can execute commands, get mappers and manage transactions. We'll talk more about SqlSession itself shortly, but first we have to learn how to acquire an instance of SqlSession. SqlSessions are created by a SqlSessionFactory instance. The SqlSessionFactory contains methods for creating instances of SqlSessions all different ways. The SqlSessionFactory itself is created by the SqlSessionFactoryBuilder that can create the SqlSessonFactory from XML, Annotations or hand coded Java configuration.</p>
@@ -70,7 +70,7 @@
 SqlSessionFactory build(InputStream inputStream, String environment)
 SqlSessionFactory build(InputStream inputStream, Properties properties)
 SqlSessionFactory build(InputStream inputStream, String env, Properties props)
-SqlSessionFactory build(Configuration config)</source>  
+SqlSessionFactory build(Configuration config)</source>
 
   <p>The first four methods are the most common, as they take an InputStream instance that refers to an XML document, or more specifically, the mybatis-config.xml file discussed above. The optional parameters are environment and properties. Environment determines which environment to load, including the datasource and transaction manager. For example:</p>
 
@@ -87,8 +87,8 @@ SqlSessionFactory build(Configuration config)</source>
     <dataSource type="JNDI">
         ...
   </environment>
-</environments>]]></source>  
-  <p>If you call a build method that takes the environment parameter, then MyBatis will use the configuration for that environment. Of course, if you specify an invalid environment, you will receive an error. If you call one of the build methods that does not take the environment parameter, then the default environment is uses (which is specified as default="development" in the example above).</p>  
+</environments>]]></source>
+  <p>If you call a build method that takes the environment parameter, then MyBatis will use the configuration for that environment. Of course, if you specify an invalid environment, you will receive an error. If you call one of the build methods that does not take the environment parameter, then the default environment is uses (which is specified as default="development" in the example above).</p>
   <p>If you call a method that takes a properties instance, then MyBatis will load those properties and make them available to your configuration. Those properties can be used in place of most values in the configuration using the syntax:  ${propName}</p>
   <p>Recall that properties can also be referenced from the mybatis-config.xml file, or specified directly within it. Therefore it's important to understand the priority. We mentioned it earlier in this document, but here it is again for easy reference:</p>
 
@@ -101,14 +101,14 @@ SqlSessionFactory build(Configuration config)</source>
   </ul>
   <p>Thus, the highest priority properties are those passed in as a method parameter, followed by resource/url attributes and finally the properties specified in the body of the properties element.</p>
   <hr/>
-  
-  <p>So to summarize, the first four methods are largely the same, but with overrides to allow you to optionally specify the environment and/or properties. Here is an example of building a SqlSessionFactory from an mybatis-config.xml file. </p>  
+
+  <p>So to summarize, the first four methods are largely the same, but with overrides to allow you to optionally specify the environment and/or properties. Here is an example of building a SqlSessionFactory from an mybatis-config.xml file. </p>
 
   <source>String <strong>resource</strong> = "org/mybatis/builder/mybatis-config.xml";
 InputStream <strong>inputStream</strong> = Resources.getResourceAsStream(resource);
 SqlSessionFactoryBuilder <strong>builder</strong> = new SqlSessionFactoryBuilder();
-SqlSessionFactory <strong>factory</strong> = builder.build(inputStream);</source>  
-  
+SqlSessionFactory <strong>factory</strong> = builder.build(inputStream);</source>
+
   <p>Notice that we're making use of the Resources utility class, which lives in the org.apache.ibatis.io package. The Resources class, as its name implies, helps you load resources from the classpath, filesystem or even a web URL. A quick look at the class source code or inspection through your IDE will reveal its fairly obvious set of useful methods. Here's a quick list:</p>
   <source>URL getResourceURL(String resource)
 URL getResourceURL(ClassLoader loader, String resource)
@@ -224,7 +224,7 @@ int delete(String statement)]]></source>
 void select (String statement, Object parameter, ResultHandler<T> handler)
 void select (String statement, Object parameter, RowBounds rowBounds, ResultHandler<T> handler)]]></source>
 
-  <p>The RowBounds parameter causes MyBatis to skip the number of records specified, as well as limit the number of results returned to some number. The RowBounds class has a constructor to take both the offset and limit, and is otherwise immutable.</p> 
+  <p>The RowBounds parameter causes MyBatis to skip the number of records specified, as well as limit the number of results returned to some number. The RowBounds class has a constructor to take both the offset and limit, and is otherwise immutable.</p>
   <source>int offset = 100;
 int limit = 25;
 RowBounds rowBounds = new RowBounds(offset, limit);</source>
@@ -232,16 +232,16 @@ RowBounds rowBounds = new RowBounds(offset, limit);</source>
   <p>Different drivers are able to achieve different levels of efficiency in this regard. For the best performance, use result set types of SCROLL_SENSITIVE or SCROLL_INSENSITIVE (in other words: not FORWARD_ONLY).</p>
   <p>The ResultHandler parameter allows you to handle each row however you like. You can add it to a List, create a Map, Set, or throw each result away and instead keep only rolled up totals of calculations. You can do pretty much anything with the ResultHandler, and it's what MyBatis uses internally itself to build result set lists.</p>
   <p>Since 3.4.6, ResultHandler passed to a CALLABLE statement is used on every REFCURSOR output parameter of the stored procedure if there is any.</p>
-  <p>The interface is very simple.</p>  
+  <p>The interface is very simple.</p>
   <source><![CDATA[package org.apache.ibatis.session;
 public interface ResultHandler<T> {
   void handleResult(ResultContext<? extends T> context);
 }]]></source>
 
   <p>The ResultContext parameter gives you access to the result object itself, a count of the number of result objects created, and a Boolean stop() method that you can use to stop MyBatis from loading any more results.</p>
-  
+
   <p>Using a ResultHandler has two limitations that you should be aware of:</p>
-  
+
   <ul>
   <li>Data got from a method called with a ResultHandler will not be cached.</li>
   <li>When using advanced resultmaps MyBatis will probably require several rows to build an object. If a ResultHandler is used you may be given an object whose associations or collections are not yet filled.</li>
@@ -294,12 +294,12 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
   <source>Configuration getConfiguration()</source>
 
   <h5>Using Mappers</h5>
-  <source><![CDATA[<T> T getMapper(Class<T> type)]]></source>  
+  <source><![CDATA[<T> T getMapper(Class<T> type)]]></source>
   <p>While the various insert, update, delete and select methods above are powerful, they are also very verbose, not type safe and not as helpful to your IDE or unit tests as they could be. We've already seen an example of using Mappers in the Getting Started section above.</p>
   <p>Therefore, a more common way to execute mapped statements is to use Mapper classes. A mapper class is simply an interface with method definitions that match up against the SqlSession methods. The following example class demonstrates some method signatures and how they map to the SqlSession.</p>
   <source><![CDATA[public interface AuthorMapper {
   // (Author) selectOne("selectAuthor", 5);
-  Author selectAuthor(int id); 
+  Author selectAuthor(int id);
   // (List<Author>) selectList("selectAuthors")
   List<Author> selectAuthors();
   // (Map<Integer,Author>) selectMap("selectAuthors", "id")
@@ -312,7 +312,7 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
   // delete("deleteAuthor", 5)
   int deleteAuthor(int id);
 }]]></source>
-  <p>In a nutshell, each Mapper method signature should match that of the SqlSession method that it's associated to, but without the String parameter ID. Instead, the method name must match the mapped statement ID.</p> 
+  <p>In a nutshell, each Mapper method signature should match that of the SqlSession method that it's associated to, but without the String parameter ID. Instead, the method name must match the mapped statement ID.</p>
   <p>In addition, the return type must match that of the expected result type for single results or an array or collection for multiple results or Cursor. All of the usual types are supported, including: Primitives, Maps, POJOs and JavaBeans.</p>
   <p><span class="label important">NOTE</span> Mapper interfaces do not need to implement any interface or extend any class. As long as the method signature can be used to uniquely identify a corresponding mapped statement.</p>
   <p><span class="label important">NOTE</span> Mapper interfaces can extend other interfaces. Be sure that you have the statements in the appropriate namespace when using XML binding to Mapper interfaces. Also, the only limitation is that you cannot have the same method signature in two interfaces in a hierarchy (a bad idea anyway).</p>
@@ -426,7 +426,7 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td>A mapping to a single property value of a complex type. Attributes: <code>select</code>, which is the fully
         qualified name of a mapped statement (i.e. mapper method) that can load an instance of the appropriate type,
         <code>fetchType</code>, which supersedes the global configuration parameter <code>lazyLoadingEnabled</code> for this
-        mapping. 
+        mapping.
         <span class="label important">NOTE</span> You will notice that join mapping is not supported via the Annotations API.
         This is due to the limitation in Java Annotations that does not allow for circular references.</td>
       </tr>

--- a/src/site/xdoc/logging.xml
+++ b/src/site/xdoc/logging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@
   </settings>
 </configuration>]]>
       </source>
-      <p>Valid values are SLF4J, LOG4J, LOG4J2, JDK_LOGGING, COMMONS_LOGGING, STDOUT_LOGGING, NO_LOGGING or 
+      <p>Valid values are SLF4J, LOG4J, LOG4J2, JDK_LOGGING, COMMONS_LOGGING, STDOUT_LOGGING, NO_LOGGING or
       a full qualified class name that implements <code>org.apache.ibatis.logging.Log</code> and gets
       an string as a constructor parameter.
       </p>
@@ -118,7 +118,7 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
       </ul>
       <subsection name="Logging Configuration">
         <p>To see MyBatis logging statements you may enable logging on a
-          package, a mapper fully qualified class name, a namespace 
+          package, a mapper fully qualified class name, a namespace
           o a fully qualified statement name.
         </p>
         <p>Again, how you do this is dependent on the logging implementation
@@ -153,7 +153,7 @@ public interface BlogMapper {
   @Select("SELECT * FROM blog WHERE id = #{id}")
   Blog selectBlog(int id);
 }]]></source>
-        <p>Create a file called <code>log4j.properties</code> 
+        <p>Create a file called <code>log4j.properties</code>
         as shown below and place it in your classpath:
         </p>
         <source><![CDATA[# Global logging configuration
@@ -165,32 +165,32 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
         <p>
-          The above file will cause log4J to report detailed logging for 
+          The above file will cause log4J to report detailed logging for
           <code>org.mybatis.example.BlogMapper</code>
           and just errors for the rest of the classes of your application.
         </p>
         <p>
-          If you want to tune the logging at a finer level you can turn logging 
-          on for specific statements instead of the whole mapper file. 
-          The following line will enable logging just for the <code>selectBlog</code> 
+          If you want to tune the logging at a finer level you can turn logging
+          on for specific statements instead of the whole mapper file.
+          The following line will enable logging just for the <code>selectBlog</code>
           statement:
         </p>
 
         <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
-        
-        <p>By the contrary you may want want to enable logging for a group of mappers. 
+
+        <p>By the contrary you may want want to enable logging for a group of mappers.
         In that case you should add as a logger the root package where your mappers reside:</p>
 
         <source>log4j.logger.org.mybatis.example=TRACE</source>
-        
-        <p>There are queries that can return huge result sets. In that cases you may want to see the 
+
+        <p>There are queries that can return huge result sets. In that cases you may want to see the
         SQL statement but not the results. For that purpose SQL statements are logged at the DEBUG level
         (FINE in JDK logging) and results at the TRACE level (FINER in JDK logging), so in case
         you want to see the statement but not the result, set the level to DEBUG.
         </p>
 
         <source>log4j.logger.org.mybatis.example=DEBUG</source>
-        
+
         <p>But what about if you are not using mapper interfaces but mapper XML files like this one?
         </p>
 
@@ -213,7 +213,7 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
 
         <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
 
-		<p>Yes, as you may have noticed, there is no difference in configuring 
+		<p>Yes, as you may have noticed, there is no difference in configuring
 		logging for mapper interfaces or for XML mapper files.</p>
 
         <p><span class="label important">NOTE</span> If you are using SLF4J or Log4j 2 MyBatis will call it using the marker MYBATIS.</p>
@@ -224,7 +224,7 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
           website (URL above). Or, you could simply experiment with it to see
           what effects the different configuration options have.
         </p>
-                
+
       </subsection>
     </section>
   </body>

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -1429,7 +1429,7 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
 	    	#{id}, #{name}, #{funkyNumber}, #{roundingMode}
 	    )
 	</insert>
-	
+
 	<resultMap type="org.apache.ibatis.submitted.rounding.User" id="usermap2">
 		<id column="id" property="id"/>
 		<result column="name" property="name"/>
@@ -1632,9 +1632,9 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, propert
           TransactionFactory 接口的实现类的完全限定名或类型别名代替它们。
         </p>
         <source><![CDATA[public interface TransactionFactory {
-  void setProperties(Properties props);  
+  void setProperties(Properties props);
   Transaction newTransaction(Connection conn);
-  Transaction newTransaction(DataSource dataSource, TransactionIsolationLevel level, boolean autoCommit);  
+  Transaction newTransaction(DataSource dataSource, TransactionIsolationLevel level, boolean autoCommit);
 }]]></source>
         <p>任何在 XML 中配置的属性在实例化之后将会被传递给 setProperties()
         方法。你也需要创建一个 Transaction 接口的实现类，这个接口也很简单：</p>
@@ -1737,7 +1737,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, propert
 
         <source><![CDATA[import org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory;
 import com.mchange.v2.c3p0.ComboPooledDataSource;
-        
+
 public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
 
   public C3P0DataSourceFactory() {
@@ -1776,7 +1776,7 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
 
         <source><![CDATA[<databaseIdProvider type="DB_VENDOR">
   <property name="SQL Server" value="sqlserver"/>
-  <property name="DB2" value="db2"/>        
+  <property name="DB2" value="db2"/>
   <property name="Oracle" value="oracle" />
 </databaseIdProvider>]]></source>
 

--- a/src/site/zh/xdoc/dynamic-sql.xml
+++ b/src/site/zh/xdoc/dynamic-sql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -42,8 +42,8 @@
         <p>动态 SQL 通常要做的事情是根据条件包含 where 子句的一部分。比如：</p>
         <source><![CDATA[<select id="findActiveBlogWithTitleLike"
      resultType="Blog">
-  SELECT * FROM BLOG 
-  WHERE state = ‘ACTIVE’ 
+  SELECT * FROM BLOG
+  WHERE state = ‘ACTIVE’
   <if test="title != null">
     AND title like #{title}
   </if>
@@ -52,7 +52,7 @@
         <p>如果希望通过“title”和“author”两个参数进行可选搜索该怎么办呢？首先，改变语句的名称让它更具实际意义；然后只要加入另一个条件即可。</p>
         <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG WHERE state = ‘ACTIVE’ 
+  SELECT * FROM BLOG WHERE state = ‘ACTIVE’
   <if test="title != null">
     AND title like #{title}
   </if>
@@ -84,11 +84,11 @@
         <p>前面几个例子已经合宜地解决了一个臭名昭著的动态 SQL 问题。现在回到“if”示例，这次我们将“ACTIVE = 1”也设置成动态的条件，看看会发生什么。</p>
         <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG 
-  WHERE 
+  SELECT * FROM BLOG
+  WHERE
   <if test="state != null">
     state = #{state}
-  </if> 
+  </if>
   <if test="title != null">
     AND title like #{title}
   </if>
@@ -102,17 +102,17 @@ WHERE]]></source>
         <p>这会导致查询失败。如果仅仅第二个条件匹配又会怎样？这条 SQL 最终会是这样:
         </p>
         <source><![CDATA[SELECT * FROM BLOG
-WHERE 
+WHERE
 AND title like ‘someTitle’]]></source>
         <p>这个查询也会失败。这个问题不能简单地用条件句式来解决，如果你也曾经被迫这样写过，那么你很可能从此以后都不会再写出这种语句了。</p>
         <p>MyBatis 有一个简单的处理，这在 90% 的情况下都会有用。而在不能使用的地方，你可以自定义处理方式来令其正常工作。一处简单的修改就能达到目的：</p>
         <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG 
-  <where> 
+  SELECT * FROM BLOG
+  <where>
     <if test="state != null">
          state = #{state}
-    </if> 
+    </if>
     <if test="title != null">
         AND title like #{title}
     </if>
@@ -124,7 +124,7 @@ AND title like ‘someTitle’]]></source>
         <p><em>where</em> 元素只会在至少有一个子元素的条件返回 SQL 子句的情况下才去插入“WHERE”子句。而且，若语句的开头为“AND”或“OR”，<em>where</em> 元素也会将它们去除。</p>
         <p>如果 <em>where</em> 元素没有按正常套路出牌，我们可以通过自定义 trim 元素来定制 <em>where</em> 元素的功能。比如，和 <em>where</em> 元素等价的自定义 trim 元素为：</p>
         <source><![CDATA[<trim prefix="WHERE" prefixOverrides="AND |OR ">
-  ... 
+  ...
 </trim>]]></source>
         <p><em>prefixOverrides</em> 属性会忽略通过管道分隔的文本序列（注意此例中的空格也是必要的）。它的作用是移除所有指定在 <em>prefixOverrides</em> 属性中的内容，并且插入 <em>prefix</em> 属性中指定的内容。</p>
         <p>类似的用于动态更新语句的解决方案叫做 <em>set</em>。<em>set</em> 元素可以用于动态包含需要更新的列，而舍去其它的。比如：</p>

--- a/src/site/zh/xdoc/getting-started.xml
+++ b/src/site/zh/xdoc/getting-started.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
 
   <body>
     <section name="入门">
-    
+
     <subsection name="安装">
       <p>要使用 MyBatis， 只需将
       <a href="https://github.com/mybatis/mybatis-3/releases">mybatis-x.x.x.jar</a>
@@ -40,8 +40,8 @@
   <artifactId>mybatis</artifactId>
   <version>x.x.x</version>
 </dependency>]]></source>
-    </subsection>    
-    
+    </subsection>
+
     <subsection name="从 XML 中构建 SqlSessionFactory">
       <p>
         每个基于 MyBatis 的应用都是以一个 SqlSessionFactory

--- a/src/site/zh/xdoc/java-api.xml
+++ b/src/site/zh/xdoc/java-api.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@
   <body>
   <section name="Java API" id="javaApi">
   <p>既然你已经知道如何配置 MyBatis 和创建映射文件，你就已经准备好来提升技能了。MyBatis 的 Java API 就是你收获你所做的努力的地方。正如你即将看到的，和 JDBC 相比，MyBatis 很大程度简化了你的代码并保持代码简洁，容易理解并维护。MyBatis 3 已经引入了很多重要的改进来使得 SQL 映射更加优秀。</p>
-  
+
   <subsection name="应用目录结构" id="directoryStructure">
   <p>在我们深入 Java API 之前，理解关于目录结构的最佳实践是很重要的。MyBatis 非常灵活，你可以用你自己的文件来做几乎所有的事情。但是对于任一框架，都有一些最佳的方式。
   </p>
@@ -63,7 +63,7 @@
       /web.xml</pre>
   <p>当然这是推荐的目录结构，并非强制要求，但是使用一个通用的目录结构将更利于大家沟通。</p>
   <p>这部分内容剩余的示例将假设你使用了这种目录结构。</p>
-  </subsection>  
+  </subsection>
 
   <subsection name="SqlSessions" id="sqlSessions">
   <p>使用 MyBatis 的主要 Java 接口就是 SqlSession。你可以通过这个接口来执行命令，获取映射器和管理事务。我们会概括讨论一下 SqlSession 本身，但是首先我们还是要了解如何获取一个 SqlSession 实例。SqlSessions 是由 SqlSessionFactory 实例创建的。SqlSessionFactory 对象包含创建 SqlSession 实例的所有方法。而 SqlSessionFactory 本身是由 SqlSessionFactoryBuilder 创建的，它可以从 XML、注解或手动配置 Java 代码来创建 SqlSessionFactory。</p>
@@ -75,7 +75,7 @@
 SqlSessionFactory build(InputStream inputStream, String environment)
 SqlSessionFactory build(InputStream inputStream, Properties properties)
 SqlSessionFactory build(InputStream inputStream, String env, Properties props)
-SqlSessionFactory build(Configuration config)</source>  
+SqlSessionFactory build(Configuration config)</source>
 
   <p>第一种方法是最常用的，它使用了一个参照了 XML 文档或上面讨论过的更特定的 mybatis-config.xml 文件的 Reader 实例。可选的参数是 environment 和 properties。environment 决定加载哪种环境，包括数据源和事务管理器。比如：</p>
 
@@ -92,7 +92,7 @@ SqlSessionFactory build(Configuration config)</source>
     <dataSource type="JNDI">
         ...
   </environment>
-</environments>]]></source>  
+</environments>]]></source>
   <p>如果你调用了参数有 environment 的 build 方法，那么 MyBatis 将会使用 configuration 对象来配置这个 environment。当然，如果你指定了一个不合法的 environment，你就会得到错误提示。如果你调用了不带 environment 参数的 build 方法，那么就使用默认的 environment（在上面的示例中指定为 default="development" 的代码）。</p>  
   <p>如果你调用了参数有 properties 实例的方法，那么 MyBatis 就会加载那些 properties（属性配置文件），并在配置中可用。那些属性可以用${propName} 语法形式多次用在配置文件中。</p>
   <p>回想一下，属性可以从 mybatis-config.xml 中被引用，或者直接指定它。因此理解优先级是很重要的。我们在文档前面已经提及它了，但是这里要再次重申：</p>
@@ -106,14 +106,14 @@ SqlSessionFactory build(Configuration config)</source>
   <p>因此，通过方法参数传递的属性的优先级最高，resource 或 url 指定的属性优先级中等，在 properties 元素体中指定的属性优先级最低。
   </p>
   <hr/>
-  
+
   <p>总结一下，前四个方法很大程度上是相同的，但是由于覆盖机制，便允许你可选地指定 environment 和/或 properties。以下给出一个从 mybatis-config.xml 文件创建 SqlSessionFactory 的示例：</p>  
 
   <source>String <strong>resource</strong> = "org/mybatis/builder/mybatis-config.xml";
 InputStream <strong>inputStream</strong> = Resources.getResourceAsStream(resource);
 SqlSessionFactoryBuilder <strong>builder</strong> = new SqlSessionFactoryBuilder();
-SqlSessionFactory <strong>factory</strong> = builder.build(inputStream);</source>  
-  
+SqlSessionFactory <strong>factory</strong> = builder.build(inputStream);</source>
+
   <p>注意到这里我们使用了 Resources 工具类，这个类在 org.apache.ibatis.io 包中。Resources 类正如其名，会帮助你从类路径下、文件系统或一个 web URL 中加载资源文件。看一下这个类的源代码或者通过你的 IDE 来查看，就会看到一整套相当实用的方法。这里给出一个简表：</p>
   <source>URL getResourceURL(String resource)
 URL getResourceURL(ClassLoader loader, String resource)
@@ -149,7 +149,7 @@ SqlSessionFactoryBuilder builder = new SqlSessionFactoryBuilder();
 SqlSessionFactory factory = builder.build(configuration);</source>
 
   <p>现在你就获得一个可以用来创建 SqlSession 实例的 SqlSessionFactory 了！</p>
-  
+
   <h4>SqlSessionFactory</h4>
   <p>SqlSessionFactory 有六个方法创建 SqlSession 实例。通常来说，当你选择这些方法时你需要考虑以下几点：</p>
   <ul>
@@ -227,7 +227,7 @@ int delete(String statement)]]></source>
 void select (String statement, Object parameter, ResultHandler<T> handler)
 void select (String statement, Object parameter, RowBounds rowBounds, ResultHandler<T> handler)]]></source>
 
-  <p>RowBounds 参数会告诉 MyBatis 略过指定数量的记录，还有限制返回结果的数量。RowBounds 类有一个构造方法来接收 offset 和 limit，另外，它们是不可二次赋值的。</p> 
+  <p>RowBounds 参数会告诉 MyBatis 略过指定数量的记录，还有限制返回结果的数量。RowBounds 类有一个构造方法来接收 offset 和 limit，另外，它们是不可二次赋值的。</p>
   <source>int offset = 100;
 int limit = 25;
 RowBounds rowBounds = new RowBounds(offset, limit);</source>
@@ -235,7 +235,7 @@ RowBounds rowBounds = new RowBounds(offset, limit);</source>
   <p>所以在这方面，不同的驱动能够取得不同级别的高效率。为了取得最佳的表现，请使用结果集的 SCROLL_SENSITIVE 或 SCROLL_INSENSITIVE 的类型(换句话说：不用 FORWARD_ONLY)。</p>
   <p>ResultHandler 参数允许你按你喜欢的方式处理每一行。你可以将它添加到 List 中、创建 Map 和 Set，或者丢弃每个返回值都可以，它取代了仅保留执行语句过后的总结果列表的死板结果。你可以使用 ResultHandler 做很多事，并且这是 MyBatis 自身内部会使用的方法，以创建结果集列表。</p>
   <p>Since 3.4.6, ResultHandler passed to a CALLABLE statement is used on every REFCURSOR output parameter of the stored procedure if there is any.</p>
-  <p>它的接口很简单。</p>  
+  <p>它的接口很简单。</p>
   <source><![CDATA[package org.apache.ibatis.session;
 public interface ResultHandler<T> {
   void handleResult(ResultContext<? extends T> context);
@@ -244,7 +244,7 @@ public interface ResultHandler<T> {
   <p>ResultContext 参数允许你访问结果对象本身、被创建的对象数目、以及返回值为 Boolean 的 stop 方法，你可以使用此 stop 方法来停止 MyBatis 加载更多的结果。</p>
 
   <p>使用 ResultHandler 的时候需要注意以下两种限制：</p>
-  
+
   <ul>
   <li>从被 ResultHandler 调用的方法返回的数据不会被缓存。</li>
   <li>当使用结果映射集（resultMap）时，MyBatis 大多数情况下需要数行结果来构造外键对象。如果你正在使用 ResultHandler，你可以给出外键（association）或者集合（collection）尚未赋值的对象。</li>
@@ -298,12 +298,12 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
   <source>Configuration getConfiguration()</source>
 
   <h5>使用映射器</h5>
-  <source><![CDATA[<T> T getMapper(Class<T> type)]]></source>  
+  <source><![CDATA[<T> T getMapper(Class<T> type)]]></source>
   <p>上述的各个 insert、update、delete 和 select 方法都很强大，但也有些繁琐，可能会产生类型安全问题并且对于你的 IDE 和单元测试也没有实质性的帮助。在上面的入门章节中我们已经看到了一个使用映射器的示例。</p>
   <p>因此，一个更通用的方式来执行映射语句是使用映射器类。一个映射器类就是一个仅需声明与 SqlSession 方法相匹配的方法的接口类。下面的示例展示了一些方法签名以及它们是如何映射到 SqlSession 上的。</p>
   <source><![CDATA[public interface AuthorMapper {
   // (Author) selectOne("selectAuthor",5);
-  Author selectAuthor(int id); 
+  Author selectAuthor(int id);
   // (List<Author>) selectList(“selectAuthors”)
   List<Author> selectAuthors();
   // (Map<Integer,Author>) selectMap("selectAuthors", "id")

--- a/src/site/zh/xdoc/logging.xml
+++ b/src/site/zh/xdoc/logging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -119,16 +119,16 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
         </p>
 
         <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
-        
+
         <p>与此相对，可以对一组映射器接口记录日志，只要对映射器接口所在的包开启日志功能即可：</p>
 
         <source>log4j.logger.org.mybatis.example=TRACE</source>
-        
+
         <p>某些查询可能会返回庞大的结果集，此时只想记录其执行的 SQL 语句而不想记录结果该怎么办？为此，Mybatis 中 SQL 语句的日志级别被设为DEBUG（JDK 日志设为 FINE），结果的日志级别为 TRACE（JDK 日志设为 FINER)。所以，只要将日志级别调整为 DEBUG 即可达到目的：
         </p>
 
         <source>log4j.logger.org.mybatis.example=DEBUG</source>
-        
+
         <p>要记录日志的是类似下面的映射器文件而不是映射器接口又该怎么做呢？
         </p>
 
@@ -153,12 +153,12 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
 
 		<p>你应该注意到了，为映射器接口和 XML 文件添加日志功能的语句毫无差别。
 		</p>
-		  
+
 		<p><span class="label important">注意</span> 如果你使用的是 SLF4J 或 Log4j 2，MyBatis 将以 MYBATIS 这个值进行调用。</p>
 
         <p>配置文件 <code>log4j.properties</code> 的余下内容是针对日志输出源的，这一内容已经超出本文档范围。关于 Log4J 的更多内容，可以参考Log4J 的网站。不过，你也可以简单地做做实验，看看不同的配置会产生怎样的效果。
         </p>
-		  
+
       </subsection>
     </section>
   </body>

--- a/src/site/zh/xdoc/statement-builders.xml
+++ b/src/site/zh/xdoc/statement-builders.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -362,7 +362,7 @@ public String updatePersonSql() {
               <td>
                 <code>UPDATE(String)</code>
               </td>
-              <td>开始一个update语句并指定需要更新的表明。后面都会跟着一个或者多个SET()，通常也会有一个WHERE()。 
+              <td>开始一个update语句并指定需要更新的表明。后面都会跟着一个或者多个SET()，通常也会有一个WHERE()。
               </td>
             </tr>
             <tr>

--- a/src/test/java/org/apache/ibatis/binding/BindingTest.java
+++ b/src/test/java/org/apache/ibatis/binding/BindingTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -211,7 +211,7 @@ public class BindingTest {
       assertEquals(2, blogs.size());
     }
   }
-  
+
   @Test
   public void shouldExecuteBoundSelectMapOfBlogsById() {
     try (SqlSession session = sqlSessionFactory.openSession()) {
@@ -390,7 +390,7 @@ public class BindingTest {
       assertEquals(2, posts.size());
     }
   }
-  
+
   @Disabled
   @Test // issue #480 and #101
   public void shouldExecuteBoundSelectBlogUsingConstructorWithResultMapCollection() {
@@ -404,7 +404,7 @@ public class BindingTest {
       assertTrue(posts != null && !posts.isEmpty(), "posts should not be empty");
     }
   }
-  
+
   @Test
   public void shouldExecuteBoundSelectOneBlogStatementWithConstructorUsingXMLConfig() {
     try (SqlSession session = sqlSessionFactory.openSession()) {
@@ -626,7 +626,7 @@ public class BindingTest {
       assertEquals(101, blogs.get(0).getAuthor().getId());
       assertEquals(1, blogs.get(0).getPosts().size());
       assertEquals(1, blogs.get(0).getPosts().get(0).getId());
-      assertTrue(blogs.get(1) instanceof Proxy);      
+      assertTrue(blogs.get(1) instanceof Proxy);
       assertEquals(102, blogs.get(1).getAuthor().getId());
       assertEquals(1, blogs.get(1).getPosts().size());
       assertEquals(2, blogs.get(1).getPosts().get(0).getId());
@@ -643,7 +643,7 @@ public class BindingTest {
       assertEquals(101, blogs.get(0).getAuthor().getId());
       assertEquals(1, blogs.get(0).getPosts().size());
       assertEquals(1, blogs.get(0).getPosts().get(0).getId());
-      assertFalse(blogs.get(1) instanceof Factory);      
+      assertFalse(blogs.get(1) instanceof Factory);
       assertEquals(102, blogs.get(1).getAuthor().getId());
       assertEquals(1, blogs.get(1).getPosts().size());
       assertEquals(2, blogs.get(1).getPosts().get(0).getId());

--- a/src/test/java/org/apache/ibatis/binding/BoundBlogMapper.java
+++ b/src/test/java/org/apache/ibatis/binding/BoundBlogMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -135,9 +135,9 @@ public interface BoundBlogMapper {
   Blog selectBlogUsingConstructorWithResultMap(int i);
 
   Blog selectBlogUsingConstructorWithResultMapAndProperties(int i);
-  
+
   Blog selectBlogUsingConstructorWithResultMapCollection(int i);
-  
+
   Blog selectBlogByIdUsingConstructor(int id);
 
   //======================================================
@@ -196,13 +196,13 @@ public interface BoundBlogMapper {
   Blog selectBlogWithAParamNamedValue(@Param("column") String column, @Param("id") int id, @Param("value") String title);
 
   //======================================================
-  
+
   @Select({
       "SELECT *",
       "FROM blog"
   })
-  @Results({ 
-      @Result(property = "author", column = "author_id", one = @One(select = "org.apache.ibatis.binding.BoundAuthorMapper.selectAuthor")), 
+  @Results({
+      @Result(property = "author", column = "author_id", one = @One(select = "org.apache.ibatis.binding.BoundAuthorMapper.selectAuthor")),
       @Result(property = "posts", column = "id", many = @Many(select = "selectPostsById"))
   })
   List<Blog> selectBlogsWithAutorAndPosts();
@@ -211,10 +211,10 @@ public interface BoundBlogMapper {
       "SELECT *",
       "FROM blog"
   })
-  @Results({ 
-      @Result(property = "author", column = "author_id", one = @One(select = "org.apache.ibatis.binding.BoundAuthorMapper.selectAuthor", fetchType=FetchType.EAGER)), 
+  @Results({
+      @Result(property = "author", column = "author_id", one = @One(select = "org.apache.ibatis.binding.BoundAuthorMapper.selectAuthor", fetchType=FetchType.EAGER)),
       @Result(property = "posts", column = "id", many = @Many(select = "selectPostsById", fetchType=FetchType.EAGER))
   })
   List<Blog> selectBlogsWithAutorAndPostsEagerly();
- 
+
 }

--- a/src/test/java/org/apache/ibatis/binding/BoundBlogMapper.xml
+++ b/src/test/java/org/apache/ibatis/binding/BoundBlogMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -95,45 +95,45 @@
 
     <select id="selectBlogUsingConstructorWithResultMap" parameterType="int"
             resultMap="blogUsingConstructorWithResultMap">
-      select b.*, 
-      	a.id as author_id, 
-      	a.username as author_username, 
-      	a.password as author_password, 
-      	a.email as author_email, 
-      	a.bio as author_bio, 
-      	a.favourite_section 
-      from Blog b join Author a 
-      on b.author_id = a.id 
+      select b.*,
+      	a.id as author_id,
+      	a.username as author_username,
+      	a.password as author_password,
+      	a.email as author_email,
+      	a.bio as author_bio,
+      	a.favourite_section
+      from Blog b join Author a
+      on b.author_id = a.id
       where b.id = #{id}
     </select>
 
     <select id="selectBlogUsingConstructorWithResultMapAndProperties" parameterType="int"
             resultMap="blogUsingConstructorWithResultMapAndProperties">
-      select b.*, 
-      	a.id as author_id, 
-      	a.username as author_username, 
-      	a.password as author_password, 
-      	a.email as author_email, 
-      	a.bio as author_bio, 
-      	a.favourite_section 
-      from Blog b join Author a 
-      on b.author_id = a.id 
+      select b.*,
+      	a.id as author_id,
+      	a.username as author_username,
+      	a.password as author_password,
+      	a.email as author_email,
+      	a.bio as author_bio,
+      	a.favourite_section
+      from Blog b join Author a
+      on b.author_id = a.id
       where b.id = #{id}
     </select>
-    
+
     <select id="selectBlogUsingConstructorWithResultMapCollection" parameterType="int"
             resultMap="blogUsingConstructorWithResultMapCollection">
       select b.*, p.*,
-      	a.id as author_id, 
-      	a.username as author_username, 
-      	a.password as author_password, 
-      	a.email as author_email, 
-      	a.bio as author_bio, 
-      	a.favourite_section 
-      from Blog b 
+      	a.id as author_id,
+      	a.username as author_username,
+      	a.password as author_password,
+      	a.email as author_email,
+      	a.bio as author_bio,
+      	a.favourite_section
+      from Blog b
           join Author a on b.author_id = a.id
-          join Post p on b.id = p.blog_id 
+          join Post p on b.id = p.blog_id
       where b.id = #{id}
     </select>
-    
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/binding/MapperWithOneAndMany.java
+++ b/src/test/java/org/apache/ibatis/binding/MapperWithOneAndMany.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@ public interface MapperWithOneAndMany {
     "SELECT *",
     "FROM blog"
   })
-  @Results({ 
+  @Results({
     @Result(
-       property = "author", column = "author_id", 
+       property = "author", column = "author_id",
        one = @One(select = "org.apache.ibatis.binding.BoundAuthorMapper.selectAuthor"),
        many = @Many(select = "selectPostsById"))
   })

--- a/src/test/java/org/apache/ibatis/builder/BlogMapper.xml
+++ b/src/test/java/org/apache/ibatis/builder/BlogMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
       </case>
     </discriminator>
   </resultMap>
-    
+
   <resultMap id="blogWithPosts" type="Blog">
     <id property="id" column="id"/>
     <result property="title" column="title"/>
@@ -60,7 +60,7 @@
     <association property="author" column="author_id" select="org.apache.ibatis.domain.blog.mappers.AuthorMapper.selectAuthorWithInlineParams" fetchType="lazy"/>
     <collection property="posts" column="id" select="selectPostsForBlog" fetchType="lazy"/>
   </resultMap>
-  
+
   <select id="selectBlogWithPostsUsingSubSelectLazily" parameterType="int" resultMap="blogWithPostsLazy">
     select * from Blog where id = #{id}
   </select>

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2017 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -74,7 +74,7 @@
   </objectFactory>
 
   <objectWrapperFactory type="org.apache.ibatis.builder.CustomObjectWrapperFactory" />
-  
+
   <reflectorFactory type="org.apache.ibatis.builder.CustomReflectorFactory"/>
 
   <plugins>
@@ -96,7 +96,7 @@
       </dataSource>
     </environment>
   </environments>
-  
+
   <databaseIdProvider type="DB_VENDOR">
     <property name="Apache Derby" value="derby"/>
   </databaseIdProvider>

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -141,12 +141,12 @@ public class XmlConfigBuilderTest {
   @Test
   public void registerJavaTypeInitializingTypeHandler() {
     final String MAPPER_CONFIG = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
-        + "<!DOCTYPE configuration PUBLIC \"-//mybatis.org//DTD Config 3.0//EN\" \"http://mybatis.org/dtd/mybatis-3-config.dtd\">\n" 
-        + "<configuration>\n" 
+        + "<!DOCTYPE configuration PUBLIC \"-//mybatis.org//DTD Config 3.0//EN\" \"http://mybatis.org/dtd/mybatis-3-config.dtd\">\n"
+        + "<configuration>\n"
         + "  <typeHandlers>\n"
         + "    <typeHandler javaType=\"org.apache.ibatis.builder.XmlConfigBuilderTest$MyEnum\"\n"
-        + "      handler=\"org.apache.ibatis.builder.XmlConfigBuilderTest$EnumOrderTypeHandler\"/>\n" 
-        + "  </typeHandlers>\n" 
+        + "      handler=\"org.apache.ibatis.builder.XmlConfigBuilderTest$EnumOrderTypeHandler\"/>\n"
+        + "  </typeHandlers>\n"
         + "</configuration>\n";
 
     XMLConfigBuilder builder = new XMLConfigBuilder(new StringReader(MAPPER_CONFIG));

--- a/src/test/java/org/apache/ibatis/builder/xsd/BlogMapper.xml
+++ b/src/test/java/org/apache/ibatis/builder/xsd/BlogMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2017 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@
       </case>
     </discriminator>
   </resultMap>
-    
+
   <resultMap id="blogWithPosts" type="Blog">
     <id property="id" column="id"/>
     <result property="title" column="title"/>
@@ -59,7 +59,7 @@
     <association property="author" column="author_id" select="org.apache.ibatis.domain.blog.mappers.AuthorMapper.selectAuthorWithInlineParams" fetchType="lazy"/>
     <collection property="posts" column="id" select="selectPostsForBlog" fetchType="lazy"/>
   </resultMap>
-  
+
   <select id="selectBlogWithPostsUsingSubSelectLazily" parameterType="int" resultMap="blogWithPostsLazy">
     select * from Blog where id = #{id}
   </select>

--- a/src/test/java/org/apache/ibatis/builder/xsd/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/xsd/CustomizedSettingsMapperConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2017 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@
   </objectFactory>
 
   <objectWrapperFactory type="org.apache.ibatis.builder.CustomObjectWrapperFactory" />
-  
+
   <reflectorFactory type="org.apache.ibatis.builder.CustomReflectorFactory"/>
 
   <plugins>
@@ -93,7 +93,7 @@
       </dataSource>
     </environment>
   </environments>
-  
+
   <databaseIdProvider type="DB_VENDOR">
     <property name="Apache Derby" value="derby"/>
   </databaseIdProvider>

--- a/src/test/java/org/apache/ibatis/cursor/defaults/DefaultCursorTest.java
+++ b/src/test/java/org/apache/ibatis/cursor/defaults/DefaultCursorTest.java
@@ -74,7 +74,7 @@ public class DefaultCursorTest {
     final DefaultResultSetHandler resultSetHandler = new DefaultResultSetHandler(executor, ms, parameterHandler,
       resultHandler, boundSql, rowBounds);
 
-    
+
     when(rsmd.getColumnCount()).thenReturn(2);
     doReturn("id").when(rsmd).getColumnLabel(1);
     doReturn(Types.INTEGER).when(rsmd).getColumnType(1);

--- a/src/test/java/org/apache/ibatis/domain/blog/PostLiteId.java
+++ b/src/test/java/org/apache/ibatis/domain/blog/PostLiteId.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@ package org.apache.ibatis.domain.blog;
 
 public class PostLiteId {
     private int id;
-    
+
     public PostLiteId() {
-      
+
     }
 
     public void setId(int id) {

--- a/src/test/java/org/apache/ibatis/exceptions/GeneralExceptionsTest.java
+++ b/src/test/java/org/apache/ibatis/exceptions/GeneralExceptionsTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ public class GeneralExceptionsTest {
         PersistenceException.class,
         SqlSessionException.class,
         TransactionException.class,
-        TypeException.class, 
+        TypeException.class,
         ScriptingException.class
     };
     for (Class<?> exceptionType : exceptionTypes) {

--- a/src/test/java/org/apache/ibatis/executor/ExecutorTestHelper.java
+++ b/src/test/java/org/apache/ibatis/executor/ExecutorTestHelper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -314,7 +314,7 @@ public class ExecutorTestHelper {
         }).build();
     return ms;
   }
-  
+
   public static MappedStatement createInsertAuthorWithIDof99MappedStatement(final Configuration config) {
     MappedStatement ms = new MappedStatement.Builder(config, "insertAuthor", new StaticSqlSource(config,"INSERT INTO author (id,username,password,email,bio) values(99,'someone','******','someone@apache.org',null)"), SqlCommandType.INSERT)
         .statementType(StatementType.STATEMENT)

--- a/src/test/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ public class DefaultResultSetHandlerTest {
 
   /**
    * Contrary to the spec, some drivers require case-sensitive column names when getting result.
-   * 
+   *
    * @see <a href="http://code.google.com/p/mybatis/issues/detail?id=557">Issue 557</a>
    */
   @Test

--- a/src/test/java/org/apache/ibatis/io/VFSTest.java
+++ b/src/test/java/org/apache/ibatis/io/VFSTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Unit test for VFS getInstance method in multi-thread environment
- * 
+ *
  * @author: jasonleaster
  */
 public class VFSTest {

--- a/src/test/java/org/apache/ibatis/mapping/ResultMappingTest.java
+++ b/src/test/java/org/apache/ibatis/mapping/ResultMappingTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ public class ResultMappingTest {
         .build();
     });
   }
-  
+
   //Issue 4: column is mandatory on nested queries
   @Test
   public void shouldFailWithAMissingColumnInNetstedSelect() throws Exception {

--- a/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
+++ b/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -511,7 +511,7 @@ public class SqlSessionTest extends BaseDataTest {
       assertEquals(101, author.get("ID"));
     }
   }
-  
+
   @Test
   public void shouldExecuteSelectAllAuthorsUsingMapperClassThatReturnsSet() {
     try (SqlSession session = sqlMapper.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/ancestor_ref/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/ancestor_ref/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -72,7 +72,7 @@
     <association property="blog" resultMap="blogResult" />
     <association property="reputation" resultMap="reputationResult" />
   </resultMap>
-  
+
   <resultMap type="org.apache.ibatis.submitted.ancestor_ref.Reputation"
     id="reputationResult">
     <id property="value" column="reputation" />
@@ -80,8 +80,8 @@
   </resultMap>
 
   <select id="selectBlog" resultMap="blogResult"><![CDATA[
-    select id, title, a.id author_id, a.name author_name, a.reputation author_reputation, 
-      ca.id co_author_id, ca.name co_author_name, ca.reputation co_author_reputation 
+    select id, title, a.id author_id, a.name author_name, a.reputation author_reputation,
+      ca.id co_author_id, ca.name co_author_name, ca.reputation co_author_reputation
     from blog b
     left join author a on a.id = b.author_id
     left join author ca on ca.id = b.co_author_id

--- a/src/test/java/org/apache/ibatis/submitted/associationtest/AssociationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/associationtest/AssociationTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ public class AssociationTest {
       Assertions.assertEquals(1, cars.size());
     }
   }
-  
+
   @Test
   public void shouldGetAllCarsAndDetectAssociationType() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/associationtest/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/associationtest/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@
   <resultMap type="org.apache.ibatis.submitted.associationtest.Brakes" id="brakesResult">
     <result column="brakesType" property="type"/>
   </resultMap>
-  
+
   <select id="getCars" resultMap="carResult">
     select * from cars
   </select>
@@ -43,7 +43,7 @@
   <select id="getCars2" resultMap="carResult">
     select 1 as carid, cartype, enginetype, enginecylinders, brakestype from cars where carid in (1,2)
   </select>
-  
+
   <resultMap type="org.apache.ibatis.submitted.associationtest.Car" id="carResultTypeDetect">
     <id column="carid" property="id"/>
     <result column="cartype" property="type"/>
@@ -55,9 +55,9 @@
       <result column="brakesType" property="type"/>
     </association>
   </resultMap>
-    
+
   <select id="getCarsAndDetectAssociationType" resultMap="carResultTypeDetect">
     select * from cars
   </select>
-  
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/associationtype/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/associationtype/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -32,11 +32,11 @@
     </resultMap>
 
     <select id="getUser" resultMap="sampleHashResult">
-        SELECT id as f1, name as f2 from users 
+        SELECT id as f1, name as f2 from users
     </select>
-    
+
     <select id="associationTest" resultType="java.lang.String">
-        select id from users 
+        select id from users
     </select>
-    
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2017 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -80,12 +80,12 @@
 	<resultMap type="org.apache.ibatis.submitted.automapping.Book" id="bookResult">
 		<result property="name" column="name"/>
 	</resultMap>
-	
+
 	<select id="getBooks" resultMap="bookResult">
 		select version, name from books
 	</select>
-	
+
 	<select id="getArticle" resultType="org.apache.ibatis.submitted.automapping.Article">
 		select 9 as version from INFORMATION_SCHEMA.SYSTEM_USERS
-	</select>	
+	</select>
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/awful_table/AwfulTableMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/awful_table/AwfulTableMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -35,13 +35,13 @@
     <result column="A_ACTIVE" property="active" jdbcType="BIT" />
   </resultMap>
   <sql id="Base_Column_List" >
-    A."CuStOmEr iD" as "A_CuStOmEr iD", A."first name" as "A_first name", A.FIRST_NAME as A_FIRST_NAME, 
-    A.FIRSTNAME as A_FIRSTNAME, A."last name" as "A_last name", A.E_MAIL as A_E_MAIL, 
-    A."_id1" as "A__id1", A."$id2" as "A_$id2", A."id5_" as "A_id5_", A."id6$" as "A_id6$", 
+    A."CuStOmEr iD" as "A_CuStOmEr iD", A."first name" as "A_first name", A.FIRST_NAME as A_FIRST_NAME,
+    A.FIRSTNAME as A_FIRSTNAME, A."last name" as "A_last name", A.E_MAIL as A_E_MAIL,
+    A."_id1" as "A__id1", A."$id2" as "A_$id2", A."id5_" as "A_id5_", A."id6$" as "A_id6$",
     A."id7$$" as "A_id7$$", A.EMAILADDRESS as A_EMAILADDRESS, A."from" as "A_from", A.ACTIVE as A_ACTIVE
   </sql>
   <select id="selectByPrimaryKey" resultMap="BaseResultMap" parameterType="java.lang.Integer" >
-    select 
+    select
     <include refid="Base_Column_List" />
     from "awful table" A
     where A."CuStOmEr iD" = #{customerId,jdbcType=INTEGER}
@@ -51,15 +51,15 @@
     where "CuStOmEr iD" = #{customerId,jdbcType=INTEGER}
   </delete>
   <insert id="insert" useGeneratedKeys="true" keyProperty="customerId" >
-    insert into "awful table" ("first name", FIRST_NAME, 
-      FIRSTNAME, "last name", E_MAIL, 
-      "_id1", "$id2", "id5_", "id6$", 
-      "id7$$", EMAILADDRESS, "from", 
+    insert into "awful table" ("first name", FIRST_NAME,
+      FIRSTNAME, "last name", E_MAIL,
+      "_id1", "$id2", "id5_", "id6$",
+      "id7$$", EMAILADDRESS, "from",
       ACTIVE)
-    values (#{firstFirstName,jdbcType=VARCHAR}, #{secondFirstName,jdbcType=VARCHAR}, 
-      #{thirdFirstName,jdbcType=VARCHAR}, #{lastName,jdbcType=VARCHAR}, #{eMail,jdbcType=VARCHAR}, 
-      #{id1,jdbcType=INTEGER}, #{id2,jdbcType=INTEGER}, #{id5,jdbcType=INTEGER}, #{id6,jdbcType=INTEGER}, 
-      #{id7,jdbcType=INTEGER}, #{emailaddress,jdbcType=VARCHAR}, #{from,jdbcType=VARCHAR}, 
+    values (#{firstFirstName,jdbcType=VARCHAR}, #{secondFirstName,jdbcType=VARCHAR},
+      #{thirdFirstName,jdbcType=VARCHAR}, #{lastName,jdbcType=VARCHAR}, #{eMail,jdbcType=VARCHAR},
+      #{id1,jdbcType=INTEGER}, #{id2,jdbcType=INTEGER}, #{id5,jdbcType=INTEGER}, #{id6,jdbcType=INTEGER},
+      #{id7,jdbcType=INTEGER}, #{emailaddress,jdbcType=VARCHAR}, #{from,jdbcType=VARCHAR},
       #{active,jdbcType=BIT})
   </insert>
   <insert id="insertSelective" useGeneratedKeys="true" keyProperty="customerId" >

--- a/src/test/java/org/apache/ibatis/submitted/blobtest/BlobMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/blobtest/BlobMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -31,11 +31,11 @@
       <arg column="blob" javaType="Byte[]"/>
     </constructor>
   </resultMap>
-  
+
   <insert id="insert" parameterType="org.apache.ibatis.submitted.blobtest.BlobRecord">
     insert into blobtest.blobs values (#{id}, #{blob})
   </insert>
-  
+
   <select id="selectAll" resultMap="blobRecordResult">
     select * from blobtest.blobs
   </select>

--- a/src/test/java/org/apache/ibatis/submitted/blobtest/BlobTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/blobtest/BlobTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ public class BlobTest {
     public void testInsertBlobThenSelectAll() {
         try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             BlobMapper blobMapper = sqlSession.getMapper(BlobMapper.class);
-            
+
             byte[] myblob = new byte[] {1, 2, 3, 4, 5};
             BlobRecord blobRecord = new BlobRecord(1, myblob);
             int rows = blobMapper.insert(blobRecord);

--- a/src/test/java/org/apache/ibatis/submitted/blocking_cache/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/blocking_cache/mybatis-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -23,11 +23,11 @@
 		<setting name="defaultExecutorType" value="SIMPLE"/>
 		<setting name="useGeneratedKeys" value="true"/>
 	</settings>
-	
+
 	<typeAliases>
-		<typeAlias type="org.apache.ibatis.submitted.blocking_cache.Person" alias="Person" /> 
+		<typeAlias type="org.apache.ibatis.submitted.blocking_cache.Person" alias="Person" />
 	</typeAliases>
-	
+
 	<environments default="development">
 		<environment id="development">
 			<transactionManager type="JDBC">
@@ -40,8 +40,8 @@
 			</dataSource>
 		</environment>
 	</environments>
-	
+
 	<mappers>
-		<mapper class="org.apache.ibatis.submitted.blocking_cache.PersonMapper"/>	
+		<mapper class="org.apache.ibatis.submitted.blocking_cache.PersonMapper"/>
 	</mappers>
-</configuration> 
+</configuration>

--- a/src/test/java/org/apache/ibatis/submitted/cache/CacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cache/CacheTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ public class CacheTest {
   }
 
   /*
-   * Test Plan: 
+   * Test Plan:
    *  1) SqlSession 1 executes "select * from A".
    *  2) SqlSession 1 closes.
    *  3) SqlSession 2 executes "delete from A where id = 1"
@@ -82,7 +82,7 @@ public class CacheTest {
   }
 
   /*
-   * Test Plan: 
+   * Test Plan:
    *  1) SqlSession 1 executes "select * from A".
    *  2) SqlSession 1 closes.
    *  3) SqlSession 2 executes "delete from A where id = 1"
@@ -91,7 +91,7 @@ public class CacheTest {
    *  6) SqlSession 3 executes "select * from A"
    *
    * Assert:
-   *   Step 6 returns 2 rows. 
+   *   Step 6 returns 2 rows.
    */
   @Test
   public void testplan2() {
@@ -125,7 +125,7 @@ public class CacheTest {
    *  6) SqlSession 3 closes.
    *
    * Assert:
-   *   Step 6 returns 1 row. 
+   *   Step 6 returns 1 row.
    */
   @Test
   public void testplan3() {

--- a/src/test/java/org/apache/ibatis/submitted/cache/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/cache/mybatis-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -23,11 +23,11 @@
 		<setting name="defaultExecutorType" value="SIMPLE"/>
 		<setting name="useGeneratedKeys" value="true"/>
 	</settings>
-	
+
 	<typeAliases>
-		<typeAlias type="org.apache.ibatis.submitted.cache.Person" alias="Person" /> 
+		<typeAlias type="org.apache.ibatis.submitted.cache.Person" alias="Person" />
 	</typeAliases>
-	
+
 	<environments default="development">
 		<environment id="development">
 			<transactionManager type="JDBC">
@@ -40,11 +40,11 @@
 			</dataSource>
 		</environment>
 	</environments>
-	
+
 	<mappers>
 		<mapper class="org.apache.ibatis.submitted.cache.PersonMapper"/>
 		<mapper class="org.apache.ibatis.submitted.cache.ImportantPersonMapper"/>
 		<mapper class="org.apache.ibatis.submitted.cache.CustomCacheMapper"/>
 		<mapper class="org.apache.ibatis.submitted.cache.SpecialPersonMapper"/>
 	</mappers>
-</configuration> 
+</configuration>

--- a/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
 	<select id="getUserMapped" resultMap="userMap">
 		select * from users
 	</select>
-	
+
 	<resultMap type="org.apache.ibatis.submitted.call_setters_on_nulls.User" id="userMap">
 		<id property="id" column="id" />
 		<result property="name" column="name" />
@@ -46,7 +46,7 @@
     <select id="getNameOnlyMapped" resultMap="mapResult">
         select name from users2
     </select>
-    
+
     <resultMap type="map" id="mapResult">
     	<result column="name" property="name" />
     </resultMap>

--- a/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/Person.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ public class Person {
     if (!(o instanceof Person)) return false;
 
     Person person = (Person) o;
-    
+
     if (id != null ? !id.equals(person.id) : person.id != null) return false;
 
     return true;

--- a/src/test/java/org/apache/ibatis/submitted/column_forwarding/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/column_forwarding/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 	<select id="getUser" parameterType="map" resultMap="userResult">
 		select * from users where id=#{id}
 	</select>
-	
+
 	<select id="getGroup" parameterType="map" resultMap="groupResult">
 		select * from groups where id=#{id} and state=#{state}
 	</select>
@@ -37,10 +37,10 @@
 		<result column="state" property="state" />
 		<association property="group" column="{id=group_id,state=state}" select="getGroup" javaType="org.apache.ibatis.submitted.column_forwarding.Group" />
 	</resultMap>
-	
+
 	<resultMap id="groupResult"
 		type="org.apache.ibatis.submitted.column_forwarding.Group">
 		<id column="id" property="id" />
-		<result column="state" property="state" />	
+		<result column="state" property="state" />
 	</resultMap>
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/complex_column/ComplexColumnTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_column/ComplexColumnTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,9 +27,9 @@ import org.junit.jupiter.api.Test;
 import java.io.Reader;
 
 public class ComplexColumnTest {
-    
+
     private static SqlSessionFactory sqlSessionFactory;
-    
+
     @BeforeAll
     public static void initDatabase() throws Exception {
         try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/complex_column/ibatisConfig.xml")) {
@@ -39,7 +39,7 @@ public class ComplexColumnTest {
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/complex_column/CreateDB.sql");
     }
-    
+
     @Test
     public void testWithoutComplex() {
         try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
@@ -54,7 +54,7 @@ public class ComplexColumnTest {
             Assertions.assertEquals("Smith", parent.getLastName());
         }
     }
-    
+
     @Test
     public void testWithComplex() {
         try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/complex_column/Person.xml
+++ b/src/test/java/org/apache/ibatis/submitted/complex_column/Person.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.complex_column.PersonMapper">
-    
+
     <resultMap id="personMap" type="Person">
         <id property="id" column="id"/>
         <result property="firstName" column="firstName"/>
@@ -35,8 +35,8 @@
         <result property="lastName" column="lastName"/>
         <association property="parent" column="{firstName=parent_firstName,lastName=parent_lastName}" select="getParentWithComplex"/>
     </resultMap>
-    
-    
+
+
     <select id="getWithoutComplex" resultMap="personMap" parameterType="long">
         SELECT id, firstName, lastName, parent_id, parent_firstName, parent_lastName
         FROM Person
@@ -64,5 +64,5 @@
         AND lastName = #{lastName,jdbcType=VARCHAR}
         LIMIT 1
     </select>
-    
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/complex_column/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_column/PersonMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@ package org.apache.ibatis.submitted.complex_column;
 import org.apache.ibatis.annotations.*;
 
 public interface PersonMapper {
-    
+
     public Person getWithoutComplex(Long id);
     public Person getWithComplex(Long id);
     public Person getParentWithComplex(Person person);
-    
+
     @Select({
       "SELECT id, firstName, lastName, parent_id, parent_firstName, parent_lastName",
       "FROM Person",

--- a/src/test/java/org/apache/ibatis/submitted/complex_column/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/complex_column/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
     <typeAliases>
         <typeAlias alias="Person" type="org.apache.ibatis.submitted.complex_column.Person"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -35,7 +35,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/complex_column/Person.xml"/>
     </mappers>

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 	<select id="getAllUsers" resultMap="results" resultOrdered="true">
 		select * from users order by id
 	</select>
-	
+
 	<resultMap type="org.apache.ibatis.submitted.cursor_nested.User" id="results">
 		<id column="id" property="id"/>
     <result property="name" column="name"/>

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/Mapper.xml
@@ -25,7 +25,7 @@
 	<select id="getAllUsers" resultMap="results">
 		select * from users
 	</select>
-	
+
 	<resultMap type="org.apache.ibatis.submitted.cursor_simple.User" id="results">
 		<id column="id" property="id"/>
     <result property="name" column="name"/>

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/Contact.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/Contact.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 package org.apache.ibatis.submitted.custom_collection_handling;
 
 public class Contact {
-    
+
     private Integer id;
     private String address;
     private String phone;
@@ -43,6 +43,6 @@ public class Contact {
 
     public void setPhone(String phone) {
         this.phone = phone;
-    }    
-    
+    }
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomCollection.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomCollection.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.apache.ibatis.submitted.custom_collection_handling;
 import java.util.*;
 
 public class CustomCollection<T> {
-    
+
     private List<T> data = new ArrayList<T>();
 
     public <K> K[] toArray(K[] a) {
@@ -123,5 +123,5 @@ public class CustomCollection<T> {
     public boolean add(T e) {
         return data.add(e);
     }
-    
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectFactory.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public class CustomObjectFactory implements ObjectFactory {
         }
         return classToCreate;
     }
-    
+
     @Override
     public <T> boolean isCollection(Class<T> type) {
       return CustomCollection.class.isAssignableFrom(type);

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/Person.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -43,6 +43,6 @@ public class Person {
 
     public void setContacts(CustomCollection<Contact> contacts) {
         this.contacts = contacts;
-    }    
-    
+    }
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/PersonMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/PersonMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
     <resultMap id="personRM" type="org.apache.ibatis.submitted.custom_collection_handling.Person">
         <id property="id" column="id" />
         <result property="name" column="name" />
-        <collection 
+        <collection
             property="contacts"
             ofType="org.apache.ibatis.submitted.custom_collection_handling.Contact"
             javaType="org.apache.ibatis.submitted.custom_collection_handling.CustomCollection">
@@ -38,11 +38,11 @@
     <resultMap id="personRM2" type="org.apache.ibatis.submitted.custom_collection_handling.Person">
         <id property="id" column="id" />
         <result property="name" column="name" />
-        <collection 
+        <collection
             property="contacts"
             ofType="org.apache.ibatis.submitted.custom_collection_handling.Contact"
             javaType="org.apache.ibatis.submitted.custom_collection_handling.CustomCollection"
-            column="id" 
+            column="id"
             select="findContacts" />
     </resultMap>
 

--- a/src/test/java/org/apache/ibatis/submitted/deferload_common_property/ChildMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/deferload_common_property/ChildMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,14 +21,14 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.deferload_common_property.ChildMapper">
-    
+
     <resultMap id="ChildMap" type="Child">
         <id property="id" column="id"/>
         <result property="name" column="name"/>
         <association property="father" column="father_id" select="org.apache.ibatis.submitted.deferload_common_property.FatherMapper.selectById"/>
     </resultMap>
-    
-    
+
+
     <select id="selectAll" resultMap="ChildMap">
     	SELECT id, name, father_id
     	FROM Child

--- a/src/test/java/org/apache/ibatis/submitted/deferload_common_property/FatherMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/deferload_common_property/FatherMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.deferload_common_property.FatherMapper">
-    
+
     <resultMap id="FatherMap" type="Father">
         <id property="id" column="id"/>
         <result property="name" column="name"/>
     </resultMap>
-    
-    
+
+
     <select id="selectById" resultMap="FatherMap" parameterType="int">
     	SELECT id, name
     	FROM Father

--- a/src/test/java/org/apache/ibatis/submitted/deferload_common_property/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/deferload_common_property/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,16 +21,16 @@
     "http://mybatis.org/dtd/mybatis-3-config.dtd">
 
 <configuration>
-	
+
     <settings>
         <setting name="lazyLoadingEnabled" value="false"/>
     </settings>
-	
+
     <typeAliases>
         <typeAlias alias="Child" type="org.apache.ibatis.submitted.deferload_common_property.Child"/>
         <typeAlias alias="Father" type="org.apache.ibatis.submitted.deferload_common_property.Father"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -41,7 +41,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/deferload_common_property/ChildMapper.xml"/>
         <mapper resource="org/apache/ibatis/submitted/deferload_common_property/FatherMapper.xml"/>

--- a/src/test/java/org/apache/ibatis/submitted/deferload_common_property/lazyLoadIbatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/deferload_common_property/lazyLoadIbatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,16 +21,16 @@
     "http://mybatis.org/dtd/mybatis-3-config.dtd">
 
 <configuration>
-	
+
     <settings>
         <setting name="lazyLoadingEnabled" value="true"/>
     </settings>
-	
+
     <typeAliases>
         <typeAlias alias="Child" type="org.apache.ibatis.submitted.deferload_common_property.Child"/>
         <typeAlias alias="Father" type="org.apache.ibatis.submitted.deferload_common_property.Father"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -41,7 +41,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/deferload_common_property/ChildMapper.xml"/>
         <mapper resource="org/apache/ibatis/submitted/deferload_common_property/FatherMapper.xml"/>

--- a/src/test/java/org/apache/ibatis/submitted/disallowdotsonnames/Person.xml
+++ b/src/test/java/org/apache/ibatis/submitted/disallowdotsonnames/Person.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.disallowdotsonnames.PersonMapper">
-    
+
     <resultMap id="personMap" type="Person">
         <id property="id" column="id"/>
         <result property="firstName" column="firstName"/>
@@ -33,5 +33,5 @@
         FROM person
         WHERE id = #{id}
     </select>
-        
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/disallowdotsonnames/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/disallowdotsonnames/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
     <typeAliases>
         <typeAlias alias="Person" type="org.apache.ibatis.submitted.disallowdotsonnames.Person"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -35,7 +35,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/disallowdotsonnames/Person.xml"/>
     </mappers>

--- a/src/test/java/org/apache/ibatis/submitted/duplicate_resource_loaded/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/duplicate_resource_loaded/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -30,4 +30,4 @@
     select * from blog
   </select>
 </mapper>
-  
+

--- a/src/test/java/org/apache/ibatis/submitted/duplicate_statements/AnnotatedMapperExtended.java
+++ b/src/test/java/org/apache/ibatis/submitted/duplicate_statements/AnnotatedMapperExtended.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.apache.ibatis.annotations.Select;
 /**
  * This interface should fail when added to the configuration.  It has
  * a method with the same name, but different parameters, as a method
- * in the super interface  
+ * in the super interface
  *
  */
 public interface AnnotatedMapperExtended extends AnnotatedMapper {

--- a/src/test/java/org/apache/ibatis/submitted/dynsql/CustomUtil.java
+++ b/src/test/java/org/apache/ibatis/submitted/dynsql/CustomUtil.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,5 +18,5 @@ package org.apache.ibatis.submitted.dynsql;
 public class CustomUtil {
     public static String esc(final String s) {
         return s.replace("'", "''");
-    }    
+    }
 }

--- a/src/test/java/org/apache/ibatis/submitted/empty_namespace/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/empty_namespace/Person.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ public class Person {
         EMPLOYEE,
         DIRECTOR
     }
-    
+
     private Long id;
     private String firstName;
     private String lastName;

--- a/src/test/java/org/apache/ibatis/submitted/empty_namespace/Person.xml
+++ b/src/test/java/org/apache/ibatis/submitted/empty_namespace/Person.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,14 +21,14 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="">
-    
+
     <resultMap id="personMap" type="Person">
         <id property="id" column="id"/>
         <result property="firstName" column="firstName"/>
         <result property="lastName" column="lastName"/>
     </resultMap>
-    
-    
+
+
     <select id="selectAllByType" resultMap="personMap" parameterType="org.apache.ibatis.submitted.ognl_enum.Person$Type">
         SELECT id, firstName, lastName, personType
         FROM person
@@ -53,7 +53,7 @@
             </if>
         </where>
     </select>
-    
+
     <select id="selectAllByTypeWithInterface" resultMap="personMap" parameterType="org.apache.ibatis.submitted.ognl_enum.PersonMapper$PersonType">
         SELECT id, firstName, lastName, personType
         FROM person

--- a/src/test/java/org/apache/ibatis/submitted/empty_namespace/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/empty_namespace/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
     <typeAliases>
         <typeAlias alias="Person" type="org.apache.ibatis.submitted.empty_namespace.Person"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -35,7 +35,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/empty_namespace/Person.xml"/>
     </mappers>

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_annotation/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_annotation/mybatis-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2015 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -32,5 +32,5 @@
             </dataSource>
         </environment>
     </environments>
-    
+
 </configuration>

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/EnumTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/EnumTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class EnumTypeHandlerTest {
-    
+
     private static SqlSessionFactory sqlSessionFactory;
-    
+
     @BeforeAll
     public static void initDatabase() throws Exception {
         try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/enumtypehandler_on_map/ibatisConfig.xml")) {
@@ -42,7 +42,7 @@ public class EnumTypeHandlerTest {
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/enumtypehandler_on_map/CreateDB.sql");
     }
-    
+
     @Test
     public void testEnumWithParam() {
         try (SqlSession sqlSession = sqlSessionFactory.openSession() ) {

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/Person.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,12 +16,12 @@
 package org.apache.ibatis.submitted.enumtypehandler_on_map;
 
 public class Person {
-    
+
     public enum Type {
         PERSON,
         EMPLOYEE
     }
-    
+
     private Long id;
     private String firstName;
     private String lastName;

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/Person.xml
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/Person.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,22 +21,22 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.enumtypehandler_on_map.PersonMapper">
-    
+
     <resultMap id="personMap" type="Person">
         <id property="id" column="Person_id"/>
         <result property="firstName" column="Person_firstName"/>
         <result property="lastName" column="Person_lastName"/>
     </resultMap>
-    
-    
+
+
     <sql id="columns">
         Person.id AS Person_id,
         Person.firstName AS Person_firstName,
         Person.lastName AS Person_lastName,
         Person.personType AS Person_personType
     </sql>
-    
-    
+
+
     <select id="getByType" resultMap="personMap" parameterType="map">
         SELECT <include refid="columns"/>
         FROM Person
@@ -47,5 +47,5 @@
         FROM Person
         WHERE personType = #{type,jdbcType=VARCHAR}
     </select>
-    
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/PersonMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,13 +20,13 @@ import java.util.List;
 import org.apache.ibatis.annotations.Param;
 
 public interface PersonMapper {
-    
+
     public static interface TypeName {
         public Person.Type getType();
         public String getName();
     }
-    
+
     public List<Person> getByType(@Param("type") Person.Type type, @Param("name") String name);
     public List<Person> getByTypeNoParam(TypeName typeName);
-    
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
     <typeAliases>
         <typeAlias alias="Person" type="org.apache.ibatis.submitted.enumtypehandler_on_map.Person"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -35,7 +35,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/enumtypehandler_on_map/Person.xml"/>
     </mappers>

--- a/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/NpeExtendsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/NpeExtendsTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 
 /*
  * Test for NPE when using extends.
- * 
+ *
  * @author poitrac
  */
 public class NpeExtendsTest {
@@ -47,7 +47,7 @@ public class NpeExtendsTest {
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/extends_with_constructor/CreateDB.sql");
     }
-    
+
     @Test
     public void testNoConstructorConfiguration() {
         Configuration configuration = new Configuration();
@@ -62,7 +62,7 @@ public class NpeExtendsTest {
         configuration.addMapper(TeacherMapper.class);
         configuration.getMappedStatementNames();
     }
-    
+
     private static SqlSessionFactory getSqlSessionFactoryWithConstructor() {
         UnpooledDataSourceFactory unpooledDataSourceFactory = new UnpooledDataSourceFactory();
         Properties properties = new Properties();
@@ -71,14 +71,14 @@ public class NpeExtendsTest {
         properties.setProperty("username", "sa");
         unpooledDataSourceFactory.setProperties(properties);
         Environment environment = new Environment("extends_with_constructor", new JdbcTransactionFactory(), unpooledDataSourceFactory.getDataSource());
-        
+
         Configuration configuration = new Configuration();
         configuration.setEnvironment(environment);
         configuration.addMapper(StudentConstructorMapper.class);
         configuration.addMapper(TeacherMapper.class);
         configuration.getMappedStatementNames();
         configuration.setAutoMappingBehavior(AutoMappingBehavior.NONE);
-        
+
         return new DefaultSqlSessionFactory(configuration);
     }
     @Test

--- a/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/StudentConstructorMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/StudentConstructorMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@
         	<idArg column="id" javaType="int"/>
         </constructor>
     </resultMap>
-    
+
     <select id="selectWithTeacherById" resultMap="StudentConstructorWithTeacherMap" parameterType="int">
     	SELECT id, name, teacher_id
     	FROM student

--- a/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/StudentMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/StudentMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@
     <resultMap id="StudentMapWithTeacherMap" type="org.apache.ibatis.submitted.extends_with_constructor.Student" extends="StudentMap">
     	<association property="teacher" resultMap="org.apache.ibatis.submitted.extends_with_constructor.TeacherMapper.TeacherMap"/>
     </resultMap>
-    
+
     <select id="selectAllWithTeacher" resultMap="StudentMapWithTeacherMap">
     	SELECT id, name, teacherId
     	FROM student

--- a/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/TeacherMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/TeacherMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
         <id property="id" column="id"/>
         <result property="name" column="name"/>
     </resultMap>
-    
+
     <select id="selectById" resultMap="TeacherMap" parameterType="int">
     	SELECT id, name
     	FROM teacher

--- a/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/FlushStatementNpeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/FlushStatementNpeTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,9 +27,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class FlushStatementNpeTest {
-    
+
     private static SqlSessionFactory sqlSessionFactory;
-    
+
     @BeforeAll
     public static void initDatabase() throws Exception {
         try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/flush_statement_npe/ibatisConfig.xml")) {
@@ -39,18 +39,18 @@ public class FlushStatementNpeTest {
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/flush_statement_npe/CreateDB.sql");
     }
-    
+
     @Test
     public void testSameUpdateAfterCommitSimple() {
         try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.SIMPLE)) {
             PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
             Person person = personMapper.selectById(1);
             person.setFirstName("Simone");
-            
+
             // Execute first update then commit.
             personMapper.update(person);
             sqlSession.commit();
-            
+
             // Execute same update a second time. This used to raise an NPE.
             personMapper.update(person);
             sqlSession.commit();
@@ -62,11 +62,11 @@ public class FlushStatementNpeTest {
             PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
             Person person = personMapper.selectById(1);
             person.setFirstName("Simone");
-            
+
             // Execute first update then commit.
             personMapper.update(person);
             sqlSession.commit();
-            
+
             // Execute same update a second time. This used to raise an NPE.
             personMapper.update(person);
             sqlSession.commit();
@@ -78,11 +78,11 @@ public class FlushStatementNpeTest {
             PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
             Person person = personMapper.selectById(1);
             person.setFirstName("Simone");
-            
+
             // Execute first update then commit.
             personMapper.update(person);
             sqlSession.commit();
-            
+
             // Execute same update a second time. This used to raise an NPE.
             personMapper.update(person);
             sqlSession.commit();

--- a/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/Person.xml
+++ b/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/Person.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,14 +21,14 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.flush_statement_npe.PersonMapper">
-    
+
     <resultMap id="personMap" type="Person">
         <id property="id" column="id"/>
         <result property="firstName" column="firstName"/>
         <result property="lastName" column="lastName"/>
     </resultMap>
-    
-    
+
+
     <select id="selectById" resultMap="personMap" parameterType="int">
         SELECT id, firstName, lastName
         FROM person

--- a/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
     <typeAliases>
         <typeAlias alias="Person" type="org.apache.ibatis.submitted.flush_statement_npe.Person"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -35,7 +35,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/flush_statement_npe/Person.xml"/>
     </mappers>

--- a/src/test/java/org/apache/ibatis/submitted/force_flush_on_select/Person.xml
+++ b/src/test/java/org/apache/ibatis/submitted/force_flush_on_select/Person.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,13 +24,13 @@
 
     <!-- One hour cache -->
 	<cache flushInterval="3600000"/>
-    
+
     <resultMap id="personMap" type="Person">
         <id property="id" column="id"/>
         <result property="firstName" column="firstName"/>
         <result property="lastName" column="lastName"/>
     </resultMap>
-    
+
     <select id="selectByIdFlush" resultMap="personMap" parameterType="int" flushCache="true">
         SELECT id, firstName, lastName
         FROM person
@@ -42,7 +42,7 @@
         FROM person
         WHERE id = #{id}
     </select>
-    
+
     <select id="selectAllFlush" resultMap="personMap" flushCache="true">
         SELECT id, firstName, lastName
         FROM person
@@ -54,9 +54,9 @@
         FROM person
         ORDER BY id
     </select>
-    
+
     <update id="update" parameterType="org.apache.ibatis.submitted.force_flush_on_select.Person">
-        UPDATE person set firstname = #{firstName} where id = #{id} 
+        UPDATE person set firstname = #{firstName} where id = #{id}
     </update>
-    
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/force_flush_on_select/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/force_flush_on_select/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
     <typeAliases>
         <typeAlias alias="Person" type="org.apache.ibatis.submitted.force_flush_on_select.Person"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -35,7 +35,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/force_flush_on_select/Person.xml"/>
     </mappers>

--- a/src/test/java/org/apache/ibatis/submitted/generictypes/Config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/generictypes/Config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@
       </dataSource>
     </environment>
   </environments>
-  
+
   <mappers>
     <mapper class="org.apache.ibatis.submitted.generictypes.Mapper" />
   </mappers>

--- a/src/test/java/org/apache/ibatis/submitted/global_variables_defaults/mybatis-config-custom-separator.xml
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables_defaults/mybatis-config-custom-separator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
     "http://mybatis.org/dtd/mybatis-3-config.dtd">
 
 <configuration>
-	
+
 	<settings>
 		<setting name="jdbcTypeForNull" value="${settings:jdbcTypeForNull?:NULL}"/>
 	</settings>
@@ -40,7 +40,7 @@
 			</dataSource>
 		</environment>
 	</environments>
-	
+
 	<databaseIdProvider type="DB_VENDOR">
 		<property name="${productName:hsql?:HSQL Database Engine}" value="hsql"/>
 	</databaseIdProvider>

--- a/src/test/java/org/apache/ibatis/submitted/global_variables_defaults/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables_defaults/mybatis-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
     "http://mybatis.org/dtd/mybatis-3-config.dtd">
 
 <configuration>
-	
+
 	<settings>
 		<setting name="jdbcTypeForNull" value="${settings.jdbcTypeForNull:NULL}"/>
 	</settings>
@@ -40,7 +40,7 @@
 			</dataSource>
 		</environment>
 	</environments>
-	
+
 	<databaseIdProvider type="DB_VENDOR">
 		<property name="${productName.hsql:HSQL Database Engine}" value="hsql"/>
 	</databaseIdProvider>

--- a/src/test/java/org/apache/ibatis/submitted/hashmaptypehandler/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/hashmaptypehandler/mybatis-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2017 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 <configuration>
 
-	<typeHandlers>		
+	<typeHandlers>
 		<typeHandler handler="org.apache.ibatis.submitted.hashmaptypehandler.HashMapTypeHandler" />
 	</typeHandlers>
 

--- a/src/test/java/org/apache/ibatis/submitted/heavy_initial_load/HeavyInitialLoadTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/heavy_initial_load/HeavyInitialLoadTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,19 +44,19 @@ public class HeavyInitialLoadTest {
   }
 
   private static final int THREAD_COUNT = 5;
-  
+
   /**
-   * Test to demonstrate the effect of the 
+   * Test to demonstrate the effect of the
    * https://issues.apache.org/jira/browse/OGNL-121 issue in ognl on mybatis.
-   * 
+   *
    * Use the thing mapper for the first time in multiple threads. The mapper contains
    * a lot of ognl references to static final class members like:
-   * 
+   *
    * <code>@org.apache.ibatis.submitted.heavy_initial_load.Code@_1.equals(code)</code>
-   * 
-   * Handling of these references is optimized in ognl (because they never change), but 
-   * version 2.6.9 has a bug in caching the result . As a result the reference is 
-   * translated to a 'null' value, which is used to invoke the 'equals' method on 
+   *
+   * Handling of these references is optimized in ognl (because they never change), but
+   * version 2.6.9 has a bug in caching the result . As a result the reference is
+   * translated to a 'null' value, which is used to invoke the 'equals' method on
    * (hence the 'target is null for method equals' exception).
    */
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/heavy_initial_load/ThingMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/heavy_initial_load/ThingMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@
   </resultMap>
 
   <select id="selectByCode" resultMap="thingMap" parameterType="String">
-  
-    SELECT  
+
+    SELECT
 		<if test="@org.apache.ibatis.submitted.heavy_initial_load.Code@_1.equals(code)">1</if>
 		<if test="@org.apache.ibatis.submitted.heavy_initial_load.Code@_2.equals(code)">2</if>
 		<if test="@org.apache.ibatis.submitted.heavy_initial_load.Code@_3.equals(code)">3</if>

--- a/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -36,5 +36,5 @@
         FROM immutables AS i
         WHERE i.immutable_id = #{pojoID}
     </select>
-        
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/initialized_collection_property/Author.xml
+++ b/src/test/java/org/apache/ibatis/submitted/initialized_collection_property/Author.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@
     a.name as author_name
     FROM author a
   </select>
-  
+
   <select id="getPostsFromAuthor" resultType="Post">
     SELECT
     p.post_id as post_id,
@@ -62,5 +62,5 @@
     FROM post p
     WHERE author_id = #{id}
   </select>
-  
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/javassist/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/javassist/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -25,11 +25,11 @@
 	<select id="getUser" resultMap="users" >
 		select * from users
 	</select>
-	
+
 	<select id="getGroupsForUser" resultType="org.apache.ibatis.submitted.javassist.Group">
 		select * from groups where owner = #{id}
 	</select>
-	
+
 	<resultMap type="org.apache.ibatis.submitted.javassist.User" id="users">
 		<id column="id" property="id" />
 		<result column="name" property="name" />

--- a/src/test/java/org/apache/ibatis/submitted/language/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/language/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@
   	FROM names
   	]]>
   </sql>
-  
+
   <select id="selectXml" resultType="Name" lang="xml">
     SELECT firstName
     <if test="includeLastName != null">, lastName</if>

--- a/src/test/java/org/apache/ibatis/submitted/lazy_immutable/ImmutablePOJOMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/lazy_immutable/ImmutablePOJOMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -36,5 +36,5 @@
         FROM immutables AS i
         WHERE i.id = #{pojoID}
     </select>
-    
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/ChildMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/ChildMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,15 +21,15 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.lazyload_common_property.ChildMapper">
-    
+
     <resultMap id="ChildMap" type="Child">
         <id property="id" column="id"/>
         <result property="name" column="name"/>
         <association property="father" column="father_id" select="org.apache.ibatis.submitted.lazyload_common_property.FatherMapper.selectById"/>
         <association property="grandFather" column="grand_father_id" select="org.apache.ibatis.submitted.lazyload_common_property.GrandFatherMapper.selectById"/>
     </resultMap>
-    
-    
+
+
     <select id="selectById" resultMap="ChildMap" parameterType="int">
     	SELECT id, name, father_id, grand_father_id
     	FROM Child

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/CommonPropertyLazyLoadError.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/CommonPropertyLazyLoadError.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,9 +26,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class CommonPropertyLazyLoadError {
-    
+
     private static SqlSessionFactory sqlSessionFactory;
-    
+
     @BeforeAll
     public static void initDatabase() throws Exception {
         try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/lazyload_common_property/ibatisConfig.xml")) {
@@ -38,12 +38,12 @@ public class CommonPropertyLazyLoadError {
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/lazyload_common_property/CreateDB.sql");
     }
-    
+
     @Test
     public void testLazyLoadWithNoAncestor() {
         try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             ChildMapper childMapper = sqlSession.getMapper(ChildMapper.class);
-            
+
             childMapper.selectById(1);
         }
     }
@@ -52,7 +52,7 @@ public class CommonPropertyLazyLoadError {
         try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
             ChildMapper childMapper = sqlSession.getMapper(ChildMapper.class);
-            
+
             fatherMapper.selectById(1);
             childMapper.selectById(1);
         }
@@ -63,7 +63,7 @@ public class CommonPropertyLazyLoadError {
             GrandFatherMapper grandFatherMapper = sqlSession.getMapper(GrandFatherMapper.class);
             FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
             ChildMapper childMapper = sqlSession.getMapper(ChildMapper.class);
-            
+
             grandFatherMapper.selectById(1);
             fatherMapper.selectById(1);
             childMapper.selectById(1);
@@ -74,7 +74,7 @@ public class CommonPropertyLazyLoadError {
         try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
             GrandFatherMapper grandFatherMapper = sqlSession.getMapper(GrandFatherMapper.class);
             ChildMapper childMapper = sqlSession.getMapper(ChildMapper.class);
-            
+
             grandFatherMapper.selectById(1);
             childMapper.selectById(1);
         }

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/FatherMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/FatherMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,14 +21,14 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.lazyload_common_property.FatherMapper">
-    
+
     <resultMap id="FatherMap" type="Father">
         <id property="id" column="id"/>
         <result property="name" column="name"/>
         <association property="grandFather" column="grand_father_id" select="org.apache.ibatis.submitted.lazyload_common_property.GrandFatherMapper.selectById"/>
     </resultMap>
-    
-    
+
+
     <select id="selectById" resultMap="FatherMap" parameterType="int">
     	SELECT id, name, grand_father_id
     	FROM Father

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/GrandFatherMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/GrandFatherMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,13 +21,13 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.lazyload_common_property.GrandFatherMapper">
-    
+
     <resultMap id="GrandFatherMap" type="GrandFather">
         <id property="id" column="id"/>
         <result property="name" column="name"/>
     </resultMap>
-    
-    
+
+
     <select id="selectById" resultMap="GrandFatherMap" parameterType="int">
     	SELECT id, name
     	FROM GrandFather

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,17 +21,17 @@
     "http://mybatis.org/dtd/mybatis-3-config.dtd">
 
 <configuration>
-	
+
     <settings>
         <setting name="lazyLoadingEnabled" value="true"/>
     </settings>
-	
+
     <typeAliases>
         <typeAlias alias="Child" type="org.apache.ibatis.submitted.lazyload_common_property.Child"/>
         <typeAlias alias="Father" type="org.apache.ibatis.submitted.lazyload_common_property.Father"/>
         <typeAlias alias="GrandFather" type="org.apache.ibatis.submitted.lazyload_common_property.GrandFather"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -42,7 +42,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/lazyload_common_property/ChildMapper.xml"/>
         <mapper resource="org/apache/ibatis/submitted/lazyload_common_property/FatherMapper.xml"/>

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/JavassistLazyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/JavassistLazyTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.apache.ibatis.submitted.lazyload_proxyfactory_comparison;
 import org.junit.jupiter.api.Disabled;
 
 @Disabled("See Issue 664: Javassist ProxyFactory does not handle interfaces with generics correctly.")
-public class JavassistLazyTest 
+public class JavassistLazyTest
 extends AbstractLazyTest {
   @Override
   protected String getConfiguration() {

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,69 +21,69 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.lazyload_proxyfactory_comparison.Mapper">
-	
+
 	<!-- UserWithGetObjectWithInterface -->
-	
+
 	<resultMap type="org.apache.ibatis.submitted.lazyload_proxyfactory_comparison.UserWithGetObjectWithInterface" id="user_with_get_object_with_interface_map">
 		<id column="id" property="id" />
 		<result column="name" property="name" />
 		<association property="owner" column="owner_id" select="getGroup" />
 	</resultMap>
-	
+
 	<select id="getUserWithGetObjectWithInterface" resultMap="user_with_get_object_with_interface_map">
 		select id, name, owner_id from users where id = #{id}
 	</select>
-	
+
 	<!-- UserWithGetObjectWithoutInterface -->
-	
+
 	<resultMap type="org.apache.ibatis.submitted.lazyload_proxyfactory_comparison.UserWithGetObjectWithoutInterface" id="user_with_get_object_without_interface_map">
 		<id column="id" property="id" />
 		<result column="name" property="name" />
 		<association property="owner" column="owner_id" select="getGroup" />
 	</resultMap>
-	
+
 	<select id="getUserWithGetObjectWithoutInterface" resultMap="user_with_get_object_without_interface_map">
 		select id, name, owner_id from users where id = #{id}
 	</select>
-	
+
 	<!-- UserWithGetXxxWithInterface -->
-	
+
 	<resultMap type="org.apache.ibatis.submitted.lazyload_proxyfactory_comparison.UserWithGetXxxWithInterface" id="user_with_get_xxx_with_interface_map">
 		<id column="id" property="id" />
 		<result column="name" property="name" />
 		<association property="owner" column="owner_id" select="getGroup" />
 	</resultMap>
-	
+
 	<select id="getUserWithGetXxxWithInterface" resultMap="user_with_get_xxx_with_interface_map">
 		select id, name, owner_id from users where id = #{id}
 	</select>
-	
+
 	<!-- UserWithGetXxxWithoutInterface -->
-	
+
 	<resultMap type="org.apache.ibatis.submitted.lazyload_proxyfactory_comparison.UserWithGetXxxWithoutInterface" id="user_with_get_xxx_without_interface_map">
 		<id column="id" property="id" />
 		<result column="name" property="name" />
 		<association property="owner" column="owner_id" select="getGroup" />
 	</resultMap>
-	
+
 	<select id="getUserWithGetXxxWithoutInterface" resultMap="user_with_get_xxx_without_interface_map">
 		select id, name, owner_id from users where id = #{id}
 	</select>
-	
+
 	<!-- UserWithNothingWithInterface -->
-	
+
 	<resultMap type="org.apache.ibatis.submitted.lazyload_proxyfactory_comparison.UserWithNothingWithInterface" id="user_with_nothing_with_interface_map">
 		<id column="id" property="id" />
 		<result column="name" property="name" />
 		<association property="owner" column="owner_id" select="getGroup" />
 	</resultMap>
-	
+
 	<select id="getUserWithNothingWithInterface" resultMap="user_with_nothing_with_interface_map">
 		select id, name, owner_id from users where id = #{id}
 	</select>
-	
+
 	<!-- UserWithNothingWithoutInterface -->
-	
+
 	<resultMap type="org.apache.ibatis.submitted.lazyload_proxyfactory_comparison.UserWithNothingWithoutInterface" id="user_with_nothing_without_interface_map">
 		<id column="id" property="id" />
 		<result column="name" property="name" />
@@ -93,9 +93,9 @@
 	<select id="getUserWithNothingWithoutInterface" resultMap="user_with_nothing_without_interface_map">
 		select id, name, owner_id from users where id = #{id}
 	</select>
-	
+
 	<!-- Group -->
-	
+
 	<resultMap type="org.apache.ibatis.submitted.lazyload_proxyfactory_comparison.Group" id="group_map">
 		<id column="id" property="id" />
 		<result column="name" property="name" />

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithGetObjectWithInterface.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithGetObjectWithInterface.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.apache.ibatis.submitted.lazyload_proxyfactory_comparison;
 
-public class UserWithGetObjectWithInterface 
+public class UserWithGetObjectWithInterface
 implements Owned<Group> {
 
   private Integer id;

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithGetXxxWithInterface.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithGetXxxWithInterface.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.apache.ibatis.submitted.lazyload_proxyfactory_comparison;
 
-public class UserWithGetXxxWithInterface 
+public class UserWithGetXxxWithInterface
 implements Owned<Group> {
 
   private Integer id;

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithNothingWithInterface.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/UserWithNothingWithInterface.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.apache.ibatis.submitted.lazyload_proxyfactory_comparison;
 
-public class UserWithNothingWithInterface 
+public class UserWithNothingWithInterface
 implements Owned<Group> {
 
   private Integer id;

--- a/src/test/java/org/apache/ibatis/submitted/mapper_type_parameter/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/mapper_type_parameter/mybatis-config.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0" encoding="UTF-8" ?> 
+<?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -32,11 +32,11 @@
 			</dataSource>
 		</environment>
 	</environments>
-	
+
 	<mappers>
 		<mapper class="org.apache.ibatis.submitted.mapper_type_parameter.CountryMapper" />
 		<mapper class="org.apache.ibatis.submitted.mapper_type_parameter.PersonMapper" />
 		<mapper class="org.apache.ibatis.submitted.mapper_type_parameter.PersonListMapper" />
 	</mappers>
 
-</configuration> 
+</configuration>

--- a/src/test/java/org/apache/ibatis/submitted/maptypehandler/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/maptypehandler/mybatis-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 <configuration>
 
-	<typeHandlers>		
+	<typeHandlers>
 		<typeHandler handler="org.apache.ibatis.submitted.maptypehandler.LabelsTypeHandler" />
 	</typeHandlers>
 

--- a/src/test/java/org/apache/ibatis/submitted/missing_id_property/Map.xml
+++ b/src/test/java/org/apache/ibatis/submitted/missing_id_property/Map.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@
 			ofType="Part"
 			select="getCarPartInfo" />
 	</resultMap>
-	
+
 	<resultMap id="partResult" type="Part">
 		<constructor>
 			<arg column="name" javaType="String"/>

--- a/src/test/java/org/apache/ibatis/submitted/missing_id_property/MapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/missing_id_property/MapperConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@
 			</dataSource>
 		</environment>
 	</environments>
-	
+
 	<mappers>
 		<mapper resource="org/apache/ibatis/submitted/missing_id_property/Map.xml" />
 	</mappers>

--- a/src/test/java/org/apache/ibatis/submitted/multidb/MultiDbMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/multidb/MultiDbMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@
 		</if>
 		where id=#{value}
 	</select>
-	
+
 	<sql id="sql1" databaseId="hsql">
 		hsql
 	</sql>
@@ -61,7 +61,7 @@
 	<sql id="sql1">
 		common
 	</sql>
-	
+
 	<select id="select4" resultType="string" parameterType="int">
 		select name from
 		<include refid="sql1"/>

--- a/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/Director.java
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/Director.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.apache.ibatis.submitted.multiple_discriminator;
 
 public class Director extends Employee {
     private String department;
-    
+
     public String getDepartment() {
         return department;
     }

--- a/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/Employee.java
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/Employee.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.apache.ibatis.submitted.multiple_discriminator;
 
 public class Employee extends Person {
     private String jobTitle;
-    
+
     public String getJobTitle() {
         return jobTitle;
     }

--- a/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/MultipleDiscriminatorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/MultipleDiscriminatorTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,9 +28,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class MultipleDiscriminatorTest {
-    
+
     private static SqlSessionFactory sqlSessionFactory;
-    
+
     @BeforeAll
     public static void initDatabase() throws Exception {
         try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/multiple_discriminator/ibatisConfig.xml")) {
@@ -40,7 +40,7 @@ public class MultipleDiscriminatorTest {
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/multiple_discriminator/CreateDB.sql");
     }
-    
+
     @Test
     public void testMultipleDiscriminator() {
         try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/Person.xml
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/Person.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.multiple_discriminator.PersonMapper">
-    
+
     <resultMap id="personMap2" type="Person">
         <id property="id" column="id"/>
         <result property="firstName" column="firstName"/>
@@ -65,8 +65,8 @@
             <case value="PersonType" resultMap="personMapLoop"/>
         </discriminator>
     </resultMap>
-    
-    
+
+
     <select id="get" resultMap="personMap" parameterType="long">
         SELECT id, firstName, lastName, jobTitle, department, personType, employeeType
         FROM Person
@@ -82,5 +82,5 @@
         FROM Person
         WHERE id = 3
     </select>
-    
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
         <typeAlias alias="Employee" type="org.apache.ibatis.submitted.multiple_discriminator.Employee"/>
         <typeAlias alias="Director" type="org.apache.ibatis.submitted.multiple_discriminator.Director"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -37,7 +37,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/multiple_discriminator/Person.xml"/>
     </mappers>

--- a/src/test/java/org/apache/ibatis/submitted/multiple_resultsets/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_resultsets/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@
   </select>
 
 	<resultMap type="org.apache.ibatis.submitted.multiple_resultsets.OrderDetail" id="usersResult" />
-	
+
 	<resultMap type="org.apache.ibatis.submitted.multiple_resultsets.OrderHeader" id="groupsResult" />
-	
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/multiple_resultsets/MultipleResultTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_resultsets/MultipleResultTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import ru.yandex.qatools.embed.postgresql.EmbeddedPostgres;
 import ru.yandex.qatools.embed.postgresql.util.SocketUtil;
 
 /*
- * This class contains tests for multiple results.  
+ * This class contains tests for multiple results.
  * It is based on Jeff's ref cursor tests.
  */
 @Tag("EmbeddedPostgresqlTests")

--- a/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.multipleresultsetswithassociation.Mapper">
-    
+
     <select id="getOrderDetailsWithHeaders" resultSets="orderDetailResultSet,orderHeaderResultSet" resultMap="orderDetailResultMap" statementType="CALLABLE">
         { call GetOrderDetailsAndHeaders() }
     </select>
@@ -32,9 +32,9 @@
         <association property="orderHeader" column="order_id" foreignColumn="order_id"
                      resultSet="orderHeaderResultSet" resultMap="orderHeaderResultMap" />
     </resultMap>
-	
+
     <resultMap type="org.apache.ibatis.submitted.multipleresultsetswithassociation.OrderHeader" id="orderHeaderResultMap">
         <id property="orderId" column="order_id"/>
     </resultMap>
-	
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/MultipleResultSetTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/MultipleResultSetTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 /*
  * This class contains tests for multiple result sets with an association mapping.
  * This test is based on the org.apache.ibatis.submitted.multiple_resultsets test.
- * 
+ *
  */
 public class MultipleResultSetTest {
 
@@ -60,7 +60,7 @@ public class MultipleResultSetTest {
       }
     }
   }
-  
+
   private static void runReaderScript(Connection conn, SqlSession session, Reader reader) throws Exception {
     ScriptRunner runner = new ScriptRunner(conn);
     runner.setLogWriter(null);
@@ -75,11 +75,11 @@ public class MultipleResultSetTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       List<OrderDetail> orderDetails = mapper.getOrderDetailsWithHeaders();
-      
+
       // There are six order detail records in the database
       // As long as the data does not change this should be successful
       Assertions.assertEquals(6, orderDetails.size());
-      
+
       // Each order detail should have a corresponding OrderHeader
       // Only 2 of 6 orderDetails have orderHeaders
       for(OrderDetail orderDetail : orderDetails){

--- a/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/mybatis-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
     <settings>
         <setting name="cacheEnabled" value="true"/>
         <setting name="lazyLoadingEnabled" value="true"/>
-        <setting name="multipleResultSetsEnabled" value="true"/>	
+        <setting name="multipleResultSetsEnabled" value="true"/>
         <setting name="mapUnderscoreToCamelCase" value="true" />
     </settings>
 

--- a/src/test/java/org/apache/ibatis/submitted/nested/NestedForEachTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested/NestedForEachTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 public class NestedForEachTest {
 
   protected static SqlSessionFactory sqlSessionFactory;
-  
+
   @BeforeAll
   public static void setUp() throws Exception {
     try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/nested/MapperConfig.xml")) {

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler_multiple_association/mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler_multiple_association/mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
        limitations under the License.
 
 -->
-<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" 
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
 "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="mapper">
     <resultMap id="ParentBeanResultMap" type="org.apache.ibatis.submitted.nestedresulthandler_multiple_association.ParentBean">
@@ -24,31 +24,31 @@
         <result property="value" column="value"/>
         <collection property="childs" select="selectChildsBinomes" column="id" />
     </resultMap>
-    
+
     <resultMap id="ChildsBinomesResultMap" type="org.apache.ibatis.submitted.nestedresulthandler_multiple_association.Binome">
         <association property="one" select="selectChildBeanById" column="idchild_from" javaType="org.apache.ibatis.submitted.nestedresulthandler_multiple_association.ChildBean" />
         <association property="two" select="selectChildBeanById" column="idchild_to"  javaType="org.apache.ibatis.submitted.nestedresulthandler_multiple_association.ChildBean" />
     </resultMap>
-    
+
     <resultMap id="ChildBeanResultMap" type="org.apache.ibatis.submitted.nestedresulthandler_multiple_association.ChildBean">
         <id property="id" column="id"/>
         <result property="value" column="value"/>
     </resultMap>
-    
+
     <select id="selectParentBeans" resultMap="ParentBeanResultMap" useCache="false">
     	select * from parent
     </select>
-    
+
     <select id="selectParentBeanById" resultMap="ParentBeanResultMap" useCache="false">
     	select * from parent where id = #{value}
     </select>
-    
+
     <select id="selectChildBeanById" parameterType="java.lang.Integer" resultMap="ChildBeanResultMap" useCache="false">
     	select * from child where id = #{value}
     </select>
-    
+
     <select id="selectChildsBinomes" parameterType="java.lang.Integer" resultMap="ChildsBinomesResultMap" useCache="false">
     	select * from parent_child where idparent = #{value}
     </select>
-    
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/not_null_column/FatherMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/not_null_column/FatherMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
         <result property="id" column="child_id"/>
         <result property="name" column="child_name"/>
     </resultMap>
-    
+
     <resultMap id="FatherMapNoFid" type="Father">
         <id property="id" column="id"/>
         <result property="name" column="name"/>
@@ -77,7 +77,7 @@
     	LEFT JOIN Child ON Father.id = Child.father_id
     	WHERE id = #{id}
     </select>
-    
+
     <resultMap id="ChildMapWithRefResultMap" type="Child">
         <result property="id" column="child_id"/>
         <result property="name" column="child_name"/>
@@ -113,7 +113,7 @@
     	LEFT JOIN Child ON Father.id = Child.father_id
     	WHERE id = #{id}
     </select>
-    
+
     <resultMap id="FatherMapFidMultipleNullColumnsAndBrackets" type="Father">
         <id property="id" column="id"/>
         <result property="name" column="name"/>
@@ -130,7 +130,7 @@
     	LEFT JOIN Child ON Father.id = Child.father_id
     	WHERE id = #{id}
     </select>
-    
+
     <resultMap id="FatherMapFidWorkaround" type="Father">
         <id property="id" column="id"/>
         <result property="name" column="name"/>

--- a/src/test/java/org/apache/ibatis/submitted/not_null_column/NotNullColumnTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/not_null_column/NotNullColumnTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,9 +28,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class NotNullColumnTest {
-    
+
     private static SqlSessionFactory sqlSessionFactory;
-    
+
     @BeforeAll
     public static void initDatabase() throws Exception {
         try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/not_null_column/ibatisConfig.xml")) {
@@ -40,24 +40,24 @@ public class NotNullColumnTest {
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/not_null_column/CreateDB.sql");
     }
-    
+
     @Test
     public void testNotNullColumnWithChildrenNoFid() {
       try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
           FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
-          
+
           Father test = fatherMapper.selectByIdNoFid(1);
           assertNotNull(test);
           assertNotNull(test.getChildren());
           assertEquals(2, test.getChildren().size());
       }
     }
-    
+
     @Test
     public void testNotNullColumnWithoutChildrenNoFid() {
       try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
           FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
-          
+
           Father test = fatherMapper.selectByIdNoFid(2);
           assertNotNull(test);
           assertNotNull(test.getChildren());
@@ -76,7 +76,7 @@ public class NotNullColumnTest {
           assertTrue(test.getChildren().isEmpty());
       }
     }
-  
+
     @Test
     public void testNotNullColumnWithoutChildrenWithInternalResultMap() {
       try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
@@ -88,7 +88,7 @@ public class NotNullColumnTest {
           assertTrue(test.getChildren().isEmpty());
       }
     }
-    
+
     @Test
     public void testNotNullColumnWithoutChildrenWithRefResultMap() {
       try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
@@ -100,7 +100,7 @@ public class NotNullColumnTest {
           assertTrue(test.getChildren().isEmpty());
       }
     }
-    
+
     @Test
     public void testNotNullColumnWithoutChildrenFidMultipleNullColumns() {
       try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/not_null_column/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/not_null_column/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,16 +21,16 @@
     "http://mybatis.org/dtd/mybatis-3-config.dtd">
 
 <configuration>
-	
+
     <settings>
         <setting name="lazyLoadingEnabled" value="true"/>
     </settings>
-	
+
     <typeAliases>
         <typeAlias alias="Child" type="org.apache.ibatis.submitted.not_null_column.Child"/>
         <typeAlias alias="Father" type="org.apache.ibatis.submitted.not_null_column.Father"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -41,7 +41,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/not_null_column/FatherMapper.xml"/>
     </mappers>

--- a/src/test/java/org/apache/ibatis/submitted/ognl_enum/EnumWithOgnlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognl_enum/EnumWithOgnlTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 public class EnumWithOgnlTest {
-    
+
     private static SqlSessionFactory sqlSessionFactory;
-    
+
     @BeforeAll
     public static void initDatabase() throws Exception {
         try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/ognl_enum/ibatisConfig.xml")) {
@@ -42,7 +42,7 @@ public class EnumWithOgnlTest {
         BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
                 "org/apache/ibatis/submitted/ognl_enum/CreateDB.sql");
     }
-    
+
     @Test
     public void testEnumWithOgnl() {
         try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/ognl_enum/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognl_enum/Person.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ public class Person {
         EMPLOYEE,
         DIRECTOR
     }
-    
+
     private Long id;
     private String firstName;
     private String lastName;

--- a/src/test/java/org/apache/ibatis/submitted/ognl_enum/Person.xml
+++ b/src/test/java/org/apache/ibatis/submitted/ognl_enum/Person.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,14 +21,14 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.ognl_enum.PersonMapper">
-    
+
     <resultMap id="personMap" type="Person">
         <id property="id" column="id"/>
         <result property="firstName" column="firstName"/>
         <result property="lastName" column="lastName"/>
     </resultMap>
-    
-    
+
+
     <select id="selectAllByType" resultMap="personMap" parameterType="org.apache.ibatis.submitted.ognl_enum.Person$Type">
         SELECT id, firstName, lastName, personType
         FROM person
@@ -53,7 +53,7 @@
             </if>
         </where>
     </select>
-    
+
     <select id="selectAllByTypeWithInterface" resultMap="personMap" parameterType="org.apache.ibatis.submitted.ognl_enum.PersonMapper$PersonType">
         SELECT id, firstName, lastName, personType
         FROM person

--- a/src/test/java/org/apache/ibatis/submitted/ognl_enum/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognl_enum/PersonMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@ package org.apache.ibatis.submitted.ognl_enum;
 import java.util.List;
 
 public interface PersonMapper {
-    
+
     public interface PersonType {
         public Person.Type getType();
     }
-    
+
     public List<Person> selectAllByType(Person.Type type);
     public List<Person> selectAllByTypeNameAttribute(Person.Type type);
     public List<Person> selectAllByTypeWithInterface(PersonType personType);

--- a/src/test/java/org/apache/ibatis/submitted/ognl_enum/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/ognl_enum/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
     <typeAliases>
         <typeAlias alias="Person" type="org.apache.ibatis.submitted.ognl_enum.Person"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -35,7 +35,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/ognl_enum/Person.xml"/>
     </mappers>

--- a/src/test/java/org/apache/ibatis/submitted/ognlstatic/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/ognlstatic/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -26,14 +26,14 @@
 		SELECT 	*
 		FROM 	users
 		<trim prefix="WHERE" prefixOverrides="AND |OR ">
-			AND <foreach collection="{ (@org.apache.ibatis.submitted.ognlstatic.StaticClass@value) } " item="enum" 
+			AND <foreach collection="{ (@org.apache.ibatis.submitted.ognlstatic.StaticClass@value) } " item="enum"
 					open="name IN (" close=") " separator=", ">#{enum}</foreach>
-			AND id = #{id} 
-		</trim>			
+			AND id = #{id}
+		</trim>
 	</select>
 
 	<select id="getUserIfNode" resultType="org.apache.ibatis.submitted.ognlstatic.User">
-       select * from users 
+       select * from users
        <if test="value not in {null, ''}">
        where name = #{value}
        </if>

--- a/src/test/java/org/apache/ibatis/submitted/ognlstatic/OgnlStaticTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognlstatic/OgnlStaticTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -43,9 +43,9 @@ public class OgnlStaticTest {
   }
 
   /**
-   * This is the log output. 
+   * This is the log output.
    * DEBUG [main] - ooo Using Connection [org.hsqldb.jdbc.JDBCConnection@5ae1a5c7]
-   * DEBUG [main] - ==>  Preparing: SELECT * FROM users WHERE name IN (?) AND id = ? 
+   * DEBUG [main] - ==>  Preparing: SELECT * FROM users WHERE name IN (?) AND id = ?
    * DEBUG [main] - ==> Parameters: 1(Integer), 1(Integer)
    * There are two parameter mappings but DefaulParameterHandler maps them both to input paremeter (integer)
    */

--- a/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/Person.xml
+++ b/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/Person.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -27,8 +27,8 @@
         <result property="firstName" column="firstName"/>
         <result property="lastName" column="lastName"/>
     </resultMap>
-    
-    
+
+
     <select id="select" resultMap="personMap">
         SELECT id, firstName, lastName
         FROM person

--- a/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
     <typeAliases>
         <typeAlias alias="Person" type="org.apache.ibatis.submitted.order_prefix_removed.Person"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -35,7 +35,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/order_prefix_removed/Person.xml"/>
     </mappers>

--- a/src/test/java/org/apache/ibatis/submitted/parent_childs/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/parent_childs/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -38,12 +38,12 @@
 
 	<select id="getParents" resultMap="ParentMap">
 		select
-		p.Id as p_Id, 
-		p.Name as p_Name, 
+		p.Id as p_Id,
+		p.Name as p_Name,
 		p.SurName as p_SurName,
-		c.Id as c_Id, 
-		c.Name as c_Name, 
-		c.SurName as c_SurName, 
+		c.Id as c_Id,
+		c.Name as c_Name,
+		c.SurName as c_SurName,
 		c.Age as c_Age
 		from Parent p
 		left outer join Child c on p.Id = c.ParentId

--- a/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/Mapper.xml
@@ -1,6 +1,6 @@
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -19,29 +19,29 @@
 
 <mapper namespace="org.apache.ibatis.submitted.parent_reference_3level.Mapper">
     <select id="selectBlogByPrimaryKey" parameterType="int" resultMap="BlogResultMap">
-        select 
+        select
             b.id as blog_id, b.title as blog_title,
             p.id as post_id, p.body as post_body,
             c.id as comment_id, c.comment
         from blog b
         left outer join post p on b.id = p.blog_id
-        left outer join comment c on p.id = c.post_id 
+        left outer join comment c on p.id = c.post_id
         where b.id = #{id}
     </select>
-    
+
     <resultMap id="BlogResultMap" type="Blog">
         <id column="blog_id" property="id" />
         <result column="blog_title" property="title"/>
         <collection property="posts" resultMap="PostResultMap"></collection>
     </resultMap>
-    
+
     <resultMap id="PostResultMap" type="Post">
         <id column="post_id" property="id" />
         <result column="post_body" property="body"/>
         <association property="blog" resultMap="BlogResultMap"></association>
         <collection property="comments" resultMap="CommentResultMap"></collection>
     </resultMap>
-    
+
     <resultMap id="CommentResultMap" type="Comment">
         <id column="comment_id" property="id" />
         <result column="comment" property="comment"/>
@@ -49,13 +49,13 @@
     </resultMap>
 
     <select id="selectBlogByPrimaryKeyColumnPrefix" parameterType="int" resultMap="BlogResultMapColumnPrefix">
-        select 
+        select
             b.id as blog_id, b.title as blog_title,
             p.id as post_id, p.body as post_body,
             c.id as post_comment_comment_id, c.comment as post_comment_comment
         from blog b
         left outer join post p on b.id = p.blog_id
-        left outer join comment c on p.id = c.post_id 
+        left outer join comment c on p.id = c.post_id
         where b.id = #{id}
     </select>
 

--- a/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/mybatis-config.xml
@@ -1,6 +1,6 @@
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -36,9 +36,9 @@
           </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/parent_reference_3level/Mapper.xml" />
     </mappers>
-    
+
 </configuration>

--- a/src/test/java/org/apache/ibatis/submitted/permissions/PermissionsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/permissions/PermissionsTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ public class PermissionsTest {
       final Resource firstResource = resources.get(0);
       final List<Principal> principalPermissions = firstResource.getPrincipals();
       Assertions.assertEquals(1, principalPermissions.size());
-      
+
       final Principal firstPrincipal = principalPermissions.get(0);
       final List<Permission> permissions = firstPrincipal.getPermissions();
       Assertions.assertEquals(2, permissions.size());
@@ -77,7 +77,7 @@ public class PermissionsTest {
       final Resource firstResource = resources.get(0);
       final List<Principal> principalPermissions = firstResource.getPrincipals();
       Assertions.assertEquals(1, principalPermissions.size());
-      
+
       final Principal firstPrincipal = principalPermissions.get(0);
       final List<Permission> permissions = firstPrincipal.getPermissions();
       Assertions.assertEquals(4, permissions.size());

--- a/src/test/java/org/apache/ibatis/submitted/primitive_result_type/Product.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitive_result_type/Product.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,5 +34,5 @@ public class Product {
     public void setProductType(Integer productType) {
         this.productType = productType;
     }
-    
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/primitive_result_type/ProductMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/primitive_result_type/ProductMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@
   <select id="selectProductCodesB" resultType="BigDecimal">
     select distinct productcode from product
   </select>
-  
+
   <select id="selectAllProducts" resultType="org.apache.ibatis.submitted.primitive_result_type.Product">
     select productcode,producttype from product
   </select>

--- a/src/test/java/org/apache/ibatis/submitted/refcursor/OrdersMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/refcursor/OrdersMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -30,9 +30,9 @@
       <result property="description" column="ITEM_DESCRIPTION"/>
     </collection>
   </resultMap>
-  
+
   <update id="getOrder1" parameterType="map" statementType="CALLABLE">
-    { #{order,jdbcType=OTHER,mode=OUT,resultMap=OrderResult,javaType=java.sql.ResultSet} = 
+    { #{order,jdbcType=OTHER,mode=OUT,resultMap=OrderResult,javaType=java.sql.ResultSet} =
         call mbtest.get_order(#{orderId,jdbcType=INTEGER,mode=IN}) }
   </update>
 

--- a/src/test/java/org/apache/ibatis/submitted/resultmapwithassociationstest/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resultmapwithassociationstest/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -31,8 +31,8 @@
   <select id="findAll" parameterType="map" resultMap="personRM">
     SELECT p.id, id_address, a.id as address_id
     FROM person p
-    JOIN address a 
+    JOIN address a
     on a.id = p.id_address
   </select>
-  
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/rounding/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/rounding/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@
 	    	#{id}, #{name}, #{funkyNumber}, #{roundingMode}
 	    )
 	</insert>
-	
+
 	<resultMap type="org.apache.ibatis.submitted.rounding.User" id="usermap2">
 		<id column="id" property="id"/>
 		<result column="name" property="name"/>

--- a/src/test/java/org/apache/ibatis/submitted/selectkey/AnnotatedMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/selectkey/AnnotatedMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,11 +28,11 @@ public interface AnnotatedMapper {
     @Insert("insert into table2 (name) values(#{name})")
     @SelectKey(statement="call identity()", keyProperty="nameId", before=false, resultType=int.class)
     int insertTable2(Name name);
-    
+
     @Insert("insert into table2 (name) values(#{name})")
     @Options(useGeneratedKeys=true, keyProperty="nameId,generatedName", keyColumn="ID,NAME_FRED")
     int insertTable2WithGeneratedKey(Name name);
-    
+
     int insertTable2WithGeneratedKeyXml(Name name);
 
     @Insert("insert into table2 (name) values(#{name})")

--- a/src/test/java/org/apache/ibatis/submitted/selectkey/SelectKeyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/selectkey/SelectKeyTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -140,7 +140,7 @@ public class SelectKeyTest {
         assertEquals(1, rows);
         assertEquals(22, name.getNameId());
         assertEquals("barney_fred", name.getGeneratedName());
-        
+
         name.setName("Wilma");
         rows = mapper.updateTable2WithGeneratedKey(name);
         assertEquals(1, rows);
@@ -160,7 +160,7 @@ public class SelectKeyTest {
         assertEquals(1, rows);
         assertEquals(22, name.getNameId());
         assertEquals("barney_fred", name.getGeneratedName());
-        
+
         name.setName("Wilma");
         rows = mapper.updateTable2WithGeneratedKeyXml(name);
         assertEquals(1, rows);
@@ -205,7 +205,7 @@ public class SelectKeyTest {
         assertEquals(1, rows);
         assertEquals(22, name.getNameId());
         assertEquals("barney_fred", name.getGeneratedName());
-        
+
         name.setName("Wilma");
         rows = mapper.updateTable2WithSelectKeyWithKeyMap(name);
         assertEquals(1, rows);

--- a/src/test/java/org/apache/ibatis/submitted/selectkey/Table2.xml
+++ b/src/test/java/org/apache/ibatis/submitted/selectkey/Table2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
       CALL IDENTITY()
     </selectKey>
   </insert>
-  
+
   <insert id="insertNoValuesInSelectKey" parameterType="map">
     insert into table2 (name) values (#{name})
     <selectKey resultType="java.lang.Integer" keyProperty="id">
@@ -45,5 +45,5 @@
       select id from table2
     </selectKey>
   </insert>
-  
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/AttributeMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/AttributeMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 	<resultMap id="map" type="org.apache.ibatis.submitted.serializecircular.Attribute">
 		<id column="nr_id" property="id" />
 	</resultMap>
-	
+
 	<select id="getById" parameterType="Integer" resultMap="map">
         SELECT
         	productattribute.nr_id

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/DepartmentMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/DepartmentMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@
 		<association column="nr_attribute" property="attribute" javaType="org.apache.ibatis.submitted.serializecircular.Attribute" select="org.apache.ibatis.submitted.serializecircular.AttributeMapper.getById"/>
 		<collection column="person" property="person" javaType="org.apache.ibatis.submitted.serializecircular.Person"  select="org.apache.ibatis.submitted.serializecircular.PersonMapper.getById"/>
 	</resultMap>
-		
+
 	<select id="getById" parameterType="Integer" resultMap="map">
         SELECT
 			department.nr_id,

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/MapperConfigWithAggressiveLazyLoading.xml
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/MapperConfigWithAggressiveLazyLoading.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
 
     <settings>
         <setting name="lazyLoadingEnabled" value="true"/>
-        <setting name="aggressiveLazyLoading" value="true"/> 
+        <setting name="aggressiveLazyLoading" value="true"/>
     </settings>
 
 	<environments default="development">
@@ -39,7 +39,7 @@
 			</dataSource>
 		</environment>
 	</environments>
-	
+
 	<mappers>
 		<mapper class="org.apache.ibatis.submitted.serializecircular.PersonMapper" />
 		<mapper class="org.apache.ibatis.submitted.serializecircular.AttributeMapper" />

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/MapperConfigWithoutAggressiveLazyLoading.xml
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/MapperConfigWithoutAggressiveLazyLoading.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
 <configuration>
 
     <settings>
-        <setting name="lazyLoadingEnabled" value="true"/> 
+        <setting name="lazyLoadingEnabled" value="true"/>
         <setting name="aggressiveLazyLoading" value="false"/>
     </settings>
 

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/PersonMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/PersonMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -26,14 +26,14 @@
 		<id column="id" property="id" />
 		<association column="nr_department" property="department" javaType="org.apache.ibatis.submitted.serializecircular.Department" select="org.apache.ibatis.submitted.serializecircular.DepartmentMapper.getById"/>
 	</resultMap>
-	
+
 	<sql id="columns">
 		person.id,
 		person.nr_department
 	</sql>
-	
+
 	<sql id="table">person</sql>
-		
+
 	<select id="getById" parameterType="Integer" resultMap="map">
         SELECT
         	person.id,
@@ -43,5 +43,5 @@
         WHERE
         	id = #{id}
     </select>
-	
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/SerializeCircularTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/SerializeCircularTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class SerializeCircularTest {
 
   @Test
-  public void serializeAndDeserializeObjectsWithAggressiveLazyLoadingWithoutPreloadingAttribute() 
+  public void serializeAndDeserializeObjectsWithAggressiveLazyLoadingWithoutPreloadingAttribute()
   throws Exception {
     try (SqlSession sqlSession = createSessionWithAggressiveLazyLoading()) {
       testSerializeWithoutPreloadingAttribute(sqlSession);
@@ -36,7 +36,7 @@ public class SerializeCircularTest {
   }
 
   @Test
-  public void serializeAndDeserializeObjectsWithAggressiveLazyLoadingWithPreloadingAttribute() 
+  public void serializeAndDeserializeObjectsWithAggressiveLazyLoadingWithPreloadingAttribute()
   throws Exception {
     try (SqlSession sqlSession = createSessionWithAggressiveLazyLoading()) {
       testSerializeWithPreloadingAttribute(sqlSession);
@@ -45,7 +45,7 @@ public class SerializeCircularTest {
 
 //  @Disabled("See http://code.google.com/p/mybatis/issues/detail?id=614")
   @Test
-  public void serializeAndDeserializeObjectsWithoutAggressiveLazyLoadingWithoutPreloadingAttribute() 
+  public void serializeAndDeserializeObjectsWithoutAggressiveLazyLoadingWithoutPreloadingAttribute()
   throws Exception {
     try (SqlSession sqlSession = createSessionWithoutAggressiveLazyLoading()) {
         //expected problem with deserializing
@@ -54,7 +54,7 @@ public class SerializeCircularTest {
   }
 
   @Test
-  public void serializeAndDeserializeObjectsWithoutAggressiveLazyLoadingWithPreloadingAttribute() 
+  public void serializeAndDeserializeObjectsWithoutAggressiveLazyLoadingWithPreloadingAttribute()
   throws Exception {
     try (SqlSession sqlSession = createSessionWithoutAggressiveLazyLoading()) {
       testSerializeWithPreloadingAttribute(sqlSession);

--- a/src/test/java/org/apache/ibatis/submitted/simplelistparameter/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/simplelistparameter/mybatis-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@
 			</dataSource>
 		</environment>
 	</environments>
-	
+
 	<mappers>
 		<mapper class="org.apache.ibatis.submitted.simplelistparameter.CarMapper" />
 	</mappers>

--- a/src/test/java/org/apache/ibatis/submitted/sptests/SPMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/sptests/SPMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ public interface SPMapper {
   @ResultMap("nameResult")
   @Options(statementType = StatementType.CALLABLE)
   List<Name> getNamesAnnotatedLowHighWithXMLResultMap(@Param("lowestId") int lowestId, @Param("highestId") int highestId);
-  
+
   @Select({ "{call sptest.arraytest(", "#{ids,mode=IN,jdbcType=ARRAY},", "#{requestedRows,jdbcType=INTEGER,mode=OUT},", "#{returnedIds,mode=OUT,jdbcType=ARRAY})}" })
   @Results({ @Result(column = "ID", property = "id"), @Result(column = "FIRST_NAME", property = "firstName"), @Result(column = "LAST_NAME", property = "lastName") })
   @Options(statementType = StatementType.CALLABLE)

--- a/src/test/java/org/apache/ibatis/submitted/sptests/SPMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/sptests/SPMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2017 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@
     <result column="ID" property="id"/>
     <result column="ITEM" property="item"/>
   </resultMap>
-  
+
   <parameterMap type="map" id="testParameterMap">
     <parameter property="addend1" jdbcType="INTEGER" mode="IN"/>
     <parameter property="addend2" jdbcType="INTEGER" mode="IN"/>
@@ -64,9 +64,9 @@
        the procedure returns a result set. IMPORTANT: Oracle ref
        cursors are usually returned as parameters, NOT directly
        from the stored proc.  So with ref cursors, resultMap
-       and/or resultType is usually not used.  
+       and/or resultType is usually not used.
    -->
-   
+
   <select id="adderAsSelect" parameterType="org.apache.ibatis.submitted.sptests.Parameter" statementType="CALLABLE">
     {call sptest.adder(
       #{addend1,jdbcType=INTEGER,mode=IN},
@@ -82,7 +82,7 @@
       #{sum,jdbcType=INTEGER,mode=OUT}
     )}
   </update>
-  
+
   <update id="adderWithParameterMap" parameterMap="testParameterMap" statementType="CALLABLE">
     {call sptest.adder(?, ?, ?)}
   </update>
@@ -112,7 +112,7 @@
     resultMap="nameResult,itemResult">
     {call sptest.getnamesanditems()}
   </select>
-  
+
   <select id="getNamesAndItemsLinked" statementType="CALLABLE" resultSets="names,items" resultMap="nameResultLinked">
     {call sptest.getnamesanditems()}
   </select>

--- a/src/test/java/org/apache/ibatis/submitted/sptests/SPTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sptests/SPTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class SPTest {
   /*
    * This test shows how to use input and output parameters in a stored
    * procedure. This procedure does not return a result set.
-   * 
+   *
    * This test shows using a multi-property parameter.
    */
   @Test
@@ -75,7 +75,7 @@ public class SPTest {
   /*
    * This test shows how to use input and output parameters in a stored
    * procedure. This procedure does not return a result set.
-   * 
+   *
    * This test shows using a multi-property parameter.
    */
   @Test
@@ -101,9 +101,9 @@ public class SPTest {
   /*
    * This test shows how to use input and output parameters in a stored
    * procedure. This procedure does not return a result set.
-   * 
+   *
    * This test also demonstrates session level cache for output parameters.
-   * 
+   *
    * This test shows using a multi-property parameter.
    */
   @Test
@@ -130,7 +130,7 @@ public class SPTest {
    * This test shows how to call a stored procedure defined as <update> rather
    * then <select>. Of course, this only works if you are not returning a result
    * set.
-   * 
+   *
    * This test shows using a multi-property parameter.
    */
   @Test
@@ -153,7 +153,7 @@ public class SPTest {
     }
   }
 
-  // issue #145  
+  // issue #145
   @Test
   public void testEchoDate() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
@@ -164,11 +164,11 @@ public class SPTest {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
       spMapper.echoDate(parameter);
 
-      java.sql.Date outDate = new java.sql.Date(now.getTime());      
+      java.sql.Date outDate = new java.sql.Date(now.getTime());
       assertEquals(outDate.toString(), parameter.get("output date").toString());
     }
   }
-  
+
   /*
    * This test shows the use of a declared parameter map. We generally prefer
    * inline parameters, because the syntax is more intuitive (no pesky question
@@ -197,7 +197,7 @@ public class SPTest {
   /*
    * This test shows how to use an input parameter and return a result set from
    * a stored procedure.
-   * 
+   *
    * This test shows using a single value parameter.
    */
   @Test
@@ -214,7 +214,7 @@ public class SPTest {
   /*
    * This test shows how to use a input and output parameters and return a
    * result set from a stored procedure.
-   * 
+   *
    * This test shows using a single value parameter.
    */
   @Test
@@ -233,7 +233,7 @@ public class SPTest {
   /*
    * This test shows how to use a input and output parameters and return a
    * result set from a stored procedure.
-   * 
+   *
    * This test shows using a Map parameter.
    */
   @Test
@@ -258,7 +258,7 @@ public class SPTest {
   /*
    * This test shows how to use a input and output parameters and return a
    * result set from a stored procedure.
-   * 
+   *
    * This test shows using a Map parameter.
    */
   @Test
@@ -282,7 +282,7 @@ public class SPTest {
 
   /*
    * This test shows how to use the ARRAY JDBC type with MyBatis.
-   * 
+   *
    * @throws SQLException
    */
   @Test
@@ -304,7 +304,7 @@ public class SPTest {
 
   /*
    * This test shows how to call procedures that return multiple result sets
-   * 
+   *
    * @throws SQLException
    */
   @Test
@@ -322,9 +322,9 @@ public class SPTest {
   /*
    * This test shows how to use input and output parameters in a stored
    * procedure. This procedure does not return a result set.
-   * 
+   *
    * This test shows using a multi-property parameter.
-   * 
+   *
    * This test shows using annotations for stored procedures
    */
   @Test
@@ -344,9 +344,9 @@ public class SPTest {
   /*
    * This test shows how to use input and output parameters in a stored
    * procedure. This procedure does not return a result set.
-   * 
+   *
    * This test shows using a multi-property parameter.
-   * 
+   *
    * This test shows using annotations for stored procedures
    */
   @Test
@@ -372,11 +372,11 @@ public class SPTest {
   /*
    * This test shows how to use input and output parameters in a stored
    * procedure. This procedure does not return a result set.
-   * 
+   *
    * This test also demonstrates session level cache for output parameters.
-   * 
+   *
    * This test shows using a multi-property parameter.
-   * 
+   *
    * This test shows using annotations for stored procedures
    */
   @Test
@@ -403,9 +403,9 @@ public class SPTest {
    * This test shows how to call a stored procedure defined as <update> rather
    * then <select>. Of course, this only works if you are not returning a result
    * set.
-   * 
+   *
    * This test shows using a multi-property parameter.
-   * 
+   *
    * This test shows using annotations for stored procedures
    */
   @Test
@@ -431,9 +431,9 @@ public class SPTest {
   /*
    * This test shows how to use an input parameter and return a result set from
    * a stored procedure.
-   * 
+   *
    * This test shows using a single value parameter.
-   * 
+   *
    * This test shows using annotations for stored procedures
    */
   @Test
@@ -450,9 +450,9 @@ public class SPTest {
   /*
    * This test shows how to use an input parameter and return a result set from
    * a stored procedure.
-   * 
+   *
    * This test shows using a single value parameter.
-   * 
+   *
    * This test shows using annotations for stored procedures and using a
    * resultMap in XML
    */
@@ -470,9 +470,9 @@ public class SPTest {
   /*
    * This test shows how to use a input and output parameters and return a
    * result set from a stored procedure.
-   * 
+   *
    * This test shows using a single value parameter.
-   * 
+   *
    * This test shows using annotations for stored procedures
    */
   @Test
@@ -491,9 +491,9 @@ public class SPTest {
   /*
    * This test shows how to use a input and output parameters and return a
    * result set from a stored procedure.
-   * 
+   *
    * This test shows using a single value parameter.
-   * 
+   *
    * This test shows using annotations for stored procedures and using a
    * resultMap in XML
    */
@@ -513,9 +513,9 @@ public class SPTest {
   /*
    * This test shows how to use a input and output parameters and return a
    * result set from a stored procedure.
-   * 
+   *
    * This test shows using a Map parameter.
-   * 
+   *
    * This test shows using annotations for stored procedures
    */
   @Test
@@ -540,9 +540,9 @@ public class SPTest {
   /*
    * This test shows how to use a input and output parameters and return a
    * result set from a stored procedure.
-   * 
+   *
    * This test shows using a Map parameter.
-   * 
+   *
    * This test shows using annotations for stored procedures and using a
    * resultMap in XML
    */
@@ -568,9 +568,9 @@ public class SPTest {
   /*
    * This test shows how to use a input and output parameters and return a
    * result set from a stored procedure.
-   * 
+   *
    * This test shows using a Map parameter.
-   * 
+   *
    * This test shows using annotations for stored procedures
    */
   @Test
@@ -595,9 +595,9 @@ public class SPTest {
   /*
    * This test shows how to use a input and output parameters and return a
    * result set from a stored procedure.
-   * 
+   *
    * This test shows using a Map parameter.
-   * 
+   *
    * This test shows using annotations for stored procedures and using a
    * resultMap in XML
    */
@@ -621,9 +621,9 @@ public class SPTest {
   }
 
   /*
-   * 
+   *
    * This test shows using a two named parameters.
-   * 
+   *
    * This test shows using annotations for stored procedures and using a
    * resultMap in XML
    */
@@ -638,9 +638,9 @@ public class SPTest {
 
   /*
    * This test shows how to use the ARRAY JDBC type with MyBatis.
-   * 
+   *
    * This test shows using annotations for stored procedures
-   * 
+   *
    * @throws SQLException
    */
   @Test
@@ -662,10 +662,10 @@ public class SPTest {
 
   /*
    * This test shows how to use the ARRAY JDBC type with MyBatis.
-   * 
+   *
    * This test shows using annotations for stored procedures and using a
    * resultMap in XML
-   * 
+   *
    * @throws SQLException
    */
   @Test
@@ -687,10 +687,10 @@ public class SPTest {
 
   /*
    * This test shows how to call procedures that return multiple result sets
-   * 
+   *
    * This test shows using annotations for stored procedures and referring to
    * multiple resultMaps in XML
-   * 
+   *
    * @throws SQLException
    */
   @Test
@@ -716,7 +716,7 @@ public class SPTest {
       assertEquals(3, results.get(1).size());
     }
   }
-  
+
   @Test
   public void testGetNamesAndItemsLinked() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/stringlist/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/stringlist/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 	<select id="getUsersAndGroups" resultMap="results">
 		select * from users
 	</select>
-	
+
 	<resultMap type="org.apache.ibatis.submitted.stringlist.User" id="results">
 		<id column="id" property="id"/>
 		<collection property="groups" ofType="string">

--- a/src/test/java/org/apache/ibatis/submitted/unknownobject/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/unknownobject/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@
 	<select id="getUser" resultMap="map">
 		select * from users
 	</select>
-	
+
 	<resultMap type="org.apache.ibatis.submitted.unknownobject.User" id="map" autoMapping="false">
 		<result column="id" property="id" />
 		<result column="name" property="name" />

--- a/src/test/java/org/apache/ibatis/submitted/valueinmap/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/valueinmap/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 	</select>
 
 	<select id="count2" resultType="int">
-		select count(*) from ${listx} 
+		select count(*) from ${listx}
 	</select>
 
 </mapper>

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/InvalidWithInsertMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/InvalidWithInsertMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 		<include refid="wrongId" />
 		FROM person
 	</select>
-	
+
 	<insert id="insert" parameterType="java.util.Map">
 		INSERT INTO Person (person_name)
 		VALUES (#{name})

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/XmlExternalRefTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/XmlExternalRefTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class XmlExternalRefTest {
       configuration.getMappedStatementNames();
     });
   }
-  
+
   @Test
   public void testFailFastOnBuildAllWithInsert() throws Exception {
     Configuration configuration = new Configuration();

--- a/src/test/java/org/apache/ibatis/submitted/xml_references/EnumWithOgnlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_references/EnumWithOgnlTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.Test;
 
 public class EnumWithOgnlTest {
-    
+
     @Test
     public void testConfiguration() {
         UnpooledDataSourceFactory dataSourceFactory = new UnpooledDataSourceFactory();

--- a/src/test/java/org/apache/ibatis/submitted/xml_references/Person.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_references/Person.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ public class Person {
         EMPLOYEE,
         DIRECTOR
     }
-    
+
     private Long id;
     private String firstName;
     private String lastName;

--- a/src/test/java/org/apache/ibatis/submitted/xml_references/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_references/PersonMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@ package org.apache.ibatis.submitted.xml_references;
 import java.util.List;
 
 public interface PersonMapper {
-    
+
     public interface PersonType {
         public Person.Type getType();
     }
-    
+
     public List<Person> selectAllByType(Person.Type type);
     public List<Person> selectAllByTypeNameAttribute(Person.Type type);
     public List<Person> selectAllByTypeWithInterface(PersonType personType);

--- a/src/test/java/org/apache/ibatis/submitted/xml_references/PersonMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/xml_references/PersonMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,14 +21,14 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.xml_references.PersonMapper">
-    
+
     <resultMap id="personMap" type="Person">
         <id property="id" column="id"/>
         <result property="firstName" column="firstName"/>
         <result property="lastName" column="lastName"/>
     </resultMap>
-    
-    
+
+
     <sql id="selectByIdScript">
         SELECT id, firstName, lastName, personType
         FROM person

--- a/src/test/java/org/apache/ibatis/submitted/xml_references/PersonMapper2.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_references/PersonMapper2.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,11 +18,11 @@ package org.apache.ibatis.submitted.xml_references;
 import java.util.List;
 
 public interface PersonMapper2 {
-    
+
     public interface PersonType {
         public Person.Type getType();
     }
-    
+
     public List<Person> selectAllByType(Person.Type type);
     public List<Person> selectAllByTypeNameAttribute(Person.Type type);
     public List<Person> selectAllByTypeWithInterface(PersonType personType);

--- a/src/test/java/org/apache/ibatis/submitted/xml_references/PersonMapper2.xml
+++ b/src/test/java/org/apache/ibatis/submitted/xml_references/PersonMapper2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -21,14 +21,14 @@
     "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.xml_references.PersonMapper2">
-    
+
     <resultMap id="personMap" type="Person">
         <id property="id" column="id"/>
         <result property="firstName" column="firstName"/>
         <result property="lastName" column="lastName"/>
     </resultMap>
-    
-    
+
+
     <select id="selectById" resultMap="personMap" parameterType="int">
     	<include refid="org.apache.ibatis.submitted.xml_references.PersonMapper.selectByIdScript"/>
     </select>

--- a/src/test/java/org/apache/ibatis/submitted/xml_references/ibatisConfig.xml
+++ b/src/test/java/org/apache/ibatis/submitted/xml_references/ibatisConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
     <typeAliases>
         <typeAlias alias="Person" type="org.apache.ibatis.submitted.xml_references.Person"/>
     </typeAliases>
-    
+
     <environments default="test">
         <environment id="test">
             <transactionManager type="JDBC"></transactionManager>
@@ -35,7 +35,7 @@
             </dataSource>
         </environment>
     </environments>
-    
+
     <mappers>
         <mapper resource="org/apache/ibatis/submitted/xml_references/PersonMapper.xml"/>
     </mappers>

--- a/src/test/java/org/apache/ibatis/type/MonthTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/MonthTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.apache.ibatis.executor.result.ResultMapException;
 import org.junit.jupiter.api.Test;
 
 /**
- * 
+ *
  * @author Eduardo Macarron
  */
 public class MonthTypeHandlerTest extends BaseTypeHandlerTest {

--- a/src/test/java/org/apache/ibatis/type/YearTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/YearTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.time.Year;
 import org.junit.jupiter.api.Test;
 
 /**
- * 
+ *
  * @author Eduardo Macarron
  */
 public class YearTypeHandlerTest extends BaseTypeHandlerTest {


### PR DESCRIPTION
no-op action.  This trims all trailing space which results in little to see on git.  This is another attempt at aligning code for future locking of formatting into builds.  This plugin can do more than java files so it has cleared issues in xml and some deeper issues in at least two of the site pages which seemed to cause license header to post twice.