### PR TITLE
Add resolveMapperTypes

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
+++ b/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
@@ -31,6 +31,21 @@ import java.util.Arrays;
 public class TypeParameterResolver {
 
   /**
+   * @return The generic {@link Type}s of the mapper interface which the method is declare.<br>
+   *         If mapper interface have generic types in the declaration,<br>
+   *         they will be resolved to the actual runtime {@link Type}s.
+   */
+  public static Type[] resolveMapperTypes(Method method, Type srcType) {
+    Class<?> declaringClass = method.getDeclaringClass();
+    TypeVariable<? extends Class<?>>[] typeParameters = declaringClass.getTypeParameters();
+    Type[] result = new Type[typeParameters.length];
+    for (int i = 0; i < typeParameters.length; i++) {
+      result[i] = resolveType(typeParameters[i], srcType, declaringClass);
+    }
+    return result;
+  }
+
+  /**
    * @return The field type as {@link Type}. If it has type parameters in the declaration,<br>
    *         they will be resolved to the actual runtime {@link Type}s.
    */


### PR DESCRIPTION
usage:
```java
public interface SelectAllMapper<T> {
  @SelectProvider(type = SelectAllProvider.class, method = "selectAll")
  List<T> selectAll();
}

public interface DeleteByPrimaryKeyMapper<T> {
  @DeleteProvider(type = DeleteByPrimaryKeyProvider.class, method = "deleteByPrimaryKey")
  int deleteByPrimaryKey(Object key);
}

public interface MyMapper extends SelectAllMapper<Country>, DeleteByPrimaryKeyMapper<City> {
}
```

DeleteByPrimaryKeyProvider as follows:

```java
public String deleteByPrimaryKey(Object key, ProviderContext context){
       Method mapperMethod = context.getMapperMethod();
       Class<?> mapperType = context.getMapperType();
       Class genericType = (Class)TypeParameterResolver.resolveMapperTypes(mapperType, mapperMethod)[0];
       Table table = (Table) genericType.getAnnotation(Table.class);
       return "delete from " + table.name() + " where id = #{_parameter}";
}
```

@harawata Although this usage is not common, it will be used when needed.  After adding this method, this class will be complete.