### PR TITLE
refactor: optimize the code in ParamNameResolver.java

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/ParamNameResolver.java
+++ b/src/main/java/org/apache/ibatis/reflection/ParamNameResolver.java
@@ -119,7 +119,7 @@ public class ParamNameResolver {
       for (Map.Entry<Integer, String> entry : names.entrySet()) {
         param.put(entry.getValue(), args[entry.getKey()]);
         // add generic param names (param1, param2, ...)
-        final String genericParamName = GENERIC_NAME_PREFIX + String.valueOf(i + 1);
+        final String genericParamName = GENERIC_NAME_PREFIX + (i + 1);
         // ensure not to overwrite parameter named with @Param
         if (!names.containsValue(genericParamName)) {
           param.put(genericParamName, args[entry.getKey()]);


### PR DESCRIPTION
* Optimize the code inline 122 of `ParamNameResolver.java`. The method `String.valueOf` is unnecessary and can be deleted.