### PR TITLE
Remove unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,18 +228,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-dbcp2</artifactId>
-      <version>2.6.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.transaction</groupId>
-      <artifactId>javax.transaction-api</artifactId>
-      <version>1.3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.velocity</groupId>
       <artifactId>velocity-engine-core</artifactId>
       <version>2.1</version>


### PR DESCRIPTION
Hello. I noticed that dependencies `org.apache.commons:commons-dbcp2` and `javax.transaction:javax.transaction-api` are declared in the `pom` but they are not used. Hence, these direct dependencies can be safely removed to make the `pom` clearer.