### PR TITLE
Controls whether a short key is used in the map. 

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -15,11 +15,6 @@
  */
 package org.apache.ibatis.builder.xml;
 
-import java.io.InputStream;
-import java.io.Reader;
-import java.util.Properties;
-import javax.sql.DataSource;
-
 import org.apache.ibatis.builder.BaseBuilder;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.datasource.DataSourceFactory;
@@ -38,13 +33,14 @@ import org.apache.ibatis.reflection.MetaClass;
 import org.apache.ibatis.reflection.ReflectorFactory;
 import org.apache.ibatis.reflection.factory.ObjectFactory;
 import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
-import org.apache.ibatis.session.AutoMappingBehavior;
-import org.apache.ibatis.session.AutoMappingUnknownColumnBehavior;
-import org.apache.ibatis.session.Configuration;
-import org.apache.ibatis.session.ExecutorType;
-import org.apache.ibatis.session.LocalCacheScope;
+import org.apache.ibatis.session.*;
 import org.apache.ibatis.transaction.TransactionFactory;
 import org.apache.ibatis.type.JdbcType;
+
+import javax.sql.DataSource;
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.Properties;
 
 /**
  * @author Clinton Begin
@@ -265,6 +261,7 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setCallSettersOnNulls(booleanValueOf(props.getProperty("callSettersOnNulls"), false));
     configuration.setUseActualParamName(booleanValueOf(props.getProperty("useActualParamName"), true));
     configuration.setReturnInstanceForEmptyRow(booleanValueOf(props.getProperty("returnInstanceForEmptyRow"), false));
+    configuration.setUserShortKey(booleanValueOf(props.getProperty("userShortKey"), true));
     configuration.setLogPrefix(props.getProperty("logPrefix"));
     configuration.setConfigurationFactory(resolveClass(props.getProperty("configurationFactory")));
   }

--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -462,6 +462,24 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
             </tr>
             <tr>
               <td>
+                userShortKey
+              </td>
+              <td>
+                When we generate mapping relationships such as <code>mappedStatements</code>, <code>resultMaps</code>,
+                <code>sqlFragments</code> for each mapping file, a short key is generated synchronously for convenience of operation
+                (in this case, there will be two keys in the collection pointing to the same object at the same time).
+                But if we do multiple mapping file parsing, then the objects corresponding to these short keys may exist in the form of Ambiguity.
+                So we can disable this feature to generate a collection of unique mappings.
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                true
+              </td>
+            </tr>
+            <tr>
+              <td>
                 logPrefix
               </td>
               <td>

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -549,6 +549,24 @@ SqlSessionFactory factory =
             </tr>
             <tr>
               <td>
+                userShortKey
+              </td>
+              <td>
+                When we generate mapping relationships such as <code>mappedStatements</code>, <code>resultMaps</code>,
+                <code>sqlFragments</code> for each mapping file, a short key is generated synchronously for convenience of operation
+                (in this case, there will be two keys in the collection pointing to the same object at the same time).
+                But if we do multiple mapping file parsing, then the objects corresponding to these short keys may exist in the form of Ambiguity.
+                So we can disable this feature to generate a collection of unique mappings.
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                true
+              </td>
+            </tr>
+            <tr>
+              <td>
                 logPrefix
               </td>
               <td>

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -480,6 +480,23 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
             </tr>
             <tr>
               <td>
+                userShortKey
+              </td>
+              <td>
+                当我们为每一个映射文件生成<code>mappedStatements</code>，<code>resultMaps</code>，<code>sqlFragments</code>等映射关系时，
+                为了方便操作，会同步生成简短的key（此时集合中会存在两个key同时指向同一个对象）。
+                但是如果我们进行多个映射文件解析，那么这些简短的key所对应的对象则有可能是以Ambiguity形式存在。
+                因此我们可以禁用该功能，用以生成唯一映射关系的集合。
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                true
+              </td>
+            </tr>
+            <tr>
+              <td>
                 logPrefix
               </td>
               <td>


### PR DESCRIPTION
When we generate mapping relationships such as `mappedStatements`, `resultMaps`, `sqlFragments `for each mapping file, a short key is generated synchronously for convenience of operation (in this case, there will be two keys in the collection pointing to the same object at the same time). 

But if we do multiple mapping file parsing, then the objects corresponding to these short keys may exist in the form of Ambiguity.

So we can disable this feature to generate a collection of unique mappings.