### PR TITLE
Use ThreadLocal.withInitial to lazily init ThreadLocal

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/ErrorContext.java
+++ b/src/main/java/org/apache/ibatis/executor/ErrorContext.java
@@ -21,7 +21,7 @@ package org.apache.ibatis.executor;
 public class ErrorContext {
 
   private static final String LINE_SEPARATOR = System.lineSeparator();
-  private static final ThreadLocal<ErrorContext> LOCAL = new ThreadLocal<>();
+  private static final ThreadLocal<ErrorContext> LOCAL = ThreadLocal.withInitial(ErrorContext::new);
 
   private ErrorContext stored;
   private String resource;
@@ -35,12 +35,7 @@ public class ErrorContext {
   }
 
   public static ErrorContext instance() {
-    ErrorContext context = LOCAL.get();
-    if (context == null) {
-      context = new ErrorContext();
-      LOCAL.set(context);
-    }
-    return context;
+   return LOCAL.get();
   }
 
   public ErrorContext store() {


### PR DESCRIPTION
Use ThreadLocal.withInitial to lazy lazily init ThreadLocal.
This makes the code more concise, and is no different from the original code logic.
Hope to consider merging this PR.
