### PR TITLE
Add openjdk13 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 
 jdk:
   - openjdk-ea
+  - openjdk13
   - openjdk12
   - openjdk11
   - oraclejdk8


### PR DESCRIPTION
openjdk-ea now points to 14, it seems.