### PR TITLE
fix: bug nested structure function will cause data lost.

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -1051,7 +1051,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
       if (resultMapping.getNestedResultMapId() != null && resultMapping.getResultSet() == null) {
         // Issue #392
         final ResultMap nestedResultMap = configuration.getResultMap(resultMapping.getNestedResultMapId());
-        createRowKeyForMappedProperties(nestedResultMap, rsw, cacheKey, nestedResultMap.getConstructorResultMappings(),
+        createRowKeyForMappedProperties(nestedResultMap, rsw, cacheKey, nestedResultMap.getResultMappings(),
             prependPrefix(resultMapping.getColumnPrefix(), columnPrefix));
       } else if (resultMapping.getNestedQueryId() == null) {
         final String column = prependPrefix(resultMapping.getColumn(), columnPrefix);

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2019 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,19 +15,6 @@
  */
 package org.apache.ibatis.executor.resultset;
 
-import java.lang.reflect.Constructor;
-import java.sql.CallableStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-
 import org.apache.ibatis.annotations.AutomapConstructor;
 import org.apache.ibatis.binding.MapperMethod.ParamMap;
 import org.apache.ibatis.cache.CacheKey;
@@ -42,25 +29,22 @@ import org.apache.ibatis.executor.parameter.ParameterHandler;
 import org.apache.ibatis.executor.result.DefaultResultContext;
 import org.apache.ibatis.executor.result.DefaultResultHandler;
 import org.apache.ibatis.executor.result.ResultMapException;
-import org.apache.ibatis.mapping.BoundSql;
-import org.apache.ibatis.mapping.Discriminator;
-import org.apache.ibatis.mapping.MappedStatement;
-import org.apache.ibatis.mapping.ParameterMapping;
-import org.apache.ibatis.mapping.ParameterMode;
-import org.apache.ibatis.mapping.ResultMap;
-import org.apache.ibatis.mapping.ResultMapping;
+import org.apache.ibatis.mapping.*;
 import org.apache.ibatis.reflection.MetaClass;
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.ReflectorFactory;
 import org.apache.ibatis.reflection.factory.ObjectFactory;
-import org.apache.ibatis.session.AutoMappingBehavior;
-import org.apache.ibatis.session.Configuration;
-import org.apache.ibatis.session.ResultContext;
-import org.apache.ibatis.session.ResultHandler;
-import org.apache.ibatis.session.RowBounds;
+import org.apache.ibatis.session.*;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
+
+import java.lang.reflect.Constructor;
+import java.sql.CallableStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.*;
 
 /**
  * @author Clinton Begin
@@ -287,7 +271,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   private void validateResultMapsCount(ResultSetWrapper rsw, int resultMapCount) {
     if (rsw != null && resultMapCount < 1) {
       throw new ExecutorException("A query was run and no Result Maps were found for the Mapped Statement '" + mappedStatement.getId()
-          + "'.  It's likely that neither a Result Type nor a Result Map was specified.");
+        + "'.  It's likely that neither a Result Type nor a Result Map was specified.");
     }
   }
 
@@ -332,20 +316,20 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   private void ensureNoRowBounds() {
     if (configuration.isSafeRowBoundsEnabled() && rowBounds != null && (rowBounds.getLimit() < RowBounds.NO_ROW_LIMIT || rowBounds.getOffset() > RowBounds.NO_ROW_OFFSET)) {
       throw new ExecutorException("Mapped Statements with nested result mappings cannot be safely constrained by RowBounds. "
-          + "Use safeRowBoundsEnabled=false setting to bypass this check.");
+        + "Use safeRowBoundsEnabled=false setting to bypass this check.");
     }
   }
 
   protected void checkResultHandler() {
     if (resultHandler != null && configuration.isSafeResultHandlerEnabled() && !mappedStatement.isResultOrdered()) {
       throw new ExecutorException("Mapped Statements with nested result mappings cannot be safely used with a custom ResultHandler. "
-          + "Use safeResultHandlerEnabled=false setting to bypass this check "
-          + "or ensure your statement returns ordered data and set resultOrdered=true on it.");
+        + "Use safeResultHandlerEnabled=false setting to bypass this check "
+        + "or ensure your statement returns ordered data and set resultOrdered=true on it.");
     }
   }
 
   private void handleRowValuesForSimpleResultMap(ResultSetWrapper rsw, ResultMap resultMap, ResultHandler<?> resultHandler, RowBounds rowBounds, ResultMapping parentMapping)
-      throws SQLException {
+    throws SQLException {
     DefaultResultContext<Object> resultContext = new DefaultResultContext<>();
     ResultSet resultSet = rsw.getResultSet();
     skipRows(resultSet, rowBounds);
@@ -425,7 +409,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   //
 
   private boolean applyPropertyMappings(ResultSetWrapper rsw, ResultMap resultMap, MetaObject metaObject, ResultLoaderMap lazyLoader, String columnPrefix)
-      throws SQLException {
+    throws SQLException {
     final List<String> mappedColumnNames = rsw.getMappedColumnNames(resultMap, columnPrefix);
     boolean foundValues = false;
     final List<ResultMapping> propertyMappings = resultMap.getPropertyResultMappings();
@@ -436,8 +420,8 @@ public class DefaultResultSetHandler implements ResultSetHandler {
         column = null;
       }
       if (propertyMapping.isCompositeResult()
-          || (column != null && mappedColumnNames.contains(column.toUpperCase(Locale.ENGLISH)))
-          || propertyMapping.getResultSet() != null) {
+        || (column != null && mappedColumnNames.contains(column.toUpperCase(Locale.ENGLISH)))
+        || propertyMapping.getResultSet() != null) {
         Object value = getPropertyMappingValue(rsw.getResultSet(), metaObject, propertyMapping, lazyLoader, columnPrefix);
         // issue #541 make property optional
         final String property = propertyMapping.getProperty();
@@ -460,7 +444,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   }
 
   private Object getPropertyMappingValue(ResultSet rs, MetaObject metaResultObject, ResultMapping propertyMapping, ResultLoaderMap lazyLoader, String columnPrefix)
-      throws SQLException {
+    throws SQLException {
     if (propertyMapping.getNestedQueryId() != null) {
       return getNestedQueryMappingValue(rs, metaResultObject, propertyMapping, lazyLoader, columnPrefix);
     } else if (propertyMapping.getResultSet() != null) {
@@ -501,11 +485,11 @@ public class DefaultResultSetHandler implements ResultSetHandler {
             autoMapping.add(new UnMappedColumnAutoMapping(columnName, property, typeHandler, propertyType.isPrimitive()));
           } else {
             configuration.getAutoMappingUnknownColumnBehavior()
-                .doAction(mappedStatement, columnName, property, propertyType);
+              .doAction(mappedStatement, columnName, property, propertyType);
           }
         } else {
           configuration.getAutoMappingUnknownColumnBehavior()
-              .doAction(mappedStatement, columnName, (property != null) ? property : propertyName, null);
+            .doAction(mappedStatement, columnName, (property != null) ? property : propertyName, null);
         }
       }
       autoMappingsCache.put(mapKey, autoMapping);
@@ -604,7 +588,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   }
 
   private Object createResultObject(ResultSetWrapper rsw, ResultMap resultMap, List<Class<?>> constructorArgTypes, List<Object> constructorArgs, String columnPrefix)
-      throws SQLException {
+    throws SQLException {
     final Class<?> resultType = resultMap.getType();
     final MetaClass metaType = MetaClass.forClass(resultType, reflectorFactory);
     final List<ResultMapping> constructorMappings = resultMap.getConstructorResultMappings();
@@ -737,7 +721,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   }
 
   private Object getNestedQueryMappingValue(ResultSet rs, MetaObject metaResultObject, ResultMapping propertyMapping, ResultLoaderMap lazyLoader, String columnPrefix)
-      throws SQLException {
+    throws SQLException {
     final String nestedQueryId = propertyMapping.getNestedQueryId();
     final String property = propertyMapping.getProperty();
     final MappedStatement nestedQuery = configuration.getMappedStatement(nestedQueryId);
@@ -1051,8 +1035,21 @@ public class DefaultResultSetHandler implements ResultSetHandler {
       if (resultMapping.getNestedResultMapId() != null && resultMapping.getResultSet() == null) {
         // Issue #392
         final ResultMap nestedResultMap = configuration.getResultMap(resultMapping.getNestedResultMapId());
-        createRowKeyForMappedProperties(nestedResultMap, rsw, cacheKey, nestedResultMap.getResultMappings(),
-            prependPrefix(resultMapping.getColumnPrefix(), columnPrefix));
+        createRowKeyForMappedProperties(nestedResultMap, rsw, cacheKey, nestedResultMap.getConstructorResultMappings(),
+          prependPrefix(resultMapping.getColumnPrefix(), columnPrefix));
+        if (nestedResultMap.getResultMappings() != null) {
+          for (ResultMapping mapping : nestedResultMap.getResultMappings()) {
+            final String column = prependPrefix(mapping.getColumn(), columnPrefix);
+            final TypeHandler<?> th = mapping.getTypeHandler();
+            if (column != null) {
+              final Object value = th.getResult(rsw.getResultSet(), column);
+              if (value != null || configuration.isReturnInstanceForEmptyRow()) {
+                cacheKey.update(column);
+                cacheKey.update(value);
+              }
+            }
+          }
+        }
       } else if (resultMapping.getNestedQueryId() == null) {
         final String column = prependPrefix(resultMapping.getColumn(), columnPrefix);
         final TypeHandler<?> th = resultMapping.getTypeHandler();

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/CreateDB.sql
@@ -1,3 +1,19 @@
+--
+--    Copyright 2009-2020 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
 DROP TABLE subject
 IF EXISTS;
 

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/CreateDB.sql
@@ -22,12 +22,13 @@ IF EXISTS;
 
 CREATE TABLE subject (
   id     INT NOT NULL,
-  name   VARCHAR(20)
+  name   VARCHAR(20),
+  pid     INT NOT NULL,
 );
 
-insert into subject (id, name) values (1, 'zhangsan');
-insert into subject (id, name) values (2, 'lisi');
-insert into subject (id, name) values (3, 'wangwu');
+insert into subject (id, name, pid) values (1, 'zhangsan', 0);
+insert into subject (id, name, pid) values (2, 'lisi', 1);
+insert into subject (id, name, pid) values (3, 'wangwu', 1);
 
 CREATE TABLE match1 (
   id        INT NOT NULL,

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/CreateDB.sql
@@ -1,0 +1,25 @@
+DROP TABLE subject
+IF EXISTS;
+
+DROP TABLE match1
+IF EXISTS;
+
+CREATE TABLE subject (
+  id     INT NOT NULL,
+  name   VARCHAR(20)
+);
+
+insert into subject (id, name) values (1, 'zhangsan');
+insert into subject (id, name) values (2, 'lisi');
+insert into subject (id, name) values (3, 'wangwu');
+
+CREATE TABLE match1 (
+  id        INT NOT NULL,
+  user_id   INT,
+  score     INT
+);
+
+insert into match1 (id, user_id, score) VALUES (1, 1, 1000);
+insert into match1 (id, user_id, score) VALUES (2, 1, 300);
+insert into match1 (id, user_id, score) VALUES (3, 2, 500);
+insert into match1 (id, user_id, score) VALUES (4, 3, 500);

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/DefaultResultSetHandlerNestedStructTest.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/DefaultResultSetHandlerNestedStructTest.java
@@ -1,17 +1,17 @@
 /**
- * Copyright 2009-2020 the original author or authors.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
  */
 package org.apache.ibatis.executor.resultset.nested;
 

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/DefaultResultSetHandlerNestedStructTest.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/DefaultResultSetHandlerNestedStructTest.java
@@ -1,17 +1,17 @@
 /**
- *    Copyright 2009-2020 the original author or authors.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Copyright 2009-2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.ibatis.executor.resultset.nested;
 
@@ -28,6 +28,7 @@ import java.io.Reader;
 import java.util.List;
 
 class DefaultResultSetHandlerNestedStructTest {
+
   private static SqlSessionFactory sqlSessionFactory;
 
   @BeforeAll
@@ -41,11 +42,30 @@ class DefaultResultSetHandlerNestedStructTest {
   }
 
   @Test
-  void testSNestedStructBug() {
+  void testNestedStructAssociation() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       final MyMapper mapper = sqlSession.getMapper(MyMapper.class);
       List<RankItem> list = mapper.selectRank();
       Assert.assertEquals(3, list.size());
     }
   }
+
+  @Test
+  void testNestedStructCollect() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      final MyMapper mapper = sqlSession.getMapper(MyMapper.class);
+      List<RankItem> list = mapper.selectRank1();
+      Assert.assertEquals(3, list.size());
+    }
+  }
+
+  @Test
+  public void testSelfNested() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      final MyMapper mapper = sqlSession.getMapper(MyMapper.class);
+      List<Subject> list = mapper.selectSubject();
+      Assert.assertEquals(3, list.size());
+    }
+  }
+
 }

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/DefaultResultSetHandlerNestedStructTest.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/DefaultResultSetHandlerNestedStructTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2009-2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.executor.resultset.nested;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.Reader;
+import java.util.List;
+
+class DefaultResultSetHandlerNestedStructTest {
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/executor/resultset/nested/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/executor/resultset/nested/CreateDB.sql");
+  }
+
+  @Test
+  void testSNestedStructBug() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      final MyMapper mapper = sqlSession.getMapper(MyMapper.class);
+      List<RankItem> list = mapper.selectRank();
+      Assert.assertEquals(3, list.size());
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/Match1.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/Match1.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.executor.resultset.nested;
 
 public class Match1 {

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/Match1.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/Match1.java
@@ -1,0 +1,31 @@
+package org.apache.ibatis.executor.resultset.nested;
+
+public class Match1 {
+  private Integer id;
+  private Integer userId;
+  private Integer score;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public Integer getUserId() {
+    return userId;
+  }
+
+  public void setUserId(Integer userId) {
+    this.userId = userId;
+  }
+
+  public Integer getScore() {
+    return score;
+  }
+
+  public void setScore(Integer score) {
+    this.score = score;
+  }
+}

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/Match1.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/Match1.java
@@ -43,4 +43,13 @@ public class Match1 {
   public void setScore(Integer score) {
     this.score = score;
   }
+
+  @Override
+  public String toString() {
+    return "Match1{" +
+      "id=" + id +
+      ", userId=" + userId +
+      ", score=" + score +
+      '}';
+  }
 }

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/MyMapper.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/MyMapper.java
@@ -1,0 +1,7 @@
+package org.apache.ibatis.executor.resultset.nested;
+
+import java.util.List;
+
+public interface MyMapper {
+  List<RankItem> selectRank();
+}

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/MyMapper.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/MyMapper.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.executor.resultset.nested;
 
 import java.util.List;

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/MyMapper.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/MyMapper.java
@@ -15,8 +15,16 @@
  */
 package org.apache.ibatis.executor.resultset.nested;
 
+import org.apache.ibatis.annotations.Select;
+
 import java.util.List;
 
 public interface MyMapper {
+
   List<RankItem> selectRank();
+
+  List<RankItem> selectRank1();
+
+  List<Subject> selectSubject();
+
 }

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/MyMapper.xml
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/MyMapper.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2020 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/MyMapper.xml
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/MyMapper.xml
@@ -27,10 +27,41 @@
         on t.user_id = subject.id
     </select>
     <resultMap id="rankItem" type="org.apache.ibatis.executor.resultset.nested.RankItem">
-        <result property="score" column="score_num"/>
+        <result column="score_num" property="score"/>
         <association property="subject" javaType="org.apache.ibatis.executor.resultset.nested.Subject">
-            <result property="id" column="id"/>
-            <result property="name" column="name"/>
+            <result column="id" property="id"/>
+            <result column="name" property="name"/>
         </association>
     </resultMap>
+
+    <select id="selectRank1" resultMap="rankItem1">
+        select subject.id, subject.name, t.score_num
+        from (select user_id, sum(score) as score_num from match1 group by user_id) t
+        inner join subject
+        on t.user_id = subject.id
+    </select>
+
+    <resultMap id="rankItem1" type="org.apache.ibatis.executor.resultset.nested.RankItem">
+        <result column="score_num" property="score"/>
+        <collection property="children" ofType="org.apache.ibatis.executor.resultset.nested.Subject">
+           <result column="id" property="id"/>
+           <result column="name" property="name"/>
+        </collection>
+    </resultMap>
+
+    <select id="selectSubject" resultMap="subjectNested">
+        select s1.id, s1.name, s2.id as cid,s2.name as cname from subject s1
+        left join subject s2
+        on s1.id = s2.pid
+    </select>
+
+    <resultMap id="subjectNested" type="org.apache.ibatis.executor.resultset.nested.Subject">
+        <id property="id" column="id"/>
+        <result property="name" column="name"/>
+        <collection property="children" ofType="org.apache.ibatis.executor.resultset.nested.Subject">
+            <id column="cid" property="id"/>
+            <result column="cname" property="name"/>
+        </collection>
+    </resultMap>
+
 </mapper>

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/MyMapper.xml
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/MyMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.executor.resultset.nested.MyMapper">
+    <select id="selectRank" resultMap="rankItem">
+        select subject.id, subject.name, t.score_num
+        from (select user_id, sum(score) as score_num from match1 group by user_id) t
+        inner join subject
+        on t.user_id = subject.id
+    </select>
+    <resultMap id="rankItem" type="org.apache.ibatis.executor.resultset.nested.RankItem">
+        <result property="score" column="score_num"/>
+        <association property="subject" javaType="org.apache.ibatis.executor.resultset.nested.Subject">
+            <result property="id" column="id"/>
+            <result property="name" column="name"/>
+        </association>
+    </resultMap>
+</mapper>

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/RankItem.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/RankItem.java
@@ -1,45 +1,58 @@
 /**
- *    Copyright 2009-2020 the original author or authors.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Copyright 2009-2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.ibatis.executor.resultset.nested;
 
+import java.util.List;
+
 public class RankItem {
-    private Subject subject;
-    private int score;
+  private Subject subject;
+  private int score;
 
-    public Subject getSubject() {
-        return subject;
-    }
+  private List<Subject> children;
 
-    public void setSubject(Subject subject) {
-        this.subject = subject;
-    }
+  public Subject getSubject() {
+    return subject;
+  }
 
-    public int getScore() {
-        return score;
-    }
+  public void setSubject(Subject subject) {
+    this.subject = subject;
+  }
 
-    public void setScore(int score) {
-        this.score = score;
-    }
+  public int getScore() {
+    return score;
+  }
+
+  public void setScore(int score) {
+    this.score = score;
+  }
+
+  public List<Subject> getChildren() {
+    return children;
+  }
+
+  public void setChildren(List<Subject> children) {
+    this.children = children;
+  }
 
   @Override
   public String toString() {
     return "RankItem{" +
-      "user=" + subject +
+      "subject=" + subject +
       ", score=" + score +
+      ", children=" + children +
       '}';
   }
 }

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/RankItem.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/RankItem.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.executor.resultset.nested;
 
 public class RankItem {

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/RankItem.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/RankItem.java
@@ -1,0 +1,30 @@
+package org.apache.ibatis.executor.resultset.nested;
+
+public class RankItem {
+    private Subject subject;
+    private int score;
+
+    public Subject getSubject() {
+        return subject;
+    }
+
+    public void setSubject(Subject subject) {
+        this.subject = subject;
+    }
+
+    public int getScore() {
+        return score;
+    }
+
+    public void setScore(int score) {
+        this.score = score;
+    }
+
+  @Override
+  public String toString() {
+    return "RankItem{" +
+      "user=" + subject +
+      ", score=" + score +
+      '}';
+  }
+}

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/Subject.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/Subject.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.executor.resultset.nested;
 
 public class Subject {

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/Subject.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/Subject.java
@@ -1,45 +1,58 @@
 /**
- *    Copyright 2009-2020 the original author or authors.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Copyright 2009-2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.ibatis.executor.resultset.nested;
 
+import java.util.List;
+
 public class Subject {
-    private Integer id;
-    private String name;
+  private Integer id;
+  private String name;
 
-    public Integer getId() {
-        return id;
-    }
+  private List<Subject> children;
 
-    public void setId(Integer id) {
-        this.id = id;
-    }
+  public List<Subject> getChildren() {
+    return children;
+  }
 
-    public String getName() {
-        return name;
-    }
+  public void setChildren(List<Subject> children) {
+    this.children = children;
+  }
 
-    public void setName(String name) {
-        this.name = name;
-    }
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
 
   @Override
   public String toString() {
     return "Subject{" +
       "id=" + id +
       ", name='" + name + '\'' +
+      ", children=" + children +
       '}';
   }
 }

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/Subject.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/Subject.java
@@ -1,0 +1,30 @@
+package org.apache.ibatis.executor.resultset.nested;
+
+public class Subject {
+    private Integer id;
+    private String name;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+  @Override
+  public String toString() {
+    return "Subject{" +
+      "id=" + id +
+      ", name='" + name + '\'' +
+      '}';
+  }
+}

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/mybatis-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2017 the original author or authors.
+       Copyright 2009-2020 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/executor/resultset/nested/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/executor/resultset/nested/mybatis-config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2017 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <!-- autoMappingBehavior should be set in each test case -->
+
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value=""/>
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="org.hsqldb.jdbcDriver"/>
+                <property name="url" value="jdbc:hsqldb:mem:automapping"/>
+                <property name="username" value="sa"/>
+            </dataSource>
+        </environment>
+    </environments>
+
+    <mappers>
+        <mapper resource="org/apache//ibatis/executor/resultset/nested/MyMapper.xml"/>
+    </mappers>
+
+</configuration>


### PR DESCRIPTION
## description
This is a obvious bug. It will cause data lost.
The nested structure function will be affect.
For example
```
     <resultMap id="rankItem" type="org.apache.ibatis.executor.resultset.nested.RankItem">
            <result property="score" column="score_num"/>
            <association property="user" javaType="org.apache.ibatis.executor.resultset.nested.User">
                <result property="id" column="id"/>
                <result property="name" column="name"/>
            </association>
     </resultMap>
```
## unit test
I have a unit test, Expect 3, actual 2 because of the bug.
## version
mybatis version: 3.5.4+
## reproduce bug
This is a simple [bug reproduction](https://github.com/blindpirate/mybatis-bug-reproduction)