### PR TITLE
Allow omit a 'method' attribute on SqlProvider annotation

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/DeleteProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/DeleteProvider.java
@@ -28,7 +28,33 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface DeleteProvider {
+
+  /**
+   * Specify a type that implements an SQL provider method.
+   *
+   * @return a type that implements an SQL provider method
+   */
   Class<?> type();
 
+  /**
+   * Specify a method for providing an SQL.
+   *
+   * <p>
+   * Since 3.5.1, this attribute can omit.
+   * If this attribute omit, the MyBatis will call a method that decide by following rules.
+   * <ul>
+   *   <li>
+   *     If class that specified the {@link #type()} attribute implements the {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver},
+   *     the MyBatis use a method that returned by it
+   *   </li>
+   *   <li>
+   *     If cannot resolve a method by {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver}(= not implement it or it was returned {@code null}),
+   *     the MyBatis will search and use a fallback method that named {@code resolveSql} from specified type
+   *   </li>
+   * </ul>
+   *
+   * @return a method name of method for providing an SQL
+   */
   String method() default "";
+
 }

--- a/src/main/java/org/apache/ibatis/annotations/DeleteProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/DeleteProvider.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,5 +30,5 @@ import java.lang.annotation.Target;
 public @interface DeleteProvider {
   Class<?> type();
 
-  String method();
+  String method() default "";
 }

--- a/src/main/java/org/apache/ibatis/annotations/DeleteProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/DeleteProvider.java
@@ -49,7 +49,7 @@ public @interface DeleteProvider {
    *   </li>
    *   <li>
    *     If cannot resolve a method by {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver}(= not implement it or it was returned {@code null}),
-   *     the MyBatis will search and use a fallback method that named {@code resolveSql} from specified type
+   *     the MyBatis will search and use a fallback method that named {@code provideSql} from specified type
    *   </li>
    * </ul>
    *

--- a/src/main/java/org/apache/ibatis/annotations/InsertProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/InsertProvider.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,5 +30,5 @@ import java.lang.annotation.Target;
 public @interface InsertProvider {
   Class<?> type();
 
-  String method();
+  String method() default "";
 }

--- a/src/main/java/org/apache/ibatis/annotations/InsertProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/InsertProvider.java
@@ -28,7 +28,33 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface InsertProvider {
+
+  /**
+   * Specify a type that implements an SQL provider method.
+   *
+   * @return a type that implements an SQL provider method
+   */
   Class<?> type();
 
+  /**
+   * Specify a method for providing an SQL.
+   *
+   * <p>
+   * Since 3.5.1, this attribute can omit.
+   * If this attribute omit, the MyBatis will call a method that decide by following rules.
+   * <ul>
+   *   <li>
+   *     If class that specified the {@link #type()} attribute implements the {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver},
+   *     the MyBatis use a method that returned by it
+   *   </li>
+   *   <li>
+   *     If cannot resolve a method by {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver}(= not implement it or it was returned {@code null}),
+   *     the MyBatis will search and use a fallback method that named {@code resolveSql} from specified type
+   *   </li>
+   * </ul>
+   *
+   * @return a method name of method for providing an SQL
+   */
   String method() default "";
+
 }

--- a/src/main/java/org/apache/ibatis/annotations/InsertProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/InsertProvider.java
@@ -49,7 +49,7 @@ public @interface InsertProvider {
    *   </li>
    *   <li>
    *     If cannot resolve a method by {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver}(= not implement it or it was returned {@code null}),
-   *     the MyBatis will search and use a fallback method that named {@code resolveSql} from specified type
+   *     the MyBatis will search and use a fallback method that named {@code provideSql} from specified type
    *   </li>
    * </ul>
    *

--- a/src/main/java/org/apache/ibatis/annotations/SelectProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/SelectProvider.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,5 +30,5 @@ import java.lang.annotation.Target;
 public @interface SelectProvider {
   Class<?> type();
 
-  String method();
+  String method() default "";
 }

--- a/src/main/java/org/apache/ibatis/annotations/SelectProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/SelectProvider.java
@@ -49,7 +49,7 @@ public @interface SelectProvider {
    *   </li>
    *   <li>
    *     If cannot resolve a method by {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver}(= not implement it or it was returned {@code null}),
-   *     the MyBatis will search and use a fallback method that named {@code resolveSql} from specified type
+   *     the MyBatis will search and use a fallback method that named {@code provideSql} from specified type
    *   </li>
    * </ul>
    *

--- a/src/main/java/org/apache/ibatis/annotations/SelectProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/SelectProvider.java
@@ -28,7 +28,33 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface SelectProvider {
+
+  /**
+   * Specify a type that implements an SQL provider method.
+   *
+   * @return a type that implements an SQL provider method
+   */
   Class<?> type();
 
+  /**
+   * Specify a method for providing an SQL.
+   *
+   * <p>
+   * Since 3.5.1, this attribute can omit.
+   * If this attribute omit, the MyBatis will call a method that decide by following rules.
+   * <ul>
+   *   <li>
+   *     If class that specified the {@link #type()} attribute implements the {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver},
+   *     the MyBatis use a method that returned by it
+   *   </li>
+   *   <li>
+   *     If cannot resolve a method by {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver}(= not implement it or it was returned {@code null}),
+   *     the MyBatis will search and use a fallback method that named {@code resolveSql} from specified type
+   *   </li>
+   * </ul>
+   *
+   * @return a method name of method for providing an SQL
+   */
   String method() default "";
+
 }

--- a/src/main/java/org/apache/ibatis/annotations/UpdateProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/UpdateProvider.java
@@ -49,7 +49,7 @@ public @interface UpdateProvider {
    *   </li>
    *   <li>
    *     If cannot resolve a method by {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver}(= not implement it or it was returned {@code null}),
-   *     the MyBatis will search and use a fallback method that named {@code resolveSql} from specified type
+   *     the MyBatis will search and use a fallback method that named {@code provideSql} from specified type
    *   </li>
    * </ul>
    *

--- a/src/main/java/org/apache/ibatis/annotations/UpdateProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/UpdateProvider.java
@@ -28,7 +28,33 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface UpdateProvider {
+
+  /**
+   * Specify a type that implements an SQL provider method.
+   *
+   * @return a type that implements an SQL provider method
+   */
   Class<?> type();
 
+  /**
+   * Specify a method for providing an SQL.
+   *
+   * <p>
+   * Since 3.5.1, this attribute can omit.
+   * If this attribute omit, the MyBatis will call a method that decide by following rules.
+   * <ul>
+   *   <li>
+   *     If class that specified the {@link #type()} attribute implements the {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver},
+   *     the MyBatis use a method that returned by it
+   *   </li>
+   *   <li>
+   *     If cannot resolve a method by {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver}(= not implement it or it was returned {@code null}),
+   *     the MyBatis will search and use a fallback method that named {@code resolveSql} from specified type
+   *   </li>
+   * </ul>
+   *
+   * @return a method name of method for providing an SQL
+   */
   String method() default "";
+
 }

--- a/src/main/java/org/apache/ibatis/annotations/UpdateProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/UpdateProvider.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,5 +30,5 @@ import java.lang.annotation.Target;
 public @interface UpdateProvider {
   Class<?> type();
 
-  String method();
+  String method() default "";
 }

--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderMethodResolver.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderMethodResolver.java
@@ -18,7 +18,6 @@ package org.apache.ibatis.builder.annotation;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -50,18 +49,25 @@ public interface ProviderMethodResolver {
    * @throws BuilderException Throws when cannot resolve a target method
    */
   default Method resolveMethod(ProviderContext context) {
-    List<Method> targetMethods = Arrays.stream(getClass().getMethods())
+    List<Method> sameNameMethods = Arrays.stream(getClass().getMethods())
         .filter(m -> m.getName().equals(context.getMapperMethod().getName()))
+        .collect(Collectors.toList());
+    if (sameNameMethods.isEmpty()) {
+      throw new BuilderException("Cannot resolve the provider method because '"
+          + context.getMapperMethod().getName() + "' not found in SqlProvider '" + getClass().getName() + "'.");
+    }
+    List<Method> targetMethods = sameNameMethods.stream()
         .filter(m -> CharSequence.class.isAssignableFrom(m.getReturnType()))
         .collect(Collectors.toList());
     if (targetMethods.size() == 1) {
       return targetMethods.get(0);
     }
     if (targetMethods.isEmpty()) {
-      throw new BuilderException("Cannot resolve the provide method because '"
-          + context.getMapperMethod().getName() + "' not found in SqlProvider '" + getClass().getName() + "'.");
+      throw new BuilderException("Cannot resolve the provider method because '"
+          + context.getMapperMethod().getName() + "' does not return the CharSequence or its subclass in SqlProvider '"
+          + getClass().getName() + "'.");
     } else {
-      throw new BuilderException("Cannot resolve the provide method because '"
+      throw new BuilderException("Cannot resolve the provider method because '"
           + context.getMapperMethod().getName() + "' is found multiple in SqlProvider '" + getClass().getName() + "'.");
     }
   }

--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderMethodResolver.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderMethodResolver.java
@@ -1,0 +1,69 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.builder.annotation;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.ibatis.builder.BuilderException;
+
+/**
+ * The interface that resolve an SQL provider method via an SQL provider class.
+ *
+ * <p> This interface need to implements at an SQL provider class and
+ * it need to define the default constructor for creating a new instance.
+ *
+ * @since 3.5.1
+ * @author Kazuki Shimizu
+ */
+public interface ProviderMethodResolver {
+
+  /**
+   * Resolve an SQL provider method.
+   *
+   * <p> The default implementation return a method that matches following conditions.
+   * <ul>
+   *   <li>Method name matches with mapper method</li>
+   *   <li>Return type matches the {@link CharSequence}({@link String}, {@link StringBuilder}, etc...)</li>
+   * </ul>
+   * If matched method is zero or multiple, it throws a {@link BuilderException}.
+   *
+   * @param context a context for SQL provider
+   * @return an SQL provider method
+   * @throws BuilderException Throws when cannot resolve a target method
+   */
+  default Method resolveMethod(ProviderContext context) {
+    List<Method> targetMethods = Arrays.stream(getClass().getMethods())
+        .filter(m -> m.getName().equals(context.getMapperMethod().getName()))
+        .filter(m -> CharSequence.class.isAssignableFrom(m.getReturnType()))
+        .collect(Collectors.toList());
+    if (targetMethods.size() == 1) {
+      return targetMethods.get(0);
+    }
+    if (targetMethods.isEmpty()) {
+      throw new BuilderException("Cannot resolve the provide method because '"
+          + context.getMapperMethod().getName() + "' not found in SqlProvider '" + getClass().getName() + "'.");
+    } else {
+      throw new BuilderException("Cannot resolve the provide method because '"
+          + context.getMapperMethod().getName() + "' is found multiple in SqlProvider '" + getClass().getName() + "'.");
+    }
+  }
+
+}

--- a/src/site/es/xdoc/java-api.xml
+++ b/src/site/es/xdoc/java-api.xml
@@ -464,7 +464,13 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         </td>
         <td>Estas anotaciones SQL alternativas te permiten especificar un nombre de clases y un método que devolverán la SQL que debe ejecutarse (Since 3.4.6, you can specify the <code>CharSequence</code> instead of <code>String</code> as a method return type).
           Cuando se ejecute el método MyBatis instanciará la clase y ejecutará el método especificados en el provider. You can pass objects that passed to arguments of a mapper method, "Mapper interface type" and "Mapper method"
-          via the <code>ProviderContext</code>(available since MyBatis 3.4.5 or later) as method argument.(In MyBatis 3.4 or later, it's allow multiple parameters) Atributos: type, method.  El atributo type es el nombre completamente cualificado de una clase. El method es el nombre un método de dicha clase. Nota: A continuación hay una sección sobre la clase, que puede ayudar a construir SQL dinámico de una forma más clara y sencilla de leer.</td>
+          via the <code>ProviderContext</code>(available since MyBatis 3.4.5 or later) as method argument.(In MyBatis 3.4 or later, it's allow multiple parameters)
+          Atributos: type, method.  El atributo type es el nombre completamente cualificado de una clase.
+          El method es el nombre un método de dicha clase
+          (Since 3.5.1, you can omit <code>method</code> attribute, the MyBatis will resolve a target method via the
+          <code>ProviderMethodResolver</code> interface.
+          If not resolve by it, the MyBatis use the reserved fallback method that named <code>provideSql</code>).
+          Nota: A continuación hay una sección sobre la clase, que puede ayudar a construir SQL dinámico de una forma más clara y sencilla de leer.</td>
       </tr>
       <tr>
         <td><code>@Param</code></td>
@@ -579,6 +585,44 @@ class UserSqlBuilder {
       FROM("users");
       WHERE("name like #{name} || '%'");
       ORDER_BY(orderByColumn);
+    }}.toString();
+  }
+}]]></source>
+
+    <p>This example shows usage the default implementation of <code>ProviderMethodResolver</code>(available since MyBatis 3.5.1 or later):</p>
+    <source><![CDATA[@SelectProvider(type = UserSqlProvider.class)
+List<User> getUsersByName(String name);
+
+// Implements the ProviderMethodResolver on your provider class
+class UserSqlProvider implements ProviderMethodResolver {
+  // In default implementation, it will resolve a method that method name is matched with mapper method
+  public static String getUsersByName(final String name) {
+    return new SQL(){{
+      SELECT("*");
+      FROM("users");
+      if (name != null) {
+        WHERE("name like #{value} || '%'");
+      }
+      ORDER_BY("id");
+    }}.toString();
+  }
+}]]></source>
+
+    <p>This example shows usage the default implementation of <code>ProviderMethodResolver</code>(available since MyBatis 3.5.1 or later):</p>
+    <source><![CDATA[@SelectProvider(type = UserSqlProvider.class)
+List<User> getUsersByName(String name);
+
+// Implements the ProviderMethodResolver on your provider class
+class UserSqlProvider implements ProviderMethodResolver {
+  // In default implementation, it will resolve a method that method name is matched with mapper method
+  public static String getUsersByName(final String name) {
+    return new SQL(){{
+      SELECT("*");
+      FROM("users");
+      if (name != null) {
+        WHERE("name like #{value} || '%'");
+      }
+      ORDER_BY("id");
     }}.toString();
   }
 }]]></source>

--- a/src/site/ja/xdoc/java-api.xml
+++ b/src/site/ja/xdoc/java-api.xml
@@ -477,7 +477,10 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         <td>これらのアノテーションは動的 SQL を生成するためのものです。実行時に指定されたメソッドが呼び出され、メソッドから返された SQL ステートメントが実行されます (MyBatis 3.4.6以降では、メソッドの返り値として <code>String</code> ではなく <code>CharSequence</code> を指定することができます)。
         マップドステートメントを実行する際、プロバイダーによって指定したクラスのインスタンスが作成され、指定されたメソッドが実行されます。
         なお、メソッド引数にはMapperメソッドの引数に渡したオブジェクトに加え、<code>ProviderContext</code>(MyBatis 3.4.5以降で利用可能)を介して「Mapperインタフェースの型」と「Mapperメソッド」を渡すことができます。(MyBatis 3.4以降では、複数の引数を渡すことができます)
-        キー: <code>type</code>, <code>method</code>. <code>type</code> にはクラスオブジェクト、<code>method</code> にはメソッド名を指定します。 <span class="label important">NOTE</span> 次の章で、クリーンで可読性の高いコードで動的 SQL を構築するためのクラスについて説明します。
+        キー: <code>type</code>, <code>method</code>. <code>type</code> にはクラスオブジェクト、<code>method</code> にはメソッド名を指定します
+        (MyBatis 3.5.1以降では、<code>method</code> 属性を省略することができます。その際MyBatisは、<code>ProviderMethodResolver</code> インタフェースを介して対象メソッドの解決を試み、
+        対象メソッドが解決できない場合は、<code>provideSql</code>という名前のメソッドを代替メソッドとして利用します)。
+        <span class="label important">NOTE</span> 次の章で、クリーンで可読性の高いコードで動的 SQL を構築するためのクラスについて説明します。
 </td>
       </tr>
       <tr>
@@ -591,6 +594,27 @@ class UserSqlBuilder {
       ORDER_BY(orderByColumn);
     }}.toString();
   }
+}]]></source>
+
+    <p>次のコードは、<code>ProviderMethodResolver</code>(MyBatis 3.5.1以降で利用可能)のデフォルト実装の利用例です。</p>
+    <source><![CDATA[@SelectProvider(type = UserSqlProvider.class)
+List<User> getUsersByName(String name);
+
+// SQLプロバイダクラスにProviderMethodResolverを実装する
+class UserSqlProvider implements ProviderMethodResolver {
+
+  // デフォルト実装では、マッパーメソッドと同名のメソッドが対象メソッドとして扱われます。
+  public static String getUsersByName(final String name) {
+    return new SQL(){{
+      SELECT("*");
+      FROM("users");
+      if (name != null) {
+        WHERE("name like #{value} || '%'");
+      }
+      ORDER_BY("id");
+    }}.toString();
+  }
+
 }]]></source>
 
   </subsection>

--- a/src/site/ko/xdoc/java-api.xml
+++ b/src/site/ko/xdoc/java-api.xml
@@ -601,7 +601,10 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
     Mapper 메서드의 인수인 "Mapper interface type" 과 <code>ProviderContext</code>(Mybatis 3.4.5 부터) 를 이용한 "Mapper method" 로 전달 된 객체를 메서드 매개변수로 전달할 수 있다.(마이바티스 3.4이상에서는 복수 파라미터를 허용한다.)
 		사용가능한 속성들 : type, method.
 		type 속성은 클래스.
-		method 속성은 메소드명이다.
+		method 속성은 메소드명이다
+    (Since 3.5.1, you can omit <code>method</code> attribute, the MyBatis will resolve a target method via the
+    <code>ProviderMethodResolver</code> interface.
+    If not resolve by it, the MyBatis use the reserved fallback method that named <code>provideSql</code>).
 		Note: 이 섹션은 클래스에 대한 설명으로 동적 SQL 을 좀더 깔끔하고 읽기 쉽게 만드는데 도움이 될 수 있다.</td>
       </tr>
       <tr>
@@ -730,6 +733,25 @@ class UserSqlBuilder {
       FROM("users");
       WHERE("name like #{name} || '%'");
       ORDER_BY(orderByColumn);
+    }}.toString();
+  }
+}]]></source>
+
+    <p>This example shows usage the default implementation of <code>ProviderMethodResolver</code>(available since MyBatis 3.5.1 or later):</p>
+    <source><![CDATA[@SelectProvider(type = UserSqlProvider.class)
+List<User> getUsersByName(String name);
+
+// Implements the ProviderMethodResolver on your provider class
+class UserSqlProvider implements ProviderMethodResolver {
+  // In default implementation, it will resolve a method that method name is matched with mapper method
+  public static String getUsersByName(final String name) {
+    return new SQL(){{
+      SELECT("*");
+      FROM("users");
+      if (name != null) {
+        WHERE("name like #{value} || '%'");
+      }
+      ORDER_BY("id");
     }}.toString();
   }
 }]]></source>

--- a/src/site/xdoc/java-api.xml
+++ b/src/site/xdoc/java-api.xml
@@ -515,7 +515,11 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
         via the <code>ProviderContext</code>(available since MyBatis 3.4.5 or later) as method argument.
         (In MyBatis 3.4 or later, it's allow multiple parameters)
         Attributes: <code>type</code>, <code>method</code>. The <code>type</code> attribute is a class.
-        The <code>method</code> is the name of the method on that class. <span class="label important">NOTE</span>
+        The <code>method</code> is the name of the method on that class
+        (Since 3.5.1, you can omit <code>method</code> attribute, the MyBatis will resolve a target method via the
+        <code>ProviderMethodResolver</code> interface.
+        If not resolve by it, the MyBatis use the reserved fallback method that named <code>provideSql</code>).
+        <span class="label important">NOTE</span>
         Following this section is a discussion about the class, which can help build dynamic SQL in a cleaner, easier to read way.</td>
       </tr>
       <tr>
@@ -648,6 +652,26 @@ class UserSqlBuilder {
     }}.toString();
   }
 }]]></source>
+
+    <p>This example shows usage the default implementation of <code>ProviderMethodResolver</code>(available since MyBatis 3.5.1 or later):</p>
+    <source><![CDATA[@SelectProvider(type = UserSqlProvider.class)
+List<User> getUsersByName(String name);
+
+// Implements the ProviderMethodResolver on your provider class
+class UserSqlProvider implements ProviderMethodResolver {
+  // In default implementation, it will resolve a method that method name is matched with mapper method
+  public static String getUsersByName(final String name) {
+    return new SQL(){{
+      SELECT("*");
+      FROM("users");
+      if (name != null) {
+        WHERE("name like #{value} || '%'");
+      }
+      ORDER_BY("id");
+    }}.toString();
+  }
+}]]></source>
+
   </subsection>
 
   </section>

--- a/src/site/zh/xdoc/java-api.xml
+++ b/src/site/zh/xdoc/java-api.xml
@@ -465,7 +465,14 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
             <li><code>&lt;select&gt;</code></li>
           </ul>
         </td>
-        <td>允许构建动态 SQL。这些备选的 SQL 注解允许你指定类名和返回在运行时执行的 SQL 语句的方法。（自从MyBatis 3.4.6开始，你可以用 <code>CharSequence</code> 代替 <code>String</code> 来返回类型返回值了。）当执行映射语句的时候，MyBatis 会实例化类并执行方法，类和方法就是填入了注解的值。你可以把已经传递给映射方法了的对象作为参数，"Mapper interface type" 和 "Mapper method" 会经过 <code>ProviderContext</code> （仅在MyBatis 3.4.5及以上支持）作为参数值。（MyBatis 3.4及以上的版本，支持多参数传入）属性有： <code>type</code>, <code>method</code>。<code>type</code> 属性需填入类。<code>method</code> 需填入该类定义了的方法名。<span class="label important">注意</span> 接下来的小节将会讨论类，能帮助你更轻松地构建动态 SQL。</td>
+        <td>允许构建动态 SQL。这些备选的 SQL 注解允许你指定类名和返回在运行时执行的 SQL 语句的方法。（自从MyBatis 3.4.6开始，你可以用 <code>CharSequence</code> 代替 <code>String</code> 来返回类型返回值了。）当执行映射语句的时候，MyBatis 会实例化类并执行方法，类和方法就是填入了注解的值。你可以把已经传递给映射方法了的对象作为参数，"Mapper interface type" 和 "Mapper method" 会经过 <code>ProviderContext</code> （仅在MyBatis 3.4.5及以上支持）作为参数值。（MyBatis 3.4及以上的版本，支持多参数传入）
+        属性有： <code>type</code>, <code>method</code>。
+        <code>type</code> 属性需填入类。
+        <code>method</code> 需填入该类定义了的方法名
+        (Since 3.5.1, you can omit <code>method</code> attribute, the MyBatis will resolve a target method via the
+        <code>ProviderMethodResolver</code> interface.
+        If not resolve by it, the MyBatis use the reserved fallback method that named <code>provideSql</code>)。
+        <span class="label important">注意</span> 接下来的小节将会讨论类，能帮助你更轻松地构建动态 SQL。</td>
       </tr>
       <tr>
         <td><code>@Param</code></td>
@@ -574,6 +581,25 @@ class UserSqlBuilder {
       FROM("users");
       WHERE("name like #{name} || '%'");
       ORDER_BY(orderByColumn);
+    }}.toString();
+  }
+}]]></source>
+
+    <p>This example shows usage the default implementation of <code>ProviderMethodResolver</code>(available since MyBatis 3.5.1 or later):</p>
+    <source><![CDATA[@SelectProvider(type = UserSqlProvider.class)
+List<User> getUsersByName(String name);
+
+// Implements the ProviderMethodResolver on your provider class
+class UserSqlProvider implements ProviderMethodResolver {
+  // In default implementation, it will resolve a method that method name is matched with mapper method
+  public static String getUsersByName(final String name) {
+    return new SQL(){{
+      SELECT("*");
+      FROM("users");
+      if (name != null) {
+        WHERE("name like #{value} || '%'");
+      }
+      ORDER_BY("id");
     }}.toString();
   }
 }]]></source>

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/CreateDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2009-2017 the original author or authors.
+--    Copyright 2009-2019 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 --
 
 drop table users if exists;
+drop table memos if exists;
 
 create table users (
   id int,
@@ -22,8 +23,14 @@ create table users (
   logical_delete boolean default false
 );
 
+create table memos (
+   id int,
+   memo varchar(1024),
+);
+
 insert into users (id, name) values(1, 'User1');
 insert into users (id, name) values(2, 'User2');
 insert into users (id, name) values(3, 'User3');
 insert into users (id, name, logical_delete) values(4, 'User4', true);
 
+insert into memos (id, memo) values(1, 'memo1');

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/ProviderMethodResolutionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/ProviderMethodResolutionTest.java
@@ -1,0 +1,233 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.sqlprovider;
+
+import java.io.Reader;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.annotations.DeleteProvider;
+import org.apache.ibatis.annotations.InsertProvider;
+import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.annotations.UpdateProvider;
+import org.apache.ibatis.builder.BuilderException;
+import org.apache.ibatis.builder.annotation.ProviderContext;
+import org.apache.ibatis.builder.annotation.ProviderMethodResolver;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test for https://github.com/mybatis/mybatis-3/issues/1279
+ */
+class ProviderMethodResolutionTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/sqlprovider/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().addMapper(ProvideMethodResolverMapper.class);
+    }
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+        "org/apache/ibatis/submitted/sqlprovider/CreateDB.sql");
+  }
+
+  @Test
+  void shouldResolveWhenDefaultResolverMatchedMethodIsOne() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      ProvideMethodResolverMapper mapper = sqlSession.getMapper(ProvideMethodResolverMapper.class);
+      assertEquals(1, mapper.select());
+    }
+  }
+
+  @Test
+  void shouldErrorWhenDefaultResolverMatchedMethodIsNone() {
+    BuilderException e = Assertions.assertThrows(BuilderException.class,
+        () -> sqlSessionFactory.getConfiguration().addMapper(DefaultProvideMethodResolverMatchedMethodIsNoneMapper.class));
+    assertEquals(
+        "Cannot resolve the provide method because 'insert' not found in SqlProvider 'org.apache.ibatis.submitted.sqlprovider.ProviderMethodResolutionTest$DefaultProvideMethodResolverMatchedMethodIsNoneMapper$MethodResolverBasedSqlProvider'.",
+        e.getCause().getMessage());
+  }
+
+  @Test
+  void shouldErrorWhenDefaultResolverMatchedMethodIsMultiple() {
+    BuilderException e = Assertions.assertThrows(BuilderException.class,
+        () -> sqlSessionFactory.getConfiguration().addMapper(DefaultProvideMethodResolverMatchedMethodIsMultipleMapper.class));
+    assertEquals(
+        "Cannot resolve the provide method because 'update' is found multiple in SqlProvider 'org.apache.ibatis.submitted.sqlprovider.ProviderMethodResolutionTest$DefaultProvideMethodResolverMatchedMethodIsMultipleMapper$MethodResolverBasedSqlProvider'.",
+        e.getCause().getMessage());
+  }
+
+  @Test
+  void shouldResolveReservedMethod() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      ProvideMethodResolverMapper mapper = sqlSession.getMapper(ProvideMethodResolverMapper.class);
+      assertEquals(1, mapper.delete());
+    }
+  }
+
+  @Test
+  void shouldUseSpecifiedMethodOnSqlProviderAnnotation() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      ProvideMethodResolverMapper mapper = sqlSession.getMapper(ProvideMethodResolverMapper.class);
+      assertEquals(2, mapper.select2());
+    }
+  }
+
+  @Test
+  void shouldResolveMethodUsingCustomResolver() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      ProvideMethodResolverMapper mapper = sqlSession.getMapper(ProvideMethodResolverMapper.class);
+      assertEquals(3, mapper.select3());
+    }
+  }
+
+  @Test
+  void shouldResolveReservedNameMethodWhenCustomResolverReturnNull() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      ProvideMethodResolverMapper mapper = sqlSession.getMapper(ProvideMethodResolverMapper.class);
+      assertEquals(99, mapper.select4());
+    }
+  }
+
+  @Test
+  void shouldErrorWhenCannotDetectsReservedNameMethod() {
+    BuilderException e = Assertions.assertThrows(BuilderException.class,
+        () -> sqlSessionFactory.getConfiguration().addMapper(ReservedNameMethodIsNoneMapper.class));
+    assertEquals(
+        "Error creating SqlSource for SqlProvider. Method 'provideSql' not found in SqlProvider 'org.apache.ibatis.submitted.sqlprovider.ProviderMethodResolutionTest$ReservedNameMethodIsNoneMapper$SqlProvider'.",
+        e.getCause().getMessage());
+  }
+
+  interface ProvideMethodResolverMapper {
+
+    @SelectProvider(type = MethodResolverBasedSqlProvider.class)
+    int select();
+
+    @SelectProvider(type = MethodResolverBasedSqlProvider.class, method = "provideSelect2Sql")
+    int select2();
+
+    @SelectProvider(type = CustomMethodResolverBasedSqlProvider.class)
+    int select3();
+
+    @SelectProvider(type = CustomMethodResolverBasedSqlProvider.class)
+    int select4();
+
+    @DeleteProvider(type = ReservedMethodNameBasedSqlProvider.class)
+    int delete();
+
+    class MethodResolverBasedSqlProvider implements ProviderMethodResolver {
+      public static String select() {
+        return "SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS";
+      }
+
+      public static String select2() {
+        throw new IllegalStateException("This method should not called when specify `method` attribute on @SelectProvider.");
+      }
+
+      public static String provideSelect2Sql() {
+        return "SELECT 2 FROM INFORMATION_SCHEMA.SYSTEM_USERS";
+      }
+    }
+
+    class ReservedMethodNameBasedSqlProvider {
+      public static String provideSql() {
+        return "DELETE FROM memos WHERE id = 1";
+      }
+    }
+
+    class CustomMethodResolverBasedSqlProvider implements CustomProviderMethodResolver {
+      public static String select3Sql() {
+        return "SELECT 3 FROM INFORMATION_SCHEMA.SYSTEM_USERS";
+      }
+
+      public static String provideSql() {
+        return "SELECT 99 FROM INFORMATION_SCHEMA.SYSTEM_USERS";
+      }
+    }
+
+  }
+
+  interface CustomProviderMethodResolver extends ProviderMethodResolver {
+    @Override
+    default Method resolveMethod(ProviderContext context) {
+      List<Method> targetMethods = Arrays.stream(getClass().getMethods())
+          .filter(m -> m.getName().equals(context.getMapperMethod().getName() + "Sql"))
+          .filter(m -> CharSequence.class.isAssignableFrom(m.getReturnType()))
+          .collect(Collectors.toList());
+      if (targetMethods.size() == 1) {
+        return targetMethods.get(0);
+      }
+      return null;
+    }
+  }
+
+  interface DefaultProvideMethodResolverMatchedMethodIsNoneMapper {
+
+    @InsertProvider(type = MethodResolverBasedSqlProvider.class)
+    int insert();
+
+    class MethodResolverBasedSqlProvider implements ProviderMethodResolver {
+      public static int insert() {
+        return 1;
+      }
+    }
+
+  }
+
+  interface DefaultProvideMethodResolverMatchedMethodIsMultipleMapper {
+
+    @UpdateProvider(type = MethodResolverBasedSqlProvider.class)
+    int update();
+
+    class MethodResolverBasedSqlProvider implements ProviderMethodResolver {
+      public static String update() {
+        return "UPDATE foo SET name = #{name} WHERE id = #{id}";
+      }
+
+      public static StringBuilder update(ProviderContext context) {
+        return new StringBuilder("UPDATE foo SET name = #{name} WHERE id = #{id}");
+      }
+    }
+
+  }
+
+  interface ReservedNameMethodIsNoneMapper {
+
+    @UpdateProvider(type = SqlProvider.class)
+    int update();
+
+    class SqlProvider {
+      public static String select() {
+        return "SELECT 1 FROM INFORMATION_SCHEMA.SYSTEM_USERS";
+      }
+    }
+
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/ProviderMethodResolutionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/ProviderMethodResolutionTest.java
@@ -66,11 +66,20 @@ class ProviderMethodResolutionTest {
   }
 
   @Test
-  void shouldErrorWhenDefaultResolverMatchedMethodIsNone() {
+  void shouldErrorWhenDefaultResolverMethodNameMatchedMethodIsNone() {
     BuilderException e = Assertions.assertThrows(BuilderException.class,
-        () -> sqlSessionFactory.getConfiguration().addMapper(DefaultProvideMethodResolverMatchedMethodIsNoneMapper.class));
+        () -> sqlSessionFactory.getConfiguration().addMapper(DefaultProvideMethodResolverMethodNameMatchedMethodIsNoneMapper.class));
     assertEquals(
-        "Cannot resolve the provide method because 'insert' not found in SqlProvider 'org.apache.ibatis.submitted.sqlprovider.ProviderMethodResolutionTest$DefaultProvideMethodResolverMatchedMethodIsNoneMapper$MethodResolverBasedSqlProvider'.",
+        "Cannot resolve the provider method because 'insert' not found in SqlProvider 'org.apache.ibatis.submitted.sqlprovider.ProviderMethodResolutionTest$DefaultProvideMethodResolverMethodNameMatchedMethodIsNoneMapper$MethodResolverBasedSqlProvider'.",
+        e.getCause().getMessage());
+  }
+
+  @Test
+  void shouldErrorWhenDefaultResolverReturnTypeMatchedMethodIsNone() {
+    BuilderException e = Assertions.assertThrows(BuilderException.class,
+        () -> sqlSessionFactory.getConfiguration().addMapper(DefaultProvideMethodResolverReturnTypeMatchedMethodIsNoneMapper.class));
+    assertEquals(
+        "Cannot resolve the provider method because 'insert' does not return the CharSequence or its subclass in SqlProvider 'org.apache.ibatis.submitted.sqlprovider.ProviderMethodResolutionTest$DefaultProvideMethodResolverReturnTypeMatchedMethodIsNoneMapper$MethodResolverBasedSqlProvider'.",
         e.getCause().getMessage());
   }
 
@@ -79,7 +88,7 @@ class ProviderMethodResolutionTest {
     BuilderException e = Assertions.assertThrows(BuilderException.class,
         () -> sqlSessionFactory.getConfiguration().addMapper(DefaultProvideMethodResolverMatchedMethodIsMultipleMapper.class));
     assertEquals(
-        "Cannot resolve the provide method because 'update' is found multiple in SqlProvider 'org.apache.ibatis.submitted.sqlprovider.ProviderMethodResolutionTest$DefaultProvideMethodResolverMatchedMethodIsMultipleMapper$MethodResolverBasedSqlProvider'.",
+        "Cannot resolve the provider method because 'update' is found multiple in SqlProvider 'org.apache.ibatis.submitted.sqlprovider.ProviderMethodResolutionTest$DefaultProvideMethodResolverMatchedMethodIsMultipleMapper$MethodResolverBasedSqlProvider'.",
         e.getCause().getMessage());
   }
 
@@ -187,7 +196,20 @@ class ProviderMethodResolutionTest {
     }
   }
 
-  interface DefaultProvideMethodResolverMatchedMethodIsNoneMapper {
+  interface DefaultProvideMethodResolverMethodNameMatchedMethodIsNoneMapper {
+
+    @InsertProvider(type = MethodResolverBasedSqlProvider.class)
+    int insert();
+
+    class MethodResolverBasedSqlProvider implements ProviderMethodResolver {
+      public static String provideInsertSql() {
+        return "INSERT INTO foo (name) VALUES(#{name})";
+      }
+    }
+
+  }
+
+  interface DefaultProvideMethodResolverReturnTypeMatchedMethodIsNoneMapper {
 
     @InsertProvider(type = MethodResolverBasedSqlProvider.class)
     int insert();


### PR DESCRIPTION
Fixes gh-1279

I've tried to fix gh-1279. In this change, a developer can omit the `method` attribute on SqlProvider annotation (such as `@SelectProvider`, etc...).

If the `method` attribute was omitted, the MyBatis try to resolve a target method as follow:

* If specified type is implements `ProviderMethodResolver` added by this PR, the MyBatis use a method that returned by it

* If cannot resolve by `ProviderMethodResolver`(= not implement or it was returned  `null`), the MyBatis will search a `resolveSql` method(= reserved fallback method) from specified type.

If cannot resolve a target method by above processing, the MyBatis throw a `BuilderException`.

**NOTE:**
For this change, I add the `ProviderMethodResolver` interface and default implementation. In default implementation, it return a method that method name is matched with mapper method. If not found or found multiple methods, it throw a `BuilderException`.

WDYT?

### Related Issues or PRs

* gh-1283