### PR TITLE
unit test for cachenamespaceref

### DIFF
--- a/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/BusinessDao.java
+++ b/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/BusinessDao.java
@@ -1,0 +1,27 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.cachenamespaceref_exception;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.CacheNamespaceRef;
+import org.apache.ibatis.annotations.Select;
+
+@CacheNamespaceRef(name = "org.apache.ibatis.submitted.cachenamespaceref_exception.Mapper")
+public interface BusinessDao {
+	@Select("select name from users;")
+	public List<String> selectUserNames();
+}

--- a/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/CacheNamespaceRefTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/CacheNamespaceRefTest.java
@@ -1,0 +1,55 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.cachenamespaceref_exception;
+
+import static org.junit.Assert.assertNotNull;
+
+import java.io.Reader;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class CacheNamespaceRefTest {
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/cachenamespaceref_exception/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+
+    // populate in-memory database
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/cachenamespaceref_exception/CreateDB.sql");
+  }
+  
+  @Test
+  public void getUserByIdTest()
+  {
+	  try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+	      Mapper mapper = sqlSession.getMapper(Mapper.class);
+	      User user = mapper.getUserById(1);
+	      assertNotNull(user);
+	    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/CreateDB.sql
@@ -1,0 +1,25 @@
+--
+--    Copyright 2009-2020 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(20)
+);
+
+insert into users (id, name) values
+(1, 'User1'), (2, 'User2'), (3, 'User3');

--- a/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/Mapper.java
@@ -1,0 +1,23 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.cachenamespaceref_exception;
+
+import org.apache.ibatis.annotations.Param;
+
+public interface Mapper {
+  
+  User getUserById(@Param("id") Integer id);
+}

--- a/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/Mapper.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2020 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.cachenamespaceref_exception.Mapper">
+	<cache/>
+	<select id="getUserById" resultType="org.apache.ibatis.submitted.cachenamespaceref_exception.User">
+		select * from users where id = #{id};
+	</select>
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/User.java
@@ -1,0 +1,36 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.cachenamespaceref_exception;
+
+import java.io.Serializable;
+
+public class User implements Serializable{
+  private static final long serialVersionUID = 1L;
+  private Integer id;
+  private String name;
+  public Integer getId() {
+    return id;
+  }
+  public void setId(Integer id) {
+    this.id = id;
+  }
+  public String getName() {
+    return name;
+  }
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/cachenamespaceref_exception/mybatis-config.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2020 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url" value="jdbc:hsqldb:mem:cachenamespaceref" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper class="org.apache.ibatis.submitted.cachenamespaceref_exception.BusinessDao" />
+    <mapper class="org.apache.ibatis.submitted.cachenamespaceref_exception.Mapper" />
+  </mappers>
+
+</configuration>


### PR DESCRIPTION
When mapper annotated with @CacheNamespaceRef is parsed before the one where the refered cache is defined, an unreasonable IllegalArgumentException is throw.I debuged and found that this is because when parse the mapper with unresolvedCacheRef,the method is add to incompleteMethods to resolve it later, but the default resultMap is already added to Configuration.resultMaps by MapperAnnotationBuilder.applyResultMap,when resolve the incompleteMethod later, it try to add the same resultMap,this causes IllegalArgumentException.
I think this maybe a bug and create this unit test to reproduce it.