### PR TITLE
Pojo mapping declaration feature

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/ConstructorArgs.java
+++ b/src/main/java/org/apache/ibatis/annotations/ConstructorArgs.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
 public @interface ConstructorArgs {
   Arg[] value() default {};
 }

--- a/src/main/java/org/apache/ibatis/annotations/Result.java
+++ b/src/main/java/org/apache/ibatis/annotations/Result.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2016 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,21 +15,22 @@
  */
 package org.apache.ibatis.annotations;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.UnknownTypeHandler;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * @author Clinton Begin
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target({})
+@Target(ElementType.FIELD)
 public @interface Result {
   boolean id() default false;
 

--- a/src/main/java/org/apache/ibatis/builder/annotation/ResultsData.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ResultsData.java
@@ -1,0 +1,83 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.builder.annotation;
+
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.Results;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Data wrapper for {@link org.apache.ibatis.annotations.Results} annotation
+ * @author Alexander Pozdnyakov
+ */
+class ResultsData {
+
+  private String id;
+  private List<ResultData> mappings;
+
+  ResultsData(Results results) {
+    this.id = results.id();
+    this.mappings = Arrays.stream(results.value())
+                          .map(result -> new ResultData(result.property(), result))
+                          .collect(Collectors.toList());
+  }
+
+  ResultsData(String id, Result[] results) {
+    this.id = id;
+    this.mappings = Arrays.stream(results)
+                          .map(result -> new ResultData(result.property(), result))
+                          .collect(Collectors.toList());
+  }
+
+  ResultsData() {
+    this.id = "";
+    this.mappings = new ArrayList<>();
+  }
+
+  void addResult(String property, Result result) {
+    this.mappings.add(new ResultData(property, result));
+  }
+
+  List<ResultData> getMappings() {
+    return mappings;
+  }
+
+  String getId() {
+    return id;
+  }
+
+  static class ResultData {
+    private String property;
+    private Result result;
+
+    private ResultData(String property, Result result) {
+      this.property = property;
+      this.result = result;
+    }
+
+    String getProperty() {
+      return property;
+    }
+
+    Result getResult() {
+      return result;
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/binding/PojoBindingTest.java
+++ b/src/test/java/org/apache/ibatis/binding/PojoBindingTest.java
@@ -1,0 +1,101 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.binding;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.transaction.TransactionFactory;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+/**
+ * @author Alexander Pozdnyakov
+ */
+public class PojoBindingTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setup() throws Exception {
+    DataSource dataSource = BaseDataTest.createBlogDataSource();
+    BaseDataTest.runScript(dataSource, BaseDataTest.BLOG_DDL);
+    BaseDataTest.runScript(dataSource, BaseDataTest.BLOG_DATA);
+    TransactionFactory transactionFactory = new JdbcTransactionFactory();
+    Environment environment = new Environment("Production", transactionFactory, dataSource);
+    Configuration configuration = new Configuration(environment);
+    configuration.setLazyLoadingEnabled(true);
+    configuration.setUseActualParamName(false); // to test legacy style reference (#{0} #{1})
+    configuration.addMapper(PojoBoundAuthorMapper.class);
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+  }
+
+  @Test
+  void shouldSelectAuthorAndMapUsingAnnotations() {
+    try (SqlSession session = sqlSessionFactory.openSession()) {
+      PojoBoundAuthorMapper mapper = session.getMapper(PojoBoundAuthorMapper.class);
+      PojoBoundAuthorMapper.AnnotatedAuthor author = mapper.selectAuthor(101L);
+      assertEquals(101L, author.getId());
+      assertEquals("jim", author.getUsername());
+      assertEquals("********", author.getPassword());
+      assertEquals("jim@ibatis.apache.org", author.getEmail());
+      assertEquals(0, author.getBio().length());
+    }
+  }
+
+  @Test
+  void shouldSelectAllAuthorsAndMapUsingAnnotations() {
+    try (SqlSession session = sqlSessionFactory.openSession()) {
+      PojoBoundAuthorMapper mapper = session.getMapper(PojoBoundAuthorMapper.class);
+      List<PojoBoundAuthorMapper.AnnotatedAuthor> authors = mapper.selectAllAuthors();
+      assertEquals(2, authors.size());
+      assertEquals(101L, authors.get(0).getId());
+      assertEquals("jim", authors.get(0).getUsername());
+      assertEquals("********", authors.get(0).getPassword());
+      assertEquals("jim@ibatis.apache.org", authors.get(0).getEmail());
+      assertEquals(0, authors.get(0).getBio().length());
+      assertEquals(102L, authors.get(1).getId());
+      assertEquals("sally", authors.get(1).getUsername());
+      assertEquals("********", authors.get(1).getPassword());
+      assertEquals("sally@ibatis.apache.org", authors.get(1).getEmail());
+      assertNull(authors.get(1).getBio());
+    }
+  }
+
+  @Test
+  void shouldSelectAllBlogsWithAuthorAndPostsAndMapUsingAnnotations() {
+    try (SqlSession session = sqlSessionFactory.openSession()) {
+      PojoBoundAuthorMapper mapper = session.getMapper(PojoBoundAuthorMapper.class);
+      List<PojoBoundAuthorMapper.AnnotatedBlog> blogs = mapper.selectBlogsWithAuthorAndPosts();
+      assertEquals(2, blogs.size());
+      assertNotNull(blogs.get(0).getAuthor());
+      assertEquals(101L, blogs.get(0).getAuthor().getId());
+      assertNotNull(blogs.get(0).getPosts());
+      assertEquals(2, blogs.get(0).getPosts().size());
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/binding/PojoBoundAuthorMapper.java
+++ b/src/test/java/org/apache/ibatis/binding/PojoBoundAuthorMapper.java
@@ -1,0 +1,127 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.binding;
+
+import org.apache.ibatis.annotations.Arg;
+import org.apache.ibatis.annotations.ConstructorArgs;
+import org.apache.ibatis.annotations.Many;
+import org.apache.ibatis.annotations.One;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.Select;
+
+import java.util.List;
+
+/**
+ * @author Alexander Pozdnyakov
+ */
+public interface PojoBoundAuthorMapper {
+
+  @Select({
+    "SELECT ",
+    "  ID as AUTHOR_ID,",
+    "  USERNAME as AUTHOR_USERNAME,",
+    "  PASSWORD as AUTHOR_PASSWORD,",
+    "  EMAIL as AUTHOR_EMAIL,",
+    "  BIO as AUTHOR_BIO",
+    "FROM AUTHOR WHERE ID = #{id}"})
+  AnnotatedAuthor selectAuthor(long id);
+
+  @Select({
+    "SELECT ",
+    "  ID as AUTHOR_ID,",
+    "  USERNAME as AUTHOR_USERNAME,",
+    "  PASSWORD as AUTHOR_PASSWORD,",
+    "  EMAIL as AUTHOR_EMAIL,",
+    "  BIO as AUTHOR_BIO",
+    "FROM AUTHOR"})
+  List<AnnotatedAuthor> selectAllAuthors();
+
+  @Select("SELECT * FROM " +
+          "post WHERE blog_id = #{blogId}")
+  List<AnnotatedPost> selectPostsByBlogId(long blogId);
+
+  @Select({
+    "SELECT *",
+    "FROM blog"
+  })
+  List<AnnotatedBlog> selectBlogsWithAuthorAndPosts();
+
+  class AnnotatedAuthor {
+    private Long id;
+    @Result(column = "AUTHOR_USERNAME")
+    private String username;
+    @Result(property = "password", column = "AUTHOR_PASSWORD")
+    private String password;
+    private String email;
+    @Result(property = "bio", column = "AUTHOR_BIO")
+    private String bio;
+
+    @ConstructorArgs({
+      @Arg(column = "AUTHOR_ID", id = true, javaType = Long.class),
+      @Arg(column = "AUTHOR_EMAIL", javaType = String.class)
+    })
+    public AnnotatedAuthor(Long id, String email) {
+      this.id = id;
+      this.email = email;
+    }
+
+    public Long getId() {
+      return id;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public String getEmail() {
+      return email;
+    }
+
+    public String getBio() {
+      return bio;
+    }
+  }
+
+  class AnnotatedBlog {
+    @Result(column = "id")
+    private Long id;
+    @Result(column = "title")
+    private String title;
+    @Result(column = "author_id", one = @One(select = "selectAuthor"))
+    private AnnotatedAuthor author;
+    @Result(column = "id", many = @Many(select = "selectPostsByBlogId"))
+    private List<AnnotatedPost> posts;
+
+    public AnnotatedAuthor getAuthor() {
+      return author;
+    }
+
+    public List<AnnotatedPost> getPosts() {
+      return posts;
+    }
+  }
+
+  class AnnotatedPost {
+    @Result(column = "id")
+    private Long id;
+    @Result(column = "section")
+    private String section;
+  }
+}


### PR DESCRIPTION
Possibility to declare `@Result` and `@ConstructorArgs` in POJO models instead of mappers. Supports extending POJO classes and declaring mappings both on constructors and fields.