### PR TITLE
Add `.editorconfig` to maintain consistent coding styles

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*.{adoc, bat, groovy, html, java, js, jsp, kt, kts, md, properties, py, rb, sh, sql, svg, txt, vm, xml, xsd}]
+charset = utf-8
+
+[*.{groovy, java, kt, kts, vm, xml, xsd}]
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+


### PR DESCRIPTION
See [here](https://editorconfig.org/) for usage.