### PR TITLE
Use String#replace instead of String#replaceAll.

### DIFF
--- a/src/main/java/org/apache/ibatis/jdbc/ScriptRunner.java
+++ b/src/main/java/org/apache/ibatis/jdbc/ScriptRunner.java
@@ -234,7 +234,7 @@ public class ScriptRunner {
       statement.setEscapeProcessing(escapeProcessing);
       String sql = command;
       if (removeCRs) {
-        sql = sql.replaceAll("\r\n", "\n");
+        sql = sql.replace("\r\n", "\n");
       }
       try {
         boolean hasResults = statement.execute(sql);


### PR DESCRIPTION
String#replace does not use a regular expression for the replacement on Java 9+ and is therefore faster.