### PR TITLE
JDBC 4.2 for LocalTime, LocalDate & LocalDateTime

### DIFF
--- a/src/main/java/org/apache/ibatis/type/LocalDateTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalDateTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 /**
@@ -31,31 +30,21 @@ public class LocalDateTimeTypeHandler extends BaseTypeHandler<LocalDateTime> {
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, LocalDateTime parameter, JdbcType jdbcType)
           throws SQLException {
-    ps.setTimestamp(i, Timestamp.valueOf(parameter));
+    ps.setObject(i, parameter);
   }
 
   @Override
   public LocalDateTime getNullableResult(ResultSet rs, String columnName) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnName);
-    return getLocalDateTime(timestamp);
+    return rs.getObject(columnName, LocalDateTime.class);
   }
 
   @Override
   public LocalDateTime getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
-    Timestamp timestamp = rs.getTimestamp(columnIndex);
-    return getLocalDateTime(timestamp);
+    return rs.getObject(columnIndex, LocalDateTime.class);
   }
 
   @Override
   public LocalDateTime getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Timestamp timestamp = cs.getTimestamp(columnIndex);
-    return getLocalDateTime(timestamp);
-  }
-
-  private static LocalDateTime getLocalDateTime(Timestamp timestamp) {
-    if (timestamp != null) {
-      return timestamp.toLocalDateTime();
-    }
-    return null;
+    return cs.getObject(columnIndex, LocalDateTime.class);
   }
 }

--- a/src/main/java/org/apache/ibatis/type/LocalDateTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalDateTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.apache.ibatis.type;
 
 import java.sql.CallableStatement;
-import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -31,31 +30,21 @@ public class LocalDateTypeHandler extends BaseTypeHandler<LocalDate> {
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, LocalDate parameter, JdbcType jdbcType)
           throws SQLException {
-    ps.setDate(i, Date.valueOf(parameter));
+    ps.setObject(i, parameter);
   }
 
   @Override
   public LocalDate getNullableResult(ResultSet rs, String columnName) throws SQLException {
-    Date date = rs.getDate(columnName);
-    return getLocalDate(date);
+    return rs.getObject(columnName, LocalDate.class);
   }
 
   @Override
   public LocalDate getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
-    Date date = rs.getDate(columnIndex);
-    return getLocalDate(date);
+    return rs.getObject(columnIndex, LocalDate.class);
   }
 
   @Override
   public LocalDate getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Date date = cs.getDate(columnIndex);
-    return getLocalDate(date);
-  }
-
-  private static LocalDate getLocalDate(Date date) {
-    if (date != null) {
-      return date.toLocalDate();
-    }
-    return null;
+    return cs.getObject(columnIndex, LocalDate.class);
   }
 }

--- a/src/main/java/org/apache/ibatis/type/LocalTimeTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/LocalTimeTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Time;
 import java.time.LocalTime;
 
 /**
@@ -31,31 +30,21 @@ public class LocalTimeTypeHandler extends BaseTypeHandler<LocalTime> {
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, LocalTime parameter, JdbcType jdbcType)
           throws SQLException {
-    ps.setTime(i, Time.valueOf(parameter));
+    ps.setObject(i, parameter);
   }
 
   @Override
   public LocalTime getNullableResult(ResultSet rs, String columnName) throws SQLException {
-    Time time = rs.getTime(columnName);
-    return getLocalTime(time);
+    return rs.getObject(columnName, LocalTime.class);
   }
 
   @Override
   public LocalTime getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
-    Time time = rs.getTime(columnIndex);
-    return getLocalTime(time);
+    return rs.getObject(columnIndex, LocalTime.class);
   }
 
   @Override
   public LocalTime getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
-    Time time = cs.getTime(columnIndex);
-    return getLocalTime(time);
-  }
-
-  private static LocalTime getLocalTime(Time time) {
-    if (time != null) {
-      return time.toLocalTime();
-    }
-    return null;
+    return cs.getObject(columnIndex, LocalTime.class);
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/localtime/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/localtime/CreateDB.sql
@@ -1,0 +1,25 @@
+--
+--    Copyright 2009-2019 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table records if exists;
+
+create table records (
+  id int,
+  t time(9)
+);
+
+insert into records (id, t) values
+(1, '11:22:33.123456789');

--- a/src/test/java/org/apache/ibatis/submitted/localtime/LocalTimeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/localtime/LocalTimeTest.java
@@ -1,0 +1,72 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.localtime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.Reader;
+import java.time.LocalTime;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class LocalTimeTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/localtime/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+        "org/apache/ibatis/submitted/localtime/CreateDB.sql");
+  }
+
+  @Test
+  void shouldSelectLocalTimeWithNanoseconds() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Record record = mapper.selectById(1);
+      assertEquals(LocalTime.of(11, 22, 33, 123456789), record.getT());
+    }
+  }
+
+  @Test
+  void shouldInsertLocalTimeWithNanoseconds() {
+    LocalTime t = LocalTime.of(11, 22, 33, 123456789);
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Record record = new Record();
+      record.setId(2);
+      record.setT(t);
+      int result = mapper.insertLocalTime(record);
+      assertEquals(1, result);
+      sqlSession.commit();
+    }
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Record record = mapper.selectById(2);
+      assertEquals(t, record.getT());
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/localtime/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/localtime/Mapper.java
@@ -1,0 +1,29 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.localtime;
+
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Select;
+
+public interface Mapper {
+
+  @Select("select id, t from records where id = #{id}")
+  Record selectById(Integer id);
+
+  @Insert("insert into records (id, t) values (#{id}, #{t})")
+  int insertLocalTime(Record record);
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/localtime/Record.java
+++ b/src/test/java/org/apache/ibatis/submitted/localtime/Record.java
@@ -1,0 +1,41 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.localtime;
+
+import java.time.LocalTime;
+
+public class Record {
+
+  private Integer id;
+
+  private LocalTime t;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public LocalTime getT() {
+    return t;
+  }
+
+  public void setT(LocalTime t) {
+    this.t = t;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/localtime/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/localtime/mybatis-config.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2019 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url" value="jdbc:hsqldb:mem:localtime" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper class="org.apache.ibatis.submitted.localtime.Mapper" />
+  </mappers>
+
+</configuration>

--- a/src/test/java/org/apache/ibatis/submitted/timezone_edge_case/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/timezone_edge_case/CreateDB.sql
@@ -1,0 +1,26 @@
+--
+--    Copyright 2009-2019 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table records if exists;
+
+create table records (
+  id int,
+  ts timestamp(9),
+  d date
+);
+
+insert into records (id, ts, d) values
+(1, '2019-03-10 02:30:00', '2011-12-30');

--- a/src/test/java/org/apache/ibatis/submitted/timezone_edge_case/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/timezone_edge_case/Mapper.java
@@ -1,0 +1,29 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.timezone_edge_case;
+
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Select;
+
+public interface Mapper {
+
+  @Select("select id, ts, d from records where id = #{id}")
+  Record selectById(Integer id);
+
+  @Insert("insert into records (id, ts, d) values (#{id}, #{ts}, #{d})")
+  int insert(Record record);
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/timezone_edge_case/Record.java
+++ b/src/test/java/org/apache/ibatis/submitted/timezone_edge_case/Record.java
@@ -1,0 +1,51 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.timezone_edge_case;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class Record {
+
+  private Integer id;
+
+  private LocalDateTime ts;
+  private LocalDate d;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public LocalDateTime getTs() {
+    return ts;
+  }
+
+  public void setTs(LocalDateTime ts) {
+    this.ts = ts;
+  }
+
+  public LocalDate getD() {
+    return d;
+  }
+
+  public void setD(LocalDate d) {
+    this.d = d;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/timezone_edge_case/TimezoneEdgeCaseTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/timezone_edge_case/TimezoneEdgeCaseTest.java
@@ -1,0 +1,125 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.timezone_edge_case;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.Reader;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.TimeZone;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TimezoneEdgeCaseTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+  private TimeZone timeZone;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/timezone_edge_case/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+        "org/apache/ibatis/submitted/timezone_edge_case/CreateDB.sql");
+  }
+
+  @BeforeEach
+  void saveTimeZone() {
+    timeZone = TimeZone.getDefault();
+  }
+
+  @AfterEach
+  void restoreTimeZone() {
+    TimeZone.setDefault(timeZone);
+  }
+
+  @Test
+  void shouldSelectNonExistentLocalTimestampAsIs() {
+    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Record record = mapper.selectById(1);
+      assertEquals(LocalDateTime.of(LocalDate.of(2019, 3, 10), LocalTime.of(2, 30)), record.getTs());
+    }
+  }
+
+  @Test
+  void shouldInsertNonExistentLocalTimestampAsIs() throws Exception {
+    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+    LocalDateTime localDateTime = LocalDateTime.of(LocalDate.of(2019, 3, 10), LocalTime.of(2, 30));
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Record record = new Record();
+      record.setId(2);
+      record.setTs(localDateTime);
+      mapper.insert(record);
+      sqlSession.commit();
+    }
+    try (SqlSession sqlSession = sqlSessionFactory.openSession();
+        Connection con = sqlSession.getConnection();
+        Statement stmt = con.createStatement();
+        ResultSet rs = stmt.executeQuery("select count(*) from records where id = 2 and ts = '2019-03-10 02:30:00'")) {
+      rs.next();
+      assertEquals(1, rs.getInt(1));
+    }
+  }
+
+  @Test
+  void shouldSelectNonExistentLocalDateAsIs() {
+    TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Apia"));
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Record record = mapper.selectById(1);
+      assertEquals(LocalDate.of(2011, 12, 30), record.getD());
+    }
+  }
+
+  @Test
+  void shouldInsertNonExistentLocalDateAsIs() throws Exception {
+    TimeZone.setDefault(TimeZone.getTimeZone("Pacific/Apia"));
+    LocalDate localDate = LocalDate.of(2011, 12, 30);
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Record record = new Record();
+      record.setId(3);
+      record.setD(localDate);
+      mapper.insert(record);
+      sqlSession.commit();
+    }
+    try (SqlSession sqlSession = sqlSessionFactory.openSession();
+        Connection con = sqlSession.getConnection();
+        Statement stmt = con.createStatement();
+        ResultSet rs = stmt.executeQuery("select count(*) from records where id = 3 and d = '2011-12-30'")) {
+      rs.next();
+      assertEquals(1, rs.getInt(1));
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/timezone_edge_case/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/timezone_edge_case/mybatis-config.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2019 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url" value="jdbc:hsqldb:mem:tzedge" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper class="org.apache.ibatis.submitted.timezone_edge_case.Mapper" />
+  </mappers>
+
+</configuration>

--- a/src/test/java/org/apache/ibatis/type/LocalDateTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/LocalDateTimeTypeHandlerTest.java
@@ -18,7 +18,6 @@ package org.apache.ibatis.type;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.Test;
@@ -27,19 +26,18 @@ class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
 
   private static final TypeHandler<LocalDateTime> TYPE_HANDLER = new LocalDateTimeTypeHandler();
   private static final LocalDateTime LOCAL_DATE_TIME = LocalDateTime.now();
-  private static final Timestamp TIMESTAMP = Timestamp.valueOf(LOCAL_DATE_TIME);
 
   @Override
   @Test
   public void shouldSetParameter() throws Exception {
     TYPE_HANDLER.setParameter(ps, 1, LOCAL_DATE_TIME, null);
-    verify(ps).setTimestamp(1, TIMESTAMP);
+    verify(ps).setObject(1, LOCAL_DATE_TIME);
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
-    when(rs.getTimestamp("column")).thenReturn(TIMESTAMP);
+    when(rs.getObject("column", LocalDateTime.class)).thenReturn(LOCAL_DATE_TIME);
     assertEquals(LOCAL_DATE_TIME, TYPE_HANDLER.getResult(rs, "column"));
     verify(rs, never()).wasNull();
   }
@@ -47,7 +45,7 @@ class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    when(rs.getTimestamp("column")).thenReturn(null);
+    when(rs.getObject("column", LocalDateTime.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
     verify(rs, never()).wasNull();
   }
@@ -55,7 +53,7 @@ class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
-    when(rs.getTimestamp(1)).thenReturn(TIMESTAMP);
+    when(rs.getObject(1, LocalDateTime.class)).thenReturn(LOCAL_DATE_TIME);
     assertEquals(LOCAL_DATE_TIME, TYPE_HANDLER.getResult(rs, 1));
     verify(rs, never()).wasNull();
   }
@@ -63,7 +61,7 @@ class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    when(rs.getTimestamp(1)).thenReturn(null);
+    when(rs.getObject(1, LocalDateTime.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
     verify(rs, never()).wasNull();
   }
@@ -71,7 +69,7 @@ class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
-    when(cs.getTimestamp(1)).thenReturn(TIMESTAMP);
+    when(cs.getObject(1, LocalDateTime.class)).thenReturn(LOCAL_DATE_TIME);
     assertEquals(LOCAL_DATE_TIME, TYPE_HANDLER.getResult(cs, 1));
     verify(cs, never()).wasNull();
   }
@@ -79,7 +77,7 @@ class LocalDateTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    when(cs.getTimestamp(1)).thenReturn(null);
+    when(cs.getObject(1, LocalDateTime.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
     verify(cs, never()).wasNull();
   }

--- a/src/test/java/org/apache/ibatis/type/LocalDateTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/LocalDateTypeHandlerTest.java
@@ -18,7 +18,6 @@ package org.apache.ibatis.type;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.sql.Date;
 import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
@@ -27,19 +26,18 @@ class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
 
   private static final TypeHandler<LocalDate> TYPE_HANDLER = new LocalDateTypeHandler();
   private static final LocalDate LOCAL_DATE = LocalDate.now();
-  private static final Date DATE = Date.valueOf(LOCAL_DATE);
 
   @Override
   @Test
   public void shouldSetParameter() throws Exception {
     TYPE_HANDLER.setParameter(ps, 1, LOCAL_DATE, null);
-    verify(ps).setDate(1, DATE);
+    verify(ps).setObject(1, LOCAL_DATE);
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
-    when(rs.getDate("column")).thenReturn(DATE);
+    when(rs.getObject("column", LocalDate.class)).thenReturn(LOCAL_DATE);
     assertEquals(LOCAL_DATE, TYPE_HANDLER.getResult(rs, "column"));
     verify(rs, never()).wasNull();
   }
@@ -47,7 +45,7 @@ class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    when(rs.getDate("column")).thenReturn(null);
+    when(rs.getObject("column", LocalDate.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
     verify(rs, never()).wasNull();
   }
@@ -55,7 +53,7 @@ class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
-    when(rs.getDate(1)).thenReturn(DATE);
+    when(rs.getObject(1, LocalDate.class)).thenReturn(LOCAL_DATE);
     assertEquals(LOCAL_DATE, TYPE_HANDLER.getResult(rs, 1));
     verify(rs, never()).wasNull();
   }
@@ -63,7 +61,7 @@ class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    when(rs.getDate(1)).thenReturn(null);
+    when(rs.getObject(1, LocalDate.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
     verify(rs, never()).wasNull();
   }
@@ -71,7 +69,7 @@ class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
-    when(cs.getDate(1)).thenReturn(DATE);
+    when(cs.getObject(1, LocalDate.class)).thenReturn(LOCAL_DATE);
     assertEquals(LOCAL_DATE, TYPE_HANDLER.getResult(cs, 1));
     verify(cs, never()).wasNull();
   }
@@ -79,7 +77,7 @@ class LocalDateTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    when(cs.getDate(1)).thenReturn(null);
+    when(cs.getObject(1, LocalDate.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
     verify(cs, never()).wasNull();
   }

--- a/src/test/java/org/apache/ibatis/type/LocalTimeTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/LocalTimeTypeHandlerTest.java
@@ -18,7 +18,6 @@ package org.apache.ibatis.type;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.sql.Time;
 import java.time.LocalTime;
 
 import org.junit.jupiter.api.Test;
@@ -26,21 +25,19 @@ import org.junit.jupiter.api.Test;
 class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
 
   private static final TypeHandler<LocalTime> TYPE_HANDLER = new LocalTimeTypeHandler();
-  // java.sql.Time doesn't contain millis, so set nano to 0
-  private static final LocalTime LOCAL_TIME = LocalTime.now().withNano(0);
-  private static final Time TIME = Time.valueOf(LOCAL_TIME);
+  private static final LocalTime LOCAL_TIME = LocalTime.now();
 
   @Override
   @Test
   public void shouldSetParameter() throws Exception {
     TYPE_HANDLER.setParameter(ps, 1, LOCAL_TIME, null);
-    verify(ps).setTime(1, TIME);
+    verify(ps).setObject(1, LOCAL_TIME);
   }
 
   @Override
   @Test
   public void shouldGetResultFromResultSetByName() throws Exception {
-    when(rs.getTime("column")).thenReturn(TIME);
+    when(rs.getObject("column", LocalTime.class)).thenReturn(LOCAL_TIME);
     assertEquals(LOCAL_TIME, TYPE_HANDLER.getResult(rs, "column"));
     verify(rs, never()).wasNull();
   }
@@ -48,7 +45,7 @@ class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByName() throws Exception {
-    when(rs.getTime("column")).thenReturn(null);
+    when(rs.getObject("column", LocalTime.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
     verify(rs, never()).wasNull();
   }
@@ -56,7 +53,7 @@ class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromResultSetByPosition() throws Exception {
-    when(rs.getTime(1)).thenReturn(TIME);
+    when(rs.getObject(1, LocalTime.class)).thenReturn(LOCAL_TIME);
     assertEquals(LOCAL_TIME, TYPE_HANDLER.getResult(rs, 1));
     verify(rs, never()).wasNull();
   }
@@ -64,7 +61,7 @@ class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromResultSetByPosition() throws Exception {
-    when(rs.getTime(1)).thenReturn(null);
+    when(rs.getObject(1, LocalTime.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(rs, 1));
     verify(rs, never()).wasNull();
   }
@@ -72,7 +69,7 @@ class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultFromCallableStatement() throws Exception {
-    when(cs.getTime(1)).thenReturn(TIME);
+    when(cs.getObject(1, LocalTime.class)).thenReturn(LOCAL_TIME);
     assertEquals(LOCAL_TIME, TYPE_HANDLER.getResult(cs, 1));
     verify(cs, never()).wasNull();
   }
@@ -80,7 +77,7 @@ class LocalTimeTypeHandlerTest extends BaseTypeHandlerTest {
   @Override
   @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
-    when(cs.getTime(1)).thenReturn(null);
+    when(cs.getObject(1, LocalTime.class)).thenReturn(null);
     assertNull(TYPE_HANDLER.getResult(cs, 1));
     verify(cs, never()).wasNull();
   }


### PR DESCRIPTION
The follows other recent commits for OffsetDateTime & ZonedDateTime to defer to the driver’s JDBC 4.2 support for JSR 310 objects.