### PR TITLE
More convenient way to pass collections as params

### DIFF
--- a/src/main/java/org/apache/ibatis/scripting/xmltags/TextNodeParser.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/TextNodeParser.java
@@ -1,0 +1,67 @@
+package org.apache.ibatis.scripting.xmltags;
+
+import org.apache.ibatis.session.Configuration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class TextNodeParser {
+
+  private final static String COLLECTION_OPEN_TOKEN = "#{";
+  private final static String COLLECTION_CLOSE_TOKEN = "...}";
+  private final static Pattern COLLECTION_PATTERN;
+
+  static {
+    String quotedOpenToken = Pattern.quote(COLLECTION_OPEN_TOKEN);
+    String quotedCloseToken = Pattern.quote(COLLECTION_CLOSE_TOKEN);
+    COLLECTION_PATTERN = Pattern.compile(quotedOpenToken + "([^}]*?)" + quotedCloseToken);
+  }
+
+  public static TextNodeParserResult parse(Configuration configuration, String text) {
+    List<SqlNode> nodes = new ArrayList<>();
+    boolean isDynamic = false;
+
+    int index = 0;
+    Matcher matcher = COLLECTION_PATTERN.matcher(text);
+    while (matcher.find()) {
+      isDynamic = true;
+
+      //process text node before any collection operator
+      if (matcher.start() > index) {
+        String textPart = text.substring(index, matcher.start());
+        TextSqlNode textSqlNode = new TextSqlNode(textPart);
+        if (textSqlNode.isDynamic()) {
+          nodes.add(textSqlNode);
+        } else {
+          nodes.add(new StaticTextSqlNode(textPart));
+        }
+      }
+
+      //process collection operator
+      String collectionExp = matcher.group();
+      collectionExp = collectionExp.substring(COLLECTION_OPEN_TOKEN.length(), collectionExp.length() - COLLECTION_CLOSE_TOKEN.length());
+
+      MixedSqlNode contents = new MixedSqlNode(Arrays.asList(new TextSqlNode("#{item}")));
+      nodes.add(new ForEachSqlNode(configuration, contents, collectionExp, null, "item", null, null, ","));
+
+      index = matcher.end();
+    }
+
+    //process remaining text
+    if (index < text.length()) {
+      String textPart = text.substring(index, text.length());
+      TextSqlNode textSqlNode = new TextSqlNode(textPart);
+      if (textSqlNode.isDynamic()) {
+        nodes.add(textSqlNode);
+        isDynamic = true;
+      } else {
+        nodes.add(new StaticTextSqlNode(textPart));
+      }
+    }
+
+    return new TextNodeParserResult(nodes, isDynamic);
+  }
+}

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/TextNodeParser.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/TextNodeParser.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.scripting.xmltags;
 
 import org.apache.ibatis.session.Configuration;

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/TextNodeParserResult.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/TextNodeParserResult.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.scripting.xmltags;
 
 import java.util.List;

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/TextNodeParserResult.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/TextNodeParserResult.java
@@ -1,0 +1,21 @@
+package org.apache.ibatis.scripting.xmltags;
+
+import java.util.List;
+
+public class TextNodeParserResult {
+  public final List<SqlNode> nodes;
+  public final boolean isDynamic;
+
+  public TextNodeParserResult(List<SqlNode> nodes, boolean isDynamic) {
+    this.nodes = nodes;
+    this.isDynamic = isDynamic;
+  }
+
+  public SqlNode toSingleSqlNode() {
+    if (nodes.size() == 1) {
+      return nodes.get(0);
+    } else {
+      return new MixedSqlNode(nodes);
+    }
+  }
+}

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
@@ -53,11 +53,11 @@ public class XMLLanguageDriver implements LanguageDriver {
     } else {
       // issue #127
       script = PropertyParser.parse(script, configuration.getVariables());
-      TextSqlNode textSqlNode = new TextSqlNode(script);
-      if (textSqlNode.isDynamic()) {
-        return new DynamicSqlSource(configuration, textSqlNode);
+      TextNodeParserResult parserResult = TextNodeParser.parse(configuration, script);
+      if (parserResult.isDynamic) {
+        return new DynamicSqlSource(configuration, parserResult.toSingleSqlNode());
       } else {
-        return new RawSqlSource(configuration, script, parameterType);
+        return new RawSqlSource(configuration, parserResult.toSingleSqlNode(), parameterType);
       }
     }
   }

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2019 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -81,13 +81,9 @@ public class XMLScriptBuilder extends BaseBuilder {
       XNode child = node.newXNode(children.item(i));
       if (child.getNode().getNodeType() == Node.CDATA_SECTION_NODE || child.getNode().getNodeType() == Node.TEXT_NODE) {
         String data = child.getStringBody("");
-        TextSqlNode textSqlNode = new TextSqlNode(data);
-        if (textSqlNode.isDynamic()) {
-          contents.add(textSqlNode);
-          isDynamic = true;
-        } else {
-          contents.add(new StaticTextSqlNode(data));
-        }
+        TextNodeParserResult parserResult = TextNodeParser.parse(configuration, data);
+        contents.addAll(parserResult.nodes);
+        isDynamic = isDynamic || parserResult.isDynamic;
       } else if (child.getNode().getNodeType() == Node.ELEMENT_NODE) { // issue #628
         String nodeName = child.getNode().getNodeName();
         NodeHandler handler = nodeHandlerMap.get(nodeName);

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/CollectionInAnnotationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/CollectionInAnnotationTest.java
@@ -1,0 +1,112 @@
+package org.apache.ibatis.submitted.expand_collection_param;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.submitted.expand_collection_param.mapper.AnnotationMapper;
+import org.apache.ibatis.submitted.expand_collection_param.model.User;
+import org.apache.ibatis.submitted.expand_collection_param.model.UserRole;
+import org.apache.ibatis.submitted.expand_collection_param.model.UserStatus;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.Reader;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CollectionInAnnotationTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void initDatabase() throws Exception {
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/expand_collection_param/config/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().getMapperRegistry().addMapper(AnnotationMapper.class);
+    }
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/submitted/expand_collection_param/config/CreateDB.sql");
+  }
+
+  @Test
+  public void shouldQueryByIntCollection() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      AnnotationMapper mapper = sqlSession.getMapper(AnnotationMapper.class);
+      List<User> users = mapper.getUsersByIds(Arrays.asList(1, 2, 4));
+      assertEquals(3, users.size());
+      assertEquals(1, users.get(0).getId());
+      assertEquals(2, users.get(1).getId());
+      assertEquals(4, users.get(2).getId());
+    }
+  }
+
+  @Test
+  public void shouldQueryByIntArray() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      AnnotationMapper mapper = sqlSession.getMapper(AnnotationMapper.class);
+      List<User> users = mapper.getUsersByArrayIds(new int[]{1, 8, 5});
+      assertEquals(2, users.size());
+      assertEquals(1, users.get(0).getId());
+      assertEquals(5, users.get(1).getId());
+    }
+  }
+
+
+  @Test
+  public void shouldQueryByStringCollection() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      AnnotationMapper mapper = sqlSession.getMapper(AnnotationMapper.class);
+      List<User> users = mapper.getUsersByNames(Arrays.asList("John", "Mark", "Bill"));
+      assertEquals(4, users.size());
+      assertEquals(1, users.get(0).getId());
+      assertEquals(4, users.get(1).getId());
+      assertEquals(5, users.get(2).getId());
+      assertEquals(6, users.get(3).getId());
+    }
+  }
+
+  @Test
+  public void shouldQueryByEnumCollection() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      AnnotationMapper mapper = sqlSession.getMapper(AnnotationMapper.class);
+      List<User> users = mapper.getUsersByRoles(Arrays.asList(UserRole.REVIEWER, UserRole.WRITER));
+      assertEquals(4, users.size());
+      assertEquals(1, users.get(0).getId());
+      assertEquals(2, users.get(1).getId());
+      assertEquals(3, users.get(2).getId());
+      assertEquals(4, users.get(3).getId());
+    }
+  }
+
+  @Test
+  public void shouldQueryByOrdinalEnumCollection() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      AnnotationMapper mapper = sqlSession.getMapper(AnnotationMapper.class);
+      List<User> users = mapper.getUsersByStatus(Arrays.asList(UserStatus.NOT_ACTIVATED, UserStatus.DELETED));
+      assertEquals(4, users.size());
+      assertEquals(1, users.get(0).getId());
+      assertEquals(3, users.get(1).getId());
+      assertEquals(4, users.get(2).getId());
+      assertEquals(6, users.get(3).getId());
+    }
+  }
+
+  @Test
+  public void shouldQueryByMultiplesLists() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      AnnotationMapper mapper = sqlSession.getMapper(AnnotationMapper.class);
+      List<UserStatus> status = Arrays.asList(UserStatus.NOT_ACTIVATED, UserStatus.DELETED);
+      List<UserRole> roles = Arrays.asList(UserRole.WRITER, UserRole.ADMIN);
+      List<User> users = mapper.getUsersByStatusAndRoles(status, roles);
+      assertEquals(2, users.size());
+      assertEquals(1, users.get(0).getId());
+      assertEquals(6, users.get(1).getId());
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/CollectionInAnnotationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/CollectionInAnnotationTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.submitted.expand_collection_param;
 
 import org.apache.ibatis.BaseDataTest;

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/CollectionInProviderlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/CollectionInProviderlTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.submitted.expand_collection_param;
 
 import org.apache.ibatis.BaseDataTest;

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/CollectionInProviderlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/CollectionInProviderlTest.java
@@ -1,0 +1,62 @@
+package org.apache.ibatis.submitted.expand_collection_param;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.submitted.expand_collection_param.mapper.ProviderMapper;
+import org.apache.ibatis.submitted.expand_collection_param.model.User;
+import org.apache.ibatis.submitted.expand_collection_param.model.UserRole;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CollectionInProviderlTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void initDatabase() throws Exception {
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/expand_collection_param/config/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().getMapperRegistry().addMapper(ProviderMapper.class);
+    }
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/submitted/expand_collection_param/config/CreateDB.sql");
+  }
+
+  @Test
+  public void shouldQueryByCollection() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      ProviderMapper mapper = sqlSession.getMapper(ProviderMapper.class);
+      List<User> users = mapper.getUsers(6, Arrays.asList(UserRole.ADMIN, UserRole.REVIEWER));
+      assertEquals(3, users.size());
+      assertEquals(3, users.get(0).getId());
+      assertEquals(4, users.get(1).getId());
+      assertEquals(5, users.get(2).getId());
+    }
+  }
+
+  @Test
+  public void shouldQueryByEmptyCollection() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      ProviderMapper mapper = sqlSession.getMapper(ProviderMapper.class);
+      List<User> users = mapper.getUsers(6, new ArrayList<>());
+      assertEquals(5, users.size());
+      assertEquals(1, users.get(0).getId());
+      assertEquals(2, users.get(1).getId());
+      assertEquals(3, users.get(2).getId());
+      assertEquals(4, users.get(3).getId());
+      assertEquals(5, users.get(4).getId());
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/CollectionInXmlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/CollectionInXmlTest.java
@@ -1,0 +1,47 @@
+package org.apache.ibatis.submitted.expand_collection_param;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.submitted.expand_collection_param.mapper.XmlMapper;
+import org.apache.ibatis.submitted.expand_collection_param.model.User;
+import org.apache.ibatis.submitted.expand_collection_param.model.UserRole;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.Reader;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CollectionInXmlTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void initDatabase() throws Exception {
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/expand_collection_param/config/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().getMapperRegistry().addMapper(XmlMapper.class);
+    }
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/submitted/expand_collection_param/config/CreateDB.sql");
+  }
+
+  @Test
+  public void shouldQueryByCollection() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      XmlMapper mapper = sqlSession.getMapper(XmlMapper.class);
+      List<User> users = mapper.getUsers(2, Arrays.asList(UserRole.WRITER, UserRole.REVIEWER));
+      assertEquals(3, users.size());
+      assertEquals(1, users.get(0).getId());
+      assertEquals(3, users.get(1).getId());
+      assertEquals(4, users.get(2).getId());
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/CollectionInXmlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/CollectionInXmlTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.submitted.expand_collection_param;
 
 import org.apache.ibatis.BaseDataTest;

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/TextNodeParserTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/TextNodeParserTest.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.submitted.expand_collection_param;
 
 import org.apache.ibatis.scripting.xmltags.*;

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/TextNodeParserTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/TextNodeParserTest.java
@@ -1,0 +1,89 @@
+package org.apache.ibatis.submitted.expand_collection_param;
+
+import org.apache.ibatis.scripting.xmltags.*;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class TextNodeParserTest {
+
+  @Test
+  public void shouldParseStaticText() {
+    TextNodeParserResult result = TextNodeParser.parse(new Configuration(), "" +
+      "SELECT id, name " +
+      "FROM blog WHERE id = 1");
+
+    assertEquals(false, result.isDynamic);
+    assertEquals(1, result.nodes.size());
+    assertTrue(result.nodes.get(0) instanceof StaticTextSqlNode);
+  }
+
+  @Test
+  public void shouldParseStaticTextWithParameter() {
+    TextNodeParserResult result = TextNodeParser.parse(new Configuration(), "SELECT id, name FROM blog WHERE id = #{id}");
+
+    assertEquals(false, result.isDynamic);
+    assertEquals(1, result.nodes.size());
+    assertTrue(result.nodes.get(0) instanceof StaticTextSqlNode);
+  }
+
+  @Test
+  public void shouldParseDynamicText() {
+    TextNodeParserResult result = TextNodeParser.parse(new Configuration(), "" +
+      "SELECT id, name " +
+      "FROM blog " +
+      "WHERE ${column} = 1");
+
+    assertEquals(true, result.isDynamic);
+    assertEquals(1, result.nodes.size());
+    assertTrue(result.nodes.get(0) instanceof TextSqlNode);
+  }
+
+  @Test
+  public void shouldParseOneCollection() {
+    TextNodeParserResult result = TextNodeParser.parse(new Configuration(), "" +
+      "SELECT id, name " +
+      "FROM blog " +
+      "WHERE id IN (#{ids...})");
+
+    assertEquals(true, result.isDynamic);
+    assertEquals(3, result.nodes.size());
+    assertTrue(result.nodes.get(0) instanceof StaticTextSqlNode);
+    assertTrue(result.nodes.get(1) instanceof ForEachSqlNode);
+    assertTrue(result.nodes.get(2) instanceof StaticTextSqlNode);
+  }
+
+  @Test
+  public void shouldParseOneCollectionAndDynamicText() {
+    TextNodeParserResult result = TextNodeParser.parse(new Configuration(), "" +
+      "SELECT id, name FROM blog " +
+      "WHERE id IN (#{ids...}) " +
+      "AND ${column} = 1");
+
+    assertEquals(true, result.isDynamic);
+    assertEquals(3, result.nodes.size());
+    assertTrue(result.nodes.get(0) instanceof StaticTextSqlNode);
+    assertTrue(result.nodes.get(1) instanceof ForEachSqlNode);
+    assertTrue(result.nodes.get(2) instanceof TextSqlNode);
+  }
+
+
+  @Test
+  public void shouldParseMultipleCollections() {
+    TextNodeParserResult result = TextNodeParser.parse(new Configuration(), "" +
+      "SELECT id, name FROM blog " +
+      "WHERE id IN (#{ids...}) " +
+      "AND category IN (#{categories...})" +
+      "AND ${column} = 1");
+
+    assertEquals(true, result.isDynamic);
+    assertEquals(5, result.nodes.size());
+    assertTrue(result.nodes.get(0) instanceof StaticTextSqlNode);
+    assertTrue(result.nodes.get(1) instanceof ForEachSqlNode);
+    assertTrue(result.nodes.get(2) instanceof StaticTextSqlNode);
+    assertTrue(result.nodes.get(3) instanceof ForEachSqlNode);
+    assertTrue(result.nodes.get(4) instanceof TextSqlNode);
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/config/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/config/CreateDB.sql
@@ -1,0 +1,15 @@
+create table users (
+  id int,
+  first_name varchar(100),
+  last_name varchar(100),
+  role varchar(20),
+  status int
+);
+
+INSERT INTO users (id, first_name, last_name, role, status) VALUES (1, 'John', 'Twain', 'WRITER', 0);
+INSERT INTO users (id, first_name, last_name, role, status) VALUES (2, 'Jacob', 'Smith', 'WRITER', 1);
+INSERT INTO users (id, first_name, last_name, role, status) VALUES (3, 'Thomas', 'Clinton', 'REVIEWER', 2);
+INSERT INTO users (id, first_name, last_name, role, status) VALUES (4, 'Bill', 'Snow', 'REVIEWER', 0);
+INSERT INTO users (id, first_name, last_name, role, status) VALUES (5, 'Mark', 'Carlson', 'ADMIN', 1);
+INSERT INTO users (id, first_name, last_name, role, status) VALUES (6, 'John', 'Peterson', 'ADMIN', 2);
+

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/config/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/config/CreateDB.sql
@@ -1,3 +1,19 @@
+--
+--    Copyright 2009-2020 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
 create table users (
   id int,
   first_name varchar(100),

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/config/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/config/mybatis-config.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+       Copyright 2009-2020 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
 <!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN" "http://mybatis.org/dtd/mybatis-3-config.dtd">
 
 <configuration>

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/config/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/config/mybatis-config.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE configuration PUBLIC "-//mybatis.org//DTD Config 3.0//EN" "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <typeHandlers>
+    <typeHandler
+      javaType="org.apache.ibatis.submitted.expand_collection_param.model.UserStatus"
+      handler="org.apache.ibatis.type.EnumOrdinalTypeHandler"/>
+  </typeHandlers>
+
+  <environments default="test">
+    <environment id="test">
+      <transactionManager type="JDBC"/>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver"/>
+        <property name="url" value="jdbc:hsqldb:mem:expand_collection_param"/>
+        <property name="username" value="sa"/>
+      </dataSource>
+    </environment>
+  </environments>
+
+
+</configuration>

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/AnnotationMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/AnnotationMapper.java
@@ -1,0 +1,32 @@
+package org.apache.ibatis.submitted.expand_collection_param.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.submitted.expand_collection_param.model.User;
+import org.apache.ibatis.submitted.expand_collection_param.model.UserRole;
+import org.apache.ibatis.submitted.expand_collection_param.model.UserStatus;
+
+import java.util.List;
+
+public interface AnnotationMapper {
+
+  @Select("select * from users WHERE id in (#{ids...}) order by id")
+  List<User> getUsersByIds(@Param("ids") List<Integer> ids);
+
+  @Select("select * from users WHERE id in (#{ids...}) order by id")
+  List<User> getUsersByArrayIds(@Param("ids") int[] ids);
+
+  @Select("select * from users WHERE first_name in (#{names...}) order by id")
+  List<User> getUsersByNames(@Param("names") List<String> names);
+
+  @Select("select * from users WHERE role in (#{roles...}) order by id")
+  List<User> getUsersByRoles(@Param("roles") List<UserRole> roles);
+
+  @Select("select * from users WHERE status in (#{status...}) order by id")
+  List<User> getUsersByStatus(@Param("status") List<UserStatus> status);
+
+  @Select("select * from users WHERE status in (#{status...}) and role in (#{roles...}) order by id")
+  List<User> getUsersByStatusAndRoles(@Param("status") List<UserStatus> status, @Param("roles") List<UserRole> roles);
+
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/AnnotationMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/AnnotationMapper.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.submitted.expand_collection_param.mapper;
 
 import org.apache.ibatis.annotations.Param;

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/ProviderMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/ProviderMapper.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.submitted.expand_collection_param.mapper;
 
 import org.apache.ibatis.annotations.Param;

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/ProviderMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/ProviderMapper.java
@@ -1,0 +1,17 @@
+package org.apache.ibatis.submitted.expand_collection_param.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.jdbc.SQL;
+import org.apache.ibatis.submitted.expand_collection_param.model.User;
+import org.apache.ibatis.submitted.expand_collection_param.model.UserRole;
+
+import java.util.List;
+
+public interface ProviderMapper {
+
+  @SelectProvider(type = StatementProvider.class, method = "getUsers")
+  List<User> getUsers(@Param("id") Integer id, @Param("roles") List<UserRole> roles);
+
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/StatementProvider.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/StatementProvider.java
@@ -1,0 +1,21 @@
+package org.apache.ibatis.submitted.expand_collection_param.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.jdbc.SQL;
+import org.apache.ibatis.submitted.expand_collection_param.model.UserRole;
+
+import java.util.List;
+
+class StatementProvider {
+  public String getUsers(@Param("id") Integer id, @Param("roles") List<UserRole> roles) {
+    SQL sql = new SQL();
+    sql.SELECT("*");
+    sql.FROM("users");
+    if (!roles.isEmpty()) {
+      sql.WHERE("role in (#{roles...})");
+    }
+    sql.WHERE("id != #{id}");
+    sql.ORDER_BY("id");
+    return sql.toString();
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/StatementProvider.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/StatementProvider.java
@@ -21,7 +21,7 @@ import org.apache.ibatis.submitted.expand_collection_param.model.UserRole;
 
 import java.util.List;
 
-class StatementProvider {
+public class StatementProvider {
   public String getUsers(@Param("id") Integer id, @Param("roles") List<UserRole> roles) {
     SQL sql = new SQL();
     sql.SELECT("*");

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/StatementProvider.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/StatementProvider.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.submitted.expand_collection_param.mapper;
 
 import org.apache.ibatis.annotations.Param;

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/XmlMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/XmlMapper.java
@@ -1,0 +1,13 @@
+package org.apache.ibatis.submitted.expand_collection_param.mapper;
+
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.submitted.expand_collection_param.model.User;
+import org.apache.ibatis.submitted.expand_collection_param.model.UserRole;
+
+import java.util.List;
+
+public interface XmlMapper {
+
+  List<User> getUsers(@Param("id") Integer id, @Param("roles") List<UserRole> roles);
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/XmlMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/XmlMapper.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.submitted.expand_collection_param.mapper;
 
 import org.apache.ibatis.annotations.Param;

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/XmlMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/XmlMapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.expand_collection_param.mapper.XmlMapper">
+
+  <select id="getUsers" resultType="org.apache.ibatis.submitted.expand_collection_param.model.User">
+      select * from users
+      where id != #{id}
+      and role in (#{roles...})
+      order by id
+  </select>
+
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/XmlMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/mapper/XmlMapper.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2020 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="org.apache.ibatis.submitted.expand_collection_param.mapper.XmlMapper">

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/model/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/model/User.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.submitted.expand_collection_param.model;
 
 public class User {

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/model/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/model/User.java
@@ -1,0 +1,39 @@
+package org.apache.ibatis.submitted.expand_collection_param.model;
+
+public class User {
+
+  public User(Integer id, String firstName, String lastName, UserRole role, UserStatus status) {
+    this.id = id;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.role = role;
+    this.status = status;
+  }
+
+  private Integer id;
+  private String firstName;
+  private String lastName;
+  private UserRole role;
+  private UserStatus status;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public UserStatus getStatus() {
+    return status;
+  }
+
+  public UserRole getRole() {
+    return role;
+  }
+}
+

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/model/UserRole.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/model/UserRole.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.submitted.expand_collection_param.model;
 
 public enum UserRole {

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/model/UserRole.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/model/UserRole.java
@@ -1,0 +1,8 @@
+package org.apache.ibatis.submitted.expand_collection_param.model;
+
+public enum UserRole {
+  ADMIN,
+  REVIEWER,
+  WRITER,
+}
+

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/model/UserStatus.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/model/UserStatus.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.submitted.expand_collection_param.model;
 
 public enum UserStatus {

--- a/src/test/java/org/apache/ibatis/submitted/expand_collection_param/model/UserStatus.java
+++ b/src/test/java/org/apache/ibatis/submitted/expand_collection_param/model/UserStatus.java
@@ -1,0 +1,7 @@
+package org.apache.ibatis.submitted.expand_collection_param.model;
+
+public enum UserStatus {
+  NOT_ACTIVATED,
+  ACTIVATED,
+  DELETED
+}


### PR DESCRIPTION
This PR is proposition for more convenient way to pass collections into queries.
I added ability to expand collections by introducing new format of parameter operator: `#{param...}`. When parsing query, format `#{params...}` is resolved as ForEachSqlNode. 

In other words existing operator `#{param}` is always translated to single param `?`, but `#{param...}` expands collections to list of parameters, for example to `?, ?, ?`.


This should cover these cases:

1. No need to use `<script>` and `<foreach>` tags when using annotations 
This can be simplified:
```java
  @Select({
    "<script>select * from users ",
    "<foreach item=\"item\" collection=\"ids\" open=\"(\" separator=\",\" close=\")\">#{item}</foreach> ",
    "order by id</script>"})
```
to:
```java
  @Select("select * from users WHERE id in (#{ids...}) order by id")
```

2. This works also in xml mappers:

```xml
  <select id="getUsers" resultType="org.apache.ibatis.submitted.expand_collection_param.model.User">
    select * from users where id != #{id} and role in
    <foreach item='item' index='index' collection='roles' open='(' separator=',' close=')'>
      #{item}
    </foreach>
    order by id
  </select>
```
vs:

```xml
  <select id="getUsers" resultType="org.apache.ibatis.submitted.expand_collection_param.model.User">
      select * from users
      where id != #{id} and role in (#{roles...})
      order by id
  </select>
```

3. This will also reduce code when using providers:
```java
  @SelectProvider(type = StatementProvider.class, method = "getUsers")
```
```java
  public String getUsers(@Param("roles") List<UserRole> roles) {
    SQL sql = new SQL().SELECT("*").FROM("users");
    if (!roles.isEmpty()) {
      sql.WHERE("role in (#{roles...})");
    }
    sql.ORDER_BY("id");
    return sql.toString();
  }
```

What do you think?





