### PR TITLE
name conventions: getExtensiveSubject to getExtensiveSubjects

### DIFF
--- a/src/test/java/org/apache/ibatis/autoconstructor/AutoConstructorMapper.java
+++ b/src/test/java/org/apache/ibatis/autoconstructor/AutoConstructorMapper.java
@@ -33,5 +33,5 @@ public interface AutoConstructorMapper {
   List<BadSubject> getBadSubjects();
 
   @Select("SELECT * FROM extensive_subject")
-  List<ExtensiveSubject> getExtensiveSubject();
+  List<ExtensiveSubject> getExtensiveSubjects();
 }

--- a/src/test/java/org/apache/ibatis/autoconstructor/AutoConstructorTest.java
+++ b/src/test/java/org/apache/ibatis/autoconstructor/AutoConstructorTest.java
@@ -83,7 +83,7 @@ class AutoConstructorTest {
   void extensiveSubject() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       final AutoConstructorMapper mapper = sqlSession.getMapper(AutoConstructorMapper.class);
-      verifySubjects(mapper.getExtensiveSubject());
+      verifySubjects(mapper.getExtensiveSubjects());
     }
   }
 


### PR DESCRIPTION
In interface org.apache.ibatis.autoconstructor.AutoConstructorMapper: method getExtensiveSubject should be renamed to getExtensiveSubjects