### PR TITLE
Allow a user created map when processing generated keys

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
+++ b/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
@@ -88,8 +88,8 @@ public class Jdbc3KeyGenerator implements KeyGenerator {
   @SuppressWarnings("unchecked")
   private void assignKeys(Configuration configuration, ResultSet rs, ResultSetMetaData rsmd, String[] keyProperties,
       Object parameter) throws SQLException {
-    if (parameter instanceof ParamMap || parameter instanceof StrictMap) {
-      // Multi-param or single param with @Param
+    if (parameter instanceof Map) {
+      // Multi-param or single param with @Param or user created Map as a parameter
       assignKeysToParamMap(configuration, rs, rsmd, keyProperties, (Map<String, ?>) parameter);
     } else if (parameter instanceof ArrayList && !((ArrayList<?>) parameter).isEmpty()
         && ((ArrayList<?>) parameter).get(0) instanceof ParamMap) {

--- a/src/test/java/org/apache/ibatis/submitted/keygen/CountryMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/CountryMapper.java
@@ -100,4 +100,10 @@ public interface CountryMapper {
   @Options(useGeneratedKeys = true, keyProperty = "country.id")
   @Insert({ "insert into country (countryname,countrycode) values ('a','A'), ('b', 'B')" })
   int tooManyGeneratedKeysParamMap(@Param("country") Country country, @Param("someId") Integer someId);
+  
+  @Options(useGeneratedKeys = true, keyProperty = "records.id,records.code")
+  @Insert({
+      "${statement}"
+  })
+  int insertPlanetsWithMap(Map<String, Object> parameter);
 }

--- a/src/test/java/org/apache/ibatis/submitted/keygen/Jdbc3KeyGeneratorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/keygen/Jdbc3KeyGeneratorTest.java
@@ -403,6 +403,32 @@ class Jdbc3KeyGeneratorTest {
   }
 
   @Test
+  void shouldAssignMultipleGeneratedKeysToBeansInAMap() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      try {
+        CountryMapper mapper = sqlSession.getMapper(CountryMapper.class);
+        Planet planet1 = new Planet();
+        planet1.setName("pluto");
+        Planet planet2 = new Planet();
+        planet2.setName("neptune");
+        List<Planet> planets = Arrays.asList(planet1, planet2);
+        
+        String statement = "insert into planet (name) values (#{records[0].name}), (#{records[1].name})";
+        
+        Map<String, Object> parameter = new HashMap<>();
+        parameter.put("statement", statement);
+        parameter.put("records", planets);
+        
+        mapper.insertPlanetsWithMap(parameter);
+        assertEquals("pluto-" + planet1.getId(), planet1.getCode());
+        assertEquals("neptune-" + planet2.getId(), planet2.getCode());
+      } finally {
+        sqlSession.rollback();
+      }
+    }
+  }
+
+  @Test
   void shouldAssignMultipleGeneratedKeysToABean_MultiParams() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       try {


### PR DESCRIPTION
I was experimenting with adding support for multi-inserts to MyBatis Dynamic SQL. The paradigm is that it will generate a single object that holds both a generated statement and a matching set of parameters. I would use some specialization of a Map in this case.

I was surprised to find that if I create my own Map as a parameter, then the generated keys failed. On inspection I see that the code was checking for ParamMap or StrictMap, but I don't think that's really necessary. If any Map is passed as a parameter it should work. 

What do you think?