### PR TITLE
Replace postgresql-embedded with Testcontainers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ jdk:
   - oraclejdk11
   - oraclejdk8
 
+services:
+  - docker
+
 cache:
   directories:
     - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -264,13 +264,13 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>1.11.1</version>
+      <version>1.11.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>1.11.1</version>
+      <version>1.11.2</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 
   <properties>
     <clirr.comparisonVersion>3.4.6</clirr.comparisonVersion>
-    <excludedGroups>EmbeddedPostgresqlTests</excludedGroups>
+    <excludedGroups>TestcontainersTests</excludedGroups>
     <maven.compiler.testCompilerArgument>-parameters</maven.compiler.testCompilerArgument>
     <module.name>org.mybatis</module.name>
     <osgi.export>org.apache.ibatis.*;version=${project.version};-noimport:=true</osgi.export>
@@ -262,9 +262,15 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>ru.yandex.qatools.embed</groupId>
-      <artifactId>postgresql-embedded</artifactId>
-      <version>2.10</version>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>1.11.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>1.11.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/PostgresCursorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/PostgresCursorTest.java
@@ -29,30 +29,23 @@ import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.testcontainers.PgContainer;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Tag("TestcontainersTests")
-@Testcontainers
 class PostgresCursorTest {
-
-  @Container
-  private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>().withDatabaseName("cursor_simple")
-      .withUsername("u").withPassword("p");
 
   private static SqlSessionFactory sqlSessionFactory;
 
   @BeforeAll
   static void setUp() throws Exception {
-    String url = postgres.getJdbcUrl();
+    String url = PgContainer.INSTANCE.getJdbcUrl();
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(),
-        new UnpooledDataSource("org.postgresql.Driver", url, "u", "p"));
+        new UnpooledDataSource(PgContainer.DRIVER, url, PgContainer.USER, PgContainer.PW));
     configuration.setEnvironment(environment);
     configuration.addMapper(Mapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/PostgresCursorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/PostgresCursorTest.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.cursor.Cursor;
-import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.ExecutorType;
@@ -42,10 +41,9 @@ class PostgresCursorTest {
 
   @BeforeAll
   static void setUp() throws Exception {
-    String url = PgContainer.INSTANCE.getJdbcUrl();
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(),
-        new UnpooledDataSource(PgContainer.DRIVER, url, PgContainer.USER, PgContainer.PW));
+        PgContainer.getUnpooledDataSource());
     configuration.setEnvironment(environment);
     configuration.addMapper(Mapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/PostgresCursorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/PostgresCursorTest.java
@@ -18,8 +18,6 @@ package org.apache.ibatis.submitted.cursor_simple;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.Iterator;
 
 import org.apache.ibatis.BaseDataTest;
@@ -32,42 +30,35 @@ import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
-import ru.yandex.qatools.embed.postgresql.EmbeddedPostgres;
-import ru.yandex.qatools.embed.postgresql.util.SocketUtil;
-
-@Tag("EmbeddedPostgresqlTests")
+@Tag("TestcontainersTests")
+@Testcontainers
 class PostgresCursorTest {
 
-  private static final EmbeddedPostgres postgres = new EmbeddedPostgres();
+  @Container
+  private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>().withDatabaseName("cursor_simple")
+      .withUsername("u").withPassword("p");
 
   private static SqlSessionFactory sqlSessionFactory;
 
   @BeforeAll
   static void setUp() throws Exception {
-    // Launch PostgreSQL server. Download / unarchive if necessary.
-    String url = postgres.start(
-      EmbeddedPostgres.cachedRuntimeConfig(Paths.get(System.getProperty("java.io.tmpdir"), "pgembed")), "localhost",
-      SocketUtil.findFreePort(), "cursor_simple", "postgres", "root", Collections.emptyList());
-
+    String url = postgres.getJdbcUrl();
     Configuration configuration = new Configuration();
-    Environment environment = new Environment("development", new JdbcTransactionFactory(), new UnpooledDataSource(
-      "org.postgresql.Driver", url, null));
+    Environment environment = new Environment("development", new JdbcTransactionFactory(),
+        new UnpooledDataSource("org.postgresql.Driver", url, "u", "p"));
     configuration.setEnvironment(environment);
     configuration.addMapper(Mapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
       "org/apache/ibatis/submitted/cursor_simple/CreateDB.sql");
-  }
-
-  @AfterAll
-  static void tearDown() {
-    postgres.stop();
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/keycolumn/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/keycolumn/CreateDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2009-2018 the original author or authors.
+--    Copyright 2009-2019 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 --    See the License for the specific language governing permissions and
 --    limitations under the License.
 --
+
+DROP SCHEMA IF EXISTS mbtest;
 
 CREATE SCHEMA mbtest;
 

--- a/src/test/java/org/apache/ibatis/submitted/keycolumn/InsertTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/keycolumn/InsertTest.java
@@ -28,33 +28,26 @@ import org.apache.ibatis.session.ExecutorType;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.testcontainers.PgContainer;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * @author Jeff Butler
  */
 @Tag("TestcontainersTests")
-@Testcontainers
 class InsertTest {
-
-  @Container
-  private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>().withDatabaseName("keycolumn")
-      .withUsername("u").withPassword("p");
 
   private static SqlSessionFactory sqlSessionFactory;
 
   @BeforeAll
   static void setUp() throws Exception {
-    String url = postgres.getJdbcUrl();
+    String url = PgContainer.INSTANCE.getJdbcUrl();
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(),
-        new UnpooledDataSource("org.postgresql.Driver", url, "u", "p"));
+        new UnpooledDataSource(PgContainer.DRIVER, url, PgContainer.USER, PgContainer.PW));
     configuration.setEnvironment(environment);
     configuration.addMapper(InsertMapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);

--- a/src/test/java/org/apache/ibatis/submitted/keycolumn/InsertTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/keycolumn/InsertTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.List;
 
 import org.apache.ibatis.BaseDataTest;
-import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.executor.BatchResult;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
@@ -44,10 +43,9 @@ class InsertTest {
 
   @BeforeAll
   static void setUp() throws Exception {
-    String url = PgContainer.INSTANCE.getJdbcUrl();
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(),
-        new UnpooledDataSource(PgContainer.DRIVER, url, PgContainer.USER, PgContainer.PW));
+        PgContainer.getUnpooledDataSource());
     configuration.setEnvironment(environment);
     configuration.addMapper(InsertMapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);

--- a/src/test/java/org/apache/ibatis/submitted/multiple_resultsets/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_resultsets/CreateDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2009-2018 the original author or authors.
+--    Copyright 2009-2019 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 --    See the License for the specific language governing permissions and
 --    limitations under the License.
 --
+
+DROP SCHEMA IF EXISTS mbtest;
 
 CREATE SCHEMA mbtest;
 

--- a/src/test/java/org/apache/ibatis/submitted/multiple_resultsets/MultipleResultTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_resultsets/MultipleResultTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.ibatis.BaseDataTest;
-import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -43,10 +42,9 @@ class MultipleResultTest {
 
   @BeforeAll
   static void setUp() throws Exception {
-    String url = PgContainer.INSTANCE.getJdbcUrl();
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(),
-        new UnpooledDataSource(PgContainer.DRIVER, url, PgContainer.USER, PgContainer.PW));
+        PgContainer.getUnpooledDataSource());
     configuration.setEnvironment(environment);
     configuration.setMapUnderscoreToCamelCase(true);
     configuration.addMapper(Mapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/multiple_resultsets/MultipleResultTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_resultsets/MultipleResultTest.java
@@ -25,35 +25,28 @@ import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.testcontainers.PgContainer;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 /*
  * This class contains tests for multiple results.
  * It is based on Jeff's ref cursor tests.
  */
 @Tag("TestcontainersTests")
-@Testcontainers
 class MultipleResultTest {
-
-  @Container
-  private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>().withDatabaseName("multiple_resultsets")
-      .withUsername("u").withPassword("p");
 
   private static SqlSessionFactory sqlSessionFactory;
 
   @BeforeAll
   static void setUp() throws Exception {
-    String url = postgres.getJdbcUrl();
+    String url = PgContainer.INSTANCE.getJdbcUrl();
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(),
-        new UnpooledDataSource("org.postgresql.Driver", url, "u", "p"));
+        new UnpooledDataSource(PgContainer.DRIVER, url, PgContainer.USER, PgContainer.PW));
     configuration.setEnvironment(environment);
     configuration.setMapUnderscoreToCamelCase(true);
     configuration.addMapper(Mapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/postgres_genkeys/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/postgres_genkeys/CreateDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2009-2018 the original author or authors.
+--    Copyright 2009-2019 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 --    See the License for the specific language governing permissions and
 --    limitations under the License.
 --
+
+DROP SCHEMA IF EXISTS mbtest;
 
 CREATE SCHEMA mbtest;
 

--- a/src/test/java/org/apache/ibatis/submitted/postgres_genkeys/PostgresGeneratedKeysTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/postgres_genkeys/PostgresGeneratedKeysTest.java
@@ -17,9 +17,6 @@ package org.apache.ibatis.submitted.postgres_genkeys;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.nio.file.Paths;
-import java.util.Collections;
-
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.mapping.Environment;
@@ -28,29 +25,29 @@ import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
-import ru.yandex.qatools.embed.postgresql.EmbeddedPostgres;
-import ru.yandex.qatools.embed.postgresql.util.SocketUtil;
-
-@Tag("EmbeddedPostgresqlTests")
+@Tag("TestcontainersTests")
+@Testcontainers
 class PostgresGeneratedKeysTest {
 
-  private static final EmbeddedPostgres postgres = new EmbeddedPostgres();
+  @Container
+  private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>().withDatabaseName("postgres_genkeys")
+      .withUsername("u").withPassword("p");
 
   private static SqlSessionFactory sqlSessionFactory;
 
   @BeforeAll
   static void setUp() throws Exception {
-    //  Launch PostgreSQL server. Download / unarchive if necessary.
-    String url = postgres.start(EmbeddedPostgres.cachedRuntimeConfig(Paths.get(System.getProperty("java.io.tmpdir"), "pgembed")), "localhost", SocketUtil.findFreePort(), "postgres_genkeys", "postgres", "root", Collections.emptyList());
-
+    String url = postgres.getJdbcUrl();
     Configuration configuration = new Configuration();
-    Environment environment = new Environment("development", new JdbcTransactionFactory(), new UnpooledDataSource(
-        "org.postgresql.Driver", url, null));
+    Environment environment = new Environment("development", new JdbcTransactionFactory(),
+        new UnpooledDataSource("org.postgresql.Driver", url, "u", "p"));
     configuration.setEnvironment(environment);
     configuration.setUseGeneratedKeys(true);
     configuration.addMapper(Mapper.class);
@@ -58,11 +55,6 @@ class PostgresGeneratedKeysTest {
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
         "org/apache/ibatis/submitted/postgres_genkeys/CreateDB.sql");
-  }
-
-  @AfterAll
-  static void tearDown() {
-    postgres.stop();
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/postgres_genkeys/PostgresGeneratedKeysTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/postgres_genkeys/PostgresGeneratedKeysTest.java
@@ -24,30 +24,23 @@ import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.testcontainers.PgContainer;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Tag("TestcontainersTests")
-@Testcontainers
 class PostgresGeneratedKeysTest {
-
-  @Container
-  private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>().withDatabaseName("postgres_genkeys")
-      .withUsername("u").withPassword("p");
 
   private static SqlSessionFactory sqlSessionFactory;
 
   @BeforeAll
   static void setUp() throws Exception {
-    String url = postgres.getJdbcUrl();
+    String url = PgContainer.INSTANCE.getJdbcUrl();
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(),
-        new UnpooledDataSource("org.postgresql.Driver", url, "u", "p"));
+        new UnpooledDataSource(PgContainer.DRIVER, url, PgContainer.USER, PgContainer.PW));
     configuration.setEnvironment(environment);
     configuration.setUseGeneratedKeys(true);
     configuration.addMapper(Mapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/postgres_genkeys/PostgresGeneratedKeysTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/postgres_genkeys/PostgresGeneratedKeysTest.java
@@ -18,7 +18,6 @@ package org.apache.ibatis.submitted.postgres_genkeys;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.ibatis.BaseDataTest;
-import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -37,10 +36,9 @@ class PostgresGeneratedKeysTest {
 
   @BeforeAll
   static void setUp() throws Exception {
-    String url = PgContainer.INSTANCE.getJdbcUrl();
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(),
-        new UnpooledDataSource(PgContainer.DRIVER, url, PgContainer.USER, PgContainer.PW));
+        PgContainer.getUnpooledDataSource());
     configuration.setEnvironment(environment);
     configuration.setUseGeneratedKeys(true);
     configuration.addMapper(Mapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/refcursor/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/refcursor/CreateDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2009-2018 the original author or authors.
+--    Copyright 2009-2019 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 --    See the License for the specific language governing permissions and
 --    limitations under the License.
 --
+
+DROP SCHEMA IF EXISTS mbtest;
 
 CREATE SCHEMA mbtest;
 

--- a/src/test/java/org/apache/ibatis/submitted/refcursor/RefCursorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/refcursor/RefCursorTest.java
@@ -31,33 +31,26 @@ import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.testcontainers.PgContainer;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * @author Jeff Butler
  */
 @Tag("TestcontainersTests")
-@Testcontainers
 class RefCursorTest {
-
-  @Container
-  private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>().withDatabaseName("refcursor")
-      .withUsername("u").withPassword("p");
 
   private static SqlSessionFactory sqlSessionFactory;
 
   @BeforeAll
   static void setUp() throws Exception {
-    String url = postgres.getJdbcUrl();
+    String url = PgContainer.INSTANCE.getJdbcUrl();
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(),
-        new UnpooledDataSource("org.postgresql.Driver", url, "u", "p"));
+        new UnpooledDataSource(PgContainer.DRIVER, url, PgContainer.USER, PgContainer.PW));
     configuration.setEnvironment(environment);
     configuration.addMapper(OrdersMapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);

--- a/src/test/java/org/apache/ibatis/submitted/refcursor/RefCursorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/refcursor/RefCursorTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.ibatis.BaseDataTest;
-import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.ResultContext;
@@ -47,10 +46,9 @@ class RefCursorTest {
 
   @BeforeAll
   static void setUp() throws Exception {
-    String url = PgContainer.INSTANCE.getJdbcUrl();
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(),
-        new UnpooledDataSource(PgContainer.DRIVER, url, PgContainer.USER, PgContainer.PW));
+        PgContainer.getUnpooledDataSource());
     configuration.setEnvironment(environment);
     configuration.addMapper(OrdersMapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);

--- a/src/test/java/org/apache/ibatis/testcontainers/PgContainer.java
+++ b/src/test/java/org/apache/ibatis/testcontainers/PgContainer.java
@@ -16,22 +16,31 @@
 
 package org.apache.ibatis.testcontainers;
 
+import javax.sql.DataSource;
+
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 public class PgContainer {
 
-  public static String USER = "u";
-  public static String PW = "p";
-  public static String DRIVER = "org.postgresql.Driver";
+  private static final String DB_NAME = "mybatis_test";
+  private static final String USERNAME = "u";
+  private static final String PASSWORD = "p";
+  private static final String DRIVER = "org.postgresql.Driver";
 
-  public static final PostgreSQLContainer<?> INSTANCE = initContainer();
+  private static final PostgreSQLContainer<?> INSTANCE = initContainer();
 
   private static PostgreSQLContainer<?> initContainer() {
     @SuppressWarnings("resource")
-    PostgreSQLContainer<?> container = new PostgreSQLContainer<>().withDatabaseName("mybatis_test").withUsername(USER)
-        .withPassword(PW);
+    PostgreSQLContainer<?> container = new PostgreSQLContainer<>().withDatabaseName(DB_NAME).withUsername(USERNAME)
+        .withPassword(PASSWORD);
     container.start();
     return container;
+  }
+
+  public static DataSource getUnpooledDataSource() {
+    return new UnpooledDataSource(PgContainer.DRIVER, INSTANCE.getJdbcUrl(), PgContainer.USERNAME,
+        PgContainer.PASSWORD);
   }
 
   private PgContainer() {

--- a/src/test/java/org/apache/ibatis/testcontainers/PgContainer.java
+++ b/src/test/java/org/apache/ibatis/testcontainers/PgContainer.java
@@ -1,0 +1,40 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.testcontainers;
+
+import org.testcontainers.containers.PostgreSQLContainer;
+
+public class PgContainer {
+
+  public static String USER = "u";
+  public static String PW = "p";
+  public static String DRIVER = "org.postgresql.Driver";
+
+  public static final PostgreSQLContainer<?> INSTANCE = initContainer();
+
+  private static PostgreSQLContainer<?> initContainer() {
+    @SuppressWarnings("resource")
+    PostgreSQLContainer<?> container = new PostgreSQLContainer<>().withDatabaseName("mybatis_test").withUsername(USER)
+        .withPassword(PW);
+    container.start();
+    return container;
+  }
+
+  private PgContainer() {
+    super();
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/SqlxmlTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/SqlxmlTypeHandlerTest.java
@@ -24,7 +24,6 @@ import java.sql.SQLXML;
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Select;
-import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -51,10 +50,9 @@ class SqlxmlTypeHandlerTest extends BaseTypeHandlerTest {
 
   @BeforeAll
   static void setUp() throws Exception {
-    String url = PgContainer.INSTANCE.getJdbcUrl();
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(),
-        new UnpooledDataSource(PgContainer.DRIVER, url, PgContainer.USER, PgContainer.PW));
+        PgContainer.getUnpooledDataSource());
     configuration.setEnvironment(environment);
     configuration.addMapper(Mapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);

--- a/src/test/java/org/apache/ibatis/type/SqlxmlTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/SqlxmlTypeHandlerTest.java
@@ -30,22 +30,16 @@ import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.testcontainers.PgContainer;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Tag("TestcontainersTests")
-@Testcontainers
 class SqlxmlTypeHandlerTest extends BaseTypeHandlerTest {
   private static final TypeHandler<String> TYPE_HANDLER = new SqlxmlTypeHandler();
-  @Container
-  private static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>().withDatabaseName("postgres_sqlxml")
-      .withUsername("u").withPassword("p");
 
   private static SqlSessionFactory sqlSessionFactory;
 
@@ -57,10 +51,10 @@ class SqlxmlTypeHandlerTest extends BaseTypeHandlerTest {
 
   @BeforeAll
   static void setUp() throws Exception {
-    String url = postgres.getJdbcUrl();
+    String url = PgContainer.INSTANCE.getJdbcUrl();
     Configuration configuration = new Configuration();
     Environment environment = new Environment("development", new JdbcTransactionFactory(),
-        new UnpooledDataSource("org.postgresql.Driver", url, "u", "p"));
+        new UnpooledDataSource(PgContainer.DRIVER, url, PgContainer.USER, PgContainer.PW));
     configuration.setEnvironment(environment);
     configuration.addMapper(Mapper.class);
     sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);

--- a/src/test/java/org/apache/ibatis/type/SqlxmlTypeHandlerTest.sql
+++ b/src/test/java/org/apache/ibatis/type/SqlxmlTypeHandlerTest.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2009-2018 the original author or authors.
+--    Copyright 2009-2019 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 --    See the License for the specific language governing permissions and
 --    limitations under the License.
 --
+
+DROP SCHEMA IF EXISTS mbtest;
 
 CREATE SCHEMA mbtest;
 


### PR DESCRIPTION
postgresql-embedded is [no longer actively maintained](https://github.com/yandex-qatools/postgresql-embedded#note-this-project-is-not-being-actively-maintained-anymore) and it is recommended to migrate to [Testcontainers](https://www.testcontainers.org).

The tests that require PostgreSQL are still excluded from maven test by default.
To run them, execute `mvn verify -D"env.TRAVIS"`.

### Note to macOS users

When running the tests in Eclipse on macOS Mojave, I got an error (the tests still passed, though).

> Cannot run program "docker-credential-osxkeychain": error=2, No such file or directory

<details>
<summary>Full stack trace</summary>

```
ERROR [main] - Could not start process:
java.io.IOException: Cannot run program "docker-credential-osxkeychain": error=2, No such file or directory
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1048)
	at org.testcontainers.shaded.org.zeroturnaround.exec.ProcessExecutor.invokeStart(ProcessExecutor.java:1016)
	at org.testcontainers.shaded.org.zeroturnaround.exec.ProcessExecutor.startInternal(ProcessExecutor.java:989)
	at org.testcontainers.shaded.org.zeroturnaround.exec.ProcessExecutor.execute(ProcessExecutor.java:925)
	at org.testcontainers.utility.RegistryAuthLocator.runCredentialProgram(RegistryAuthLocator.java:327)
	at org.testcontainers.utility.RegistryAuthLocator.runCredentialProvider(RegistryAuthLocator.java:223)
	at org.testcontainers.utility.RegistryAuthLocator.authConfigUsingStore(RegistryAuthLocator.java:190)
	at org.testcontainers.utility.RegistryAuthLocator.lookupAuthConfig(RegistryAuthLocator.java:120)
	at org.testcontainers.dockerclient.auth.AuthDelegatingDockerClientConfig.effectiveAuthConfig(AuthDelegatingDockerClientConfig.java:43)
	at com.github.dockerjava.core.DockerClientImpl.createContainerCmd(DockerClientImpl.java:316)
	at org.testcontainers.dockerclient.AuditLoggingDockerClient.createContainerCmd(AuditLoggingDockerClient.java:32)
	at org.testcontainers.utility.ResourceReaper.start(ResourceReaper.java:75)
	at org.testcontainers.DockerClientFactory.client(DockerClientFactory.java:125)
	at org.testcontainers.containers.GenericContainer.<init>(GenericContainer.java:138)
	at org.testcontainers.containers.JdbcDatabaseContainer.<init>(JdbcDatabaseContainer.java:45)
	at org.testcontainers.containers.PostgreSQLContainer.<init>(PostgreSQLContainer.java:32)
	at org.testcontainers.containers.PostgreSQLContainer.<init>(PostgreSQLContainer.java:28)
	at org.apache.ibatis.type.SqlxmlTypeHandlerTest.<clinit>(SqlxmlTypeHandlerTest.java:47)
	at sun.misc.Unsafe.ensureClassInitialized(Native Method)
	at sun.reflect.UnsafeFieldAccessorFactory.newFieldAccessor(UnsafeFieldAccessorFactory.java:43)
	at sun.reflect.ReflectionFactory.newFieldAccessor(ReflectionFactory.java:156)
	at java.lang.reflect.Field.acquireFieldAccessor(Field.java:1088)
	at java.lang.reflect.Field.getFieldAccessor(Field.java:1069)
	at java.lang.reflect.Field.get(Field.java:393)
	at org.testcontainers.junit.jupiter.TestcontainersExtension.getContainerInstance(TestcontainersExtension.java:109)
	at org.testcontainers.junit.jupiter.TestcontainersExtension.lambda$findSharedContainers$5(TestcontainersExtension.java:71)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1374)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:481)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:471)
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:418)
	at org.testcontainers.junit.jupiter.TestcontainersExtension.beforeAll(TestcontainersExtension.java:39)
	at org.junit.jupiter.engine.descriptor.ClassTestDescriptor.lambda$invokeBeforeAllCallbacks$8(ClassTestDescriptor.java:361)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.jupiter.engine.descriptor.ClassTestDescriptor.invokeBeforeAllCallbacks(ClassTestDescriptor.java:361)
	at org.junit.jupiter.engine.descriptor.ClassTestDescriptor.before(ClassTestDescriptor.java:197)
	at org.junit.jupiter.engine.descriptor.ClassTestDescriptor.before(ClassTestDescriptor.java:77)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:132)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
	at java.util.ArrayList.forEach(ArrayList.java:1249)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:229)
	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$6(DefaultLauncher.java:197)
	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:211)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:191)
	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:137)
	at org.eclipse.jdt.internal.junit5.runner.JUnit5TestReference.run(JUnit5TestReference.java:89)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:41)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:541)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:763)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:463)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:209)
Caused by: java.io.IOException: error=2, No such file or directory
	at java.lang.UNIXProcess.forkAndExec(Native Method)
	at java.lang.UNIXProcess.<init>(UNIXProcess.java:247)
	at java.lang.ProcessImpl.start(ProcessImpl.java:134)
	at java.lang.ProcessBuilder.start(ProcessBuilder.java:1029)
	... 71 more
```
</details>


This error occurs because `docker-credential-osxkeychain` is in `/usr/local/bin` which is not included in the `PATH` Eclipse sees.
The easiest workaround would be to launch Eclipse from command line.

```sh
# verify /usr/local/bin is included in the PATH
$ echo $PATH
/usr/local/bin:/usr/bin:/usr/sbin:...
# launch eclipse
$ open /Applications/Eclipse.app
```
