### PR TITLE
Avoid creating unused result map when parsing collection/association

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
@@ -379,10 +379,8 @@ public class XMLMapperBuilder extends BaseBuilder {
     String javaType = context.getStringAttribute("javaType");
     String jdbcType = context.getStringAttribute("jdbcType");
     String nestedSelect = context.getStringAttribute("select");
-    String nestedResultMap = context.getStringAttribute("resultMap");
-    if(nestedResultMap == null) {
-      nestedResultMap = processNestedResultMappings(context, Collections.emptyList(), resultType);
-    }
+    String nestedResultMap = context.getStringAttribute("resultMap", () ->
+      processNestedResultMappings(context, Collections.emptyList(), resultType));
     String notNullColumn = context.getStringAttribute("notNullColumn");
     String columnPrefix = context.getStringAttribute("columnPrefix");
     String typeHandler = context.getStringAttribute("typeHandler");

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
@@ -379,8 +379,10 @@ public class XMLMapperBuilder extends BaseBuilder {
     String javaType = context.getStringAttribute("javaType");
     String jdbcType = context.getStringAttribute("jdbcType");
     String nestedSelect = context.getStringAttribute("select");
-    String nestedResultMap = context.getStringAttribute("resultMap",
-        processNestedResultMappings(context, Collections.emptyList(), resultType));
+    String nestedResultMap = context.getStringAttribute("resultMap");
+    if(nestedResultMap == null) {
+      nestedResultMap = processNestedResultMappings(context, Collections.emptyList(), resultType);
+    }
     String notNullColumn = context.getStringAttribute("notNullColumn");
     String columnPrefix = context.getStringAttribute("columnPrefix");
     String typeHandler = context.getStringAttribute("typeHandler");

--- a/src/main/java/org/apache/ibatis/parsing/XNode.java
+++ b/src/main/java/org/apache/ibatis/parsing/XNode.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.function.Supplier;
 
 import org.w3c.dom.CharacterData;
 import org.w3c.dom.Element;
@@ -82,7 +83,7 @@ public class XNode {
       }
       String value = current.getStringAttribute("id",
           current.getStringAttribute("value",
-              current.getStringAttribute("property", null)));
+              current.getStringAttribute("property", (String) null)));
       if (value != null) {
         value = value.replace('.', '_');
         builder.insert(0, "]");
@@ -209,8 +210,13 @@ public class XNode {
     }
   }
 
+  public String getStringAttribute(String name, Supplier<String> defSupplier) {
+    String value = attributes.getProperty(name);
+    return value == null ? defSupplier.get() : value;
+  }
+
   public String getStringAttribute(String name) {
-    return getStringAttribute(name, null);
+    return getStringAttribute(name, (String) null);
   }
 
   public String getStringAttribute(String name, String def) {

--- a/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/Blog.java
+++ b/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/Blog.java
@@ -1,0 +1,47 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.orphan_result_maps;
+
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.submitted.parent_reference_3level.Post;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Blog {
+
+  private int id;
+  private String title;
+  private List<Post> posts;
+
+  public Blog(@Param("id") int id, @Param("title") String title) {
+    this.id = id;
+    this.title = title;
+    this.posts = new ArrayList<>();
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public List<Post> getPosts() {
+    return posts;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/NestedCollectionMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/NestedCollectionMapper.java
@@ -1,0 +1,22 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.orphan_result_maps;
+
+public interface NestedCollectionMapper {
+
+  public Blog selectBlogWithPosts(int blogId);
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/NestedCollectionMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/NestedCollectionMapper.xml
@@ -1,0 +1,43 @@
+<!--
+
+       Copyright 2009-2019 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.orphan_result_maps.NestedCollectionMapper">
+  <select id="selectBlogWithPosts" resultMap="BlogResultMap">
+        select
+            b.id as blog_id, b.title as blog_title,
+            p.id as post_id, p.body as post_body
+        from blog b
+        left join post p on b.id = p.blog_id
+        where b.id = #{id}
+    </select>
+
+  <resultMap id="BlogResultMap" type="Blog">
+    <constructor>
+      <idArg column="blog_id" name="id"/>
+      <arg column="blog_title" name="title"/>
+    </constructor>
+    <collection property="posts" ofType="Post">
+      <constructor>
+        <idArg column="post_id" name="id"/>
+        <arg column="post_body" name="body"/>
+      </constructor>
+    </collection>
+  </resultMap>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/OrphanResultMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/OrphanResultMapTest.java
@@ -1,0 +1,73 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.orphan_result_maps;
+
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class OrphanResultMapTest {
+
+  private static String RESULT_MAP_BLOG = "BlogResultMap";
+  private static String RESULT_MAP_POST = "PostResultMap";
+  private static String RESULT_MAP_INNER = "mapper_resultMap[BlogResultMap]_collection[posts]";
+
+  @Test
+  void testSeparateResultMaps() {
+    //given
+    Configuration configuration = new Configuration();
+    configuration.getTypeAliasRegistry().registerAlias(Blog.class);
+    configuration.getTypeAliasRegistry().registerAlias(Post.class);
+    configuration.addMapper(SeparateCollectionMapper.class);
+
+    //there should be two result maps declared, with two name variants each
+    assertEquals(4, configuration.getResultMaps().size());
+
+    //test short names
+    assertNotNull(configuration.getResultMap(RESULT_MAP_BLOG));
+    assertNotNull(configuration.getResultMap(RESULT_MAP_POST));
+    assertThrows(IllegalArgumentException.class, () -> configuration.getResultMap(RESULT_MAP_INNER));
+
+    //test long names
+    String prefix = SeparateCollectionMapper.class.getName() + ".";
+    assertNotNull(configuration.getResultMap(prefix + RESULT_MAP_BLOG));
+    assertNotNull(configuration.getResultMap(prefix + RESULT_MAP_POST));
+    assertThrows(IllegalArgumentException.class, () -> configuration.getResultMap(prefix + RESULT_MAP_INNER));
+  }
+
+  @Test
+  void testNestedResultMap() {
+    //given
+    Configuration configuration = new Configuration();
+    configuration.getTypeAliasRegistry().registerAlias(Blog.class);
+    configuration.getTypeAliasRegistry().registerAlias(Post.class);
+    configuration.addMapper(NestedCollectionMapper.class);
+
+    //there should be two result maps declared, with two name variants each
+    assertEquals(4, configuration.getResultMaps().size());
+
+    //test short names
+    assertNotNull(configuration.getResultMap(RESULT_MAP_BLOG));
+    assertNotNull(configuration.getResultMap(RESULT_MAP_INNER));
+
+    //test long names
+    String prefix = NestedCollectionMapper.class.getName() + ".";
+    assertNotNull(configuration.getResultMap(prefix + RESULT_MAP_BLOG));
+    assertNotNull(configuration.getResultMap(prefix + RESULT_MAP_INNER));
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/Post.java
+++ b/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/Post.java
@@ -1,0 +1,37 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.orphan_result_maps;
+
+import org.apache.ibatis.annotations.Param;
+
+public class Post {
+
+  private final int id;
+  private final String body;
+
+  public Post(@Param("id") int id, @Param("body") String body) {
+    this.id = id;
+    this.body = body;
+  }
+
+  public int getId() {
+    return id;
+  }
+
+  public String getBody() {
+    return body;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/SeparateCollectionMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/SeparateCollectionMapper.java
@@ -1,0 +1,22 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.orphan_result_maps;
+
+public interface SeparateCollectionMapper {
+
+  public Blog selectBlogWithPosts(int blogId);
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/SeparateCollectionMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/SeparateCollectionMapper.xml
@@ -1,0 +1,46 @@
+<!--
+
+       Copyright 2009-2019 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.orphan_result_maps.SeparateCollectionMapper">
+  <select id="selectBlogWithPosts" resultMap="BlogResultMap">
+        select
+            b.id as blog_id, b.title as blog_title,
+            p.id as post_id, p.body as post_body
+        from blog b
+        left join post p on b.id = p.blog_id
+        where b.id = #{id}
+    </select>
+
+  <resultMap id="BlogResultMap" type="Blog">
+    <constructor>
+      <idArg column="blog_id" name="id"/>
+      <arg column="blog_title" name="title"/>
+    </constructor>
+    <collection property="posts" resultMap="PostResultMap"/>
+  </resultMap>
+
+  <resultMap id="PostResultMap" type="Post">
+    <constructor>
+      <idArg column="post_id" name="id"/>
+      <arg column="post_body" name="body"/>
+    </constructor>
+  </resultMap>
+
+
+</mapper>


### PR DESCRIPTION
When referencing id of another `resultMap` in association/collection, unessesery ResultMap is created and stored in configuration. For example:

1. When using nested collection:
```xml 
  <resultMap id="BlogResultMap" type="Blog">
    <constructor>
      <idArg column="blog_id" name="id"/>
      <arg column="blog_title" name="title"/>
    </constructor>
    <collection property="posts" ofType="Post">
      <constructor>
        <idArg column="post_id" name="id"/>
        <arg column="post_body" name="body"/>
      </constructor>
    </collection>
  </resultMap>
```
Two ResultMaps are added to configuration:
- `BlogResultMap` based on provided id of resultMap
- `mapper_resultMap[BlogResultMap]_collection[posts]` for nested unnamed resultMap
This works as expected so far.

2. When referencing collection by id (different approach to map same result):
```xml
 <resultMap id="BlogResultMap" type="Blog">
    <constructor>
      <idArg column="blog_id" name="id"/>
      <arg column="blog_title" name="title"/>
    </constructor>
    <collection property="posts" resultMap="PostResultMap"/>
  </resultMap>

  <resultMap id="PostResultMap" type="Post">
    <constructor>
      <idArg column="post_id" name="id"/>
      <arg column="post_body" name="body"/>
    </constructor>
  </resultMap>
```
Three ResultMaps are added to configuration:
- `BlogResultMap` based on provided id of 1st resultMap
- `PostResultMap` based on provided id of 2nd resultMap
- `mapper_resultMap[BlogResultMap]_collection[posts]` this one should not be created as it is not needed and doesn't even contain any mapped columns

Fix implemented in https://github.com/mybatis/mybatis-3/compare/master...piotrponikowski:remove-orphan-result-maps?expand=1#diff-c066585c40ce9a447125a1ba15b3a5a2

Method `processNestedResultMappings` should be evaluated only when attribute `resultMap` is empty.



