### PR TITLE
Make tests more stable by adding a test condition

### DIFF
--- a/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
@@ -212,7 +212,7 @@ class ReflectorTest {
     assertNotNull(reflector.getSetInvoker("prop1"));
 
     Class<?> paramType = reflector.getSetterType("prop2");
-    assertTrue(String.class.equals(paramType) || Integer.class.equals(paramType)|| boolean.class.equals(paramType));
+    assertTrue(String.class.equals(paramType) || Integer.class.equals(paramType) || boolean.class.equals(paramType));
 
     Invoker ambiguousInvoker = reflector.getSetInvoker("prop2");
     Object[] param = String.class.equals(paramType)? new String[]{"x"} : new Integer[]{1};

--- a/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
@@ -212,7 +212,7 @@ class ReflectorTest {
     assertNotNull(reflector.getSetInvoker("prop1"));
 
     Class<?> paramType = reflector.getSetterType("prop2");
-    assertTrue(String.class.equals(paramType) || Integer.class.equals(paramType));
+    assertTrue(String.class.equals(paramType) || Integer.class.equals(paramType)|| boolean.class.equals(paramType));
 
     Invoker ambiguousInvoker = reflector.getSetInvoker("prop2");
     Object[] param = String.class.equals(paramType)? new String[]{"x"} : new Integer[]{1};


### PR DESCRIPTION
`reflector.getSetterType` in `ReflectorTest` can return `String`, `Integer`, and `boolean` these three type. However the test `assertTrue` includes two types. So, the test can fail when `reflector.getSetterType` return `boolean`.

This PR proposes to add test a condition so that the test is deterministic.