### PR TITLE
Ambiguous setters/getters should throw exception only when they are invoked

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/Reflector.java
+++ b/src/main/java/org/apache/ibatis/reflection/Reflector.java
@@ -154,14 +154,19 @@ public class Reflector {
     for (String propName : conflictingSetters.keySet()) {
       List<Method> setters = conflictingSetters.get(propName);
       Class<?> getterType = getTypes.get(propName);
+      boolean isGetterAmbiguous = getMethods.get(propName) instanceof AmbiguousMethodInvoker;
+      boolean isSetterAmbiguous = false;
       Method match = null;
       for (Method setter : setters) {
-        if (setter.getParameterTypes()[0].equals(getterType)) {
+        if (!isGetterAmbiguous && setter.getParameterTypes()[0].equals(getterType)) {
           // should be the best match
           match = setter;
           break;
         }
-        match = pickBetterSetter(match, setter, propName);
+        if (!isSetterAmbiguous) {
+          match = pickBetterSetter(match, setter, propName);
+          isSetterAmbiguous = match == null;
+        }
       }
       if (match != null) {
         addSetMethod(propName, match);

--- a/src/main/java/org/apache/ibatis/reflection/Reflector.java
+++ b/src/main/java/org/apache/ibatis/reflection/Reflector.java
@@ -118,9 +118,7 @@ public class Reflector {
           break;
         }
       }
-      if (winner != null) {
-        addGetMethod(propName, winner, isAmbiguous);
-      }
+      addGetMethod(propName, winner, isAmbiguous);
     }
   }
 

--- a/src/main/java/org/apache/ibatis/reflection/Reflector.java
+++ b/src/main/java/org/apache/ibatis/reflection/Reflector.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.ReflectPermission;
 import java.lang.reflect.Type;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,6 +34,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.ibatis.reflection.invoker.AmbiguousMethodInvoker;
 import org.apache.ibatis.reflection.invoker.GetFieldInvoker;
 import org.apache.ibatis.reflection.invoker.Invoker;
 import org.apache.ibatis.reflection.invoker.MethodInvoker;
@@ -92,6 +94,7 @@ public class Reflector {
     for (Entry<String, List<Method>> entry : conflictingGetters.entrySet()) {
       Method winner = null;
       String propName = entry.getKey();
+      boolean isAmbiguous = false;
       for (Method candidate : entry.getValue()) {
         if (winner == null) {
           winner = candidate;
@@ -101,10 +104,8 @@ public class Reflector {
         Class<?> candidateType = candidate.getReturnType();
         if (candidateType.equals(winnerType)) {
           if (!boolean.class.equals(candidateType)) {
-            throw new ReflectionException(
-                "Illegal overloaded getter method with ambiguous type for property "
-                    + propName + " in class " + winner.getDeclaringClass()
-                    + ". This breaks the JavaBeans specification and can cause unpredictable results.");
+            isAmbiguous = true;
+            break;
           } else if (candidate.getName().startsWith("is")) {
             winner = candidate;
           }
@@ -113,22 +114,25 @@ public class Reflector {
         } else if (winnerType.isAssignableFrom(candidateType)) {
           winner = candidate;
         } else {
-          throw new ReflectionException(
-              "Illegal overloaded getter method with ambiguous type for property "
-                  + propName + " in class " + winner.getDeclaringClass()
-                  + ". This breaks the JavaBeans specification and can cause unpredictable results.");
+          isAmbiguous = true;
+          break;
         }
       }
-      addGetMethod(propName, winner);
+      if (winner != null) {
+        addGetMethod(propName, winner, isAmbiguous);
+      }
     }
   }
 
-  private void addGetMethod(String name, Method method) {
-    if (isValidPropertyName(name)) {
-      getMethods.put(name, new MethodInvoker(method));
-      Type returnType = TypeParameterResolver.resolveReturnType(method, type);
-      getTypes.put(name, typeToClass(returnType));
-    }
+  private void addGetMethod(String name, Method method, boolean isAmbiguous) {
+    MethodInvoker invoker = isAmbiguous
+        ? new AmbiguousMethodInvoker(method, MessageFormat.format(
+            "Illegal overloaded getter method with ambiguous type for property ''{0}'' in class ''{1}''. This breaks the JavaBeans specification and can cause unpredictable results.",
+            name, method.getDeclaringClass().getName()))
+        : new MethodInvoker(method);
+    getMethods.put(name, invoker);
+    Type returnType = TypeParameterResolver.resolveReturnType(method, type);
+    getTypes.put(name, typeToClass(returnType));
   }
 
   private void addSetMethods(Class<?> clazz) {
@@ -140,8 +144,10 @@ public class Reflector {
   }
 
   private void addMethodConflict(Map<String, List<Method>> conflictingMethods, String name, Method method) {
-    List<Method> list = conflictingMethods.computeIfAbsent(name, k -> new ArrayList<>());
-    list.add(method);
+    if (isValidPropertyName(name)) {
+      List<Method> list = conflictingMethods.computeIfAbsent(name, k -> new ArrayList<>());
+      list.add(method);
+    }
   }
 
   private void resolveSetterConflicts(Map<String, List<Method>> conflictingSetters) {
@@ -149,26 +155,15 @@ public class Reflector {
       List<Method> setters = conflictingSetters.get(propName);
       Class<?> getterType = getTypes.get(propName);
       Method match = null;
-      ReflectionException exception = null;
       for (Method setter : setters) {
         if (setter.getParameterTypes()[0].equals(getterType)) {
           // should be the best match
           match = setter;
           break;
         }
-        if (exception == null) {
-          try {
-            match = pickBetterSetter(match, setter, propName);
-          } catch (ReflectionException e) {
-            // there could still be the 'best match'
-            match = null;
-            exception = e;
-          }
-        }
+        match = pickBetterSetter(match, setter, propName);
       }
-      if (match == null) {
-        throw exception;
-      } else {
+      if (match != null) {
         addSetMethod(propName, match);
       }
     }
@@ -185,17 +180,21 @@ public class Reflector {
     } else if (paramType2.isAssignableFrom(paramType1)) {
       return setter1;
     }
-    throw new ReflectionException("Ambiguous setters defined for property '" + property + "' in class '"
-        + setter2.getDeclaringClass() + "' with types '" + paramType1.getName() + "' and '"
-        + paramType2.getName() + "'.");
+    MethodInvoker invoker = new AmbiguousMethodInvoker(setter1,
+        MessageFormat.format(
+            "Ambiguous setters defined for property ''{0}'' in class ''{1}'' with types ''{2}'' and ''{3}''.",
+            property, setter2.getDeclaringClass().getName(), paramType1.getName(), paramType2.getName()));
+    setMethods.put(property, invoker);
+    Type[] paramTypes = TypeParameterResolver.resolveParamTypes(setter1, type);
+    setTypes.put(property, typeToClass(paramTypes[0]));
+    return null;
   }
 
   private void addSetMethod(String name, Method method) {
-    if (isValidPropertyName(name)) {
-      setMethods.put(name, new MethodInvoker(method));
-      Type[] paramTypes = TypeParameterResolver.resolveParamTypes(method, type);
-      setTypes.put(name, typeToClass(paramTypes[0]));
-    }
+    MethodInvoker invoker = new MethodInvoker(method);
+    setMethods.put(name, invoker);
+    Type[] paramTypes = TypeParameterResolver.resolveParamTypes(method, type);
+    setTypes.put(name, typeToClass(paramTypes[0]));
   }
 
   private Class<?> typeToClass(Type src) {

--- a/src/main/java/org/apache/ibatis/reflection/invoker/AmbiguousMethodInvoker.java
+++ b/src/main/java/org/apache/ibatis/reflection/invoker/AmbiguousMethodInvoker.java
@@ -1,0 +1,36 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.reflection.invoker;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.apache.ibatis.reflection.ReflectionException;
+
+public class AmbiguousMethodInvoker extends MethodInvoker {
+  private final String exceptionMessage;
+
+  public AmbiguousMethodInvoker(Method method, String exceptionMessage) {
+    super(method);
+    this.exceptionMessage = exceptionMessage;
+  }
+
+  @Override
+  public Object invoke(Object target, Object[] args) throws IllegalAccessException, InvocationTargetException {
+    throw new ReflectionException(exceptionMessage);
+  }
+}

--- a/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
@@ -18,10 +18,13 @@ package org.apache.ibatis.reflection;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.List;
 
+import org.apache.ibatis.reflection.invoker.Invoker;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
 import static com.googlecode.catchexception.apis.BDDCatchException.*;
 import static org.assertj.core.api.BDDAssertions.then;
 
@@ -189,20 +192,99 @@ class ReflectorTest {
   }
 
   @Test
-  void shouldSettersWithUnrelatedArgTypesThrowException() {
+  void shouldSettersWithUnrelatedArgTypesThrowException() throws Exception {
     @SuppressWarnings("unused")
     class BeanClass {
-      public void setTheProp(String arg) {}
-      public void setTheProp(Integer arg) {}
+      public void setProp1(String arg) {}
+      public void setProp2(String arg) {}
+      public void setProp2(Integer arg) {}
     }
-
     ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
-    when(reflectorFactory).findForClass(BeanClass.class);
+    Reflector reflector = reflectorFactory.findForClass(BeanClass.class);
+
+    List<String> setableProps = Arrays.asList(reflector.getSetablePropertyNames());
+    assertTrue(setableProps.contains("prop1"));
+    assertTrue(setableProps.contains("prop2"));
+    assertEquals("prop1", reflector.findPropertyName("PROP1"));
+    assertEquals("prop2", reflector.findPropertyName("PROP2"));
+
+    assertEquals(String.class, reflector.getSetterType("prop1"));
+    assertNotNull(reflector.getSetInvoker("prop1"));
+
+    Class<?> paramType = reflector.getSetterType("prop2");
+    assertTrue(String.class.equals(paramType) || Integer.class.equals(paramType));
+
+    Invoker ambiguousInvoker = reflector.getSetInvoker("prop2");
+    Object[] param = String.class.equals(paramType)? new String[]{"x"} : new Integer[]{1};
+    when(ambiguousInvoker).invoke(new BeanClass(), param);
     then(caughtException()).isInstanceOf(ReflectionException.class)
-      .hasMessageContaining("theProp")
-      .hasMessageContaining("BeanClass")
+      .hasMessageContaining("Ambiguous setters defined for property 'prop2' in class '" + BeanClass.class.getName() + "' with types")
       .hasMessageContaining("java.lang.String")
       .hasMessageContaining("java.lang.Integer");
+  }
+
+  @Test
+  public void shouldTwoGettersForNonBooleanPropertyThrowException() throws Exception {
+    @SuppressWarnings("unused")
+    class BeanClass {
+      public Integer getProp1() {return 1;}
+      public int getProp2() {return 0;}
+      public int isProp2() {return 0;}
+    }
+    ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
+    Reflector reflector = reflectorFactory.findForClass(BeanClass.class);
+
+    List<String> getableProps = Arrays.asList(reflector.getGetablePropertyNames());
+    assertTrue(getableProps.contains("prop1"));
+    assertTrue(getableProps.contains("prop2"));
+    assertEquals("prop1", reflector.findPropertyName("PROP1"));
+    assertEquals("prop2", reflector.findPropertyName("PROP2"));
+
+    assertEquals(Integer.class, reflector.getGetterType("prop1"));
+    Invoker getInvoker = reflector.getGetInvoker("prop1");
+    assertEquals(Integer.valueOf(1), getInvoker.invoke(new BeanClass(), null));
+
+    Class<?> paramType = reflector.getGetterType("prop2");
+    assertEquals(int.class, paramType);
+
+    Invoker ambiguousInvoker = reflector.getGetInvoker("prop2");
+    when(ambiguousInvoker).invoke(new BeanClass(), new Integer[] {1});
+    then(caughtException()).isInstanceOf(ReflectionException.class)
+        .hasMessageContaining("Illegal overloaded getter method with ambiguous type for property 'prop2' in class '"
+            + BeanClass.class.getName()
+            + "'. This breaks the JavaBeans specification and can cause unpredictable results.");
+  }
+
+  @Test
+  public void shouldTwoGettersWithDifferentTypesThrowException() throws Exception {
+    @SuppressWarnings("unused")
+    class BeanClass {
+      public Integer getProp1() {return 1;}
+      public Integer getProp2() {return 1;}
+      public boolean isProp2() {return false;}
+    }
+    ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
+    Reflector reflector = reflectorFactory.findForClass(BeanClass.class);
+
+    List<String> getableProps = Arrays.asList(reflector.getGetablePropertyNames());
+    assertTrue(getableProps.contains("prop1"));
+    assertTrue(getableProps.contains("prop2"));
+    assertEquals("prop1", reflector.findPropertyName("PROP1"));
+    assertEquals("prop2", reflector.findPropertyName("PROP2"));
+
+    assertEquals(Integer.class, reflector.getGetterType("prop1"));
+    Invoker getInvoker = reflector.getGetInvoker("prop1");
+    assertEquals(Integer.valueOf(1), getInvoker.invoke(new BeanClass(), null));
+
+    Class<?> returnType = reflector.getGetterType("prop2");
+    assertTrue(Integer.class.equals(returnType) || boolean.class.equals(returnType));
+
+    Invoker ambiguousInvoker = reflector.getGetInvoker("prop2");
+    when(ambiguousInvoker).invoke(new BeanClass(), null);
+    then(caughtException()).isInstanceOf(ReflectionException.class)
+        .hasMessageContaining("Illegal overloaded getter method with ambiguous type for property 'prop2' in class '"
+            + BeanClass.class.getName()
+            + "'. This breaks the JavaBeans specification and can cause unpredictable results.");
   }
 
   @Test


### PR DESCRIPTION
Lower impact fix for #1201 ,
Unlike #1335 , this version throws exception only when the ambiguous setter/getter is actually invoked.