### PR TITLE
support a simple ResultMap with one or more ResultMapping which isCompositeResult

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2018 the original author or authors.
+       Copyright 2009-2020 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -245,7 +245,7 @@ lang CDATA #IMPLIED
 refid CDATA #REQUIRED
 >
 
-<!ELEMENT bind EMPTY>
+<!ELEMENT bind (#PCDATA)*>
 <!ATTLIST bind
  name CDATA #REQUIRED
  value CDATA #REQUIRED

--- a/src/main/java/org/apache/ibatis/mapping/ResultMapping.java
+++ b/src/main/java/org/apache/ibatis/mapping/ResultMapping.java
@@ -146,8 +146,10 @@ public class ResultMapping {
       if (resultMapping.nestedQueryId != null && resultMapping.nestedResultMapId != null) {
         throw new IllegalStateException("Cannot define both nestedQueryId and nestedResultMapId in property " + resultMapping.property);
       }
+
       // Issue #5: there should be no mappings without typehandler
-      if (resultMapping.nestedQueryId == null && resultMapping.nestedResultMapId == null && resultMapping.typeHandler == null) {
+      // when mapping is composites result is not need a typehandler
+      if (resultMapping.nestedQueryId == null && resultMapping.nestedResultMapId == null && resultMapping.typeHandler == null && resultMapping.composites.isEmpty()) {
         throw new IllegalStateException("No typehandler found for property " + resultMapping.property);
       }
       // Issue #4 and GH #39: column is optional only in nested resultmaps but not in the rest

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2019 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -116,6 +116,17 @@ public class XMLScriptBuilder extends BaseBuilder {
       final String expression = nodeToHandle.getStringAttribute("value");
       final VarDeclSqlNode node = new VarDeclSqlNode(name, expression);
       targetContents.add(node);
+
+      String data = nodeToHandle.getStringBody("");
+      TextSqlNode textSqlNode = new TextSqlNode(data);
+      if (textSqlNode.isDynamic()) {
+        targetContents.add(textSqlNode);
+        isDynamic = true;
+      } else {
+        targetContents.add(new StaticTextSqlNode(data));
+      }
+
+
     }
   }
 

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -101,7 +101,7 @@ public class XMLScriptBuilder extends BaseBuilder {
     return new MixedSqlNode(contents);
   }
 
-  private interface NodeHandler {
+  public interface NodeHandler {
     void handleNode(XNode nodeToHandle, List<SqlNode> targetContents);
   }
 

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -1,17 +1,17 @@
 /**
- *    Copyright 2009-2020 the original author or authors.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *       http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
+ * Copyright 2009-2020 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.apache.ibatis.scripting.xmltags;
 
@@ -118,12 +118,14 @@ public class XMLScriptBuilder extends BaseBuilder {
       targetContents.add(node);
 
       String data = nodeToHandle.getStringBody("");
-      TextSqlNode textSqlNode = new TextSqlNode(data);
-      if (textSqlNode.isDynamic()) {
-        targetContents.add(textSqlNode);
-        isDynamic = true;
-      } else {
-        targetContents.add(new StaticTextSqlNode(data));
+      if (data != null && !data.isEmpty()) {
+        TextSqlNode textSqlNode = new TextSqlNode(data);
+        if (textSqlNode.isDynamic()) {
+          targetContents.add(textSqlNode);
+          isDynamic = true;
+        } else {
+          targetContents.add(new StaticTextSqlNode(data));
+        }
       }
 
 


### PR DESCRIPTION
when do a query with a ResultMap which has one or more ResultMapping which isCompositeResult is return true and nestedResultMapId is null will throw a exception with npe.

The ResultMap is build from a JavaBean class when use the Interceptor. the ResultMap struct is such as 

```xml
<ResultMap id="...", javaType="...">
       <ResultMapping property="" column=""  javaType="...">
              <ResultMapping property="" column=""  javaType="...">
              </ResultMapping>
       </ResultMapping>
</ResultMap>
```