### PR TITLE
Replace to openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
   - openjdk13
   - openjdk12
   - openjdk11
-  - oraclejdk8
+  - openjdk8
 
 services:
   - docker


### PR DESCRIPTION
Fix build error on latest travis CI env.

See https://travis-ci.org/mybatis/mybatis-3/builds/594954100