### PR TITLE
made closeConnection in the Runner classes deprecated

### DIFF
--- a/src/main/java/org/apache/ibatis/jdbc/ScriptRunner.java
+++ b/src/main/java/org/apache/ibatis/jdbc/ScriptRunner.java
@@ -151,6 +151,10 @@ public class ScriptRunner {
     }
   }
 
+  /**
+   * @deprecated Since 3.5.4, this method is deprecated. Please close the {@link Connection} outside of this class.
+   */
+  @Deprecated
   public void closeConnection() {
     try {
       connection.close();

--- a/src/main/java/org/apache/ibatis/jdbc/SqlRunner.java
+++ b/src/main/java/org/apache/ibatis/jdbc/SqlRunner.java
@@ -191,6 +191,10 @@ public class SqlRunner {
     }
   }
 
+  /**
+   * @deprecated Since 3.5.4, this method is deprecated. Please close the {@link Connection} outside of this class.
+   */
+  @Deprecated
   public void closeConnection() {
     try {
       connection.close();


### PR DESCRIPTION
Because the Runners are not responsible to close the connection.