### PR TITLE
Map StringTypeHandler to LONGVARCHAR instead of ClobTypeHandler

### DIFF
--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -96,14 +96,14 @@ public final class TypeHandlerRegistry {
     register(String.class, JdbcType.CHAR, new StringTypeHandler());
     register(String.class, JdbcType.CLOB, new ClobTypeHandler());
     register(String.class, JdbcType.VARCHAR, new StringTypeHandler());
-    register(String.class, JdbcType.LONGVARCHAR, new ClobTypeHandler());
+    register(String.class, JdbcType.LONGVARCHAR, new StringTypeHandler());
     register(String.class, JdbcType.NVARCHAR, new NStringTypeHandler());
     register(String.class, JdbcType.NCHAR, new NStringTypeHandler());
     register(String.class, JdbcType.NCLOB, new NClobTypeHandler());
     register(JdbcType.CHAR, new StringTypeHandler());
     register(JdbcType.VARCHAR, new StringTypeHandler());
     register(JdbcType.CLOB, new ClobTypeHandler());
-    register(JdbcType.LONGVARCHAR, new ClobTypeHandler());
+    register(JdbcType.LONGVARCHAR, new StringTypeHandler());
     register(JdbcType.NVARCHAR, new NStringTypeHandler());
     register(JdbcType.NCHAR, new NStringTypeHandler());
     register(JdbcType.NCLOB, new NClobTypeHandler());


### PR DESCRIPTION
See #1484 .

I cannot test all variations, but the following columns are treated as `LONGVARCHAR` in JDBC and `PreparedStatement#setString()` and `ResultSet#getString()` works fine with them, so `StringTypeHandler` should work as well.

- Oracle : `LONG VARCHAR`
- MySQL : `MEDIUMTEXT`, `LONGTEXT`
- MariaDB : `LONGTEXT`
- SAP ASE : `CHAR(n)`,`VARCHAR(n)` (only when n≥256)
