### PR TITLE
 Support to assign single primitive parameter on SQL provider method

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
@@ -38,6 +38,7 @@ public class ProviderSqlSource implements SqlSource {
   private final Configuration configuration;
   private final Class<?> providerType;
   private final LanguageDriver languageDriver;
+  private final Method mapperMethod;
   private Method providerMethod;
   private String[] providerMethodArgumentNames;
   private Class<?>[] providerMethodParameterTypes;
@@ -59,6 +60,7 @@ public class ProviderSqlSource implements SqlSource {
     String providerMethodName;
     try {
       this.configuration = configuration;
+      this.mapperMethod = mapperMethod;
       Lang lang = mapperMethod == null ? null : mapperMethod.getAnnotation(Lang.class);
       this.languageDriver = configuration.getLanguageDriver(lang == null ? null : lang.value());
       this.providerType = getProviderType(provider, mapperMethod);
@@ -116,33 +118,45 @@ public class ProviderSqlSource implements SqlSource {
     try {
       int bindParameterCount = providerMethodParameterTypes.length - (providerContext == null ? 0 : 1);
       String sql;
-      if (providerMethodParameterTypes.length == 0) {
+      if (parameterObject instanceof Map) {
+        if (bindParameterCount == 1 && providerMethodParameterTypes[0] == Map.class) {
+          sql = invokeProviderMethod(extractProviderMethodArguments(parameterObject));
+        } else {
+          @SuppressWarnings("unchecked")
+          Map<String, Object> params = (Map<String, Object>) parameterObject;
+          sql = invokeProviderMethod(extractProviderMethodArguments(params, providerMethodArgumentNames));
+        }
+      } else if (providerMethodParameterTypes.length == 0) {
         sql = invokeProviderMethod();
-      } else if (bindParameterCount == 0) {
-        sql = invokeProviderMethod(providerContext);
-      } else if (bindParameterCount == 1
-           && (parameterObject == null || providerMethodParameterTypes[providerContextIndex == null || providerContextIndex == 1 ? 0 : 1].isAssignableFrom(parameterObject.getClass()))) {
+      } else if (providerMethodParameterTypes.length == 1) {
+        if (providerContext == null) {
+          sql = invokeProviderMethod(parameterObject);
+        } else {
+          sql = invokeProviderMethod(providerContext);
+        }
+      } else if (providerMethodParameterTypes.length == 2) {
         sql = invokeProviderMethod(extractProviderMethodArguments(parameterObject));
-      } else if (parameterObject instanceof Map) {
-        @SuppressWarnings("unchecked")
-        Map<String, Object> params = (Map<String, Object>) parameterObject;
-        sql = invokeProviderMethod(extractProviderMethodArguments(params, providerMethodArgumentNames));
       } else {
-        throw new BuilderException("Error invoking SqlProvider method ("
-                + providerType.getName() + "." + providerMethod.getName()
-                + "). Cannot invoke a method that holds "
-                + (bindParameterCount == 1 ? "named argument(@Param)" : "multiple arguments")
-                + " using a specifying parameterObject. In this case, please specify a 'java.util.Map' object.");
+        throw new BuilderException("Cannot invoke SqlProvider method '" + providerMethod
+          + "' with specify parameter '" + (parameterObject == null ? null : parameterObject.getClass())
+          + "' because SqlProvider method arguments for '" + mapperMethod + "' is an invalid combination.");
       }
       Class<?> parameterType = parameterObject == null ? Object.class : parameterObject.getClass();
       return languageDriver.createSqlSource(configuration, sql, parameterType);
     } catch (BuilderException e) {
       throw e;
     } catch (Exception e) {
-      throw new BuilderException("Error invoking SqlProvider method ("
-          + providerType.getName() + "." + providerMethod.getName()
-          + ").  Cause: " + e, e);
+      throw new BuilderException("Error invoking SqlProvider method '" + providerMethod
+          + "' with specify parameter '" + (parameterObject == null ? null : parameterObject.getClass()) + "'.  Cause: " + extractRootCause(e), e);
     }
+  }
+
+  private Throwable extractRootCause(Exception e) {
+    Throwable cause = e;
+    while(cause.getCause() != null) {
+      cause = e.getCause();
+    }
+    return cause;
   }
 
   private Object[] extractProviderMethodArguments(Object parameterObject) {

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -40,6 +40,9 @@ public interface Mapper extends BaseMapper<User> {
 
   @SelectProvider(type = OurSqlBuilder.class, method = "buildGetUsersByCriteriaMapQuery")
   List<User> getUsersByCriteriaMap(Map<String, Object> criteria);
+
+  @SelectProvider(type = OurSqlBuilder.class, method = "buildGetUsersByCriteriaMapWithParamQuery")
+  List<User> getUsersByCriteriaMapWithParam(Map<String, Object> criteria);
 
   @SelectProvider(type = OurSqlBuilder.class, method = "buildGetUsersByNameQuery")
   List<User> getUsersByName(String name, String orderByColumn);

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/OurSqlBuilder.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/OurSqlBuilder.java
@@ -84,6 +84,19 @@ public class OurSqlBuilder {
     }}.toString();
   }
 
+  public String buildGetUsersByCriteriaMapWithParamQuery(@Param("id") Integer id, @Param("name") String name) {
+    return new SQL() {{
+      SELECT("*");
+      FROM("users");
+      if (id != null) {
+        WHERE("id = #{id}");
+      }
+      if (name != null) {
+        WHERE("name like #{name} || '%'");
+      }
+    }}.toString();
+  }
+
   public String buildGetUsersByNameQuery(final String name, final String orderByColumn) {
     return new SQL(){{
       SELECT("*");

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
@@ -503,6 +503,78 @@ class SqlProviderTest {
   }
 
   @Test
+  void staticMethodOnePrimitiveByteArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals((byte) 10, mapper.onePrimitiveByteArgument((byte) 10));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveShortArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals((short) 10, mapper.onePrimitiveShortArgument((short) 10));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveIntArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals(10, mapper.onePrimitiveIntArgument(10));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveLongArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals(10L, mapper.onePrimitiveLongArgument(10L));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveFloatArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals(10.1F, mapper.onePrimitiveFloatArgument(10.1F));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveDoubleArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals(10.1D, mapper.onePrimitiveDoubleArgument(10.1D));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveBooleanArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertTrue(mapper.onePrimitiveBooleanArgument(true));
+    }
+  }
+
+  @Test
+  void staticMethodOnePrimitiveCharArgument() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals('A', mapper.onePrimitiveCharArgument('A'));
+    }
+  }
+
+  @Test
   void staticMethodMultipleArgument() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       StaticMethodSqlProviderMapper mapper =
@@ -587,6 +659,30 @@ class SqlProviderTest {
     @SelectProvider(type = SqlProvider.class, method = "oneArgument")
     int oneArgument(Integer value);
 
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveByteArgument")
+    byte onePrimitiveByteArgument(byte value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveShortArgument")
+    short onePrimitiveShortArgument(short value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveIntArgument")
+    int onePrimitiveIntArgument(int value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveLongArgument")
+    long onePrimitiveLongArgument(long value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveFloatArgument")
+    float onePrimitiveFloatArgument(float value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveDoubleArgument")
+    double onePrimitiveDoubleArgument(double value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveBooleanArgument")
+    boolean onePrimitiveBooleanArgument(boolean value);
+
+    @SelectProvider(type = SqlProvider.class, method = "onePrimitiveCharArgument")
+    char onePrimitiveCharArgument(char value);
+
     @SelectProvider(type = SqlProvider.class, method = "multipleArgument")
     int multipleArgument(@Param("value1") Integer value1, @Param("value2") Integer value2);
 
@@ -606,6 +702,46 @@ class SqlProviderTest {
       public static StringBuilder oneArgument(Integer value) {
         return new StringBuilder().append("SELECT ").append(value)
             .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveByteArgument(byte value) {
+        return new StringBuilder().append("SELECT ").append(value)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveShortArgument(short value) {
+        return new StringBuilder().append("SELECT ").append(value)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveIntArgument(int value) {
+        return new StringBuilder().append("SELECT ").append(value)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveLongArgument(long value) {
+        return new StringBuilder().append("SELECT ").append(value)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveFloatArgument(float value) {
+        return new StringBuilder().append("SELECT ").append(value)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveDoubleArgument(double value) {
+        return new StringBuilder().append("SELECT ").append(value)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveBooleanArgument(boolean value) {
+        return new StringBuilder().append("SELECT ").append(value ? 1 : 0)
+          .append(" FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder onePrimitiveCharArgument(char value) {
+        return new StringBuilder().append("SELECT '").append(value)
+          .append("' FROM INFORMATION_SCHEMA.SYSTEM_USERS");
       }
 
       public static CharSequence multipleArgument(@Param("value1") Integer value1,

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
@@ -575,6 +575,24 @@ class SqlProviderTest {
   }
 
   @Test
+  void boxing() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals(10, mapper.boxing(10));
+    }
+  }
+
+  @Test
+  void unboxing() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      StaticMethodSqlProviderMapper mapper =
+        sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
+      assertEquals(100, mapper.unboxing(100));
+    }
+  }
+
+  @Test
   void staticMethodMultipleArgument() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       StaticMethodSqlProviderMapper mapper =
@@ -683,6 +701,12 @@ class SqlProviderTest {
     @SelectProvider(type = SqlProvider.class, method = "onePrimitiveCharArgument")
     char onePrimitiveCharArgument(char value);
 
+    @SelectProvider(type = SqlProvider.class, method = "boxing")
+    int boxing(int value);
+
+    @SelectProvider(type = SqlProvider.class, method = "unboxing")
+    int unboxing(Integer value);
+
     @SelectProvider(type = SqlProvider.class, method = "multipleArgument")
     int multipleArgument(@Param("value1") Integer value1, @Param("value2") Integer value2);
 
@@ -740,6 +764,16 @@ class SqlProviderTest {
       }
 
       public static StringBuilder onePrimitiveCharArgument(char value) {
+        return new StringBuilder().append("SELECT '").append(value)
+          .append("' FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder boxing(Integer value) {
+        return new StringBuilder().append("SELECT '").append(value)
+          .append("' FROM INFORMATION_SCHEMA.SYSTEM_USERS");
+      }
+
+      public static StringBuilder unboxing(int value) {
         return new StringBuilder().append("SELECT '").append(value)
           .append("' FROM INFORMATION_SCHEMA.SYSTEM_USERS");
       }


### PR DESCRIPTION
Current implementation cannot use primitive type on SQL provider method. For details, see gh-1595. 
I've fixed gh-1595 using based on solution that suggested by @harawata (See https://github.com/mybatis/mybatis-3/pull/1595#issuecomment-509443667), however I've changed some implementations from suggested implementation by @harawata  for keeping backward compatibility with 3.5.1 as follows:

* target type for `instanceof` (`ParamMap` -> `Map`) 
* support to use together with `ProviderContext` and `Map`

@harawata WDYT?