### PR TITLE
Optimization code

### DIFF
--- a/src/main/java/org/apache/ibatis/io/DefaultVFS.java
+++ b/src/main/java/org/apache/ibatis/io/DefaultVFS.java
@@ -292,18 +292,6 @@ public class DefaultVFS extends VFS {
   }
 
   /**
-   * Converts a Java package name to a path that can be looked up with a call to
-   * {@link ClassLoader#getResources(String)}.
-   *
-   * @param packageName
-   *          The Java package name to convert to a path
-   * @return the package path
-   */
-  protected String getPackagePath(String packageName) {
-    return packageName == null ? null : packageName.replace('.', '/');
-  }
-
-  /**
    * Returns true if the resource located at the given URL is a JAR file.
    *
    * @param url


### PR DESCRIPTION
The method getPackagePath exists in two classes, one is in DefaultVFS.java, the other one is in ResolverUtil.java. And they are identical. Delete that in DefaultVFS.java.