### PR TITLE
added getter for additionalParameters

### DIFF
--- a/src/main/java/org/apache/ibatis/mapping/BoundSql.java
+++ b/src/main/java/org/apache/ibatis/mapping/BoundSql.java
@@ -73,4 +73,8 @@ public class BoundSql {
   public Object getAdditionalParameter(String name) {
     return metaParameters.getValue(name);
   }
+
+  public Map<String, Object> getAdditionalParameters() {
+    return additionalParameters;
+  }
 }


### PR DESCRIPTION
For now its not possible to copy BoundSql to another BoundSql without using reflection.

Goal is to modify sql on the fly. This class inserts "SET LOCAL SCHEMA..." to the beginning of sql.
Absence of getter for "additionalParameters" field makes us use reflection. If we not set additionalParameters, dynamic sql features like <foreach collection....  would't work.

```java
import lombok.extern.slf4j.Slf4j;
import org.apache.ibatis.executor.Executor;
import org.apache.ibatis.mapping.BoundSql;
import org.apache.ibatis.mapping.MappedStatement;
import org.apache.ibatis.mapping.SqlSource;
import org.apache.ibatis.plugin.Interceptor;
import org.apache.ibatis.plugin.Intercepts;
import org.apache.ibatis.plugin.Invocation;
import org.apache.ibatis.plugin.Plugin;
import org.apache.ibatis.plugin.Signature;
import org.apache.ibatis.session.Configuration;
import org.apache.ibatis.session.ResultHandler;
import org.apache.ibatis.session.RowBounds;
import org.springframework.stereotype.Component;

import java.lang.reflect.Field;
import java.util.Map;
import java.util.Properties;

@Slf4j
@Component
@Intercepts({
        @Signature(type = Executor.class, method = "query", args = {
                MappedStatement.class, Object.class, RowBounds.class,
                ResultHandler.class}),
        @Signature(type = Executor.class, method = "update", args = {
                MappedStatement.class, Object.class})})
public class SchemeInterceptor implements Interceptor {

    private static int MAPPED_STATEMENT_INDEX = 0;
    private static int PARAMETER_INDEX = 1;

    @Override
    public Object intercept(Invocation invocation) throws Throwable {
        final Object[] queryArgs = invocation.getArgs();
        processSql(queryArgs);
        return invocation.proceed();
    }

    @Override
    public Object plugin(Object target) {
        return Plugin.wrap(target, this);
    }

    @Override
    public void setProperties(Properties properties) {
        log.info("Intercepted setProperties: {}", properties);
    }

    private void processSql(final Object[] queryArgs) {
        Object parameter = queryArgs[PARAMETER_INDEX];
        MappedStatement ms = (MappedStatement) queryArgs[MAPPED_STATEMENT_INDEX];
        BoundSql boundSql = ms.getBoundSql(parameter);
        String sql = ms.getBoundSql(parameter).getSql().trim();

        MappedStatement newMs = copyFromMappedStatement(ms, parameterObject -> {
            String modifiedSql = modifySQL(sql, ms.getId(), ms.getConfiguration());
            BoundSql boundSql1 = new BoundSql(ms.getConfiguration(),
                    modifiedSql, boundSql.getParameterMappings(),
                    parameterObject);

            // important fot dynamic sql
            try {
                Field f = boundSql.getClass().getDeclaredField("additionalParameters");
                f.setAccessible(true);
                Map<String, Object> iWantThis = (Map<String, Object>) f.get(boundSql);
                for (Map.Entry<String,Object> additionalParam : iWantThis.entrySet()) {
                    boundSql1.setAdditionalParameter(additionalParam.getKey(), additionalParam.getValue());
                }
            } catch (Exception e) {
                log.warn("Cannot set additional params to new BoundSql for {}",modifiedSql, e);
            }

            return boundSql1;
        });
        queryArgs[MAPPED_STATEMENT_INDEX] = newMs;
    }

    private String modifySQL(String sql, String id, Configuration configuration) {
        Properties variables = configuration.getVariables();
        for (String key : variables.stringPropertyNames()) {
            if (id.startsWith(key)) {
                return String.format("set local schema '%s';\n%s", variables.getProperty(key), sql);
            }
        }
        return sql;
    }


    private MappedStatement copyFromMappedStatement(MappedStatement ms, SqlSource newSqlSource) {
        MappedStatement.Builder builder = new MappedStatement.Builder(ms.getConfiguration(), ms.getId(), newSqlSource, ms.getSqlCommandType());

        builder.resource(ms.getResource());
        builder.fetchSize(ms.getFetchSize());
        builder.statementType(ms.getStatementType());
        builder.keyGenerator(ms.getKeyGenerator());
        if (ms.getKeyProperties() != null && ms.getKeyProperties().length != 0) {
            StringBuffer keyProperties = new StringBuffer();
            for (String keyProperty : ms.getKeyProperties()) {
                keyProperties.append(keyProperty).append(",");
            }
            keyProperties.delete(keyProperties.length() - 1, keyProperties.length());
            builder.keyProperty(keyProperties.toString());
        }

        //setStatementTimeout()
        builder.timeout(ms.getTimeout());

        //setStatementResultMap()
        builder.parameterMap(ms.getParameterMap());

        //setStatementResultMap()
        builder.resultMaps(ms.getResultMaps());
        builder.resultSetType(ms.getResultSetType());

        //setStatementCache()
        builder.cache(ms.getCache());
        builder.flushCacheRequired(ms.isFlushCacheRequired());
        builder.useCache(ms.isUseCache());


        return builder.build();
    }
}
```