### PR TITLE
check mapper method related mappedStatement whether exist 

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -517,11 +517,11 @@ public class MapperAnnotationBuilder {
     return SqlCommandType.valueOf(type.getSimpleName().toUpperCase(Locale.ENGLISH));
   }
 
-  private Class<? extends Annotation> getSqlAnnotationType(Method method) {
+  public Class<? extends Annotation> getSqlAnnotationType(Method method) {
     return chooseAnnotationType(method, SQL_ANNOTATION_TYPES);
   }
 
-  private Class<? extends Annotation> getSqlProviderAnnotationType(Method method) {
+  public Class<? extends Annotation> getSqlProviderAnnotationType(Method method) {
     return chooseAnnotationType(method, SQL_PROVIDER_ANNOTATION_TYPES);
   }
 

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -163,7 +163,21 @@ public class XMLConfigBuilder extends BaseBuilder {
 
       String mappedStatementId = mapperType.getName() + "." + method.getName();
       boolean hasStatement = configuration.hasStatement(mappedStatementId, false);
-      if (!hasStatement) {
+
+      if (hasStatement){
+        continue;
+      }
+      boolean mapperMethodRelatedMappedStatementExist = false;
+      if (configuration.getIncompleteStatements() != null && configuration.getIncompleteStatements().size() > 0) {
+        for (XMLStatementBuilder xmlStatementBuilder : configuration.getIncompleteStatements()) {
+          if (mappedStatementId.equals(xmlStatementBuilder.getMappedStatementId())) {
+            mapperMethodRelatedMappedStatementExist = true;
+            break;
+          }
+        }
+      }
+
+      if (!mapperMethodRelatedMappedStatementExist) {
         throw new IncompleteElementException(String.format("mappedStatementId (%s) related mappedStatement not found ", mappedStatementId));
       }
     }

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -17,11 +17,16 @@ package org.apache.ibatis.builder.xml;
 
 import java.io.InputStream;
 import java.io.Reader;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Collection;
 import java.util.Properties;
 import javax.sql.DataSource;
 
 import org.apache.ibatis.builder.BaseBuilder;
 import org.apache.ibatis.builder.BuilderException;
+import org.apache.ibatis.builder.IncompleteElementException;
+import org.apache.ibatis.builder.annotation.MapperAnnotationBuilder;
 import org.apache.ibatis.datasource.DataSourceFactory;
 import org.apache.ibatis.executor.ErrorContext;
 import org.apache.ibatis.executor.loader.ProxyFactory;
@@ -117,8 +122,50 @@ public class XMLConfigBuilder extends BaseBuilder {
       databaseIdProviderElement(root.evalNode("databaseIdProvider"));
       typeHandlerElement(root.evalNode("typeHandlers"));
       mapperElement(root.evalNode("mappers"));
+      checkMappersRelatedMappedStatementExist();
     } catch (Exception e) {
       throw new BuilderException("Error parsing SQL Mapper Configuration. Cause: " + e, e);
+    }
+  }
+
+  private void checkMappersRelatedMappedStatementExist() {
+    if (!configuration.isCheckMapperMethodRelatedMappedStatementExist()) {
+      return;
+    }
+
+    Collection<Class<?>> mapperClasses = configuration.getMapperRegistry().getMappers();
+    for (Class<?> mapperType : mapperClasses) {
+      doCheckMapperRelatedMappedStatementExist(mapperType);
+    }
+
+  }
+
+  private void doCheckMapperRelatedMappedStatementExist(Class<?> mapperType) {
+
+    Method[] methods = mapperType.getDeclaredMethods();
+    for (Method method : methods) {
+      MapperAnnotationBuilder mab = new MapperAnnotationBuilder(configuration, mapperType);
+      Class<? extends Annotation> sqlAnnotationType = mab.getSqlAnnotationType(method);
+      /**
+       * this method has sql annotation
+       */
+      if (sqlAnnotationType != null) {
+        continue;
+      }
+
+      Class<? extends Annotation> sqlProviderAnnotationType = mab.getSqlProviderAnnotationType(method);
+      /**
+       * this method has sql provider annotation
+       */
+      if (sqlProviderAnnotationType != null) {
+        continue;
+      }
+
+      String mappedStatementId = mapperType.getName() + "." + method.getName();
+      boolean hasStatement = configuration.hasStatement(mappedStatementId, false);
+      if (!hasStatement) {
+        throw new IncompleteElementException(String.format("mappedStatementId (%s) related mappedStatement not found ", mappedStatementId));
+      }
     }
   }
 
@@ -266,6 +313,7 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setReturnInstanceForEmptyRow(booleanValueOf(props.getProperty("returnInstanceForEmptyRow"), false));
     configuration.setLogPrefix(props.getProperty("logPrefix"));
     configuration.setConfigurationFactory(resolveClass(props.getProperty("configurationFactory")));
+    configuration.setCheckMapperMethodRelatedMappedStatementExist(booleanValueOf(props.getProperty("checkMapperMethodRelatedMappedStatementExist"), false));
   }
 
   private void environmentsElement(XNode context) throws Exception {

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
@@ -200,4 +200,8 @@ public class XMLStatementBuilder extends BaseBuilder {
     return configuration.getLanguageDriver(langClass);
   }
 
+  public String getMappedStatementId(){
+    return this.builderAssistant.getCurrentNamespace()+"."+this.context.getStringAttribute("id");
+  }
+
 }

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -164,6 +164,8 @@ public class Configuration {
   protected final Collection<ResultMapResolver> incompleteResultMaps = new LinkedList<>();
   protected final Collection<MethodResolver> incompleteMethods = new LinkedList<>();
 
+  private boolean checkMapperMethodRelatedMappedStatementExist = false ;
+
   /*
    * A map holds cache-ref relationship. The key is the namespace that
    * references a cache bound to another namespace and the value is the
@@ -216,6 +218,14 @@ public class Configuration {
 
   public void setLogPrefix(String logPrefix) {
     this.logPrefix = logPrefix;
+  }
+
+  public boolean isCheckMapperMethodRelatedMappedStatementExist() {
+    return checkMapperMethodRelatedMappedStatementExist;
+  }
+
+  public void setCheckMapperMethodRelatedMappedStatementExist(boolean checkMapperMethodRelatedMappedStatementExist) {
+    this.checkMapperMethodRelatedMappedStatementExist = checkMapperMethodRelatedMappedStatementExist;
   }
 
   public Class<? extends Log> getLogImpl() {

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -43,11 +43,7 @@ import org.apache.ibatis.logging.slf4j.Slf4jImpl;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.scripting.defaults.RawLanguageDriver;
 import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
-import org.apache.ibatis.session.AutoMappingBehavior;
-import org.apache.ibatis.session.AutoMappingUnknownColumnBehavior;
-import org.apache.ibatis.session.Configuration;
-import org.apache.ibatis.session.ExecutorType;
-import org.apache.ibatis.session.LocalCacheScope;
+import org.apache.ibatis.session.*;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.apache.ibatis.type.BaseTypeHandler;
 import org.apache.ibatis.type.EnumOrdinalTypeHandler;
@@ -298,5 +294,7 @@ class XmlConfigBuilderTest {
     then(caughtException()).isInstanceOf(BuilderException.class)
       .hasMessageContaining("The properties element cannot specify both a URL and a resource based property file reference.  Please specify one or the other.");
   }
+
+
 
 }

--- a/src/test/java/org/apache/ibatis/builder/xml/ManMapper.xml
+++ b/src/test/java/org/apache/ibatis/builder/xml/ManMapper.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2019 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.builder.xml.mapper.ManMapper" >
+    <resultMap id="BaseResultMap" type="org.apache.ibatis.builder.xml.dto.ManDTO">
+        <id column="id" jdbcType="INTEGER" property="id" />
+        <result column="name" jdbcType="VARCHAR" property="name" />
+        <result column="age" jdbcType="INTEGER" property="age" />
+    </resultMap>
+
+    <select id="findManListByName" parameterType="java.lang.String" resultMap="BaseResultMap">
+        SELECT * FROM CNT_USER WHERE name =#{name}
+    </select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/builder/xml/ManMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/xml/ManMapperConfig.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2019 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <properties resource="org/apache/ibatis/databases/blog/blog-derby.properties"/>
+
+    <settings>
+        <setting name="cacheEnabled" value="true"/>
+        <setting name="lazyLoadingEnabled" value="false"/>
+        <setting name="multipleResultSetsEnabled" value="true"/>
+        <setting name="useColumnLabel" value="true"/>
+        <setting name="useGeneratedKeys" value="false"/>
+        <setting name="defaultExecutorType" value="SIMPLE"/>
+        <setting name="defaultStatementTimeout" value="25"/>
+        <setting name="checkMapperMethodRelatedMappedStatementExist" value="true"/>
+    </settings>
+
+    <typeAliases>
+        <typeAlias alias="Author" type="org.apache.ibatis.domain.blog.Author"/>
+        <typeAlias alias="Blog" type="org.apache.ibatis.domain.blog.Blog"/>
+        <typeAlias alias="Comment" type="org.apache.ibatis.domain.blog.Comment"/>
+        <typeAlias alias="Post" type="org.apache.ibatis.domain.blog.Post"/>
+        <typeAlias alias="Section" type="org.apache.ibatis.domain.blog.Section"/>
+        <typeAlias alias="Tag" type="org.apache.ibatis.domain.blog.Tag"/>
+    </typeAliases>
+
+    <typeHandlers>
+        <typeHandler javaType="String" jdbcType="VARCHAR" handler="org.apache.ibatis.builder.CustomStringTypeHandler"/>
+    </typeHandlers>
+
+    <objectFactory type="org.apache.ibatis.builder.ExampleObjectFactory">
+        <property name="objectFactoryProperty" value="100"/>
+    </objectFactory>
+
+    <plugins>
+        <plugin interceptor="org.apache.ibatis.builder.ExamplePlugin">
+            <property name="pluginProperty" value="100"/>
+        </plugin>
+    </plugins>
+
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value=""/>
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="${driver}"/>
+                <property name="url" value="${url}"/>
+                <property name="username" value="${username}"/>
+                <property name="password" value="${password}"/>
+            </dataSource>
+        </environment>
+    </environments>
+
+    <mappers>
+        <mapper resource="org/apache/ibatis/builder/xml/ManMapper.xml"/>
+    </mappers>
+
+</configuration>

--- a/src/test/java/org/apache/ibatis/builder/xml/PersonMapper.xml
+++ b/src/test/java/org/apache/ibatis/builder/xml/PersonMapper.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2019 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.builder.xml.mapper.PersonMapper" >
+    <resultMap id="BaseResultMap" type="org.apache.ibatis.builder.xml.dto.PersonDTO">
+        <id column="id" jdbcType="INTEGER" property="id" />
+        <result column="name" jdbcType="VARCHAR" property="name" />
+        <result column="age" jdbcType="INTEGER" property="age" />
+    </resultMap>
+
+    <select id="findPersonListByName" parameterType="java.lang.String" resultMap="BaseResultMap">
+        SELECT * FROM CNT_USER WHERE name =#{name}
+    </select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/builder/xml/PersonMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/xml/PersonMapperConfig.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2019 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <properties resource="org/apache/ibatis/databases/blog/blog-derby.properties"/>
+
+    <settings>
+        <setting name="cacheEnabled" value="true"/>
+        <setting name="lazyLoadingEnabled" value="false"/>
+        <setting name="multipleResultSetsEnabled" value="true"/>
+        <setting name="useColumnLabel" value="true"/>
+        <setting name="useGeneratedKeys" value="false"/>
+        <setting name="defaultExecutorType" value="SIMPLE"/>
+        <setting name="defaultStatementTimeout" value="25"/>
+        <setting name="checkMapperMethodRelatedMappedStatementExist" value="false"/>
+    </settings>
+
+    <typeAliases>
+        <typeAlias alias="Author" type="org.apache.ibatis.domain.blog.Author"/>
+        <typeAlias alias="Blog" type="org.apache.ibatis.domain.blog.Blog"/>
+        <typeAlias alias="Comment" type="org.apache.ibatis.domain.blog.Comment"/>
+        <typeAlias alias="Post" type="org.apache.ibatis.domain.blog.Post"/>
+        <typeAlias alias="Section" type="org.apache.ibatis.domain.blog.Section"/>
+        <typeAlias alias="Tag" type="org.apache.ibatis.domain.blog.Tag"/>
+    </typeAliases>
+
+    <typeHandlers>
+        <typeHandler javaType="String" jdbcType="VARCHAR" handler="org.apache.ibatis.builder.CustomStringTypeHandler"/>
+    </typeHandlers>
+
+    <objectFactory type="org.apache.ibatis.builder.ExampleObjectFactory">
+        <property name="objectFactoryProperty" value="100"/>
+    </objectFactory>
+
+    <plugins>
+        <plugin interceptor="org.apache.ibatis.builder.ExamplePlugin">
+            <property name="pluginProperty" value="100"/>
+        </plugin>
+    </plugins>
+
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value=""/>
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="${driver}"/>
+                <property name="url" value="${url}"/>
+                <property name="username" value="${username}"/>
+                <property name="password" value="${password}"/>
+            </dataSource>
+        </environment>
+    </environments>
+
+    <mappers>
+        <mapper resource="org/apache/ibatis/builder/xml/ManMapper.xml"/>
+    </mappers>
+
+</configuration>

--- a/src/test/java/org/apache/ibatis/builder/xml/UserMapper.xml
+++ b/src/test/java/org/apache/ibatis/builder/xml/UserMapper.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2019 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.builder.xml.mapper.UserMapper" >
+    <resultMap id="BaseResultMap" type="org.apache.ibatis.builder.xml.dto.UserDTO">
+        <id column="id" jdbcType="INTEGER" property="id" />
+        <result column="name" jdbcType="VARCHAR" property="name" />
+        <result column="age" jdbcType="INTEGER" property="age" />
+    </resultMap>
+
+    <select id="findUserListByName" parameterType="java.lang.String" resultMap="BaseResultMap">
+        SELECT * FROM CNT_USER WHERE name =#{name}
+    </select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/builder/xml/UserMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/xml/UserMapperConfig.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2019 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <properties resource="org/apache/ibatis/databases/blog/blog-derby.properties"/>
+
+    <settings>
+        <setting name="cacheEnabled" value="true"/>
+        <setting name="lazyLoadingEnabled" value="false"/>
+        <setting name="multipleResultSetsEnabled" value="true"/>
+        <setting name="useColumnLabel" value="true"/>
+        <setting name="useGeneratedKeys" value="false"/>
+        <setting name="defaultExecutorType" value="SIMPLE"/>
+        <setting name="defaultStatementTimeout" value="25"/>
+        <setting name="checkMapperMethodRelatedMappedStatementExist" value="true"/>
+    </settings>
+
+    <typeAliases>
+        <typeAlias alias="Author" type="org.apache.ibatis.domain.blog.Author"/>
+        <typeAlias alias="Blog" type="org.apache.ibatis.domain.blog.Blog"/>
+        <typeAlias alias="Comment" type="org.apache.ibatis.domain.blog.Comment"/>
+        <typeAlias alias="Post" type="org.apache.ibatis.domain.blog.Post"/>
+        <typeAlias alias="Section" type="org.apache.ibatis.domain.blog.Section"/>
+        <typeAlias alias="Tag" type="org.apache.ibatis.domain.blog.Tag"/>
+    </typeAliases>
+
+    <typeHandlers>
+        <typeHandler javaType="String" jdbcType="VARCHAR" handler="org.apache.ibatis.builder.CustomStringTypeHandler"/>
+    </typeHandlers>
+
+    <objectFactory type="org.apache.ibatis.builder.ExampleObjectFactory">
+        <property name="objectFactoryProperty" value="100"/>
+    </objectFactory>
+
+    <plugins>
+        <plugin interceptor="org.apache.ibatis.builder.ExamplePlugin">
+            <property name="pluginProperty" value="100"/>
+        </plugin>
+    </plugins>
+
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value=""/>
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="${driver}"/>
+                <property name="url" value="${url}"/>
+                <property name="username" value="${username}"/>
+                <property name="password" value="${password}"/>
+            </dataSource>
+        </environment>
+    </environments>
+
+    <mappers>
+        <mapper resource="org/apache/ibatis/builder/xml/UserMapper.xml"/>
+    </mappers>
+
+</configuration>

--- a/src/test/java/org/apache/ibatis/builder/xml/UserMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/xml/UserMapperConfig.xml
@@ -32,7 +32,7 @@
         <setting name="useGeneratedKeys" value="false"/>
         <setting name="defaultExecutorType" value="SIMPLE"/>
         <setting name="defaultStatementTimeout" value="25"/>
-        <setting name="checkMapperMethodRelatedMappedStatementExist" value="true"/>
+        <setting name="checkMapperMethodRelatedMappedStatementExist" value="false"/>
     </settings>
 
     <typeAliases>

--- a/src/test/java/org/apache/ibatis/builder/xml/UserMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/xml/UserMapperConfig.xml
@@ -32,7 +32,7 @@
         <setting name="useGeneratedKeys" value="false"/>
         <setting name="defaultExecutorType" value="SIMPLE"/>
         <setting name="defaultStatementTimeout" value="25"/>
-        <setting name="checkMapperMethodRelatedMappedStatementExist" value="false"/>
+        <setting name="checkMapperMethodRelatedMappedStatementExist" value="true"/>
     </settings>
 
     <typeAliases>

--- a/src/test/java/org/apache/ibatis/builder/xml/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/XmlConfigBuilderTest.java
@@ -15,17 +15,13 @@
  */
 package org.apache.ibatis.builder.xml;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.Test;
 
 import java.io.InputStream;
 
-import org.apache.ibatis.builder.xml.mapper.UserMapper;
-import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.session.SqlSession;
-import org.apache.ibatis.session.SqlSessionFactory;
-import org.apache.ibatis.session.SqlSessionFactoryBuilder;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class XmlConfigBuilderTest {
 
@@ -48,18 +44,6 @@ public class XmlConfigBuilderTest {
       noExceptionThrow = false;
     }
     assertThat(noExceptionThrow).isFalse();
-  }
-
-  @Test
-  public void testUpdateByName() throws Exception {
-    String resource = "org/apache/ibatis/builder/xml/UserMapperConfig.xml";
-    InputStream inputStream = Resources.getResourceAsStream(resource);
-    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream);
-    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
-      UserMapper userMapper = sqlSession.getMapper(UserMapper.class);
-      int result = userMapper.updateByName("any param", 0);
-      assertEquals(result, 1);
-    }
   }
 
   /**

--- a/src/test/java/org/apache/ibatis/builder/xml/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/XmlConfigBuilderTest.java
@@ -15,13 +15,17 @@
  */
 package org.apache.ibatis.builder.xml;
 
-import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.session.SqlSessionFactoryBuilder;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.InputStream;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.apache.ibatis.builder.xml.mapper.UserMapper;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.Test;
 
 public class XmlConfigBuilderTest {
 
@@ -44,6 +48,18 @@ public class XmlConfigBuilderTest {
       noExceptionThrow = false;
     }
     assertThat(noExceptionThrow).isFalse();
+  }
+
+  @Test
+  public void testUpdateByName() throws Exception {
+    String resource = "org/apache/ibatis/builder/xml/UserMapperConfig.xml";
+    InputStream inputStream = Resources.getResourceAsStream(resource);
+    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream);
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      UserMapper userMapper = sqlSession.getMapper(UserMapper.class);
+      int result = userMapper.updateByName("any param", 0);
+      assertEquals(result, 1);
+    }
   }
 
   /**

--- a/src/test/java/org/apache/ibatis/builder/xml/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/XmlConfigBuilderTest.java
@@ -1,0 +1,82 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder.xml;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XmlConfigBuilderTest {
+
+  /**
+   * set checkMapperMethodRelatedMappedStatementExist= true , and there is one  RelatedMappedStatement(updateByName) not exist
+   * <p>
+   * and throw exception when startup
+   * <p>
+   * and this will throw exception to interrupt startup and find bug as soon as possible
+   */
+  @Test
+  public void testParseExceptionThrowWhenNoMappedStatement() {
+    boolean noExceptionThrow = true;
+    try {
+      String resource = "org/apache/ibatis/builder/xml/UserMapperConfig.xml";
+      InputStream inputStream = Resources.getResourceAsStream(resource);
+      new SqlSessionFactoryBuilder().build(inputStream);
+    } catch (Exception exp) {
+      assertThat(exp.getMessage().contains("related mappedStatement not found")).isTrue();
+      noExceptionThrow = false;
+    }
+    assertThat(noExceptionThrow).isFalse();
+  }
+
+  /**
+   * set checkMapperMethodRelatedMappedStatementExist= true , and all RelatedMappedStatement exist and no exception throw
+   */
+  @Test
+  public void testParseNoExceptionThrow() {
+    boolean noExceptionThrow = true;
+    try {
+      String resource = "org/apache/ibatis/builder/xml/ManMapperConfig.xml";
+      InputStream inputStream = Resources.getResourceAsStream(resource);
+      new SqlSessionFactoryBuilder().build(inputStream);
+    } catch (Exception exp) {
+      assertThat(exp.getMessage().contains("related mappedStatement not found")).isTrue();
+      noExceptionThrow = false;
+    }
+    assertThat(noExceptionThrow).isTrue();
+  }
+
+  /**
+   * set checkMapperMethodRelatedMappedStatementExist= false , and not check mapper method related mapped statement exist
+   */
+  @Test
+  public void testParseNotCheckMapperMethodRelatedMappedStatementExist() {
+    boolean noExceptionThrow = true;
+    try {
+      String resource = "org/apache/ibatis/builder/xml/PersonMapperConfig.xml";
+      InputStream inputStream = Resources.getResourceAsStream(resource);
+      new SqlSessionFactoryBuilder().build(inputStream);
+    } catch (Exception exp) {
+      assertThat(exp.getMessage().contains("related mappedStatement not found")).isTrue();
+      noExceptionThrow = false;
+    }
+    assertThat(noExceptionThrow).isTrue();
+  }
+}

--- a/src/test/java/org/apache/ibatis/builder/xml/dto/ManDTO.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/dto/ManDTO.java
@@ -1,0 +1,62 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder.xml.dto;
+
+import java.io.Serializable;
+
+public class ManDTO implements Serializable {
+
+  private static final long serialVersionUID = -2533018270773798450L;
+
+  private Integer id;
+
+  private String name;
+
+  private Integer age;
+
+  public ManDTO() {
+
+  }
+
+  public ManDTO(String name, Integer age) {
+    this.name = name;
+    this.age = age;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Integer getAge() {
+    return age;
+  }
+
+  public void setAge(Integer age) {
+    this.age = age;
+  }
+}

--- a/src/test/java/org/apache/ibatis/builder/xml/dto/PersonDTO.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/dto/PersonDTO.java
@@ -1,0 +1,62 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder.xml.dto;
+
+import java.io.Serializable;
+
+public class PersonDTO implements Serializable {
+
+  private static final long serialVersionUID = -2533018270773798450L;
+
+  private Integer id;
+
+  private String name;
+
+  private Integer age;
+
+  public PersonDTO() {
+
+  }
+
+  public PersonDTO(String name, Integer age) {
+    this.name = name;
+    this.age = age;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Integer getAge() {
+    return age;
+  }
+
+  public void setAge(Integer age) {
+    this.age = age;
+  }
+}

--- a/src/test/java/org/apache/ibatis/builder/xml/dto/UserDTO.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/dto/UserDTO.java
@@ -1,0 +1,62 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder.xml.dto;
+
+import java.io.Serializable;
+
+public class UserDTO implements Serializable {
+
+  private static final long serialVersionUID = -2533018270773798450L;
+
+  private Integer id;
+
+  private String name;
+
+  private Integer age;
+
+  public UserDTO() {
+
+  }
+
+  public UserDTO(String name, Integer age) {
+    this.name = name;
+    this.age = age;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Integer getAge() {
+    return age;
+  }
+
+  public void setAge(Integer age) {
+    this.age = age;
+  }
+}

--- a/src/test/java/org/apache/ibatis/builder/xml/mapper/ManMapper.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/mapper/ManMapper.java
@@ -1,0 +1,27 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder.xml.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.builder.xml.dto.ManDTO;
+
+import java.util.List;
+
+public interface ManMapper {
+
+    List<ManDTO> findManListByName(@Param("name") String name);
+
+}

--- a/src/test/java/org/apache/ibatis/builder/xml/mapper/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/mapper/PersonMapper.java
@@ -1,0 +1,29 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder.xml.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.builder.xml.dto.PersonDTO;
+
+import java.util.List;
+
+public interface PersonMapper {
+
+    List<PersonDTO> findPersonListByName(@Param("name") String name);
+
+    int updateByName(@Param("name") String name, @Param("age") int age);
+
+}

--- a/src/test/java/org/apache/ibatis/builder/xml/mapper/UserMapper.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/mapper/UserMapper.java
@@ -1,0 +1,29 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder.xml.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.builder.xml.dto.UserDTO;
+
+import java.util.List;
+
+public interface UserMapper {
+
+    List<UserDTO> findUserListByName(@Param("name") String name);
+
+    int updateByName(@Param("name") String name ,@Param("age") int age);
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/mybatis-config.xml
@@ -22,6 +22,11 @@
 
 <configuration>
 
+  <settings>
+    <setting name="checkMapperMethodRelatedMappedStatementExist"
+      value="true" />
+  </settings>
+
   <environments default="development">
     <environment id="development">
       <transactionManager type="JDBC">

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/mybatis-config.xml
@@ -22,6 +22,11 @@
 
 <configuration>
 
+  <settings>
+    <setting name="checkMapperMethodRelatedMappedStatementExist"
+      value="true" />
+  </settings>
+
   <environments default="development">
     <environment id="development">
       <transactionManager type="JDBC">

--- a/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/mybatis-config.xml
@@ -22,6 +22,11 @@
 
 <configuration>
 
+  <settings>
+    <setting name="checkMapperMethodRelatedMappedStatementExist"
+      value="true" />
+  </settings>
+
   <environments default="development">
     <environment id="development">
       <transactionManager type="JDBC">


### PR DESCRIPTION
add properties checkMapperMethodRelatedMappedStatementExist to find bug as soon as possible, false as default value ,when setting true ,this will check mapper method related mappedStatement whether exist when application startup ,exception will be thrown when related mappedStatement not exist.