### PR TITLE
[enhance] use enum to skip the type detection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,18 @@
       <version>2.10</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.21</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.21</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/apache/ibatis/binding/MapperMethod.java
+++ b/src/main/java/org/apache/ibatis/binding/MapperMethod.java
@@ -52,53 +52,57 @@ public class MapperMethod {
   }
 
   public Object execute(SqlSession sqlSession, Object[] args) {
-    Object result;
-    switch (command.getType()) {
-      case INSERT: {
-    	Object param = method.convertArgsToSqlCommandParam(args);
-        result = rowCountResult(sqlSession.insert(command.getName(), param));
-        break;
-      }
-      case UPDATE: {
-        Object param = method.convertArgsToSqlCommandParam(args);
-        result = rowCountResult(sqlSession.update(command.getName(), param));
-        break;
-      }
-      case DELETE: {
-        Object param = method.convertArgsToSqlCommandParam(args);
-        result = rowCountResult(sqlSession.delete(command.getName(), param));
-        break;
-      }
-      case SELECT:
-        if (method.returnsVoid() && method.hasResultHandler()) {
-          executeWithResultHandler(sqlSession, args);
-          result = null;
-        } else if (method.returnsMany()) {
-          result = executeForMany(sqlSession, args);
-        } else if (method.returnsMap()) {
-          result = executeForMap(sqlSession, args);
-        } else if (method.returnsCursor()) {
-          result = executeForCursor(sqlSession, args);
-        } else {
-          Object param = method.convertArgsToSqlCommandParam(args);
-          result = sqlSession.selectOne(command.getName(), param);
-          if (method.returnsOptional() &&
-              (result == null || !method.getReturnType().equals(result.getClass()))) {
-            result = Optional.ofNullable(result);
-          }
-        }
-        break;
-      case FLUSH:
-        result = sqlSession.flushStatements();
-        break;
-      default:
-        throw new BindingException("Unknown execution method for: " + command.getName());
-    }
+    Object result = command.getType().executeCommand(this, sqlSession, args);
     if (result == null && method.getReturnType().isPrimitive() && !method.returnsVoid()) {
       throw new BindingException("Mapper method '" + command.getName() 
           + " attempted to return null from a method with a primitive return type (" + method.getReturnType() + ").");
     }
     return result;
+  }
+
+  public Object executeInsert(SqlSession sqlSession, Object[] args){
+    Object param = method.convertArgsToSqlCommandParam(args);
+    return rowCountResult(sqlSession.insert(command.getName(), param));
+  }
+
+  public Object executeUpdate(SqlSession sqlSession, Object[] args){
+    Object param = method.convertArgsToSqlCommandParam(args);
+    return rowCountResult(sqlSession.update(command.getName(), param));
+  }
+
+  public Object executeDelete(SqlSession sqlSession, Object[] args){
+    Object param = method.convertArgsToSqlCommandParam(args);
+    return rowCountResult(sqlSession.delete(command.getName(), param));
+  }
+
+  public Object executeSelect(SqlSession sqlSession, Object[] args){
+    Object result;
+    if (method.returnsVoid() && method.hasResultHandler()) {
+      executeWithResultHandler(sqlSession, args);
+      result = null;
+    } else if (method.returnsMany()) {
+      result = executeForMany(sqlSession, args);
+    } else if (method.returnsMap()) {
+      result = executeForMap(sqlSession, args);
+    } else if (method.returnsCursor()) {
+      result = executeForCursor(sqlSession, args);
+    } else {
+      Object param = method.convertArgsToSqlCommandParam(args);
+      result = sqlSession.selectOne(command.getName(), param);
+      if (method.returnsOptional() &&
+              (result == null || !method.getReturnType().equals(result.getClass()))) {
+        result = Optional.ofNullable(result);
+      }
+    }
+    return result;
+  }
+
+  public Object executeFlush(SqlSession sqlSession){
+    return sqlSession.flushStatements();
+  }
+
+  public Object executeUnknown(){
+    throw new BindingException("Unknown execution method for: " + command.getName());
   }
 
   private Object rowCountResult(int rowCount) {

--- a/src/main/java/org/apache/ibatis/binding/MapperMethod.java
+++ b/src/main/java/org/apache/ibatis/binding/MapperMethod.java
@@ -52,7 +52,7 @@ public class MapperMethod {
   }
 
   public Object execute(SqlSession sqlSession, Object[] args) {
-    Object result = command.getType().executeCommand(this, sqlSession, args);
+    Object result = command.getType().getSqlCommandExecutor().execute(this, sqlSession, args);
     if (result == null && method.getReturnType().isPrimitive() && !method.returnsVoid()) {
       throw new BindingException("Mapper method '" + command.getName() 
           + " attempted to return null from a method with a primitive return type (" + method.getReturnType() + ").");

--- a/src/main/java/org/apache/ibatis/executor/statement/RoutingStatementHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/statement/RoutingStatementHandler.java
@@ -15,19 +15,18 @@
  */
 package org.apache.ibatis.executor.statement;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.List;
-
 import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.Executor;
-import org.apache.ibatis.executor.ExecutorException;
 import org.apache.ibatis.executor.parameter.ParameterHandler;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.RowBounds;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
 
 /**
  * @author Clinton Begin
@@ -38,19 +37,7 @@ public class RoutingStatementHandler implements StatementHandler {
 
   public RoutingStatementHandler(Executor executor, MappedStatement ms, Object parameter, RowBounds rowBounds, ResultHandler resultHandler, BoundSql boundSql) {
 
-    switch (ms.getStatementType()) {
-      case STATEMENT:
-        delegate = new SimpleStatementHandler(executor, ms, parameter, rowBounds, resultHandler, boundSql);
-        break;
-      case PREPARED:
-        delegate = new PreparedStatementHandler(executor, ms, parameter, rowBounds, resultHandler, boundSql);
-        break;
-      case CALLABLE:
-        delegate = new CallableStatementHandler(executor, ms, parameter, rowBounds, resultHandler, boundSql);
-        break;
-      default:
-        throw new ExecutorException("Unknown statement type: " + ms.getStatementType());
-    }
+    delegate = ms.getStatementType().createHandler(executor, ms, parameter, rowBounds, resultHandler, boundSql);
 
   }
 

--- a/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
+++ b/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
@@ -308,7 +308,25 @@ public abstract class AbstractSQL<T> {
   private static class SQLStatement {
 
     public enum StatementType {
-      DELETE, INSERT, SELECT, UPDATE
+      DELETE((sqlStatement,builder) -> sqlStatement.deleteSQL(builder)),
+      INSERT((sqlStatement,builder) -> sqlStatement.insertSQL(builder)),
+      SELECT((sqlStatement,builder) -> sqlStatement.selectSQL(builder)),
+      UPDATE((sqlStatement,builder) -> sqlStatement.updateSQL(builder));
+
+      private SqlBuilder sqlBuilder;
+
+      StatementType(SqlBuilder sqlBuilder){
+        this.sqlBuilder = sqlBuilder;
+      }
+
+      public String build(SQLStatement sqlStatement, SafeAppendable builder){
+        return sqlBuilder.buildSql(sqlStatement, builder);
+      }
+
+    }
+
+    private interface SqlBuilder{
+      String buildSql(SQLStatement sqlStatement, SafeAppendable builder);
     }
 
     StatementType statementType;
@@ -406,30 +424,7 @@ public abstract class AbstractSQL<T> {
         return null;
       }
 
-      String answer;
-
-      switch (statementType) {
-        case DELETE:
-          answer = deleteSQL(builder);
-          break;
-
-        case INSERT:
-          answer = insertSQL(builder);
-          break;
-
-        case SELECT:
-          answer = selectSQL(builder);
-          break;
-
-        case UPDATE:
-          answer = updateSQL(builder);
-          break;
-
-        default:
-          answer = null;
-      }
-
-      return answer;
+      return statementType.build(this, builder);
     }
   }
 }

--- a/src/main/java/org/apache/ibatis/mapping/SqlCommandExecutor.java
+++ b/src/main/java/org/apache/ibatis/mapping/SqlCommandExecutor.java
@@ -1,0 +1,36 @@
+/**
+ *    Copyright 2009-2018 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.mapping;
+
+import org.apache.ibatis.binding.MapperMethod;
+import org.apache.ibatis.session.SqlSession;
+
+/**
+ * @author Helly Guo
+ * <p>
+ * Created on 19-1-14 上午11:56
+ */
+public interface SqlCommandExecutor {
+
+  SqlCommandExecutor UNKNOWN = (method, sqlSession, args) -> method.executeUnknown();
+  SqlCommandExecutor INSERT = MapperMethod::executeInsert;
+  SqlCommandExecutor UPDATE = MapperMethod::executeUpdate;
+  SqlCommandExecutor DELETE = MapperMethod::executeDelete;
+  SqlCommandExecutor SELECT = MapperMethod::executeSelect;
+  SqlCommandExecutor FLUSH = (method, sqlSession, args) -> method.executeFlush(sqlSession);
+
+  Object execute(MapperMethod method, SqlSession sqlSession, Object[] args);
+}

--- a/src/main/java/org/apache/ibatis/mapping/SqlCommandType.java
+++ b/src/main/java/org/apache/ibatis/mapping/SqlCommandType.java
@@ -15,9 +15,31 @@
  */
 package org.apache.ibatis.mapping;
 
+import org.apache.ibatis.binding.MapperMethod;
+import org.apache.ibatis.session.SqlSession;
+
 /**
  * @author Clinton Begin
  */
 public enum SqlCommandType {
-  UNKNOWN, INSERT, UPDATE, DELETE, SELECT, FLUSH;
+  UNKNOWN((method, sqlSession, args)->method.executeUnknown()),
+  INSERT((method, sqlSession, args)->method.executeInsert(sqlSession, args)),
+  UPDATE((method, sqlSession, args)->method.executeUpdate(sqlSession, args)),
+  DELETE((method, sqlSession, args)->method.executeDelete(sqlSession, args)),
+  SELECT((method, sqlSession, args)->method.executeSelect(sqlSession, args)),
+  FLUSH((method, sqlSession, args)->method.executeFlush(sqlSession));
+
+  private SqlCommandExecutor sqlCommandExecutor;
+
+  SqlCommandType(SqlCommandExecutor sqlCommandExecutor){
+    this.sqlCommandExecutor = sqlCommandExecutor;
+  }
+
+  public Object executeCommand(MapperMethod method, SqlSession sqlSession, Object[] args){
+    return sqlCommandExecutor.execute(method, sqlSession, args);
+  }
+
+  private interface SqlCommandExecutor{
+    Object execute(MapperMethod method, SqlSession sqlSession, Object[] args);
+  }
 }

--- a/src/main/java/org/apache/ibatis/mapping/SqlCommandType.java
+++ b/src/main/java/org/apache/ibatis/mapping/SqlCommandType.java
@@ -15,19 +15,16 @@
  */
 package org.apache.ibatis.mapping;
 
-import org.apache.ibatis.binding.MapperMethod;
-import org.apache.ibatis.session.SqlSession;
-
 /**
  * @author Clinton Begin
  */
 public enum SqlCommandType {
-  UNKNOWN((method, sqlSession, args)->method.executeUnknown()),
-  INSERT((method, sqlSession, args)->method.executeInsert(sqlSession, args)),
-  UPDATE((method, sqlSession, args)->method.executeUpdate(sqlSession, args)),
-  DELETE((method, sqlSession, args)->method.executeDelete(sqlSession, args)),
-  SELECT((method, sqlSession, args)->method.executeSelect(sqlSession, args)),
-  FLUSH((method, sqlSession, args)->method.executeFlush(sqlSession));
+  UNKNOWN(SqlCommandExecutor.UNKNOWN),
+  INSERT(SqlCommandExecutor.INSERT),
+  UPDATE(SqlCommandExecutor.UPDATE),
+  DELETE(SqlCommandExecutor.DELETE),
+  SELECT(SqlCommandExecutor.SELECT),
+  FLUSH(SqlCommandExecutor.FLUSH);
 
   private SqlCommandExecutor sqlCommandExecutor;
 
@@ -35,11 +32,7 @@ public enum SqlCommandType {
     this.sqlCommandExecutor = sqlCommandExecutor;
   }
 
-  public Object executeCommand(MapperMethod method, SqlSession sqlSession, Object[] args){
-    return sqlCommandExecutor.execute(method, sqlSession, args);
-  }
-
-  private interface SqlCommandExecutor{
-    Object execute(MapperMethod method, SqlSession sqlSession, Object[] args);
+  public SqlCommandExecutor getSqlCommandExecutor(){
+    return sqlCommandExecutor;
   }
 }

--- a/src/main/java/org/apache/ibatis/mapping/StatementType.java
+++ b/src/main/java/org/apache/ibatis/mapping/StatementType.java
@@ -15,9 +15,35 @@
  */
 package org.apache.ibatis.mapping;
 
+import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.executor.statement.CallableStatementHandler;
+import org.apache.ibatis.executor.statement.PreparedStatementHandler;
+import org.apache.ibatis.executor.statement.SimpleStatementHandler;
+import org.apache.ibatis.executor.statement.StatementHandler;
+import org.apache.ibatis.session.ResultHandler;
+import org.apache.ibatis.session.RowBounds;
+
 /**
  * @author Clinton Begin
  */
 public enum StatementType {
-  STATEMENT, PREPARED, CALLABLE
+  STATEMENT(SimpleStatementHandler::new), PREPARED(PreparedStatementHandler::new), CALLABLE(CallableStatementHandler::new);
+
+  private StatementHandlerCreator creator;
+
+  StatementType(StatementHandlerCreator creator){
+    this.creator = creator;
+  }
+
+  public StatementHandler createHandler(Executor executor, MappedStatement ms,
+                                        Object parameter, RowBounds rowBounds,
+                                        ResultHandler resultHandler, BoundSql boundSql){
+    return creator.create(executor, ms, parameter, rowBounds, resultHandler, boundSql);
+  }
+
+  private interface StatementHandlerCreator{
+    StatementHandler create(Executor executor, MappedStatement ms,
+                            Object parameter, RowBounds rowBounds,
+                            ResultHandler resultHandler, BoundSql boundSql);
+  }
 }

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -15,18 +15,6 @@
  */
 package org.apache.ibatis.session;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.function.BiFunction;
-
 import org.apache.ibatis.binding.MapperRegistry;
 import org.apache.ibatis.builder.CacheRefResolver;
 import org.apache.ibatis.builder.IncompleteElementException;
@@ -42,11 +30,8 @@ import org.apache.ibatis.cache.impl.PerpetualCache;
 import org.apache.ibatis.datasource.jndi.JndiDataSourceFactory;
 import org.apache.ibatis.datasource.pooled.PooledDataSourceFactory;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory;
-import org.apache.ibatis.executor.BatchExecutor;
 import org.apache.ibatis.executor.CachingExecutor;
 import org.apache.ibatis.executor.Executor;
-import org.apache.ibatis.executor.ReuseExecutor;
-import org.apache.ibatis.executor.SimpleExecutor;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
 import org.apache.ibatis.executor.loader.ProxyFactory;
 import org.apache.ibatis.executor.loader.cglib.CglibProxyFactory;
@@ -66,12 +51,7 @@ import org.apache.ibatis.logging.log4j2.Log4j2Impl;
 import org.apache.ibatis.logging.nologging.NoLoggingImpl;
 import org.apache.ibatis.logging.slf4j.Slf4jImpl;
 import org.apache.ibatis.logging.stdout.StdOutImpl;
-import org.apache.ibatis.mapping.BoundSql;
-import org.apache.ibatis.mapping.Environment;
-import org.apache.ibatis.mapping.MappedStatement;
-import org.apache.ibatis.mapping.ParameterMap;
-import org.apache.ibatis.mapping.ResultMap;
-import org.apache.ibatis.mapping.VendorDatabaseIdProvider;
+import org.apache.ibatis.mapping.*;
 import org.apache.ibatis.parsing.XNode;
 import org.apache.ibatis.plugin.Interceptor;
 import org.apache.ibatis.plugin.InterceptorChain;
@@ -93,6 +73,9 @@ import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeAliasRegistry;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
+
+import java.util.*;
+import java.util.function.BiFunction;
 
 /**
  * @author Clinton Begin
@@ -572,14 +555,7 @@ public class Configuration {
   public Executor newExecutor(Transaction transaction, ExecutorType executorType) {
     executorType = executorType == null ? defaultExecutorType : executorType;
     executorType = executorType == null ? ExecutorType.SIMPLE : executorType;
-    Executor executor;
-    if (ExecutorType.BATCH == executorType) {
-      executor = new BatchExecutor(this, transaction);
-    } else if (ExecutorType.REUSE == executorType) {
-      executor = new ReuseExecutor(this, transaction);
-    } else {
-      executor = new SimpleExecutor(this, transaction);
-    }
+    Executor executor = executorType.createExecutor(this, transaction);
     if (cacheEnabled) {
       executor = new CachingExecutor(executor);
     }

--- a/src/main/java/org/apache/ibatis/session/ExecutorType.java
+++ b/src/main/java/org/apache/ibatis/session/ExecutorType.java
@@ -15,9 +15,29 @@
  */
 package org.apache.ibatis.session;
 
+import org.apache.ibatis.executor.BatchExecutor;
+import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.executor.ReuseExecutor;
+import org.apache.ibatis.executor.SimpleExecutor;
+import org.apache.ibatis.transaction.Transaction;
+
 /**
  * @author Clinton Begin
  */
 public enum ExecutorType {
-  SIMPLE, REUSE, BATCH
+  SIMPLE(SimpleExecutor::new), REUSE(ReuseExecutor::new), BATCH(BatchExecutor::new);
+
+  private ExecutorCreator creator;
+
+  ExecutorType(ExecutorCreator creator){
+      this.creator = creator;
+  }
+
+  public Executor createExecutor(Configuration configuration, Transaction transaction){
+      return creator.create(configuration, transaction);
+  }
+
+  private interface ExecutorCreator{
+    Executor create(Configuration configuration, Transaction transaction);
+  }
 }

--- a/src/test/java/org/apache/ibatis/jmh/SkipTypeDetectionBenchmark.java
+++ b/src/test/java/org/apache/ibatis/jmh/SkipTypeDetectionBenchmark.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright 2009-2018 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.jmh;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * @author Helly Guo
+ * <p>
+ * Created on 19-1-12 下午10:14
+ */
+@Fork(value = 5)
+@BenchmarkMode({Mode.Throughput})
+@Warmup(iterations = 10, time = 1)
+@Measurement(iterations = 30, time = 1)
+@Threads(value = 4)
+public class SkipTypeDetectionBenchmark {
+    private static final DemoInvoker[] INVOKERS = new DemoInvoker[]{
+            (demoObject, blackhole) -> blackhole.consume(demoObject.getVal0()),
+            (demoObject, blackhole) -> blackhole.consume(demoObject.getVal1()),
+            (demoObject, blackhole) -> blackhole.consume(demoObject.getVal2()),
+            (demoObject, blackhole) -> blackhole.consume(demoObject.getVal3()),
+            (demoObject, blackhole) -> blackhole.consume(demoObject.getVal4()),
+            (demoObject, blackhole) -> blackhole.consume(demoObject.getVal5())
+    };
+
+    @Benchmark
+    public void testIfElse(DemoObject demoObject, Blackhole blackhole) {
+        DemoEnum demoEnum = demoObject.getDemoEnum();
+        if (DemoEnum.AAA.equals(demoEnum)) {
+            blackhole.consume(demoObject.getVal0());
+        } else if (DemoEnum.BBB.equals(demoEnum)) {
+            blackhole.consume(demoObject.getVal1());
+        } else if (DemoEnum.CCC.equals(demoEnum)) {
+            blackhole.consume(demoObject.getVal2());
+        } else if (DemoEnum.DDD.equals(demoEnum)) {
+            blackhole.consume(demoObject.getVal3());
+        } else if (DemoEnum.EEE.equals(demoEnum)) {
+            blackhole.consume(demoObject.getVal4());
+        } else if (DemoEnum.FFF.equals(demoEnum)) {
+            blackhole.consume(demoObject.getVal5());
+        } else {
+            throw new RuntimeException("should not hit");
+        }
+    }
+
+    @Benchmark
+    public void testSwitchCase(DemoObject demoObject, Blackhole blackhole) {
+        DemoEnum demoEnum = demoObject.getDemoEnum();
+        switch (demoEnum) {
+            case AAA:
+                blackhole.consume(demoObject.getVal0());
+                break;
+            case BBB:
+                blackhole.consume(demoObject.getVal1());
+                break;
+            case CCC:
+                blackhole.consume(demoObject.getVal2());
+                break;
+            case DDD:
+                blackhole.consume(demoObject.getVal3());
+                break;
+            case EEE:
+                blackhole.consume(demoObject.getVal4());
+                break;
+            case FFF:
+                blackhole.consume(demoObject.getVal5());
+                break;
+            default:
+                throw new RuntimeException("should not hit");
+        }
+    }
+
+    @Benchmark
+    public void testArray(DemoObject demoObject, Blackhole blackhole) {
+        INVOKERS[demoObject.getDemoEnum().ordinal()].invoke(demoObject, blackhole);
+    }
+
+    @Benchmark
+    public void testEnum(DemoObject demoObject, Blackhole blackhole) {
+        demoObject.getDemoEnum().getInvoker().invoke(demoObject, blackhole);
+    }
+
+    @State(Scope.Benchmark)
+    public static class DemoObject {
+        @Param(value = {"AAA", "BBB", "CCC", "DDD", "EEE", "FFF"})
+        public DemoEnum demoEnum;
+
+        private int val0 = 220183018;
+        private int val1 = 220183018;
+        private int val2 = 220183018;
+        private int val3 = 220183018;
+        private int val4 = 220183018;
+        private int val5 = 220183018;
+
+
+        public DemoEnum getDemoEnum() {
+            return demoEnum;
+        }
+
+        public int getVal0() {
+            return val0;
+        }
+
+        public int getVal1() {
+            return val1;
+        }
+
+        public int getVal2() {
+            return val2;
+        }
+
+        public int getVal3() {
+            return val3;
+        }
+
+        public int getVal4() {
+            return val4;
+        }
+
+        public int getVal5() {
+            return val5;
+        }
+    }
+
+    public enum DemoEnum {
+        AAA((demoObject, blackhole) -> {
+            blackhole.consume(demoObject.getVal0());
+        }),
+        BBB((demoObject, blackhole) -> {
+            blackhole.consume(demoObject.getVal1());
+        }),
+        CCC((demoObject, blackhole) -> {
+            blackhole.consume(demoObject.getVal2());
+        }),
+        DDD((demoObject, blackhole) -> {
+            blackhole.consume(demoObject.getVal3());
+        }),
+        EEE((demoObject, blackhole) -> {
+            blackhole.consume(demoObject.getVal4());
+        }),
+        FFF((demoObject, blackhole) -> {
+            blackhole.consume(demoObject.getVal5());
+        });
+
+        private DemoInvoker invoker;
+
+        DemoEnum(DemoInvoker invoker) {
+            this.invoker = invoker;
+        }
+
+        public DemoInvoker getInvoker() {
+            return invoker;
+        }
+    }
+
+    public interface DemoInvoker {
+        void invoke(DemoObject demoObject, Blackhole blackhole);
+    }
+}


### PR DESCRIPTION
Try to use enum to skip type detection.

**Test under JDK8**
![test_under_jdk8](https://user-images.githubusercontent.com/1480942/51097629-798f1e80-1800-11e9-9583-6edb0f36a7da.png)

Under `JDK8`, using enum is the best.

**Test under JDK10**
![test_under_jdk10](https://user-images.githubusercontent.com/1480942/51097630-798f1e80-1800-11e9-8198-f27cef1d0d84.png)

Under `JDK10`, using enum is not the best. But it is the most balanced on each branch.

**My env**:
- Intel(R) Core(TM) i5-6200U CPU @ 2.30GHz
- Fedora release 28 (Twenty Eight)
- JDK8
  > java version "1.8.0_181"
  > Java(TM) SE Runtime Environment (build 1.8.0_181-b13)
  > Java HotSpot(TM) 64-Bit Server VM (build 25.181-b13, mixed mode)
- JDK10
  > java version "10.0.2" 2018-07-17
  > Java(TM) SE Runtime Environment 18.3 (build 10.0.2+13)
  > Java HotSpot(TM) 64-Bit Server VM 18.3 (build 10.0.2+13, mixed mode)
