### PR TITLE
Make the DataSourceFactory follow the factory specification.

### DIFF
--- a/src/main/java/org/apache/ibatis/datasource/pooled/PooledDataSourceFactory.java
+++ b/src/main/java/org/apache/ibatis/datasource/pooled/PooledDataSourceFactory.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,13 +17,15 @@ package org.apache.ibatis.datasource.pooled;
 
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory;
 
+import javax.sql.DataSource;
+
 /**
  * @author Clinton Begin
  */
 public class PooledDataSourceFactory extends UnpooledDataSourceFactory {
 
-  public PooledDataSourceFactory() {
-    this.dataSource = new PooledDataSource();
+  @Override
+  protected DataSource initDataSource() {
+    return new PooledDataSource();
   }
-
 }

--- a/src/site/es/xdoc/sqlmap-xml.xml
+++ b/src/site/es/xdoc/sqlmap-xml.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/site/ja/xdoc/sqlmap-xml.xml
+++ b/src/site/ja/xdoc/sqlmap-xml.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/site/ko/xdoc/sqlmap-xml.xml
+++ b/src/site/ko/xdoc/sqlmap-xml.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/site/zh/xdoc/sqlmap-xml.xml
+++ b/src/site/zh/xdoc/sqlmap-xml.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2019 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/autoconstructor/AutoConstructorMapper.java
+++ b/src/test/java/org/apache/ibatis/autoconstructor/AutoConstructorMapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2019 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
As a data source factory, DataSourceFactory does not follow the factory specifications. It has two issues:

1. The factory can only produce one product. For example, calling getDataSource multiple times can only get the same DataSource.
2. Modifications to factory attributes can affect products that have already been shipped. For example, calling the setProperties method after calling the getDataSource method to get a DataSource will affect the DataSource.

This submission fixes the above two issues.