### PR TITLE
[tests] Replace constructor in proxy test with static before all

### DIFF
--- a/src/test/java/org/apache/ibatis/executor/loader/CglibProxyTest.java
+++ b/src/test/java/org/apache/ibatis/executor/loader/CglibProxyTest.java
@@ -27,13 +27,15 @@ import org.apache.ibatis.executor.loader.cglib.CglibProxyFactory;
 import org.apache.ibatis.reflection.factory.DefaultObjectFactory;
 import org.apache.ibatis.session.Configuration;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class CglibProxyTest extends SerializableProxyTest {
 
-  CglibProxyTest() {
+  @BeforeAll
+  static void createProxyFactory() {
     proxyFactory = new CglibProxyFactory();
   }
 

--- a/src/test/java/org/apache/ibatis/executor/loader/JavassistProxyTest.java
+++ b/src/test/java/org/apache/ibatis/executor/loader/JavassistProxyTest.java
@@ -27,13 +27,15 @@ import org.apache.ibatis.executor.loader.javassist.JavassistProxyFactory;
 import org.apache.ibatis.reflection.factory.DefaultObjectFactory;
 import org.apache.ibatis.session.Configuration;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class JavassistProxyTest extends SerializableProxyTest {
 
-  JavassistProxyTest() {
+  @BeforeAll
+  static void createProxyFactory() {
     proxyFactory = new JavassistProxyFactory();
   }
 

--- a/src/test/java/org/apache/ibatis/executor/loader/SerializableProxyTest.java
+++ b/src/test/java/org/apache/ibatis/executor/loader/SerializableProxyTest.java
@@ -39,7 +39,7 @@ public abstract class SerializableProxyTest {
 
   protected Author author = new Author(999, "someone", "!@#@!#!@#", "someone@somewhere.com", "blah", Section.NEWS);
 
-  ProxyFactory proxyFactory;
+  static ProxyFactory proxyFactory;
 
   @Test
   void shouldKeepGenericTypes() {


### PR DESCRIPTION
Issue reported via research project by Anthony Peruma questioning usage of constructor.  This has been modified to use beforeAll annotation and made static.