### PR TITLE
check mapper method related mappedStatement whether exist

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -517,11 +517,11 @@ public class MapperAnnotationBuilder {
     return SqlCommandType.valueOf(type.getSimpleName().toUpperCase(Locale.ENGLISH));
   }
 
-  private Class<? extends Annotation> getSqlAnnotationType(Method method) {
+  public Class<? extends Annotation> getSqlAnnotationType(Method method) {
     return chooseAnnotationType(method, SQL_ANNOTATION_TYPES);
   }
 
-  private Class<? extends Annotation> getSqlProviderAnnotationType(Method method) {
+  public Class<? extends Annotation> getSqlProviderAnnotationType(Method method) {
     return chooseAnnotationType(method, SQL_PROVIDER_ANNOTATION_TYPES);
   }
 

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -17,11 +17,16 @@ package org.apache.ibatis.builder.xml;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Collection;
 import java.util.Properties;
 import javax.sql.DataSource;
 
 import org.apache.ibatis.builder.BaseBuilder;
 import org.apache.ibatis.builder.BuilderException;
+import org.apache.ibatis.builder.IncompleteElementException;
+import org.apache.ibatis.builder.annotation.MapperAnnotationBuilder;
 import org.apache.ibatis.datasource.DataSourceFactory;
 import org.apache.ibatis.executor.ErrorContext;
 import org.apache.ibatis.executor.loader.ProxyFactory;
@@ -117,8 +122,50 @@ public class XMLConfigBuilder extends BaseBuilder {
       databaseIdProviderElement(root.evalNode("databaseIdProvider"));
       typeHandlerElement(root.evalNode("typeHandlers"));
       mapperElement(root.evalNode("mappers"));
+      checkMappersRelatedMappedStatementExist();
     } catch (Exception e) {
       throw new BuilderException("Error parsing SQL Mapper Configuration. Cause: " + e, e);
+    }
+  }
+
+  private void checkMappersRelatedMappedStatementExist() {
+    if (!configuration.isCheckMapperMethodRelatedMappedStatementExist()) {
+      return;
+    }
+
+    Collection<Class<?>> mapperClasses = configuration.getMapperRegistry().getMappers();
+    for (Class<?> mapperType : mapperClasses) {
+      doCheckMapperRelatedMappedStatementExist(mapperType);
+    }
+
+  }
+
+  private void doCheckMapperRelatedMappedStatementExist(Class<?> mapperType) {
+
+    Method[] methods = mapperType.getDeclaredMethods();
+    for (Method method : methods) {
+      MapperAnnotationBuilder mab = new MapperAnnotationBuilder(configuration, mapperType);
+      Class<? extends Annotation> sqlAnnotationType = mab.getSqlAnnotationType(method);
+      /**
+       * this method has sql annotation
+       */
+      if (sqlAnnotationType != null) {
+        continue;
+      }
+
+      Class<? extends Annotation> sqlProviderAnnotationType = mab.getSqlProviderAnnotationType(method);
+      /**
+       * this method has sql provider annotation
+       */
+      if (sqlProviderAnnotationType != null) {
+        continue;
+      }
+
+      String mappedStatementId = mapperType.getName() + "." + method.getName();
+      boolean hasStatement = configuration.hasStatement(mappedStatementId, false);
+      if (!hasStatement) {
+        throw new IncompleteElementException(String.format("mappedStatementId (%s) related mappedStatement not found ", mappedStatementId));
+      }
     }
   }
 
@@ -266,6 +313,7 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setReturnInstanceForEmptyRow(booleanValueOf(props.getProperty("returnInstanceForEmptyRow"), false));
     configuration.setLogPrefix(props.getProperty("logPrefix"));
     configuration.setConfigurationFactory(resolveClass(props.getProperty("configurationFactory")));
+    configuration.setCheckMapperMethodRelatedMappedStatementExist(booleanValueOf(props.getProperty("checkMapperMethodRelatedMappedStatementExist"), false));
   }
 
   private void environmentsElement(XNode context) throws Exception {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -164,6 +164,8 @@ public class Configuration {
   protected final Collection<ResultMapResolver> incompleteResultMaps = new LinkedList<>();
   protected final Collection<MethodResolver> incompleteMethods = new LinkedList<>();
 
+  private boolean checkMapperMethodRelatedMappedStatementExist = false ;
+
   /*
    * A map holds cache-ref relationship. The key is the namespace that
    * references a cache bound to another namespace and the value is the
@@ -216,6 +218,14 @@ public class Configuration {
 
   public void setLogPrefix(String logPrefix) {
     this.logPrefix = logPrefix;
+  }
+
+  public boolean isCheckMapperMethodRelatedMappedStatementExist() {
+    return checkMapperMethodRelatedMappedStatementExist;
+  }
+
+  public void setCheckMapperMethodRelatedMappedStatementExist(boolean checkMapperMethodRelatedMappedStatementExist) {
+    this.checkMapperMethodRelatedMappedStatementExist = checkMapperMethodRelatedMappedStatementExist;
   }
 
   public Class<? extends Log> getLogImpl() {


### PR DESCRIPTION
add properties checkMapperMethodRelatedMappedStatementExist to find bug as soon as possible, false as default value ,when setting true ,this will check mapper method related mappedStatement whether exist when application startup ,exception throw when related mappedStatement not exist.