### PR TITLE
Add new method for propagating mapper info on LanguageDriver

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
@@ -15,8 +15,10 @@
  */
 package org.apache.ibatis.builder.xml;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.apache.ibatis.builder.BaseBuilder;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
@@ -93,7 +95,9 @@ public class XMLStatementBuilder extends BaseBuilder {
           ? Jdbc3KeyGenerator.INSTANCE : NoKeyGenerator.INSTANCE;
     }
 
-    SqlSource sqlSource = langDriver.createSqlSource(configuration, context, parameterTypeClass);
+    Map<String, Object> langDriverContext = new HashMap<>();
+    langDriverContext.put(LanguageDriver.ContextKey.STATEMENT_ID, builderAssistant.applyCurrentNamespace(id, false));
+    SqlSource sqlSource = langDriver.createSqlSource(configuration, context, parameterTypeClass, langDriverContext);
     StatementType statementType = StatementType.valueOf(context.getStringAttribute("statementType", StatementType.PREPARED.toString()));
     Integer fetchSize = context.getIntAttribute("fetchSize");
     Integer timeout = context.getIntAttribute("timeout");
@@ -151,7 +155,9 @@ public class XMLStatementBuilder extends BaseBuilder {
     String resultMap = null;
     ResultSetType resultSetTypeEnum = null;
 
-    SqlSource sqlSource = langDriver.createSqlSource(configuration, nodeToHandle, parameterTypeClass);
+    Map<String, Object> langDriverContext = new HashMap<>();
+    langDriverContext.put(LanguageDriver.ContextKey.STATEMENT_ID, builderAssistant.applyCurrentNamespace(id, false));
+    SqlSource sqlSource = langDriver.createSqlSource(configuration, nodeToHandle, parameterTypeClass, langDriverContext);
     SqlCommandType sqlCommandType = SqlCommandType.SELECT;
 
     builderAssistant.addMappedStatement(id, sqlSource, statementType, sqlCommandType,

--- a/src/main/java/org/apache/ibatis/scripting/LanguageDriver.java
+++ b/src/main/java/org/apache/ibatis/scripting/LanguageDriver.java
@@ -15,6 +15,8 @@
  */
 package org.apache.ibatis.scripting;
 
+import java.util.Map;
+
 import org.apache.ibatis.executor.parameter.ParameterHandler;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.MappedStatement;
@@ -26,12 +28,30 @@ import org.apache.ibatis.session.Configuration;
 public interface LanguageDriver {
 
   /**
+   * Constants for language driver context.
+   *
+   * @since 3.5.1
+   */
+  class ContextKey {
+
+    private ContextKey() {
+      // NOP
+    }
+
+    /**
+     * The context key name for statement id.
+     */
+    public static final String STATEMENT_ID = "statementId";
+
+  }
+
+  /**
    * Creates a {@link ParameterHandler} that passes the actual parameters to the the JDBC statement.
    *
    * @param mappedStatement The mapped statement that is being executed
    * @param parameterObject The input parameter object (can be null)
    * @param boundSql The resulting SQL once the dynamic language has been executed.
-   * @return
+   * @return a {@link ParameterHandler} that passes the actual parameters to the the JDBC statement
    * @author Frank D. Martinez [mnesarco]
    * @see DefaultParameterHandler
    */
@@ -44,9 +64,24 @@ public interface LanguageDriver {
    * @param configuration The MyBatis configuration
    * @param script XNode parsed from a XML file
    * @param parameterType input parameter type got from a mapper method or specified in the parameterType xml attribute. Can be null.
-   * @return
+   * @return an {@link SqlSource} that will hold the statement read from a mapper xml file
    */
   SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType);
+
+  /**
+   * Creates an {@link SqlSource} that will hold the statement read from a mapper xml file.
+   * It is called during startup, when the mapped statement is read from a class or an xml file.
+   *
+   * @param configuration The MyBatis configuration
+   * @param script XNode parsed from a XML file
+   * @param parameterType input parameter type got from a mapper method or specified in the parameterType xml attribute. Can be null.
+   * @param context context for language driver (e.g. statement id, etc...)
+   * @return an {@link SqlSource} that will hold the statement read from a mapper xml file
+   * @since 3.5.1
+   */
+  default SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType, Map<String, Object> context) {
+    return createSqlSource(configuration, script, parameterType);
+  }
 
   /**
    * Creates an {@link SqlSource} that will hold the statement read from an annotation.
@@ -55,8 +90,23 @@ public interface LanguageDriver {
    * @param configuration The MyBatis configuration
    * @param script The content of the annotation
    * @param parameterType input parameter type got from a mapper method or specified in the parameterType xml attribute. Can be null.
-   * @return
+   * @return an {@link SqlSource} that will hold the statement read from an annotation
    */
   SqlSource createSqlSource(Configuration configuration, String script, Class<?> parameterType);
+
+  /**
+   * Creates an {@link SqlSource} that will hold the statement read from an annotation.
+   * It is called during startup, when the mapped statement is read from a class or an xml file.
+   *
+   * @param configuration The MyBatis configuration
+   * @param script The content of the annotation
+   * @param parameterType input parameter type got from a mapper method or specified in the parameterType xml attribute. Can be null.
+   * @param context context for language driver (e.g. statement id, etc...)
+   * @return an {@link SqlSource} that will hold the statement read from an annotation
+   * @since 3.5.1
+   */
+  default SqlSource createSqlSource(Configuration configuration, String script, Class<?> parameterType, Map<String, Object> context) {
+    return createSqlSource(configuration, script, parameterType);
+  }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/language/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/language/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,8 +17,10 @@ package org.apache.ibatis.submitted.language;
 
 import java.util.List;
 
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Lang;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.SelectKey;
 import org.apache.ibatis.scripting.defaults.RawLanguageDriver;
 import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
 
@@ -38,5 +40,10 @@ public interface Mapper {
   @Lang(XMLLanguageDriver.class)
   @Select("SELECT firstName, lastName FROM names WHERE lastName LIKE #{name} and 0 < 1")
   List<Name> selectXmlWithMapperAndSqlSymbols(Parameter p);
+
+  @Lang(LanguageTest.MyAnnotationLanguageDriver.class)
+  @Insert("INSERT INTO name (firstName) VALUES(#{firstName})")
+  @SelectKey(statement = "SELECT 1", keyProperty = "id", resultType = int.class, before = true)
+  String insertOnAnnotation(String firstName);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/language/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/language/Mapper.xml
@@ -86,4 +86,11 @@
     WHERE lastName LIKE #{name}
   </select>
 
+  <insert id="insertOnXml" lang="org.apache.ibatis.submitted.language.LanguageTest$MyXmlLanguageDriver">
+    <selectKey keyProperty="id" resultType="int" order="BEFORE">
+      SELECT 1
+    </selectKey>
+    INSERT INTO name (firstName) VALUES(#{firstName})
+  </insert>
+
 </mapper>


### PR DESCRIPTION
By this changes, scripting language plugin (mybatis-freemarker, mybatis-velocity and mybatis-thymelaf) can loaded a template file automatically by rule-based if SQL is not specify on XML or annotation.

for example:

```java
package com.example.demo.mapper;

interface DemoMapper {
  @Insert("")
  @SelectKey(statement = "", ...)
  void insert(Demo demo);
}
```

The scripting language plugin (e.g. mybatis-thymeleaf) can be load a template files (e.g. `com/example/demo/mapper/DemoMapper/insert.sql` or `com/example/demo/mapper/DemoMapper/insert_selectKey.sql`) automatically.

WDYT?