### PR TITLE
fix: issue1848

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -1016,7 +1016,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
         createRowKeyForUnmappedProperties(resultMap, rsw, cacheKey, columnPrefix);
       }
     } else {
-      createRowKeyForMappedProperties(resultMap, rsw, cacheKey, resultMappings, columnPrefix);
+      createRowKeyForMappedProperties(resultMap, rsw, cacheKey, columnPrefix);
     }
     if (cacheKey.getUpdateCount() < 2) {
       return CacheKey.NULL_CACHE_KEY;
@@ -1046,13 +1046,13 @@ public class DefaultResultSetHandler implements ResultSetHandler {
     return resultMappings;
   }
 
-  private void createRowKeyForMappedProperties(ResultMap resultMap, ResultSetWrapper rsw, CacheKey cacheKey, List<ResultMapping> resultMappings, String columnPrefix) throws SQLException {
+  private void createRowKeyForMappedProperties(ResultMap resultMap, ResultSetWrapper rsw, CacheKey cacheKey, String columnPrefix) throws SQLException {
+    List<ResultMapping> resultMappings = getResultMappingsForRowKey(resultMap);
     for (ResultMapping resultMapping : resultMappings) {
       if (resultMapping.getNestedResultMapId() != null && resultMapping.getResultSet() == null) {
         // Issue #392
         final ResultMap nestedResultMap = configuration.getResultMap(resultMapping.getNestedResultMapId());
-        createRowKeyForMappedProperties(nestedResultMap, rsw, cacheKey, nestedResultMap.getConstructorResultMappings(),
-            prependPrefix(resultMapping.getColumnPrefix(), columnPrefix));
+        createRowKeyForMappedProperties(nestedResultMap, rsw, cacheKey, prependPrefix(resultMapping.getColumnPrefix(), columnPrefix));
       } else if (resultMapping.getNestedQueryId() == null) {
         final String column = prependPrefix(resultMapping.getColumn(), columnPrefix);
         final TypeHandler<?> th = resultMapping.getTypeHandler();

--- a/src/test/java/org/apache/ibatis/submitted/issue1848/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/issue1848/CreateDB.sql
@@ -1,0 +1,39 @@
+--
+--    Copyright 2009-2020 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table USER if exists;
+
+create table USER(
+    id   int,
+    name varchar(100)
+);
+
+drop table MATCH if exists;
+
+create table MATCH(
+    id      int,
+    user_id int,
+    score   int
+);
+
+insert into USER (id, name) values (1, 'zhangsan');
+insert into USER (id, name) values (2, 'lisi');
+insert into USER (id, name) values (3, 'wangwu');
+
+insert into MATCH (id, user_id, score) VALUES (1, 1, 1000);
+insert into MATCH (id, user_id, score) VALUES (2, 1, 300);
+insert into MATCH (id, user_id, score) VALUES (3, 2, 500);
+insert into MATCH (id, user_id, score) VALUES (4, 3, 500);

--- a/src/test/java/org/apache/ibatis/submitted/issue1848/DefaultResultSetHandlerTestIssue1848.java
+++ b/src/test/java/org/apache/ibatis/submitted/issue1848/DefaultResultSetHandlerTestIssue1848.java
@@ -1,0 +1,52 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.issue1848;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.Reader;
+import java.util.List;
+
+public class DefaultResultSetHandlerTestIssue1848 {
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    // create a SqlSessionFactory
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/issue1848/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+
+    // populate in-memory database
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/submitted/issue1848/CreateDB.sql");
+  }
+
+  @Test // issue 1848
+  public void test_issue_1848() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      List<RankItem> list = sqlSession.selectList("org.apache.ibatis.submitted.issue1848.MyMapper.selectRank");
+      Assertions.assertEquals(3, list.size());
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/issue1848/MyMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/issue1848/MyMapper.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.submitted.issue1848.MyMapper">
+    <select id="selectRank" resultMap="rankItem">
+        select USER.id,USER.name,t.score_num
+        from
+            (select USER_ID,sum(SCORE) as score_num from MATCH group by USER_ID) t
+                inner join USER
+                    on t.USER_ID=USER.ID
+    </select>
+    <resultMap id="rankItem" type="org.apache.ibatis.submitted.issue1848.RankItem">
+        <result property="score" column="score_num"/>
+        <association property="user" javaType="org.apache.ibatis.submitted.issue1848.User">
+            <result property="id" column="id"/>
+            <result property="name" column="name"/>
+        </association>
+    </resultMap>
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/issue1848/RankItem.java
+++ b/src/test/java/org/apache/ibatis/submitted/issue1848/RankItem.java
@@ -1,0 +1,37 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.issue1848;
+
+public class RankItem {
+  private User user;
+  private int score;
+
+  public User getUser() {
+    return user;
+  }
+
+  public void setUser(User user) {
+    this.user = user;
+  }
+
+  public int getScore() {
+    return score;
+  }
+
+  public void setScore(int score) {
+    this.score = score;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/issue1848/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/issue1848/User.java
@@ -1,0 +1,37 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.issue1848;
+
+public class User {
+  private Integer id;
+  private String name;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/issue1848/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/issue1848/mybatis-config.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2020 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <typeAliases>
+        <package name="org.apache.ibatis.submitted.issue1848" />
+    </typeAliases>
+
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value="" />
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="org.hsqldb.jdbcDriver" />
+                <property name="url" value="jdbc:hsqldb:mem:issue1848" />
+                <property name="username" value="sa" />
+            </dataSource>
+        </environment>
+    </environments>
+
+    <mappers>
+        <mapper resource="org/apache/ibatis/submitted/issue1848/MyMapper.xml" />
+    </mappers>
+
+</configuration>


### PR DESCRIPTION
it's because **CacheKey**   is  same between RankItem{user=User{id=2, name='lisi'}, score=500}  and 
RankItem{user=User{id=3, name='wangwu'}, score=500}    , because  there score  is 500 but User is a object  which is not writting into CacheKey   

so while handle the third resultSet  RankItem{user=User{id=3, name='wangwu'}, score=500}    is while create a MetaObject which the originalObject is the second result  and it directly set User{id=3, name='wangwu'}  to second result 

in `DefaultResultSetHandler#createRowKeyForMappedProperties` 
`resultMappings` should get from current resultMap  
[(`getResultMappingsForRowKey(resultMap)`)](https://github.com/Huangxuny1/mybatis-3/blob/775e420feb01729132c3de1a75b15cbe37afe00b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java#L1050)