### PR TITLE
Fixes #1562 - Fix bug in createAutomaticMappings

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -492,7 +492,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
         }
         final String property = metaObject.findProperty(propertyName, configuration.isMapUnderscoreToCamelCase());
         if (property != null && metaObject.hasSetter(property)) {
-          if (resultMap.getMappedProperties().contains(property)) {
+          if (!resultMap.getMappedProperties().contains(property)) {
             continue;
           }
           final Class<?> propertyType = metaObject.getSetterType(property);


### PR DESCRIPTION
Fix a bug decription in #1562. https://github.com/mybatis/mybatis-3/issues/1562.
Add '!' symbol before 'resultMap.getMappedProperties().contains(property)' in org.apache.ibatis.executor.resultset.DefaultResultSetHandler.createAutomaticMappings() .