### PR TITLE
Throw exception when 'keyProperty' is missing in Jdbc3KeyGenerator.

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
+++ b/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public class Jdbc3KeyGenerator implements KeyGenerator {
   public void processBatch(MappedStatement ms, Statement stmt, Object parameter) {
     final String[] keyProperties = ms.getKeyProperties();
     if (keyProperties == null || keyProperties.length == 0) {
-      return;
+      throw new ExecutorException("Could not assign generated keys. Please specify 'keyProperty'.");
     }
     try (ResultSet rs = stmt.getGeneratedKeys()) {
       final Configuration configuration = ms.getConfiguration();

--- a/src/test/java/org/apache/ibatis/submitted/keygen/CountryMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/CountryMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -32,6 +32,10 @@ public interface CountryMapper {
   @Options(useGeneratedKeys = true, keyProperty = "id")
   @Insert({ "insert into country (countryname,countrycode) values (#{country.countryname},#{country.countrycode})" })
   int insertNamedBean(@Param("country") Country country);
+
+  @Options(useGeneratedKeys = true)
+  @Insert({ "insert into country (countryname,countrycode) values (#{countryname},#{countrycode})" })
+  int insertBean_MissingKeyProperty(Country country);
 
   int insertList(List<Country> countries);
 

--- a/src/test/java/org/apache/ibatis/submitted/keygen/Jdbc3KeyGeneratorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/Jdbc3KeyGeneratorTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -202,6 +202,21 @@ public class Jdbc3KeyGeneratorTest {
         Country country = new Country("China", "CN");
         mapper.insertMultiParams(country, Integer.valueOf(1));
         assertNotNull(country.getId());
+      } finally {
+        sqlSession.rollback();
+      }
+    }
+  }
+
+  @Test
+  public void shouldFailIfKeyPropertyIsMissing() throws Exception {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      try {
+        CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+        Country country = new Country("China", "CN");
+        when(mapper).insertBean_MissingKeyProperty(country);
+        then(caughtException()).isInstanceOf(PersistenceException.class).hasMessageContaining(
+            "Could not assign generated keys. Please specify 'keyProperty'.");
       } finally {
         sqlSession.rollback();
       }


### PR DESCRIPTION
`Jdbc3KeyGenerator` silently ignores generated keys if `keyProperty` is missing.
https://github.com/mybatis/mybatis-3/blob/87c6e794ed9c068da99b95f1eadff51c8a23af94/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java#L63-L65

It was not helpful already (e.g. #1183 ), but especially now that we fixed #1198 , users relying on the default 'keyProperty' value will experience an annoying problem with 3.5.0 i.e. assigning generated keys stops working without any error.
We should avoid it to happen.

@jeffgbutler @kazuki43zoo ,
Could you take a look and see if I am missing something, please?

