### PR TITLE
Generic type field support typehandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,12 @@
       <version>1.11.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
+++ b/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
@@ -15,6 +15,7 @@
  */
 package org.apache.ibatis.builder;
 
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -43,6 +44,7 @@ import org.apache.ibatis.mapping.SqlCommandType;
 import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.mapping.StatementType;
 import org.apache.ibatis.reflection.MetaClass;
+import org.apache.ibatis.reflection.GenericTypeRawClassPair;
 import org.apache.ibatis.scripting.LanguageDriver;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.type.JdbcType;
@@ -160,9 +162,10 @@ public class MapperBuilderAssistant extends BaseBuilder {
     resultMap = applyCurrentNamespace(resultMap, true);
 
     // Class parameterType = parameterMapBuilder.type();
-    Class<?> javaTypeClass = resolveParameterJavaType(parameterType, property, javaType, jdbcType);
-    TypeHandler<?> typeHandlerInstance = resolveTypeHandler(javaTypeClass, typeHandler);
-
+    GenericTypeRawClassPair genericTypeRawClassPair = resolveParameterJavaType(parameterType, property, javaType, jdbcType);
+    Type fieldType = genericTypeRawClassPair.getType();
+    Class<?> javaTypeClass = genericTypeRawClassPair.getRawClass();
+    TypeHandler<?> typeHandlerInstance = resolveTypeHandler(fieldType, javaTypeClass, typeHandler);
     return new ParameterMapping.Builder(configuration, property, javaTypeClass)
         .jdbcType(jdbcType)
         .resultMapId(resultMap)
@@ -367,8 +370,9 @@ public class MapperBuilderAssistant extends BaseBuilder {
       String resultSet,
       String foreignColumn,
       boolean lazy) {
-    Class<?> javaTypeClass = resolveResultJavaType(resultType, property, javaType);
-    TypeHandler<?> typeHandlerInstance = resolveTypeHandler(javaTypeClass, typeHandler);
+    GenericTypeRawClassPair genericTypeRawClassPair = resolveResultJavaType(resultType, property, javaType);
+    Class<?> javaTypeClass = genericTypeRawClassPair.getRawClass();
+    TypeHandler<?> typeHandlerInstance = resolveTypeHandler(genericTypeRawClassPair.getType(), javaTypeClass, typeHandler);
     List<ResultMapping> composites = parseCompositeColumnName(column);
     return new ResultMapping.Builder(configuration, property, column, javaTypeClass)
         .jdbcType(jdbcType)
@@ -416,36 +420,37 @@ public class MapperBuilderAssistant extends BaseBuilder {
     return composites;
   }
 
-  private Class<?> resolveResultJavaType(Class<?> resultType, String property, Class<?> javaType) {
+  private GenericTypeRawClassPair resolveResultJavaType(Class<?> resultType, String property, Class<?> javaType) {
+    GenericTypeRawClassPair genericTypeRawClassPair = null;
     if (javaType == null && property != null) {
       try {
         MetaClass metaResultType = MetaClass.forClass(resultType, configuration.getReflectorFactory());
-        javaType = metaResultType.getSetterType(property);
+        genericTypeRawClassPair = metaResultType.getSetterTypeRawClassPair(property);
       } catch (Exception e) {
         //ignore, following null check statement will deal with the situation
       }
     }
-    if (javaType == null) {
-      javaType = Object.class;
+    if (genericTypeRawClassPair == null) {
+      genericTypeRawClassPair = GenericTypeRawClassPair.newOnlyRawClassPair(Object.class);
     }
-    return javaType;
+    return genericTypeRawClassPair;
   }
 
-  private Class<?> resolveParameterJavaType(Class<?> resultType, String property, Class<?> javaType, JdbcType jdbcType) {
+  private GenericTypeRawClassPair resolveParameterJavaType(Class<?> resultType, String property, Class<?> javaType, JdbcType jdbcType) {
     if (javaType == null) {
       if (JdbcType.CURSOR.equals(jdbcType)) {
-        javaType = java.sql.ResultSet.class;
+        return GenericTypeRawClassPair.newOnlyRawClassPair(java.sql.ResultSet.class);
       } else if (Map.class.isAssignableFrom(resultType)) {
-        javaType = Object.class;
+        return GenericTypeRawClassPair.newOnlyRawClassPair(Object.class);
       } else {
         MetaClass metaResultType = MetaClass.forClass(resultType, configuration.getReflectorFactory());
-        javaType = metaResultType.getGetterType(property);
+        return metaResultType.getGetterTypeRawClassPair(property);
       }
     }
     if (javaType == null) {
-      javaType = Object.class;
+      return GenericTypeRawClassPair.newOnlyRawClassPair(Object.class);
     }
-    return javaType;
+    return GenericTypeRawClassPair.newOnlyRawClassPair(javaType);
   }
 
   /** Backward compatibility signature. */

--- a/src/main/java/org/apache/ibatis/reflection/GenericTypeRawClassPair.java
+++ b/src/main/java/org/apache/ibatis/reflection/GenericTypeRawClassPair.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.reflection;
 
 import java.lang.reflect.Type;

--- a/src/main/java/org/apache/ibatis/reflection/GenericTypeRawClassPair.java
+++ b/src/main/java/org/apache/ibatis/reflection/GenericTypeRawClassPair.java
@@ -1,0 +1,39 @@
+package org.apache.ibatis.reflection;
+
+import java.lang.reflect.Type;
+import java.util.Objects;
+
+/**
+ * @author LuckyZhan
+ **/
+public final class GenericTypeRawClassPair {
+  private final Type type;
+  private final Class<?> rawClass;
+
+  private GenericTypeRawClassPair(Type type, Class<?> rawClass){
+    this.type = type;
+    this.rawClass = rawClass;
+  }
+
+  public Type getType(){
+    return type;
+  }
+
+  public Class<?> getRawClass(){
+    return rawClass;
+  }
+
+  public static GenericTypeRawClassPair newGenericTypeRawClassPair(Type type, Class<?> rawClass){
+    Objects.requireNonNull(rawClass, "rawClass must be present");
+    if(type instanceof Class){
+      return newOnlyRawClassPair(rawClass);
+    }
+    return new GenericTypeRawClassPair(type, rawClass);
+  }
+
+  public static GenericTypeRawClassPair newOnlyRawClassPair(Class<?> rawClass){
+    Objects.requireNonNull(rawClass, "rawClass must be present");
+    return new GenericTypeRawClassPair(null, rawClass);
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/MetaClass.java
+++ b/src/main/java/org/apache/ibatis/reflection/MetaClass.java
@@ -29,7 +29,7 @@ import org.apache.ibatis.reflection.property.PropertyTokenizer;
 /**
  * @author Clinton Begin
  */
-public class MetaClass {
+public class  MetaClass {
 
   private final ReflectorFactory reflectorFactory;
   private final Reflector reflector;
@@ -75,6 +75,26 @@ public class MetaClass {
       return metaProp.getSetterType(prop.getChildren());
     } else {
       return reflector.getSetterType(prop.getName());
+    }
+  }
+
+  public GenericTypeRawClassPair getSetterTypeRawClassPair(String name) {
+    PropertyTokenizer prop = new PropertyTokenizer(name);
+    if (prop.hasNext()) {
+      MetaClass metaProp = metaClassForProperty(prop.getName());
+      return metaProp.getSetterTypeRawClassPair(prop.getChildren());
+    } else {
+      return reflector.getSetterTypeRawClassPair(prop.getName());
+    }
+  }
+
+  public GenericTypeRawClassPair getGetterTypeRawClassPair(String name) {
+    PropertyTokenizer prop = new PropertyTokenizer(name);
+    if (prop.hasNext()) {
+      MetaClass metaProp = metaClassForProperty(prop.getName());
+      return metaProp.getGetterTypeRawClassPair(prop.getChildren());
+    } else {
+      return reflector.getGetterTypeRawClassPair(prop.getName());
     }
   }
 

--- a/src/main/java/org/apache/ibatis/reflection/Reflector.java
+++ b/src/main/java/org/apache/ibatis/reflection/Reflector.java
@@ -283,6 +283,8 @@ public class Reflector {
       getMethods.put(field.getName(), new GetFieldInvoker(field));
       Type fieldType = TypeParameterResolver.resolveFieldType(field, type);
       getTypes.put(field.getName(), typeToClass(fieldType));
+      getGenericTypeRawClasses
+        .put(field.getName(), GenericTypeRawClassPair.newGenericTypeRawClassPair(fieldType, typeToClass(fieldType)));
     }
   }
 

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -440,6 +440,21 @@ public final class TypeHandlerRegistry {
     }
   }
 
+  public <T> TypeHandler<T> getInstance(Type genericType, Class<?> rawClass, Class<?> typeHandlerClass) {
+    // Try instance TypeHandler with Type first
+    if(genericType != null){
+      try {
+        Constructor<?> c = typeHandlerClass.getConstructor(Type.class);
+        return (TypeHandler<T>) c.newInstance(genericType);
+      } catch (NoSuchMethodException ignored) {
+        // ignored
+      } catch (Exception e) {
+        throw new TypeException("Failed invoking constructor for handler " + typeHandlerClass, e);
+      }
+    }
+    return getInstance(rawClass, typeHandlerClass);
+  }
+
   // scan
 
   public void register(String packageName) {

--- a/src/site/ko/xdoc/getting-started.xml
+++ b/src/site/ko/xdoc/getting-started.xml
@@ -95,7 +95,7 @@ configuration.addMapper(BlogMapper.class);
 SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);]]></source>
       <p>이 설정에서 추가로 해야 할 일은 Mapper클래스를 추가하는 것이다.
 	  Mapper클래스는 SQL 매핑 애노테이션을 가진 자바 클래스이다.
-	  어쨌든 자바 애노테이션의 몇가지 제약과 몇가지 설정방법의 목잡함에도 불구하고 XML 매핑은 세부적인 매핑을 위해 언제든 필요하다.
+	  어쨌든 자바 애노테이션의 몇가지 제약과 몇가지 설정방법의 복잡함에도 불구하고 XML 매핑은 세부적인 매핑을 위해 언제든 필요하다.
 	  좀더 세부적인 내용은 조금 뒤 다시 보도록 하자.</p>
     </subsection>
     <subsection name="SqlSessionFactory 에서 SqlSession 만들기">

--- a/src/site/zh/xdoc/dynamic-sql.xml
+++ b/src/site/zh/xdoc/dynamic-sql.xml
@@ -25,13 +25,13 @@
     <author email="nanlei1987@gmail.com">Nan Lei</author>
     <author email="echowdx@gmail.com">Dongxu Wang</author>
     <author email="lu_picc@outlook.com">ZeShen Lu</author>
-  </properties>
+  </properties>
 
   <body>
     <section name="动态 SQL">
-      <p>MyBatis 的强大特性之一便是它的动态 SQL。如果你有使用 JDBC 或其它类似框架的经验，你就能体会到根据不同条件拼接 SQL 语句的痛苦。例如拼接时要确保不能忘记添加必要的空格，还要注意去掉列表最后一个列名的逗号。利用动态 SQL 这一特性可以彻底摆脱这种痛苦。</p>
-      <p>虽然在以前使用动态 SQL 并非一件易事，但正是 MyBatis 提供了可以被用在任意 SQL 映射语句中的强大的动态 SQL 语言得以改进这种情形。</p>
-      <p>动态 SQL 元素和 JSTL 或基于类似 XML 的文本处理器相似。在 MyBatis 之前的版本中，有很多元素需要花时间了解。MyBatis 3 大大精简了元素种类，现在只需学习原来一半的元素便可。MyBatis 采用功能强大的基于 OGNL 的表达式来淘汰其它大部分元素。</p>
+      <p>MyBatis 的强大特性之一便是它的动态 SQL。如果你有使用 JDBC 或其它类似框架的经验，你就能体会到根据不同条件拼接 SQL 语句的痛苦。例如拼接时要确保不能忘记添加必要的空格，还要注意去掉列表最后一个列名的逗号。利用动态 SQL 这一特性可以彻底摆脱这种痛苦。</p>
+      <p>虽然在以前使用动态 SQL 并非一件易事，但正是 MyBatis 提供了可以被用在任意 SQL 映射语句中的强大的动态 SQL 语言得以改进这种情形。</p>
+      <p>动态 SQL 元素和 JSTL 或基于类似 XML 的文本处理器相似。在 MyBatis 之前的版本中，有很多元素需要花时间了解。MyBatis 3 大大精简了元素种类，现在只需学习原来一半的元素便可。MyBatis 采用功能强大的基于 OGNL 的表达式来淘汰其它大部分元素。</p>
       <ul>
         <li>if</li>
         <li>choose (when, otherwise)</li>
@@ -39,7 +39,7 @@
         <li>foreach</li>
       </ul>
       <subsection name="if" id="if">
-        <p>动态 SQL 通常要做的事情是根据条件包含 where 子句的一部分。比如：</p>
+        <p>动态 SQL 通常要做的事情是根据条件包含 where 子句的一部分。比如：</p>
         <source><![CDATA[<select id="findActiveBlogWithTitleLike"
      resultType="Blog">
   SELECT * FROM BLOG
@@ -48,8 +48,8 @@
     AND title like #{title}
   </if>
 </select>]]></source>
-        <p>这条语句提供了一种可选的查找文本功能。如果没有传入“title”，那么所有处于“ACTIVE”状态的BLOG都会返回；反之若传入了“title”，那么就会对“title”一列进行模糊查找并返回 BLOG 结果（细心的读者可能会发现，“title”参数值是可以包含一些掩码或通配符的）。</p>
-        <p>如果希望通过“title”和“author”两个参数进行可选搜索该怎么办呢？首先，改变语句的名称让它更具实际意义；然后只要加入另一个条件即可。</p>
+        <p>这条语句提供了一种可选的查找文本功能。如果没有传入“title”，那么所有处于“ACTIVE”状态的BLOG都会返回；反之若传入了“title”，那么就会对“title”一列进行模糊查找并返回 BLOG 结果（细心的读者可能会发现，“title”参数值是可以包含一些掩码或通配符的）。</p>
+        <p>如果希望通过“title”和“author”两个参数进行可选搜索该怎么办呢？首先，改变语句的名称让它更具实际意义；然后只要加入另一个条件即可。</p>
         <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
   SELECT * FROM BLOG WHERE state = ‘ACTIVE’
@@ -62,8 +62,8 @@
 </select>]]></source>
       </subsection>
       <subsection name="choose, when, otherwise" id="chooseWhenOtherwise">
-        <p>有时我们不想应用到所有的条件语句，而只想从中择其一项。针对这种情况，MyBatis 提供了 choose 元素，它有点像 Java 中的 switch 语句。</p>
-        <p>还是上面的例子，但是这次变为提供了“title”就按“title”查找，提供了“author”就按“author”查找的情形，若两者都没有提供，就返回所有符合条件的 BLOG（实际情况可能是由管理员按一定策略选出 BLOG 列表，而不是返回大量无意义的随机结果）。</p>
+        <p>有时我们不想应用到所有的条件语句，而只想从中择其一项。针对这种情况，MyBatis 提供了 choose 元素，它有点像 Java 中的 switch 语句。</p>
+        <p>还是上面的例子，但是这次变为提供了“title”就按“title”查找，提供了“author”就按“author”查找的情形，若两者都没有提供，就返回所有符合条件的 BLOG（实际情况可能是由管理员按一定策略选出 BLOG 列表，而不是返回大量无意义的随机结果）。</p>
         <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
   SELECT * FROM BLOG WHERE state = ‘ACTIVE’
@@ -96,7 +96,7 @@
     AND author_name like #{author.name}
   </if>
 </select>]]></source>
-        <p>如果这些条件没有一个能匹配上会发生什么？最终这条 SQL 会变成这样：</p>
+        <p>如果这些条件没有一个能匹配上会发生什么？最终这条 SQL 会变成这样：</p>
         <source><![CDATA[SELECT * FROM BLOG
 WHERE]]></source>
         <p>这会导致查询失败。如果仅仅第二个条件匹配又会怎样？这条 SQL 最终会是这样:
@@ -104,8 +104,8 @@ WHERE]]></source>
         <source><![CDATA[SELECT * FROM BLOG
 WHERE
 AND title like ‘someTitle’]]></source>
-        <p>这个查询也会失败。这个问题不能简单地用条件句式来解决，如果你也曾经被迫这样写过，那么你很可能从此以后都不会再写出这种语句了。</p>
-        <p>MyBatis 有一个简单的处理，这在 90% 的情况下都会有用。而在不能使用的地方，你可以自定义处理方式来令其正常工作。一处简单的修改就能达到目的：</p>
+        <p>这个查询也会失败。这个问题不能简单地用条件句式来解决，如果你也曾经被迫这样写过，那么你很可能从此以后都不会再写出这种语句了。</p>
+        <p>MyBatis 有一个简单的处理，这在 90% 的情况下都会有用。而在不能使用的地方，你可以自定义处理方式来令其正常工作。一处简单的修改就能达到目的：</p>
         <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
   SELECT * FROM BLOG
@@ -121,13 +121,13 @@ AND title like ‘someTitle’]]></source>
     </if>
   </where>
 </select>]]></source>
-        <p><em>where</em> 元素只会在至少有一个子元素的条件返回 SQL 子句的情况下才去插入“WHERE”子句。而且，若语句的开头为“AND”或“OR”，<em>where</em> 元素也会将它们去除。</p>
-        <p>如果 <em>where</em> 元素没有按正常套路出牌，我们可以通过自定义 trim 元素来定制 <em>where</em> 元素的功能。比如，和 <em>where</em> 元素等价的自定义 trim 元素为：</p>
+        <p><em>where</em> 元素只会在至少有一个子元素的条件返回 SQL 子句的情况下才去插入“WHERE”子句。而且，若语句的开头为“AND”或“OR”，<em>where</em> 元素也会将它们去除。</p>
+        <p>如果 <em>where</em> 元素没有按正常套路出牌，我们可以通过自定义 trim 元素来定制 <em>where</em> 元素的功能。比如，和 <em>where</em> 元素等价的自定义 trim 元素为：</p>
         <source><![CDATA[<trim prefix="WHERE" prefixOverrides="AND |OR ">
   ...
 </trim>]]></source>
-        <p><em>prefixOverrides</em> 属性会忽略通过管道分隔的文本序列（注意此例中的空格也是必要的）。它的作用是移除所有指定在 <em>prefixOverrides</em> 属性中的内容，并且插入 <em>prefix</em> 属性中指定的内容。</p>
-        <p>类似的用于动态更新语句的解决方案叫做 <em>set</em>。<em>set</em> 元素可以用于动态包含需要更新的列，而舍去其它的。比如：</p>
+        <p><em>prefixOverrides</em> 属性会忽略通过管道分隔的文本序列（注意此例中的空格也是必要的）。它的作用是移除所有指定在 <em>prefixOverrides</em> 属性中的内容，并且插入 <em>prefix</em> 属性中指定的内容。</p>
+        <p>类似的用于动态更新语句的解决方案叫做 <em>set</em>。<em>set</em> 元素可以用于动态包含需要更新的列，而舍去其它的。比如：</p>
         <source><![CDATA[<update id="updateAuthorIfNecessary">
   update Author
     <set>
@@ -138,15 +138,15 @@ AND title like ‘someTitle’]]></source>
     </set>
   where id=#{id}
 </update>]]></source>
-        <p>这里，<em>set</em> 元素会动态前置 SET 关键字，同时也会删掉无关的逗号，因为用了条件语句之后很可能就会在生成的 SQL 语句的后面留下这些逗号。（译者注：因为用的是“if”元素，若最后一个“if”没有匹配上而前面的匹配上，SQL 语句的最后就会有一个逗号遗留）</p>
-        <p>若你对 <em>set</em> 元素等价的自定义 trim 元素的代码感兴趣，那这就是它的真面目：</p>
+        <p>这里，<em>set</em> 元素会动态前置 SET 关键字，同时也会删掉无关的逗号，因为用了条件语句之后很可能就会在生成的 SQL 语句的后面留下这些逗号。（译者注：因为用的是“if”元素，若最后一个“if”没有匹配上而前面的匹配上，SQL 语句的最后就会有一个逗号遗留）</p>
+        <p>若你对 <em>set</em> 元素等价的自定义 trim 元素的代码感兴趣，那这就是它的真面目：</p>
         <source><![CDATA[<trim prefix="SET" suffixOverrides=",">
   ...
 </trim>]]></source>
-        <p>注意这里我们删去的是后缀值，同时添加了前缀值。</p>
+        <p>注意这里我们删去的是后缀值，同时添加了前缀值。</p>
       </subsection>
       <subsection name="foreach">
-        <p>动态 SQL 的另外一个常用的操作需求是对一个集合进行遍历，通常是在构建 IN 条件语句的时候。比如：</p>
+        <p>动态 SQL 的另外一个常用的操作需求是对一个集合进行遍历，通常是在构建 IN 条件语句的时候。比如：</p>
         <source><![CDATA[<select id="selectPostIn" resultType="domain.blog.Post">
   SELECT *
   FROM POST P
@@ -156,9 +156,9 @@ AND title like ‘someTitle’]]></source>
         #{item}
   </foreach>
 </select>]]></source>
-        <p><em>foreach</em> 元素的功能非常强大，它允许你指定一个集合，声明可以在元素体内使用的集合项（item）和索引（index）变量。它也允许你指定开头与结尾的字符串以及在迭代结果之间放置分隔符。这个元素是很智能的，因此它不会偶然地附加多余的分隔符。</p>
-        <p><span class="label important">注意</span> 你可以将任何可迭代对象（如 List、Set 等）、Map 对象或者数组对象传递给 <em>foreach</em> 作为集合参数。当使用可迭代对象或者数组时，index 是当前迭代的次数，item 的值是本次迭代获取的元素。当使用 Map 对象（或者 Map.Entry 对象的集合）时，index 是键，item 是值。</p>
-        <p>到此我们已经完成了涉及 XML 配置文件和 XML 映射文件的讨论。下一章将详细探讨 Java API，这样就能提高已创建的映射文件的利用效率。</p>
+        <p><em>foreach</em> 元素的功能非常强大，它允许你指定一个集合，声明可以在元素体内使用的集合项（item）和索引（index）变量。它也允许你指定开头与结尾的字符串以及在迭代结果之间放置分隔符。这个元素是很智能的，因此它不会偶然地附加多余的分隔符。</p>
+        <p><span class="label important">注意</span> 你可以将任何可迭代对象（如 List、Set 等）、Map 对象或者数组对象传递给 <em>foreach</em> 作为集合参数。当使用可迭代对象或者数组时，index 是当前迭代的次数，item 的值是本次迭代获取的元素。当使用 Map 对象（或者 Map.Entry 对象的集合）时，index 是键，item 是值。</p>
+        <p>到此我们已经完成了涉及 XML 配置文件和 XML 映射文件的讨论。下一章将详细探讨 Java API，这样就能提高已创建的映射文件的利用效率。</p>
       </subsection>
       <subsection name="bind">
         <p><code>bind</code> 元素可以从 OGNL 表达式中创建一个变量并将其绑定到上下文。比如：</p>
@@ -169,8 +169,8 @@ AND title like ‘someTitle’]]></source>
   WHERE title LIKE #{pattern}
 </select>]]></source>
       </subsection>
-      <subsection name="多数据库支持">
-        <p>一个配置了“_databaseId”变量的 databaseIdProvider 可用于动态代码中，这样就可以根据不同的数据库厂商构建特定的语句。比如下面的例子：</p>
+      <subsection name="多数据库支持">
+        <p>一个配置了“_databaseId”变量的 databaseIdProvider 可用于动态代码中，这样就可以根据不同的数据库厂商构建特定的语句。比如下面的例子：</p>
         <source><![CDATA[<insert id="insert">
   <selectKey keyProperty="id" resultType="int" order="BEFORE">
     <if test="_databaseId == 'oracle'">
@@ -185,14 +185,14 @@ AND title like ‘someTitle’]]></source>
 ]]></source>
       </subsection>
       <subsection name="动态 SQL 中的可插拔脚本语言">
-        <p>MyBatis 从 3.2 开始支持可插拔脚本语言，这允许你插入一种脚本语言驱动，并基于这种语言来编写动态 SQL 查询语句。</p>
-        <p>可以通过实现以下接口来插入一种语言：</p>
+        <p>MyBatis 从 3.2 开始支持可插拔脚本语言，这允许你插入一种脚本语言驱动，并基于这种语言来编写动态 SQL 查询语句。</p>
+        <p>可以通过实现以下接口来插入一种语言：</p>
         <source><![CDATA[public interface LanguageDriver {
   ParameterHandler createParameterHandler(MappedStatement mappedStatement, Object parameterObject, BoundSql boundSql);
   SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType);
   SqlSource createSqlSource(Configuration configuration, String script, Class<?> parameterType);
 }]]></source>
-        <p>一旦设定了自定义语言驱动，你就可以在 mybatis-config.xml 文件中将它设置为默认语言：</p>
+        <p>一旦设定了自定义语言驱动，你就可以在 mybatis-config.xml 文件中将它设置为默认语言：</p>
         <source><![CDATA[<typeAliases>
   <typeAlias type="org.sample.MyLanguageDriver" alias="myLanguage"/>
 </typeAliases>
@@ -205,7 +205,7 @@ AND title like ‘someTitle’]]></source>
         <source><![CDATA[<select id="selectBlog" lang="myLanguage">
   SELECT * FROM BLOG
 </select>]]></source>
-        <p>或者，如果你使用的是映射器接口类，在抽象方法上加上 <code>@Lang</code> 注解即可：</p>
+        <p>或者，如果你使用的是映射器接口类，在抽象方法上加上 <code>@Lang</code> 注解即可：</p>
         <source><![CDATA[public interface Mapper {
   @Lang(MyLanguageDriver.class)
   @Select("SELECT * FROM BLOG")
@@ -214,7 +214,7 @@ AND title like ‘someTitle’]]></source>
 
         <p><span class="label important">注意</span> 可以将 Apache Velocity 作为动态语言来使用，更多细节请参考 MyBatis-Velocity 项目。</p>
 
-        <p>你前面看到的所有 xml 标签都是由默认 MyBatis 语言提供的，而它由别名为 <code>xml</code> 的语言驱动器 <code>org.apache.ibatis.scripting.xmltags.XmlLanguageDriver</code> 所提供。</p>
+        <p>你前面看到的所有 xml 标签都是由默认 MyBatis 语言提供的，而它由别名为 <code>xml</code> 的语言驱动器 <code>org.apache.ibatis.scripting.xmltags.XmlLanguageDriver</code> 所提供。</p>
       </subsection>
     </section>
   </body>

--- a/src/site/zh/xdoc/logging.xml
+++ b/src/site/zh/xdoc/logging.xml
@@ -26,10 +26,9 @@
   </properties>
 
   <body>
-    <section name="日志">
+    <section name="日志">
       <p></p>
-      <p>Mybatis 的内置日志工厂提供日志功能，内置日志工厂将日志交给以下其中一种工具作代理：
-      </p>
+      <p>Mybatis 的内置日志工厂提供日志功能，内置日志工厂将日志交给以下其中一种工具作代理：</p>
       <ul>
         <li>
           SLF4J
@@ -47,8 +46,8 @@
           JDK logging
         </li>
       </ul>
-      <p>MyBatis 内置日志工厂基于运行时自省机制选择合适的日志工具。它会使用第一个查找得到的工具（按上文列举的顺序查找）。如果一个都未找到，日志功能就会被禁用。</p>
-      <p>不少应用服务器（如 Tomcat 和 WebShpere）的类路径中已经包含 Commons Logging，所以在这种配置环境下的 MyBatis 会把它作为日志工具，记住这点非常重要。这将意味着，在诸如 WebSphere 的环境中，它提供了 Commons Logging 的私有实现，你的 Log4J 配置将被忽略。MyBatis 将你的 Log4J 配置忽略掉是相当令人郁闷的（事实上，正是因为在这种配置环境下，MyBatis 才会选择使用 Commons Logging 而不是 Log4J）。如果你的应用部署在一个类路径已经包含 Commons Logging 的环境中，而你又想使用其它日志工具，你可以通过在 MyBatis 配置文件 mybatis-config.xml 里面添加一项 setting 来选择别的日志工具。</p>
+      <p>MyBatis 内置日志工厂基于运行时自省机制选择合适的日志工具。它会使用第一个查找得到的工具（按上文列举的顺序查找）。如果一个都未找到，日志功能就会被禁用。</p>
+      <p>不少应用服务器（如 Tomcat 和 WebShpere）的类路径中已经包含 Commons Logging，所以在这种配置环境下的 MyBatis 会把它作为日志工具，记住这点非常重要。这将意味着，在诸如 WebSphere 的环境中，它提供了 Commons Logging 的私有实现，你的 Log4J 配置将被忽略。MyBatis 将你的 Log4J 配置忽略掉是相当令人郁闷的（事实上，正是因为在这种配置环境下，MyBatis 才会选择使用 Commons Logging 而不是 Log4J）。如果你的应用部署在一个类路径已经包含 Commons Logging 的环境中，而你又想使用其它日志工具，你可以通过在 MyBatis 配置文件 mybatis-config.xml 里面添加一项 setting 来选择别的日志工具。</p>
       <source><![CDATA[<configuration>
   <settings>
     ...
@@ -57,18 +56,15 @@
   </settings>
 </configuration>]]>
       </source>
-      <p>logImpl 可选的值有：SLF4J、LOG4J、LOG4J2、JDK_LOGGING、COMMONS_LOGGING、STDOUT_LOGGING、NO_LOGGING，或者是实现了接口 <code>org.apache.ibatis.logging.Log</code> 的，且构造方法是以字符串为参数的类的完全限定名。（译者注：可以参考org.apache.ibatis.logging.slf4j.Slf4jImpl.java的实现）
-      </p>
-      <p>你也可以调用如下任一方法来使用日志工具：
-      </p>
+      <p>logImpl 可选的值有：SLF4J、LOG4J、LOG4J2、JDK_LOGGING、COMMONS_LOGGING、STDOUT_LOGGING、NO_LOGGING，或者是实现了接口 <code>org.apache.ibatis.logging.Log</code> 的，且构造方法是以字符串为参数的类的完全限定名。（译者注：可以参考org.apache.ibatis.logging.slf4j.Slf4jImpl.java的实现）</p>
+      <p>你也可以调用如下任一方法来使用日志工具：</p>
       <source><![CDATA[org.apache.ibatis.logging.LogFactory.useSlf4jLogging();
 org.apache.ibatis.logging.LogFactory.useLog4JLogging();
 org.apache.ibatis.logging.LogFactory.useJdkLogging();
 org.apache.ibatis.logging.LogFactory.useCommonsLogging();
 org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
-      <p>如果你决定要调用以上某个方法，请在调用其它 MyBatis 方法之前调用它。另外，仅当运行时类路径中存在该日志工具时，调用与该日志工具对应的方法才会生效，否则 MyBatis 一概忽略。如你环境中并不存在 Log4J，你却调用了相应的方法，MyBatis 就会忽略这一调用，转而以默认的查找顺序查找日志工具。
-      </p>
-      <p>关于 SLF4J、Apache Commons Logging、Apache Log4J 和 JDK Logging 的 API 介绍不在本文档介绍范围内。不过，下面的例子可以作为一个快速入门。关于这些日志框架的更多信息，可以参考以下链接：</p>
+      <p>如果你决定要调用以上某个方法，请在调用其它 MyBatis 方法之前调用它。另外，仅当运行时类路径中存在该日志工具时，调用与该日志工具对应的方法才会生效，否则 MyBatis 一概忽略。如你环境中并不存在 Log4J，你却调用了相应的方法，MyBatis 就会忽略这一调用，转而以默认的查找顺序查找日志工具。</p>
+      <p>关于 SLF4J、Apache Commons Logging、Apache Log4J 和 JDK Logging 的 API 介绍不在本文档介绍范围内。不过，下面的例子可以作为一个快速入门。关于这些日志框架的更多信息，可以参考以下链接：</p>
       <ul>
         <li>
           <a href="http://commons.apache.org/logging">Apache Commons Logging</a>
@@ -80,32 +76,26 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
           <a href="http://java.sun.com/j2se/1.4.1/docs/guide/util/logging/">JDK Logging API</a>
         </li>
       </ul>
-      <subsection name="日志配置">
-        <p>你可以对包、映射类的全限定名、命名空间或全限定语句名开启日志功能来查看 MyBatis 的日志语句。
-        </p>
-        <p>再次说明下，具体怎么做，由使用的日志工具决定，这里以 Log4J 为例。配置日志功能非常简单：添加一个或多个配置文件（如 log4j.properties），有时需要添加 jar 包（如 log4j.jar）。下面的例子将使用 Log4J 来配置完整的日志服务，共两个步骤：
-        </p>
+      <subsection name="日志配置">
+        <p>你可以对包、映射类的全限定名、命名空间或全限定语句名开启日志功能来查看 MyBatis 的日志语句。</p>
+        <p>再次说明下，具体怎么做，由使用的日志工具决定，这里以 Log4J 为例。配置日志功能非常简单：添加一个或多个配置文件（如 log4j.properties），有时需要添加 jar 包（如 log4j.jar）。下面的例子将使用 Log4J 来配置完整的日志服务，共两个步骤：</p>
         <p></p>
         <h4>
           步骤 1：添加 Log4J 的 jar 包
         </h4>
-        <p>因为我们使用的是 Log4J，就要确保它的 jar 包在应用中是可用的。要启用 Log4J，只要将 jar 包添加到应用的类路径中即可。Log4J 的 jar 包可以在上面的链接中下载。
-        </p>
-        <p>对于 web 应用或企业级应用，则需要将 <code>log4j.jar</code> 添加到 <code>WEB-INF/lib</code> 目录下；对于独立应用，可以将它添加到JVM 的 <code>-classpath</code> 启动参数中。
-        </p>
+        <p>因为我们使用的是 Log4J，就要确保它的 jar 包在应用中是可用的。要启用 Log4J，只要将 jar 包添加到应用的类路径中即可。Log4J 的 jar 包可以在上面的链接中下载。</p>
+        <p>对于 web 应用或企业级应用，则需要将 <code>log4j.jar</code> 添加到 <code>WEB-INF/lib</code> 目录下；对于独立应用，可以将它添加到JVM 的 <code>-classpath</code> 启动参数中。</p>
         <p></p>
         <h4>
           步骤 2：配置 Log4J
         </h4>
-        <p>配置 Log4J 比较简单，假如你需要记录这个映射器接口的日志：
-        </p>
+        <p>配置 Log4J 比较简单，假如你需要记录这个映射器接口的日志：</p>
         <source><![CDATA[package org.mybatis.example;
 public interface BlogMapper {
   @Select("SELECT * FROM blog WHERE id = #{id}")
   Blog selectBlog(int id);
 }]]></source>
-        <p>在应用的类路径中创建一个名称为 <code>log4j.properties</code> 的文件，文件的具体内容如下：
-        </p>
+        <p>在应用的类路径中创建一个名称为 <code>log4j.properties</code> 的文件，文件的具体内容如下：</p>
         <source><![CDATA[# Global logging configuration
 log4j.rootLogger=ERROR, stdout
 # MyBatis logging configuration...
@@ -114,23 +104,20 @@ log4j.logger.org.mybatis.example.BlogMapper=TRACE
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
-        <p>添加以上配置后，Log4J 就会记录 <code>org.mybatis.example.BlogMapper</code> 的详细执行操作，且仅记录应用中其它类的错误信息（若有）。</p>
-        <p>你也可以将日志的记录方式从接口级别切换到语句级别，从而实现更细粒度的控制。如下配置只对 <code>selectBlog</code> 语句记录日志：
-        </p>
+        <p>添加以上配置后，Log4J 就会记录 <code>org.mybatis.example.BlogMapper</code> 的详细执行操作，且仅记录应用中其它类的错误信息（若有）。</p>
+        <p>你也可以将日志的记录方式从接口级别切换到语句级别，从而实现更细粒度的控制。如下配置只对 <code>selectBlog</code> 语句记录日志：</p>
 
         <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
 
-        <p>与此相对，可以对一组映射器接口记录日志，只要对映射器接口所在的包开启日志功能即可：</p>
+        <p>与此相对，可以对一组映射器接口记录日志，只要对映射器接口所在的包开启日志功能即可：</p>
 
         <source>log4j.logger.org.mybatis.example=TRACE</source>
 
-        <p>某些查询可能会返回庞大的结果集，此时只想记录其执行的 SQL 语句而不想记录结果该怎么办？为此，Mybatis 中 SQL 语句的日志级别被设为DEBUG（JDK 日志设为 FINE），结果的日志级别为 TRACE（JDK 日志设为 FINER)。所以，只要将日志级别调整为 DEBUG 即可达到目的：
-        </p>
+        <p>某些查询可能会返回庞大的结果集，此时只想记录其执行的 SQL 语句而不想记录结果该怎么办？为此，Mybatis 中 SQL 语句的日志级别被设为DEBUG（JDK 日志设为 FINE），结果的日志级别为 TRACE（JDK 日志设为 FINER)。所以，只要将日志级别调整为 DEBUG 即可达到目的：</p>
 
         <source>log4j.logger.org.mybatis.example=DEBUG</source>
 
-        <p>要记录日志的是类似下面的映射器文件而不是映射器接口又该怎么做呢？
-        </p>
+        <p>要记录日志的是类似下面的映射器文件而不是映射器接口又该怎么做呢？</p>
 
       <source><![CDATA[<?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
@@ -142,8 +129,7 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
   </select>
 </mapper>]]></source>
 
-		<p>如需对 XML 文件记录日志，只要对命名空间增加日志记录功能即可：
-		</p>
+		<p>如需对 XML 文件记录日志，只要对命名空间增加日志记录功能即可：</p>
 
         <source>log4j.logger.org.mybatis.example.BlogMapper=TRACE</source>
 
@@ -151,13 +137,11 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n]]></source>
 
         <source>log4j.logger.org.mybatis.example.BlogMapper.selectBlog=TRACE</source>
 
-		<p>你应该注意到了，为映射器接口和 XML 文件添加日志功能的语句毫无差别。
-		</p>
+		<p>你应该注意到了，为映射器接口和 XML 文件添加日志功能的语句毫无差别。</p>
 
 		<p><span class="label important">注意</span> 如果你使用的是 SLF4J 或 Log4j 2，MyBatis 将以 MYBATIS 这个值进行调用。</p>
 
-        <p>配置文件 <code>log4j.properties</code> 的余下内容是针对日志输出源的，这一内容已经超出本文档范围。关于 Log4J 的更多内容，可以参考Log4J 的网站。不过，你也可以简单地做做实验，看看不同的配置会产生怎样的效果。
-        </p>
+        <p>配置文件 <code>log4j.properties</code> 的余下内容是针对日志输出源的，这一内容已经超出本文档范围。关于 Log4J 的更多内容，可以参考Log4J 的网站。不过，你也可以简单地做做实验，看看不同的配置会产生怎样的效果。</p>
 
       </subsection>
     </section>

--- a/src/test/java/org/apache/ibatis/type/GenericFieldJsonTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/GenericFieldJsonTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2019 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/type/GenericFieldJsonTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/GenericFieldJsonTypeHandlerTest.java
@@ -1,0 +1,152 @@
+/**
+ *    Copyright 2009-2019 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import javax.sql.DataSource;
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.Results;
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.transaction.TransactionFactory;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class GenericFieldJsonTypeHandlerTest{
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+
+  interface GenericFieldJsonTestMapper {
+    @Results({
+      @Result(property = "id", column = "id"),
+      @Result(property = "genericObj", column = "json", typeHandler = org.apache.ibatis.type.GenericTypeJsonTypeHandler.class),
+    })
+    @Select("SELECT ID, JSON FROM test_generic WHERE ID = #{id}")
+    GenericFieldType findOne(int id);
+
+    @Insert("INSERT INTO test_generic (ID, JSON) VALUES(#{id}, #{genericObj, typeHandler=org.apache.ibatis.type.GenericTypeJsonTypeHandler})")
+    void insert(GenericFieldType blobContent);
+  }
+
+  static class RawType{
+    private String name;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return "RawType{" +
+        "name='" + name + '\'' +
+        '}';
+    }
+  }
+
+  static class GenericType<T>{
+    private T genericObj;
+
+    public T getGenericObj() {
+      return genericObj;
+    }
+
+    public void setGenericObj(T genericObj) {
+      this.genericObj = genericObj;
+    }
+
+    @Override
+    public String toString() {
+      return "GenericType{" +
+        "genericObj=" + genericObj +
+        '}';
+    }
+  }
+
+  static class GenericFieldType{
+    private int id;
+    private GenericType<RawType> genericObj;
+
+    public int getId() {
+      return id;
+    }
+
+    public void setId(int id) {
+      this.id = id;
+    }
+
+    public GenericType<RawType> getGenericObj() {
+      return genericObj;
+    }
+
+    public void setGenericObj(
+      GenericType<RawType> genericObj) {
+      this.genericObj = genericObj;
+    }
+
+    @Override
+    public String toString() {
+      return "GenericFieldType{" +
+        "id=" + id +
+        ", genericObj=" + genericObj +
+        '}';
+    }
+  }
+
+  @BeforeAll
+  static void setupSqlSessionFactory() throws Exception {
+    DataSource dataSource = BaseDataTest.createUnpooledDataSource("org/apache/ibatis/type/jdbc.properties");
+    TransactionFactory transactionFactory = new JdbcTransactionFactory();
+    Environment environment = new Environment("Production", transactionFactory, dataSource);
+    Configuration configuration = new Configuration(environment);
+    configuration.addMapper(GenericFieldJsonTestMapper.class);
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/type/GenericFieldJsonTypeHandlerTest.sql");
+  }
+
+  @Test
+  public void testTypeHandlerSupportGenericField() throws Exception {
+    setupSqlSessionFactory();
+    SqlSession sqlSession = sqlSessionFactory.openSession();
+    GenericFieldJsonTestMapper mapper = sqlSession.getMapper(GenericFieldJsonTestMapper.class);
+    int id = 1;
+    GenericType<RawType> genericObj = new GenericType<>();
+    RawType rawObj = new RawType();
+    rawObj.setName("Test");
+    genericObj.setGenericObj(rawObj);
+    GenericFieldType genericFieldObj = new GenericFieldType();
+    genericFieldObj.setId(id);
+    genericFieldObj.setGenericObj(genericObj);
+    mapper.insert(genericFieldObj);
+
+    genericFieldObj = mapper.findOne(id);
+    rawObj = genericFieldObj.getGenericObj().getGenericObj();
+    System.out.println(rawObj);
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/type/GenericFieldJsonTypeHandlerTest.sql
+++ b/src/test/java/org/apache/ibatis/type/GenericFieldJsonTypeHandlerTest.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2009-2016 the original author or authors.
+--    Copyright 2009-2020 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/type/GenericFieldJsonTypeHandlerTest.sql
+++ b/src/test/java/org/apache/ibatis/type/GenericFieldJsonTypeHandlerTest.sql
@@ -1,0 +1,22 @@
+--
+--    Copyright 2009-2016 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+DROP TABLE test_generic;
+
+CREATE TABLE test_generic (
+  id INT PRIMARY KEY,
+  json VARCHAR(200)
+);

--- a/src/test/java/org/apache/ibatis/type/GenericTypeJsonTypeHandler.java
+++ b/src/test/java/org/apache/ibatis/type/GenericTypeJsonTypeHandler.java
@@ -1,0 +1,40 @@
+package org.apache.ibatis.type;
+
+import com.google.gson.Gson;
+import java.lang.reflect.Type;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class GenericTypeJsonTypeHandler implements TypeHandler{
+  private Type type;
+  private static final Gson gson = new Gson();
+
+  public GenericTypeJsonTypeHandler(Type type){
+    this.type = type;
+  }
+  @Override
+  public void setParameter(PreparedStatement ps, int i, Object parameter,
+    JdbcType jdbcType) throws SQLException {
+    ps.setString(i, gson.toJson(parameter));
+  }
+
+  @Override
+  public Object getResult(ResultSet rs, String columnName) throws SQLException {
+    String json = rs.getString(columnName);
+    return gson.fromJson(json, type);
+  }
+
+  @Override
+  public Object getResult(ResultSet rs, int columnIndex) throws SQLException {
+    String json = rs.getString(columnIndex);
+    return gson.fromJson(json, type);
+  }
+
+  @Override
+  public Object getResult(CallableStatement cs, int columnIndex) throws SQLException {
+    String json = cs.getString(columnIndex);
+    return gson.fromJson(json, type);
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/GenericTypeJsonTypeHandler.java
+++ b/src/test/java/org/apache/ibatis/type/GenericTypeJsonTypeHandler.java
@@ -1,3 +1,18 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 package org.apache.ibatis.type;
 
 import com.google.gson.Gson;

--- a/src/test/java/org/apache/ibatis/type/GenericTypeSupportedInHierarchiesTestCase.java
+++ b/src/test/java/org/apache/ibatis/type/GenericTypeSupportedInHierarchiesTestCase.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2019 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
If the resultType class declare a generic type field `GenericType<T> f` with type parameter `T`, then try construct typehandler with field `f`'s Class  `GenericType.class`,and type parameter `T` was erased. It will make a mistake when the typehandler deserialize data to type `GenericType` it known.