### PR TITLE
Add BindFunction to simplify the configuration of SqlMapper

### DIFF
--- a/src/main/java/org/apache/ibatis/registry/GenericRegistry.java
+++ b/src/main/java/org/apache/ibatis/registry/GenericRegistry.java
@@ -1,0 +1,311 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.registry;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author andyslin
+ */
+public class GenericRegistry {
+
+  /**
+   * 接口实现类注册器
+   */
+  public interface InstanceRegistry<I> {
+
+    /**
+     * 注册实现类的实例
+     *
+     * @param implInstance
+     */
+    void register(I implInstance);
+
+    /**
+     * 获取实现类的实例
+     *
+     * @return
+     */
+    I get();
+  }
+
+  /**
+   * 命名对象注册器接口
+   *
+   * @param <N>
+   */
+  public interface NamedRegistry<N extends Named> {
+
+    /**
+     * 注册命名对象
+     *
+     * @param nameds
+     */
+    void register(N... nameds);
+
+    /**
+     * 注册命名对象
+     *
+     * @param nameds
+     */
+    default void register(Collection<N> nameds) {
+      if (null != nameds && !nameds.isEmpty()) {
+        nameds.stream().filter(Objects::nonNull).forEach(this::register);
+      }
+    }
+
+    /**
+     * 获取命名对象
+     *
+     * @param name
+     * @return
+     */
+    N get(String name);
+  }
+
+  /**
+   * 排序对象注册器接口
+   *
+   * @param <O>
+   */
+  public interface OrderedRegistry<O extends Ordered> {
+
+    /**
+     * 注册排序对象
+     *
+     * @param ordereds
+     */
+    void register(O... ordereds);
+
+    /**
+     * 注册排序对象
+     *
+     * @param ordereds
+     */
+    default void register(Collection<O> ordereds) {
+      if (null != ordereds && !ordereds.isEmpty()) {
+        ordereds.stream().filter(Objects::nonNull).forEach(this::register);
+      }
+    }
+
+    /**
+     * 获取所有已注册的排序对象
+     *
+     * @return
+     */
+    List<O> get();
+
+    /**
+     * 获取第一个已注册的对象
+     *
+     * @return
+     */
+    default O getFirst() {
+      List<O> list = get();
+      return (null == list || list.isEmpty()) ? null : list.get(0);
+    }
+  }
+
+  /**
+   * 接口实现类缓存
+   */
+  private static final Map<Class<?>, Object> instances = new HashMap<>();
+
+  /**
+   * 命名对象缓存
+   */
+  private static final Map<Class<? extends Named>, Map<String, Named>> named = new HashMap<>();
+
+  /**
+   * 排序对象缓存
+   */
+  private static final Map<Class<?>, List<?>> ordered = new HashMap<>();
+
+  private static final Comparator<Ordered> ORDERED_COMPARATOR = (o1, o2) -> o1.getOrder() - o2.getOrder();
+
+  /**
+   * 注册接口的实现类实例
+   *
+   * @param interfaceClass
+   * @param implInstance
+   * @param <I>
+   */
+  public static <I> void registerInstance(Class<I> interfaceClass, I implInstance) {
+    synchronized (instances) {
+      instances.put(interfaceClass, implInstance);
+    }
+  }
+
+  /**
+   * 获取接口的实现类实例
+   *
+   * @param interfaceClass
+   * @param <I>
+   * @return
+   */
+  public static <I> I getInstance(Class<I> interfaceClass) {
+    Object o = instances.get(interfaceClass);
+    return interfaceClass.cast(o);
+  }
+
+  /**
+   * 获取接口实例注册器
+   *
+   * @param interfaceClass
+   * @param <I>
+   * @return
+   */
+  public static <I> InstanceRegistry<I> getInstanceRegistry(Class<I> interfaceClass) {
+    return new InstanceRegistry<I>() {
+      @Override
+      public void register(I implInstance) {
+        registerInstance(interfaceClass, implInstance);
+      }
+
+      @Override
+      public I get() {
+        return getInstance(interfaceClass);
+      }
+    };
+  }
+
+  /**
+   * 注册命名对象
+   *
+   * @param cls
+   * @param nameds
+   * @param <N>
+   */
+  public static <N extends Named> void registerNameds(Class<N> cls, N... nameds) {
+    Map<String, Named> cache = getNamedMap(cls);
+    synchronized (cache) {
+      Arrays.stream(nameds).filter(Objects::nonNull).forEach(n -> cache.put(n.getName(), n));
+    }
+  }
+
+  /**
+   * 获取命名对象
+   *
+   * @param cls
+   * @param name
+   * @param <N>
+   * @return
+   */
+  public static <N extends Named> N getNamed(Class<N> cls, String name) {
+    Map<String, Named> cache = getNamedMap(cls);
+    Named named = cache.get(name);
+    return cls.cast(named);
+  }
+
+  /**
+   * 获取命名对象注册器
+   *
+   * @param cls
+   * @param <N>
+   * @return
+   */
+  public static <N extends Named> NamedRegistry<N> getNamedRegistry(Class<N> cls) {
+    return new NamedRegistry<N>() {
+      @Override
+      public void register(N... nameds) {
+        registerNameds(cls, nameds);
+      }
+
+      @Override
+      public N get(String name) {
+        return getNamed(cls, name);
+      }
+    };
+  }
+
+  private static <N extends Named> Map<String, Named> getNamedMap(Class<N> cls) {
+    Map<String, Named> cache = named.get(cls);
+    if (null == cache) {
+      synchronized (named) {
+        cache = named.get(cls);
+        if (null == cache) {
+          cache = new HashMap<>();
+          named.put(cls, cache);
+        }
+      }
+    }
+    return cache;
+  }
+
+  /**
+   * 注册排序对象
+   *
+   * @param cls
+   * @param ordereds
+   * @param <O>
+   */
+  public static <O extends Ordered> void registerOrdereds(Class<O> cls, O... ordereds) {
+    List<O> list = getOrdered(cls);
+    synchronized (list) {
+      Arrays.stream(ordereds).filter(Objects::nonNull).forEach(list::add);
+      list.sort(ORDERED_COMPARATOR);
+    }
+  }
+
+  /**
+   * 获取排序对象列表
+   *
+   * @param cls
+   * @param <O>
+   * @return
+   */
+  public static <O extends Ordered> List<O> getOrdered(Class<O> cls) {
+    List<O> list = (List<O>) ordered.get(cls);
+    if (null == list) {
+      synchronized (ordered) {
+        list = (List<O>) ordered.get(cls);
+        if (null == list) {
+          list = new ArrayList<>();
+          ordered.put(cls, list);
+        }
+      }
+    }
+    return list;
+  }
+
+  /**
+   * 获取排序对象注册器
+   *
+   * @param cls
+   * @param <O>
+   * @return
+   */
+  public static <O extends Ordered> OrderedRegistry<O> getOrderedRegistry(Class<O> cls) {
+    return new OrderedRegistry<O>() {
+      @Override
+      public void register(O... ordereds) {
+        registerOrdereds(cls, ordereds);
+      }
+
+      @Override
+      public List<O> get() {
+        return getOrdered(cls);
+      }
+    };
+  }
+}

--- a/src/main/java/org/apache/ibatis/registry/Named.java
+++ b/src/main/java/org/apache/ibatis/registry/Named.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.registry;
+
+/**
+ * @author andyslin
+ */
+public interface Named {
+
+  String getName();
+}

--- a/src/main/java/org/apache/ibatis/registry/Ordered.java
+++ b/src/main/java/org/apache/ibatis/registry/Ordered.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.registry;
+
+/**
+ * @author andyslin
+ */
+public interface Ordered {
+
+  default int getOrder() {
+    return 0;
+  }
+}

--- a/src/main/java/org/apache/ibatis/scripting/decorator/DecoratorRegistry.java
+++ b/src/main/java/org/apache/ibatis/scripting/decorator/DecoratorRegistry.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.scripting.decorator;
+
+import org.apache.ibatis.registry.GenericRegistry;
+import org.apache.ibatis.registry.GenericRegistry.NamedRegistry;
+import org.apache.ibatis.scripting.decorator.bind.BindFunction;
+import org.apache.ibatis.scripting.decorator.bind.BindFunctionFactory;
+import org.apache.ibatis.scripting.decorator.bind.impl.BaseBindFunctionFactory;
+import org.apache.ibatis.session.Configuration;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * @author andyslin
+ */
+public class DecoratorRegistry {
+
+  /**
+   * Bind函数注册器
+   */
+  private static final NamedRegistry<BindFunction> bindFunctionNamedRegistry = GenericRegistry.getNamedRegistry(BindFunction.class);
+
+  static {
+    registerBindFunctionFactory(new BaseBindFunctionFactory());
+  }
+
+  //======Bind函数=========
+  //////////////////////////
+
+  /**
+   * 执行Bind函数
+   *
+   * @param configuration
+   * @param node
+   * @return
+   */
+  public static void evalBindFunction(Configuration configuration, Node node) {
+    Element element = (Element) node;
+    String name = element.getAttribute("name").substring(1);
+    int index = name.indexOf(".");
+    String subName = null;
+    if (-1 != index) {
+      subName = name.substring(index + 1);
+      name = name.substring(0, index);
+    }
+    BindFunction bindFunction = bindFunctionNamedRegistry.get(name);
+    if (null == bindFunction) {
+      throw new RuntimeException("not found bind-function [name=" + name + "]");
+    }
+    String value = element.getAttribute("value");
+    bindFunction.eval(configuration, element, subName, value);
+  }
+
+  /**
+   * 注册Bind函数
+   *
+   * @param bindFunctions
+   */
+  public static void registerBindFunction(BindFunction... bindFunctions) {
+    bindFunctionNamedRegistry.register(bindFunctions);
+  }
+
+  /**
+   * 注册Bind函数工厂
+   *
+   * @param bindFunctionFactories
+   */
+  public static void registerBindFunctionFactory(BindFunctionFactory... bindFunctionFactories) {
+    if (null != bindFunctionFactories) {
+      Arrays.stream(bindFunctionFactories)
+        .filter(Objects::nonNull)
+        .map(BindFunctionFactory::getBindFunctions)
+        .filter(Objects::nonNull)
+        .forEach(bindFunctionNamedRegistry::register);
+    }
+  }
+}

--- a/src/main/java/org/apache/ibatis/scripting/decorator/XmlHolder.java
+++ b/src/main/java/org/apache/ibatis/scripting/decorator/XmlHolder.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.scripting.decorator;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
+
+/**
+ * @author andyslin
+ */
+public class XmlHolder {
+
+  /**
+   * 将xml转换为Node
+   * 需注意的是，这个Node属于新的Document，如果需要和另外的Document交互，需要先调用{@link Document#importNode(Node, boolean)}
+   *
+   * @param xml
+   * @return
+   */
+  public static NodeList string2Node(String xml) {
+    try {
+      DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+      factory.setNamespaceAware(false);
+      DocumentBuilder docBuilder = factory.newDocumentBuilder();
+      xml = "<virual-root>" + xml + "</virual-root>";
+      InputSource is = new InputSource(new StringReader(xml));
+      Document document = docBuilder.parse(is);
+      return document.getDocumentElement().getChildNodes();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * 替换节点
+   *
+   * @param node
+   * @param xml
+   * @return
+   */
+  public static void replaceNode(Node node, String xml) {
+    try {
+      NodeList tmp = string2Node(xml);
+      int max = tmp.getLength() - 1;
+      Document document = node.getOwnerDocument();
+      Node parentNode = node.getParentNode();
+      Node newNode = null;
+      for (int i = max; i >= 0; i--) {
+        Node item = tmp.item(i);
+        newNode = document.importNode(item, true);
+        if (i == max) {
+          parentNode.replaceChild(newNode, node);
+        } else {
+          parentNode.insertBefore(newNode, node);
+        }
+        node = newNode;
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/org/apache/ibatis/scripting/decorator/bind/BindFunction.java
+++ b/src/main/java/org/apache/ibatis/scripting/decorator/bind/BindFunction.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.scripting.decorator.bind;
+
+import org.apache.ibatis.registry.Named;
+import org.apache.ibatis.session.Configuration;
+import org.w3c.dom.Element;
+
+/**
+ * @author andyslin
+ */
+public interface BindFunction extends Named {
+
+  void eval(Configuration configuration, Element bind, String subName, String bindValue);
+}

--- a/src/main/java/org/apache/ibatis/scripting/decorator/bind/BindFunctionFactory.java
+++ b/src/main/java/org/apache/ibatis/scripting/decorator/bind/BindFunctionFactory.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.scripting.decorator.bind;
+
+import java.util.Collection;
+
+/**
+ * @author andyslin
+ */
+public interface BindFunctionFactory {
+
+  /**
+   * 产生一组Bind函数
+   *
+   * @return
+   */
+  Collection<BindFunction> getBindFunctions();
+}

--- a/src/main/java/org/apache/ibatis/scripting/decorator/bind/impl/BaseBindFunctionFactory.java
+++ b/src/main/java/org/apache/ibatis/scripting/decorator/bind/impl/BaseBindFunctionFactory.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.scripting.decorator.bind.impl;
+
+
+import org.apache.ibatis.scripting.decorator.bind.BindFunction;
+import org.apache.ibatis.scripting.decorator.bind.BindFunctionFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @author andyslin
+ */
+public class BaseBindFunctionFactory implements BindFunctionFactory {
+
+  @Override
+  public Collection<BindFunction> getBindFunctions() {
+    List<BindFunction> functions = new ArrayList<>();
+    functions.add(new IfBindFunction());
+    return functions;
+  }
+}

--- a/src/main/java/org/apache/ibatis/scripting/decorator/bind/impl/IfBindFunction.java
+++ b/src/main/java/org/apache/ibatis/scripting/decorator/bind/impl/IfBindFunction.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright 2009-2019 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.scripting.decorator.bind.impl;
+
+import org.apache.ibatis.scripting.decorator.XmlHolder;
+import org.apache.ibatis.scripting.decorator.bind.BindFunction;
+import org.apache.ibatis.session.Configuration;
+import org.w3c.dom.Element;
+
+import java.util.regex.Pattern;
+
+/**
+ * if[.where]语法：([and|or] [like|llike|rlike|eq|ne|ge|gt|le|lt|>|>=|!=] column[|property] [true|false]){1,}
+ *
+ * @author andyslin
+ */
+/*package*/  class IfBindFunction implements BindFunction {
+
+  // 逗号，分隔多个参数
+  private static final Pattern COMMA = Pattern.compile("\\s*(,)\\s*");
+  // 空格，分隔多个单词
+  private static final Pattern BLANK = Pattern.compile("\\s+");
+  // 竖线，分隔列名和属性名
+  private static final Pattern VERTICAL_LINE = Pattern.compile("[|]");
+
+  @Override
+  public String getName() {
+    return "if";
+  }
+
+  @Override
+  public void eval(Configuration configuration, Element bind, String subName, String bindValue) {
+    // 最终生成的XML字符串
+    StringBuilder xml = new StringBuilder();
+    // 循环处理空格或逗号分隔的配置参数
+    boolean addWhere = "where".equalsIgnoreCase(subName);
+    for (String arg : COMMA.split(bindValue)) {
+      if (null != arg && 0 != arg.trim().length()) {
+        Tuple tuple = parseTuple(configuration, arg);
+        xml.append(tuple.toXml());
+      }
+    }
+    if (addWhere) {
+      xml.insert(0, "<where>").append("</where>");
+    }
+    XmlHolder.replaceNode(bind, xml.toString());
+  }
+
+  /**
+   * 解析为一个元组（连接词、操作符、列名、属性名、属性是否为boolean类型、布尔类型的取值）
+   *
+   * @param arg
+   * @return
+   */
+  private Tuple parseTuple(Configuration configuration, String arg) {
+    Tuple tuple = new Tuple();
+    String[] words = BLANK.split(arg);
+    if (1 == words.length) {//只有一个单词
+      tuple.column = words[0];
+    } else if (2 == words.length) {//两个单词
+      if ("and".equalsIgnoreCase(words[0]) || "or".equalsIgnoreCase(words[0])) {
+        tuple.join = words[0];
+      } else {
+        tuple.operate = words[0].toLowerCase();
+      }
+      tuple.column = words[1];
+    } else if (3 <= words.length) {//有三个或三个以上单词
+      tuple.join = words[0];
+      tuple.operate = words[1].toLowerCase();
+      tuple.column = words[2];
+      if (words.length >= 4) {
+        tuple.isBoolean = true;
+        tuple.booleanValue = Boolean.parseBoolean(words[3]);
+      }
+    }
+
+    // 字段|属性
+    String[] arr = VERTICAL_LINE.split(tuple.column);
+    if (arr.length >= 2) {
+      tuple.property = arr[1];
+      tuple.column = arr[0];
+    } else {
+      tuple.property = column2Property(configuration, tuple.column);
+    }
+    return tuple;
+  }
+
+  private String column2Property(Configuration configuration, String column) {
+    int index = column.lastIndexOf(".");
+    if (-1 != index) {
+      column = column.substring(index + 1);
+    }
+
+    if (configuration.isMapUnderscoreToCamelCase()) {
+      StringBuilder sb = new StringBuilder();
+      boolean upper = false, first = true;
+      for (char ch : column.trim().toCharArray()) {
+        if (ch == '-' || ch == '_') {
+          upper = !first;
+        } else {
+          sb.append(upper ? Character.toUpperCase(ch) : Character.toLowerCase(ch));
+          upper = false;
+          first = false;
+        }
+      }
+      return sb.toString();
+    } else {
+      return column.trim();
+    }
+  }
+
+  private static class Tuple {
+    private String join = "and";
+    private String operate = "=";
+    private String column = "";
+    private String property = "";
+    private boolean isBoolean = false;
+    private boolean booleanValue = true;
+
+    private String toXml() {
+      StringBuilder xml = new StringBuilder();
+      if (this.isBoolean) {
+        xml.append("<if test=\"").append(this.booleanValue ? "" : "!").append(this.property).append("\">");
+      } else {
+        xml.append("<if test=\"").append("null != ").append(this.property).append(" and '' != ").append(this.property).append("\">");
+      }
+      xml.append(" ").append(this.join).append(" ");
+      if ("like".equals(this.operate) || "llike".equals(this.operate) || "rlike".equals(this.operate)) {
+        // 这里使用了$like{}配置函数
+        xml.append(this.column).append(" $").append(this.operate).append("{#{").append(this.property).append(",jdbcType=VARCHAR}}");
+      } else if ("eq".equals(this.operate)) {
+        xml.append(this.column).append(" = #{").append(this.property).append(",jdbcType=VARCHAR}");
+      } else if ("ne".equals(this.operate)) {
+        xml.append(this.column).append(" != #{").append(this.property).append(",jdbcType=VARCHAR}");
+      } else if ("ge".equals(this.operate)) {
+        xml.append(this.column).append(" >= #{").append(this.property).append(",jdbcType=VARCHAR}");
+      } else if ("gt".equals(this.operate)) {
+        xml.append(this.column).append(" > #{").append(this.property).append(",jdbcType=VARCHAR}");
+      } else if ("le".equals(this.operate) || "<=".equals(this.operate)) {
+        // le、lt通过将column写在后面实现
+        xml.append(" #{").append(this.property).append(",jdbcType=VARCHAR} >= ").append(this.column);
+      } else if ("lt".equals(this.operate) || "<".equals(this.operate)) {
+        xml.append(" #{").append(this.property).append(",jdbcType=VARCHAR} > ").append(this.column);
+      } else {
+        xml.append(this.column).append(" ").append(this.operate).append(" #{").append(this.property).append(",jdbcType=VARCHAR}");
+      }
+      xml.append("</if>");
+      return xml.toString();
+    }
+  }
+}

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
@@ -24,9 +24,12 @@ import org.apache.ibatis.parsing.PropertyParser;
 import org.apache.ibatis.parsing.XNode;
 import org.apache.ibatis.parsing.XPathParser;
 import org.apache.ibatis.scripting.LanguageDriver;
+import org.apache.ibatis.scripting.decorator.DecoratorRegistry;
 import org.apache.ibatis.scripting.defaults.DefaultParameterHandler;
 import org.apache.ibatis.scripting.defaults.RawSqlSource;
 import org.apache.ibatis.session.Configuration;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
 /**
  * @author Eduardo Macarron
@@ -40,6 +43,11 @@ public class XMLLanguageDriver implements LanguageDriver {
 
   @Override
   public SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType) {
+    Node node = script.getNode();
+    //循环处理所有装饰元素（包括装饰过程中新产生的装饰元素）
+    while (nodeDecorate(configuration, node)) {
+    }
+
     XMLScriptBuilder builder = new XMLScriptBuilder(configuration, script, parameterType);
     return builder.parseScriptNode();
   }
@@ -62,4 +70,19 @@ public class XMLLanguageDriver implements LanguageDriver {
     }
   }
 
+  private boolean nodeDecorate(Configuration configuration, Node node) {
+    if (shouldDecorate(node)) {
+      DecoratorRegistry.evalBindFunction(configuration, node);
+      return true;
+    }
+    return false;
+  }
+
+  private boolean shouldDecorate(Node node) {
+    if (node instanceof Element && "bind".equals(node.getNodeName())) {
+      Element element = (Element) node;
+      return element.getAttribute("name").startsWith("#");
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
First, by extending the semantics of <bind.../ > from bound variables to binding statements and adding `BindFunction` interfaces, a new way to extend them is provided.
Secondly, the writing of `WHERE` clauses and conditional statements is simplified by `IfBindFunction`, a concrete implementation class of `BindFunction`.
such as
```xml
          <where>
            <if test="null != userId and '' != userId">
                and U.USER_ID = #{userId, jdbcType=VARCHAR}
            </if>
            <if test="null != userName and '' != userName">
                and U.USER_NAME LIKE '%'||#{userName, jdbcType=VARCHAR}||'%'
            </if>
            <if test="null != roleId and '' != roleId">
                and R.ROLE_ID = #{roleId, jdbcType=VARCHAR}
            </if>
            <if test="null != roleName and '' != roleName">
                and R.ROLE_NAME LIKE '%'||#{roleName, jdbcType=VARCHAR}||'%'
            </if>
        </where>
```
--->
```
 <bind name="#if.where" value="U.USER_ID,LIKE U.USER_NAME,R.ROLE_ID,LIKE R.ROLE_NAME"/>
```