### PR TITLE
Support to assign single primitive parameter on SQL provider method

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
@@ -15,6 +15,13 @@
  */
 package org.apache.ibatis.builder.annotation;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.ibatis.annotations.Lang;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.mapping.BoundSql;
@@ -22,12 +29,6 @@ import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.reflection.ParamNameResolver;
 import org.apache.ibatis.scripting.LanguageDriver;
 import org.apache.ibatis.session.Configuration;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * @author Clinton Begin

--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
@@ -61,16 +61,9 @@ public class ProviderSqlSource implements SqlSource {
       return true;
     }
     if (to.isPrimitive()) {
-      return isBoxingType(from, to);
+      return from == primitiveWrapperMap.get(to);
     }
     return false;
-  }
-
-  private static boolean isBoxingType(Class<?> target, Class<?> primitive) {
-    if (!primitive.isPrimitive()) {
-      throw new IllegalArgumentException("primitive type must be given");
-    }
-    return primitiveWrapperMap.get(primitive) == target;
   }
 
   /**

--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
@@ -45,7 +45,7 @@ public class ProviderSqlSource implements SqlSource {
   private ProviderContext providerContext;
   private Integer providerContextIndex;
 
-  private static final Map<Class<?>, Class<?>> primitiveBoxingMap =
+  private static final Map<Class<?>, Class<?>> primitiveWrapperMap =
     new HashMap<Class<?>, Class<?>>() {
       { put(byte.class,    Byte.class); }
       { put(short.class,   Short.class); }
@@ -71,7 +71,7 @@ public class ProviderSqlSource implements SqlSource {
     if (!primitive.isPrimitive()) {
       throw new IllegalArgumentException("primitive type must be given");
     }
-    return primitiveBoxingMap.get(primitive) == target;
+    return primitiveWrapperMap.get(primitive) == target;
   }
 
   /**

--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
@@ -57,8 +57,8 @@ public class ProviderSqlSource implements SqlSource {
       { put(char.class,    Character.class); }
     };
 
-  private static boolean isAssignableFrom(Class<?> from, Class<?> to) {
-    if (from.isAssignableFrom(to)) {
+  private static boolean isAssignableFrom(Class<?> to, Class<?> from) {
+    if (to.isAssignableFrom(from)) {
       return true;
     }
     if (from.isPrimitive()) {

--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
@@ -61,8 +61,8 @@ public class ProviderSqlSource implements SqlSource {
     if (to.isAssignableFrom(from)) {
       return true;
     }
-    if (from.isPrimitive()) {
-      return isBoxingType(to, from);
+    if (to.isPrimitive()) {
+      return isBoxingType(from, to);
     }
     return false;
   }

--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
@@ -15,13 +15,6 @@
  */
 package org.apache.ibatis.builder.annotation;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.ibatis.annotations.Lang;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.mapping.BoundSql;
@@ -29,6 +22,12 @@ import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.reflection.ParamNameResolver;
 import org.apache.ibatis.scripting.LanguageDriver;
 import org.apache.ibatis.session.Configuration;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author Clinton Begin
@@ -45,17 +44,17 @@ public class ProviderSqlSource implements SqlSource {
   private ProviderContext providerContext;
   private Integer providerContextIndex;
 
-  private static final Map<Class<?>, Class<?>> primitiveWrapperMap =
-    new HashMap<Class<?>, Class<?>>() {
-      { put(byte.class,    Byte.class); }
-      { put(short.class,   Short.class); }
-      { put(int.class,     Integer.class); }
-      { put(long.class,    Long.class); }
-      { put(float.class,   Float.class); }
-      { put(double.class,  Double.class); }
-      { put(boolean.class, Boolean.class); }
-      { put(char.class,    Character.class); }
-    };
+  private static final Map<Class<?>, Class<?>> primitiveWrapperMap = new HashMap<>();
+  static {
+    primitiveWrapperMap.put(byte.class, Byte.class);
+    primitiveWrapperMap.put(short.class, Short.class);
+    primitiveWrapperMap.put(int.class, Integer.class);
+    primitiveWrapperMap.put(long.class, Long.class);
+    primitiveWrapperMap.put(float.class, Float.class);
+    primitiveWrapperMap.put(double.class, Double.class);
+    primitiveWrapperMap.put(boolean.class, Boolean.class);
+    primitiveWrapperMap.put(char.class, Character.class);
+  }
 
   private static boolean isAssignableFrom(Class<?> to, Class<?> from) {
     if (to.isAssignableFrom(from)) {

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
@@ -465,6 +465,15 @@ class SqlProviderTest {
   }
 
   @Test
+  void staticMethodOnePrimitiveArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals(10, mapper.onePrimitiveArgument(10));
+    }
+  }
+
+  @Test
   void staticMethodMultipleArgument() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       StaticMethodSqlProviderMapper mapper =
@@ -541,6 +550,9 @@ class SqlProviderTest {
     @SelectProvider(type = SqlProvider.class, method = "oneArgument")
     int oneArgument(Integer value);
 
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveArgument")
+    int onePrimitiveArgument(int value);
+
     @SelectProvider(type = SqlProvider.class, method = "multipleArgument")
     int multipleArgument(@Param("value1") Integer value1, @Param("value2") Integer value2);
 
@@ -560,6 +572,11 @@ class SqlProviderTest {
       public static StringBuilder oneArgument(Integer value) {
         return new StringBuilder().append("SELECT ").append(value)
             .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveArgument(int value) {
+        return new StringBuilder().append("SELECT ").append(value)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
       }
 
       public static CharSequence multipleArgument(@Param("value1") Integer value1,

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
@@ -465,11 +465,74 @@ class SqlProviderTest {
   }
 
   @Test
-  void staticMethodOnePrimitiveArgument() {
+  void staticMethodOnePrimitiveByteArgument() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       StaticMethodSqlProviderMapper mapper =
         sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
-      assertEquals(10, mapper.onePrimitiveArgument(10));
+      assertEquals((byte) 10, mapper.onePrimitiveByteArgument((byte) 10));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveShortArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals((short) 10, mapper.onePrimitiveShortArgument((short) 10));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveIntArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals(10, mapper.onePrimitiveIntArgument(10));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveLongArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals(10L, mapper.onePrimitiveLongArgument(10L));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveFloatArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals(10.1F, mapper.onePrimitiveFloatArgument(10.1F));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveDoubleArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals(10.1D, mapper.onePrimitiveDoubleArgument(10.1D));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveBooleanArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertTrue(mapper.onePrimitiveBooleanArgument(true));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveCharArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals('A', mapper.onePrimitiveCharArgument('A'));
     }
   }
 
@@ -550,8 +613,29 @@ class SqlProviderTest {
     @SelectProvider(type = SqlProvider.class, method = "oneArgument")
     int oneArgument(Integer value);
 
-    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveArgument")
-    int onePrimitiveArgument(int value);
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveByteArgument")
+    byte onePrimitiveByteArgument(byte value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveShortArgument")
+    short onePrimitiveShortArgument(short value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveIntArgument")
+    int onePrimitiveIntArgument(int value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveLongArgument")
+    long onePrimitiveLongArgument(long value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveFloatArgument")
+    float onePrimitiveFloatArgument(float value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveDoubleArgument")
+    double onePrimitiveDoubleArgument(double value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveBooleanArgument")
+    boolean onePrimitiveBooleanArgument(boolean value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveCharArgument")
+    char onePrimitiveCharArgument(char value);
 
     @SelectProvider(type = SqlProvider.class, method = "multipleArgument")
     int multipleArgument(@Param("value1") Integer value1, @Param("value2") Integer value2);
@@ -574,9 +658,44 @@ class SqlProviderTest {
             .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
       }
 
-      public static StringBuilder onePrimitiveArgument(int value) {
+      public static StringBuilder onePrimitiveByteArgument(byte value) {
         return new StringBuilder().append("SELECT ").append(value)
           .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveShortArgument(short value) {
+        return new StringBuilder().append("SELECT ").append(value)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveIntArgument(int value) {
+        return new StringBuilder().append("SELECT ").append(value)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveLongArgument(long value) {
+        return new StringBuilder().append("SELECT ").append(value)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveFloatArgument(float value) {
+        return new StringBuilder().append("SELECT ").append(value)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveDoubleArgument(double value) {
+        return new StringBuilder().append("SELECT ").append(value)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveBooleanArgument(boolean value) {
+        return new StringBuilder().append("SELECT ").append(value ? 1 : 0)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveCharArgument(char value) {
+        return new StringBuilder().append("SELECT '").append(value)
+          .append("' FROM INFORMATION_SCHEMA.SYSTEM_USERS");
       }
 
       public static CharSequence multipleArgument(@Param("value1") Integer value1,


### PR DESCRIPTION
Fix a bug in ProviderSqlSource.
A method with single primitive argument results in BuilderException.

Example (kotlin):
```kotlin
@Mapper
interface AuthorDao {

    @SelectProvider(type = SqlProvider::class)
    fun fetchOneById(id: Long): AuthorRow

    class SqlProvider : ProviderMethodResolver {
        companion object {

            @JvmStatic
            fun fetchOneById(id: Long): String {
                return """
                    SELECT * FROM author WHERE id = $id
                """.trimIndent()
            }

        }
    }

}
```
If `AuthorDao#fetchOneById()` would be called like `authorDao.fetchOneById(10)`, following exception will occur.
```
Caused by: org.apache.ibatis.builder.BuilderException: Error invoking SqlProvider method (com.khloe.web.dao.AuthorDao$SqlProvider.fetchOneById). Cannot invoke a method that holds named argument(@Param) using a specifying parameterObject. In this case, please specify a 'java.util.Map' object.
	at org.apache.ibatis.builder.annotation.ProviderSqlSource.createSqlSource(ProviderSqlSource.java:132) ~[mybatis-3.5.1.jar:3.5.1]
	at org.apache.ibatis.builder.annotation.ProviderSqlSource.getBoundSql(ProviderSqlSource.java:109) ~[mybatis-3.5.1.jar:3.5.1]
	at org.apache.ibatis.mapping.MappedStatement.getBoundSql(MappedStatement.java:297) ~[mybatis-3.5.1.jar:3.5.1]
	at org.apache.ibatis.executor.CachingExecutor.query(CachingExecutor.java:81) ~[mybatis-3.5.1.jar:3.5.1]
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:147) ~[mybatis-3.5.1.jar:3.5.1]
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:140) ~[mybatis-3.5.1.jar:3.5.1]
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectOne(DefaultSqlSession.java:76) ~[mybatis-3.5.1.jar:3.5.1]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[na:na]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[na:na]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:566) ~[na:na]
	at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:433) ~[mybatis-spring-2.0.1.jar:2.0.1]
	... 120 common frames omitted
```
