### PR TITLE
Replace to openjdk11 from oraclejdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: java
 jdk:
   - openjdk-ea
   - openjdk12
-  - oraclejdk11
+  - openjdk11
   - oraclejdk8
 
 services:


### PR DESCRIPTION
I will suggest to replace to use the `openjdk11` instead of `oraclejdk11` on Travis CI.
This PR will fix build error (https://travis-ci.community/t/cannot-install-oracle-jdk-11/3892).