### PR TITLE
Add option for allowing null value on foreach tag

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -270,6 +270,7 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setConfigurationFactory(resolveClass(props.getProperty("configurationFactory")));
     configuration.setShrinkWhitespacesInSql(booleanValueOf(props.getProperty("shrinkWhitespacesInSql"), false));
     configuration.setDefaultSqlProviderType(resolveClass(props.getProperty("defaultSqlProviderType")));
+    configuration.setNullableOnForEach(booleanValueOf(props.getProperty("nullableOnForEach"), false));
   }
 
   private void environmentsElement(XNode context) throws Exception {

--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -271,6 +271,7 @@ suffixOverrides CDATA #IMPLIED
 <!ELEMENT foreach (#PCDATA | include | trim | where | set | foreach | choose | if | bind)*>
 <!ATTLIST foreach
 collection CDATA #REQUIRED
+nullable (true|false) #IMPLIED
 item CDATA #IMPLIED
 index CDATA #IMPLIED
 open CDATA #IMPLIED

--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-mapper.xsd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-mapper.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -599,6 +599,7 @@
         <xs:element ref="bind"/>
       </xs:choice>
       <xs:attribute name="collection" use="required"/>
+      <xs:attribute name="nullable" type="xs:boolean"/>
       <xs:attribute name="item"/>
       <xs:attribute name="index"/>
       <xs:attribute name="open"/>

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/ExpressionEvaluator.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/ExpressionEvaluator.java
@@ -39,10 +39,25 @@ public class ExpressionEvaluator {
     return value != null;
   }
 
+  /**
+   * @deprecated Since 3.5.9, use the {@link #evaluateIterable(String, Object, boolean)}.
+   */
+   @Deprecated
   public Iterable<?> evaluateIterable(String expression, Object parameterObject) {
+    return evaluateIterable(expression, parameterObject, false);
+  }
+
+  /**
+   * @since 3.5.9
+   */
+  public Iterable<?> evaluateIterable(String expression, Object parameterObject, boolean nullable) {
     Object value = OgnlCache.getValue(expression, parameterObject);
     if (value == null) {
-      throw new BuilderException("The expression '" + expression + "' evaluated to a null value.");
+      if (nullable) {
+        return null;
+      } else {
+        throw new BuilderException("The expression '" + expression + "' evaluated to a null value.");
+      }
     }
     if (value instanceof Iterable) {
       return (Iterable<?>) value;

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/ForEachSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/ForEachSqlNode.java
@@ -16,6 +16,7 @@
 package org.apache.ibatis.scripting.xmltags;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.ibatis.parsing.GenericTokenParser;
 import org.apache.ibatis.session.Configuration;
@@ -28,6 +29,7 @@ public class ForEachSqlNode implements SqlNode {
 
   private final ExpressionEvaluator evaluator;
   private final String collectionExpression;
+  private final Boolean nullable;
   private final SqlNode contents;
   private final String open;
   private final String close;
@@ -36,9 +38,21 @@ public class ForEachSqlNode implements SqlNode {
   private final String index;
   private final Configuration configuration;
 
+  /**
+   * @deprecated Since 3.5.9, use the {@link #ForEachSqlNode(Configuration, SqlNode, String, Boolean, String, String, String, String, String)}.
+   */
+  @Deprecated
   public ForEachSqlNode(Configuration configuration, SqlNode contents, String collectionExpression, String index, String item, String open, String close, String separator) {
+    this(configuration, contents, collectionExpression, null, index, item, open, close, separator);
+  }
+
+  /**
+   * @since 3.5.9
+   */
+  public ForEachSqlNode(Configuration configuration, SqlNode contents, String collectionExpression, Boolean nullable, String index, String item, String open, String close, String separator) {
     this.evaluator = new ExpressionEvaluator();
     this.collectionExpression = collectionExpression;
+    this.nullable = nullable;
     this.contents = contents;
     this.open = open;
     this.close = close;
@@ -51,8 +65,9 @@ public class ForEachSqlNode implements SqlNode {
   @Override
   public boolean apply(DynamicContext context) {
     Map<String, Object> bindings = context.getBindings();
-    final Iterable<?> iterable = evaluator.evaluateIterable(collectionExpression, bindings);
-    if (!iterable.iterator().hasNext()) {
+    final Iterable<?> iterable = evaluator.evaluateIterable(collectionExpression, bindings,
+      Optional.ofNullable(nullable).orElseGet(configuration::isNullableOnForEach));
+    if (iterable == null || !iterable.iterator().hasNext()) {
       return true;
     }
     boolean first = true;

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -171,12 +171,13 @@ public class XMLScriptBuilder extends BaseBuilder {
     public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
       MixedSqlNode mixedSqlNode = parseDynamicTags(nodeToHandle);
       String collection = nodeToHandle.getStringAttribute("collection");
+      Boolean nullable = nodeToHandle.getBooleanAttribute("nullable");
       String item = nodeToHandle.getStringAttribute("item");
       String index = nodeToHandle.getStringAttribute("index");
       String open = nodeToHandle.getStringAttribute("open");
       String close = nodeToHandle.getStringAttribute("close");
       String separator = nodeToHandle.getStringAttribute("separator");
-      ForEachSqlNode forEachSqlNode = new ForEachSqlNode(configuration, mixedSqlNode, collection, index, item, open, close, separator);
+      ForEachSqlNode forEachSqlNode = new ForEachSqlNode(configuration, mixedSqlNode, collection, nullable, index, item, open, close, separator);
       targetContents.add(forEachSqlNode);
     }
   }

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -114,6 +114,7 @@ public class Configuration {
   protected boolean useActualParamName = true;
   protected boolean returnInstanceForEmptyRow;
   protected boolean shrinkWhitespacesInSql;
+  protected boolean nullableOnForEach;
 
   protected String logPrefix;
   protected Class<? extends Log> logImpl;
@@ -295,6 +296,28 @@ public class Configuration {
 
   public void setShrinkWhitespacesInSql(boolean shrinkWhitespacesInSql) {
     this.shrinkWhitespacesInSql = shrinkWhitespacesInSql;
+  }
+
+  /**
+   * Sets the default value of 'nullable' attribute on 'foreach' tag.
+   *
+   * @param nullableOnForEach If nullable, set to {@code true}
+   * @since 3.5.9
+   */
+  public void setNullableOnForEach(boolean nullableOnForEach) {
+    this.nullableOnForEach = nullableOnForEach;
+  }
+
+  /**
+   * Returns the default value of 'nullable' attribute on 'foreach' tag.
+   *
+   * <p>Default is {@code false}.
+   *
+   * @return If nullable, set to {@code true}
+   * @since 3.5.9
+   */
+  public boolean isNullableOnForEach() {
+    return nullableOnForEach;
   }
 
   public String getDatabaseId() {

--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -577,6 +577,20 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 Not set
               </td>
             </tr>
+            <tr>
+              <td>
+                nullableOnForEach
+              </td>
+              <td>
+                Specifies the default value of 'nullable' attribute on 'foreach' tag. (Since 3.5.9)
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
+              </td>
+            </tr>
           </tbody>
         </table>
         <p>

--- a/src/site/es/xdoc/dynamic-sql.xml
+++ b/src/site/es/xdoc/dynamic-sql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2019 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -147,11 +147,12 @@ AND title like ‘someTitle’]]></source>
   <source><![CDATA[<select id="selectPostIn" resultType="domain.blog.Post">
   SELECT *
   FROM POST P
-  WHERE ID in
-  <foreach item="item" index="index" collection="list"
-      open="(" separator="," close=")">
-        #{item}
-  </foreach>
+  <where>
+    <foreach item="item" index="index" collection="list"
+        open="ID in (" separator="," close=")" nullable="true">
+          #{item}
+    </foreach>
+  </where>
 </select>]]></source>
   <p>El elemento foreach es muy potente, permite especificar una colección y declarar variables elemento e índice que pueden usarse dentro del cuerpo del elemento. Permite también abrir y cerrar strings y añadir un separador entre las iteraciones. Este elemento es inteligente en tanto en cuanto no añade separadores extra accidentalmente.</p>
   <p><span class="label important">NOTA</span> You can pass any Iterable object (for example List, Set, etc.), as well as any Map or Array object to foreach as collection parameter. When using an Iterable or Array, index will be the number of current iteration and value item will be the element retrieved in this iteration. When using a Map (or Collection of Map.Entry objects), index will be the key object and item will be the value object.</p>

--- a/src/site/ja/xdoc/configuration.xml
+++ b/src/site/ja/xdoc/configuration.xml
@@ -601,6 +601,20 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 未指定
               </td>
             </tr>
+            <tr>
+              <td>
+                nullableOnForEach
+              </td>
+              <td>
+                'foreach' タグの 'nullable' 属性のデフォルト値. (導入されたバージョン: 3.5.9)
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
+              </td>
+            </tr>
           </tbody>
         </table>
         <p>

--- a/src/site/ja/xdoc/dynamic-sql.xml
+++ b/src/site/ja/xdoc/dynamic-sql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2019 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -153,11 +153,12 @@ AND title like ‘someTitle’]]></source>
   <source><![CDATA[<select id="selectPostIn" resultType="domain.blog.Post">
   SELECT *
   FROM POST P
-  WHERE ID in
-  <foreach item="item" index="index" collection="list"
-      open="(" separator="," close=")">
-        #{item}
-  </foreach>
+  <where>
+    <foreach item="item" index="index" collection="list"
+        open="ID in (" separator="," close=")" nullable="true">
+          #{item}
+    </foreach>
+  </where>
 </select>]]></source>
   <p><em>foreach</em> 要素は非常に強力で、イテレーション処理の対象となるコレクションを指定する collection と、ループ内で要素を格納する変数 item、ループ回数を格納する index 変数を宣言することができます。また、開始・終了の文字列とイテレーションの合間に出力する区切り文字を指定することもできます。foreach タグは賢いので、余分な区切り文字を出力することはありません。</p>
   <p><span class="label important">NOTE</span> collection には Iterable を実装したオブジェクト（List や Set など）の他に Map や Array を指定することもできます。collection に Iterable または Array を指定した場合、 index で指定した変数にはインデックスの数値、 item で指定した変数にはコレクション、配列の要素が格納されます。Map あるいは Map.Entry のコレクションを指定した場合は index にマップのキー、item にマップの値が格納されます。</p>

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -584,6 +584,20 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 설정하지 않음
               </td>
             </tr>
+            <tr>
+              <td>
+                nullableOnForEach
+              </td>
+              <td>
+                Specifies the default value of 'nullable' attribute on 'foreach' tag. (Since 3.5.9)
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
+              </td>
+            </tr>
           </tbody>
         </table>
         <p>위 설정을 모두 사용한 setting 엘리먼트의 예제이다:</p>

--- a/src/site/ko/xdoc/dynamic-sql.xml
+++ b/src/site/ko/xdoc/dynamic-sql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -176,11 +176,12 @@ AND title like ‘someTitle’]]></source>
         <source><![CDATA[<select id="selectPostIn" resultType="domain.blog.Post">
   SELECT *
   FROM POST P
-  WHERE ID in
-  <foreach item="item" index="index" collection="list"
-      open="(" separator="," close=")">
-        #{item}
-  </foreach>
+  <where>
+    <foreach item="item" index="index" collection="list"
+        open="ID in (" separator="," close=")" nullable="true">
+          #{item}
+    </foreach>
+  </where>
 </select>]]></source>
         <p>foreach엘리먼트는 매우 강력하고 collection 을 명시하는 것을 허용한다.
 		엘리먼트 내부에서 사용할 수 있는 item, index두가지 변수를 선언한다.

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -664,6 +664,20 @@ SqlSessionFactory factory =
                 Not set
               </td>
             </tr>
+            <tr>
+              <td>
+                nullableOnForEach
+              </td>
+              <td>
+                Specifies the default value of 'nullable' attribute on 'foreach' tag. (Since 3.5.9)
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
+              </td>
+            </tr>
           </tbody>
         </table>
         <p>

--- a/src/site/xdoc/dynamic-sql.xml
+++ b/src/site/xdoc/dynamic-sql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2019 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -146,11 +146,12 @@ AND title like ‘someTitle’]]></source>
   <source><![CDATA[<select id="selectPostIn" resultType="domain.blog.Post">
   SELECT *
   FROM POST P
-  WHERE ID in
-  <foreach item="item" index="index" collection="list"
-      open="(" separator="," close=")">
-        #{item}
-  </foreach>
+  <where>
+    <foreach item="item" index="index" collection="list"
+        open="ID in (" separator="," close=")" nullable="true">
+          #{item}
+    </foreach>
+  </where>
 </select>]]></source>
   <p>The <em>foreach</em> element is very powerful, and allows you to specify a collection, declare item and index variables that can be used inside the body of the element. It also allows you to specify opening and closing strings, and add a separator to place in between iterations. The element is smart in that it won’t accidentally append extra separators. </p>
   <p><span class="label important">NOTE</span> You can pass any Iterable object (for example List, Set, etc.), as well as any Map or Array object to foreach as collection parameter. When using an Iterable or Array, index will be the number of current iteration and value item will be the element retrieved in this iteration. When using a Map (or Collection of Map.Entry objects), index will be the key object and item will be the value object.</p>

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -595,6 +595,20 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 Not set
               </td>
             </tr>
+            <tr>
+              <td>
+                nullableOnForEach
+              </td>
+              <td>
+                Specifies the default value of 'nullable' attribute on 'foreach' tag. (Since 3.5.9)
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
+              </td>
+            </tr>
           </tbody>
         </table>
         <p>

--- a/src/site/zh/xdoc/dynamic-sql.xml
+++ b/src/site/zh/xdoc/dynamic-sql.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -150,11 +150,12 @@ AND title like ‘someTitle’]]></source>
         <source><![CDATA[<select id="selectPostIn" resultType="domain.blog.Post">
   SELECT *
   FROM POST P
-  WHERE ID in
-  <foreach item="item" index="index" collection="list"
-      open="(" separator="," close=")">
-        #{item}
-  </foreach>
+  <where>
+    <foreach item="item" index="index" collection="list"
+        open="ID in (" separator="," close=")" nullable="true">
+          #{item}
+    </foreach>
+  </where>
 </select>]]></source>
         <p><em>foreach</em> 元素的功能非常强大，它允许你指定一个集合，声明可以在元素体内使用的集合项（item）和索引（index）变量。它也允许你指定开头与结尾的字符串以及集合项迭代之间的分隔符。这个元素也不会错误地添加多余的分隔符，看它多智能！</p>
         <p><span class="label important">提示</span> 你可以将任何可迭代对象（如 List、Set 等）、Map 对象或者数组对象作为集合参数传递给 <em>foreach</em>。当使用可迭代对象或者数组时，index 是当前迭代的序号，item 的值是本次迭代获取到的元素。当使用 Map 对象（或者 Map.Entry 对象的集合）时，index 是键，item 是值。</p>

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@
     <setting name="defaultEnumTypeHandler" value="org.apache.ibatis.type.EnumOrdinalTypeHandler"/>
     <setting name="shrinkWhitespacesInSql" value="true"/>
     <setting name="defaultSqlProviderType" value="org.apache.ibatis.builder.XmlConfigBuilderTest$MySqlProvider"/>
+    <setting name="nullableOnForEach" value="true"/>
   </settings>
 
   <typeAliases>

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -103,6 +103,7 @@ class XmlConfigBuilderTest {
       assertThat(config.getTypeHandlerRegistry().getTypeHandler(RoundingMode.class)).isInstanceOf(EnumTypeHandler.class);
       assertThat(config.isShrinkWhitespacesInSql()).isFalse();
       assertThat(config.getDefaultSqlProviderType()).isNull();
+      assertThat(config.isNullableOnForEach()).isFalse();
     }
   }
 
@@ -200,6 +201,7 @@ class XmlConfigBuilderTest {
       assertThat(config.getConfigurationFactory().getName()).isEqualTo(String.class.getName());
       assertThat(config.isShrinkWhitespacesInSql()).isTrue();
       assertThat(config.getDefaultSqlProviderType().getName()).isEqualTo(MySqlProvider.class.getName());
+      assertThat(config.isNullableOnForEach()).isTrue();
 
       assertThat(config.getTypeAliasRegistry().getTypeAliases().get("blogauthor")).isEqualTo(Author.class);
       assertThat(config.getTypeAliasRegistry().getTypeAliases().get("blog")).isEqualTo(Blog.class);

--- a/src/test/java/org/apache/ibatis/submitted/foreach/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/foreach/Mapper.java
@@ -34,4 +34,10 @@ public interface Mapper {
   int itemVariableConflict(@Param("id") Integer id, @Param("ids") List<Integer> ids, @Param("ids2") List<Integer> ids2);
 
   int indexVariableConflict(@Param("idx") Integer id, @Param("idxs") List<Integer> ids, @Param("idxs2") List<Integer> ids2);
+
+  int countUserWithNullableIsOmit(User user);
+
+  int countUserWithNullableIsTrue(User user);
+
+  int countUserWithNullableIsFalse(User user);
 }

--- a/src/test/java/org/apache/ibatis/submitted/foreach/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/foreach/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2019 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -91,5 +91,35 @@
       #{idx} + 2
     </foreach>
     or id = #{idx}
+  </select>
+
+  <select id="countUserWithNullableIsOmit" resultType="_int">
+    select count(*) from users
+    <where>
+      <foreach item="item" index="index" collection="friendList" open="id in ("
+               separator="," close=")">
+        #{item.id}
+      </foreach>
+    </where>
+  </select>
+
+  <select id="countUserWithNullableIsTrue" resultType="_int">
+    select count(*) from users
+    <where>
+      <foreach item="item" index="index" collection="friendList" nullable="true" open="id in ("
+               separator="," close=")">
+        #{item.id}
+      </foreach>
+    </where>
+  </select>
+
+  <select id="countUserWithNullableIsFalse" resultType="_int">
+    select count(*) from users
+    <where>
+      <foreach item="item" index="index" collection="friendList" nullable="false" open="id in ("
+               separator="," close=")">
+        #{item.id}
+      </foreach>
+    </where>
   </select>
 </mapper>


### PR DESCRIPTION
I will propose to support new option for allowing `null` value on `collection` attribute of `foreach` tag.

In this change, a developer can omit the `if` tag as follow:

* current version

```xml
<if test="friendList != null"> <!-- Need null check using 'if' tag -->
  <foreach item="item" collection="friendList" open="id in (" separator="," close=")">
    #{item.id}
  </foreach>
</if>
```

* new version

```xml
<!-- <if test="friendList != null"> -->
<!-- Specify 'nullable="true"' instead of 'if' tag -->
<foreach item="item" collection="friendList" nullable="true" open="id in (" separator="," close=")">
  #{item.id}
</foreach>
<!-- </if> -->
```

Also, a developer can change the default `nullable` value when the `nullable` attribute is omitted using global configuration as follow:

* global configuration

XML configuration (`mybatis-config.xml`):
```xml
<settings>
  <setting name="nullableOnForEach" value="true"/>
</settings>
```
or 

Java configuration(`Configuration` class):
```java
Configuration mybatisConfiguration = new Configuration();
mybatisConfiguration.setNullableOnForEach(true);
```

* SQL definition

```xml
<!-- <if test="friendList != null"> -->
<!-- Can omit 'if' tag and 'nullable' attribute both -->
<foreach item="item" collection="friendList" open="id in (" separator="," close=")">
  #{item.id}
</foreach>
<!-- </if> -->
```

WDYT?
