### PR TITLE
Fix broken backward compatibility by gh-1604

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
@@ -116,10 +116,11 @@ public class ProviderSqlSource implements SqlSource {
 
   private SqlSource createSqlSource(Object parameterObject) {
     try {
-      int bindParameterCount = providerMethodParameterTypes.length - (providerContext == null ? 0 : 1);
       String sql;
       if (parameterObject instanceof Map) {
-        if (bindParameterCount == 1 && providerMethodParameterTypes[0] == Map.class) {
+        int bindParameterCount = providerMethodParameterTypes.length - (providerContext == null ? 0 : 1);
+        if (bindParameterCount == 1 &&
+          (providerMethodParameterTypes[Integer.valueOf(0).equals(providerContextIndex) ? 1 : 0].isAssignableFrom(parameterObject.getClass()))) {
           sql = invokeProviderMethod(extractProviderMethodArguments(parameterObject));
         } else {
           @SuppressWarnings("unchecked")


### PR DESCRIPTION
I've fixed backward compatibility with 3.5.1 by gh-1604.

* Allow to specify the `ProviderContext` at any position together with `Map` parameter as follow:

```java
public String provideSql(Map<String, Object> parameters, ProviderContext context) { // Work fine on gh-1604
 // ...
}
public String provideSql(ProviderContext context, Map<String, Object> parameters) { // Broken by gh-1604
 // ...
}
``` 

* Allow to specify the actual class(e.g. `ParamMap`) instead of interface(`Map`) as follow:

```java
public String provideSql(ParamMap<Object> parameters) { // Broken by gh-1604
 // ...
}
```