### PR TITLE
Validate nested result map cursor resultOrdered=true

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
@@ -174,6 +174,9 @@ public abstract class BaseExecutor implements Executor {
 
   @Override
   public <E> Cursor<E> queryCursor(MappedStatement ms, Object parameter, RowBounds rowBounds) throws SQLException {
+    if (ms.hasNestedResultMaps() && !ms.isResultOrdered()) {
+      throw new ExecutorException("Querying cursor having nested result maps with resultOrdered=false");
+    }
     BoundSql boundSql = ms.getBoundSql(parameter);
     return doQueryCursor(ms, parameter, rowBounds, boundSql);
   }

--- a/src/site/ja/xdoc/sqlmap-xml.xml
+++ b/src/site/ja/xdoc/sqlmap-xml.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2019 the original author or authors.
+       Copyright 2009-2020 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -225,6 +225,7 @@ ps.setInt(1,id);]]></source>
             <tr>
               <td><code>resultOrdered</code></td>
               <td>この属性は結果がネストされた select ステートメントでのみ有効です。true が設定された場合、MyBatis はクエリの結果が正しい順番にソートされているという前提でマッピングを実行します。これによりメモリ消費を抑えることができます。
+                Collection付きのResultMapを使うCursorの場合にはtrueが必須となります。
                 デフォルトは <code>false</code> です。
               </td>
             </tr>

--- a/src/site/xdoc/sqlmap-xml.xml
+++ b/src/site/xdoc/sqlmap-xml.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2019 the original author or authors.
+       Copyright 2009-2020 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -235,7 +235,9 @@ ps.setInt(1,id);]]></source>
               <td>This is only applicable for nested result select statements: If this is true, it
                 is assumed that nested results are contained or grouped together such that when a
                 new main result row is returned, no references to a previous result row will occur
-                anymore. This allows nested results to be filled much more memory friendly. Default:
+                anymore. This allows nested results to be filled much more memory friendly.
+                If collections exist in result map of a cursor SQL query, then this must be true and the query
+                must be ordered using the id columns of the resultMap. Default:
                 <code>false</code>.
               </td>
             </tr>

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/CreateDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2009-2016 the original author or authors.
+--    Copyright 2009-2020 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -38,3 +38,5 @@ insert into users values(4, 'User4', 1, 1);
 insert into users values(4, 'User4', 1, 2);
 insert into users values(4, 'User4', 2, 1);
 insert into users values(4, 'User4', 2, 2);
+insert into users values(1, 'User1', 3, 1);
+insert into users values(1, 'User1', 2, 4);

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
@@ -16,6 +16,8 @@
 package org.apache.ibatis.submitted.cursor_nested;
 
 import java.io.Reader;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 
 import org.apache.ibatis.BaseDataTest;
@@ -62,20 +64,28 @@ class CursorNestedTest {
       Assertions.assertFalse(usersCursor.isConsumed());
 
       User user = iterator.next();
-      Assertions.assertEquals(3, user.getGroups().size());
-      Assertions.assertEquals(4, user.getRoles().size());
+      Assertions.assertEquals(1, user.getId());
+      Assertions.assertEquals("User1", user.getName());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3", "4"), user.getRoles());
 
       user = iterator.next();
-      Assertions.assertEquals(1, user.getGroups().size());
-      Assertions.assertEquals(3, user.getRoles().size());
+      Assertions.assertEquals(2, user.getId());
+      Assertions.assertEquals("User2", user.getName());
+      Assertions.assertEquals(Collections.singletonList("1"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getRoles());
 
       user = iterator.next();
-      Assertions.assertEquals(3, user.getGroups().size());
-      Assertions.assertEquals(1, user.getRoles().size());
+      Assertions.assertEquals(3, user.getId());
+      Assertions.assertEquals("User3", user.getName());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getGroups());
+      Assertions.assertEquals(Collections.singletonList("1"), user.getRoles());
 
       user = iterator.next();
-      Assertions.assertEquals(2, user.getGroups().size());
-      Assertions.assertEquals(2, user.getRoles().size());
+      Assertions.assertEquals(4, user.getId());
+      Assertions.assertEquals("User4", user.getName());
+      Assertions.assertEquals(Arrays.asList("1", "2"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "2"), user.getRoles());
 
       Assertions.assertTrue(usersCursor.isOpen());
       Assertions.assertFalse(usersCursor.isConsumed());

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
@@ -29,6 +29,7 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class CursorNestedTest {
@@ -48,11 +49,171 @@ class CursorNestedTest {
   }
 
   @Test
-  void shouldGetAllUser() {
+  void getAllUsersSqlOrderedResultOrdered() {
     Cursor<User> usersCursor;
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
-      usersCursor = mapper.getAllUsers();
+      usersCursor = mapper.getAllUsersSqlOrderedResultOrdered();
+
+      Assertions.assertFalse(usersCursor.isOpen());
+      // Retrieving iterator, fetching is not started
+      Iterator<User> iterator = usersCursor.iterator();
+
+      // Check if hasNext, fetching is started
+      Assertions.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(usersCursor.isOpen());
+      Assertions.assertFalse(usersCursor.isConsumed());
+
+      User user = iterator.next();
+      Assertions.assertEquals(1, user.getId());
+      Assertions.assertEquals("User1", user.getName());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3", "4"), user.getRoles());
+
+      user = iterator.next();
+      Assertions.assertEquals(2, user.getId());
+      Assertions.assertEquals("User2", user.getName());
+      Assertions.assertEquals(Collections.singletonList("1"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getRoles());
+
+      user = iterator.next();
+      Assertions.assertEquals(3, user.getId());
+      Assertions.assertEquals("User3", user.getName());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getGroups());
+      Assertions.assertEquals(Collections.singletonList("1"), user.getRoles());
+
+      user = iterator.next();
+      Assertions.assertEquals(4, user.getId());
+      Assertions.assertEquals("User4", user.getName());
+      Assertions.assertEquals(Arrays.asList("1", "2"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "2"), user.getRoles());
+
+      Assertions.assertTrue(usersCursor.isOpen());
+      Assertions.assertFalse(usersCursor.isConsumed());
+
+      // Check no more elements
+      Assertions.assertFalse(iterator.hasNext());
+      Assertions.assertFalse(usersCursor.isOpen());
+      Assertions.assertTrue(usersCursor.isConsumed());
+    }
+    Assertions.assertFalse(usersCursor.isOpen());
+  }
+
+  @Test
+  void getAllUsersSqlOrderedResultUnordered() {
+    Cursor<User> usersCursor;
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      usersCursor = mapper.getAllUsersSqlOrderedResultUnordered();
+
+      Assertions.assertFalse(usersCursor.isOpen());
+      // Retrieving iterator, fetching is not started
+      Iterator<User> iterator = usersCursor.iterator();
+
+      // Check if hasNext, fetching is started
+      Assertions.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(usersCursor.isOpen());
+      Assertions.assertFalse(usersCursor.isConsumed());
+
+      User user = iterator.next();
+      Assertions.assertEquals(1, user.getId());
+      Assertions.assertEquals("User1", user.getName());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3", "4"), user.getRoles());
+
+      user = iterator.next();
+      Assertions.assertEquals(2, user.getId());
+      Assertions.assertEquals("User2", user.getName());
+      Assertions.assertEquals(Collections.singletonList("1"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getRoles());
+
+      user = iterator.next();
+      Assertions.assertEquals(3, user.getId());
+      Assertions.assertEquals("User3", user.getName());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getGroups());
+      Assertions.assertEquals(Collections.singletonList("1"), user.getRoles());
+
+      user = iterator.next();
+      Assertions.assertEquals(4, user.getId());
+      Assertions.assertEquals("User4", user.getName());
+      Assertions.assertEquals(Arrays.asList("1", "2"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "2"), user.getRoles());
+
+      Assertions.assertTrue(usersCursor.isOpen());
+      Assertions.assertFalse(usersCursor.isConsumed());
+
+      // Check no more elements
+      Assertions.assertFalse(iterator.hasNext());
+      Assertions.assertFalse(usersCursor.isOpen());
+      Assertions.assertTrue(usersCursor.isConsumed());
+    }
+    Assertions.assertFalse(usersCursor.isOpen());
+  }
+
+  @Test
+  @Disabled("Demonstration for unordered SQL misuse")
+  void getAllUsersSqlUnorderedResultOrdered() {
+    Cursor<User> usersCursor;
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      usersCursor = mapper.getAllUsersSqlUnorderedResultOrdered();
+
+      Assertions.assertFalse(usersCursor.isOpen());
+      // Retrieving iterator, fetching is not started
+      Iterator<User> iterator = usersCursor.iterator();
+
+      // Check if hasNext, fetching is started
+      Assertions.assertTrue(iterator.hasNext());
+      Assertions.assertTrue(usersCursor.isOpen());
+      Assertions.assertFalse(usersCursor.isConsumed());
+
+      User user = iterator.next();
+      Assertions.assertEquals(1, user.getId());
+      Assertions.assertEquals("User1", user.getName());
+      Assertions.assertEquals(Arrays.asList("1", "2"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getRoles());
+
+      user = iterator.next();
+      Assertions.assertEquals(2, user.getId());
+      Assertions.assertEquals("User2", user.getName());
+      Assertions.assertEquals(Collections.singletonList("1"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getRoles());
+
+      user = iterator.next();
+      Assertions.assertEquals(3, user.getId());
+      Assertions.assertEquals("User3", user.getName());
+      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getGroups());
+      Assertions.assertEquals(Collections.singletonList("1"), user.getRoles());
+
+      user = iterator.next();
+      Assertions.assertEquals(4, user.getId());
+      Assertions.assertEquals("User4", user.getName());
+      Assertions.assertEquals(Arrays.asList("1", "2"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "2"), user.getRoles());
+
+      user = iterator.next();
+      Assertions.assertEquals(1, user.getId());
+      Assertions.assertEquals("User1", user.getName());
+      Assertions.assertEquals(Arrays.asList("3", "2"), user.getGroups());
+      Assertions.assertEquals(Arrays.asList("1", "4"), user.getRoles());
+
+      Assertions.assertTrue(usersCursor.isOpen());
+      Assertions.assertFalse(usersCursor.isConsumed());
+
+      // Check no more elements
+      Assertions.assertFalse(iterator.hasNext());
+      Assertions.assertFalse(usersCursor.isOpen());
+      Assertions.assertTrue(usersCursor.isConsumed());
+    }
+    Assertions.assertFalse(usersCursor.isOpen());
+  }
+
+  @Test
+  void getAllUsersSqlUnorderedResultUnordered() {
+    Cursor<User> usersCursor;
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      usersCursor = mapper.getAllUsersSqlOrderedResultOrdered();
 
       Assertions.assertFalse(usersCursor.isOpen());
       // Retrieving iterator, fetching is not started
@@ -101,7 +262,8 @@ class CursorNestedTest {
   @Test
   void testCursorWithRowBound() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
-      Cursor<User> usersCursor = sqlSession.selectCursor("getAllUsers", null, new RowBounds(2, 1));
+      Cursor<User> usersCursor = sqlSession.selectCursor(
+        "getAllUsersSqlOrderedResultOrdered", null, new RowBounds(2, 1));
 
       Iterator<User> iterator = usersCursor.iterator();
 

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
@@ -62,8 +62,8 @@ class CursorNestedTest {
       Assertions.assertFalse(usersCursor.isConsumed());
 
       User user = iterator.next();
-      Assertions.assertEquals(2, user.getGroups().size());
-      Assertions.assertEquals(3, user.getRoles().size());
+      Assertions.assertEquals(3, user.getGroups().size());
+      Assertions.assertEquals(4, user.getRoles().size());
 
       user = iterator.next();
       Assertions.assertEquals(1, user.getGroups().size());

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
@@ -22,6 +22,7 @@ import java.util.Iterator;
 
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.cursor.Cursor;
+import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.session.RowBounds;
 import org.apache.ibatis.session.SqlSession;
@@ -100,54 +101,11 @@ class CursorNestedTest {
   }
 
   @Test
-  void getAllUsersSqlOrderedResultUnordered() {
-    Cursor<User> usersCursor;
+  void getAllUsersSqlOrderedResultUnorderedThrowsException() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
-      usersCursor = mapper.getAllUsersSqlOrderedResultUnordered();
-
-      Assertions.assertFalse(usersCursor.isOpen());
-      // Retrieving iterator, fetching is not started
-      Iterator<User> iterator = usersCursor.iterator();
-
-      // Check if hasNext, fetching is started
-      Assertions.assertTrue(iterator.hasNext());
-      Assertions.assertTrue(usersCursor.isOpen());
-      Assertions.assertFalse(usersCursor.isConsumed());
-
-      User user = iterator.next();
-      Assertions.assertEquals(1, user.getId());
-      Assertions.assertEquals("User1", user.getName());
-      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getGroups());
-      Assertions.assertEquals(Arrays.asList("1", "2", "3", "4"), user.getRoles());
-
-      user = iterator.next();
-      Assertions.assertEquals(2, user.getId());
-      Assertions.assertEquals("User2", user.getName());
-      Assertions.assertEquals(Collections.singletonList("1"), user.getGroups());
-      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getRoles());
-
-      user = iterator.next();
-      Assertions.assertEquals(3, user.getId());
-      Assertions.assertEquals("User3", user.getName());
-      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getGroups());
-      Assertions.assertEquals(Collections.singletonList("1"), user.getRoles());
-
-      user = iterator.next();
-      Assertions.assertEquals(4, user.getId());
-      Assertions.assertEquals("User4", user.getName());
-      Assertions.assertEquals(Arrays.asList("1", "2"), user.getGroups());
-      Assertions.assertEquals(Arrays.asList("1", "2"), user.getRoles());
-
-      Assertions.assertTrue(usersCursor.isOpen());
-      Assertions.assertFalse(usersCursor.isConsumed());
-
-      // Check no more elements
-      Assertions.assertFalse(iterator.hasNext());
-      Assertions.assertFalse(usersCursor.isOpen());
-      Assertions.assertTrue(usersCursor.isConsumed());
+      Assertions.assertThrows(PersistenceException.class, mapper::getAllUsersSqlOrderedResultUnordered);
     }
-    Assertions.assertFalse(usersCursor.isOpen());
   }
 
   @Test
@@ -209,54 +167,11 @@ class CursorNestedTest {
   }
 
   @Test
-  void getAllUsersSqlUnorderedResultUnordered() {
-    Cursor<User> usersCursor;
+  void getAllUsersSqlUnorderedResultUnorderedThrowsException() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
-      usersCursor = mapper.getAllUsersSqlOrderedResultOrdered();
-
-      Assertions.assertFalse(usersCursor.isOpen());
-      // Retrieving iterator, fetching is not started
-      Iterator<User> iterator = usersCursor.iterator();
-
-      // Check if hasNext, fetching is started
-      Assertions.assertTrue(iterator.hasNext());
-      Assertions.assertTrue(usersCursor.isOpen());
-      Assertions.assertFalse(usersCursor.isConsumed());
-
-      User user = iterator.next();
-      Assertions.assertEquals(1, user.getId());
-      Assertions.assertEquals("User1", user.getName());
-      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getGroups());
-      Assertions.assertEquals(Arrays.asList("1", "2", "3", "4"), user.getRoles());
-
-      user = iterator.next();
-      Assertions.assertEquals(2, user.getId());
-      Assertions.assertEquals("User2", user.getName());
-      Assertions.assertEquals(Collections.singletonList("1"), user.getGroups());
-      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getRoles());
-
-      user = iterator.next();
-      Assertions.assertEquals(3, user.getId());
-      Assertions.assertEquals("User3", user.getName());
-      Assertions.assertEquals(Arrays.asList("1", "2", "3"), user.getGroups());
-      Assertions.assertEquals(Collections.singletonList("1"), user.getRoles());
-
-      user = iterator.next();
-      Assertions.assertEquals(4, user.getId());
-      Assertions.assertEquals("User4", user.getName());
-      Assertions.assertEquals(Arrays.asList("1", "2"), user.getGroups());
-      Assertions.assertEquals(Arrays.asList("1", "2"), user.getRoles());
-
-      Assertions.assertTrue(usersCursor.isOpen());
-      Assertions.assertFalse(usersCursor.isConsumed());
-
-      // Check no more elements
-      Assertions.assertFalse(iterator.hasNext());
-      Assertions.assertFalse(usersCursor.isOpen());
-      Assertions.assertTrue(usersCursor.isConsumed());
+      Assertions.assertThrows(PersistenceException.class, mapper::getAllUsersSqlUnorderedResultUnordered);
     }
-    Assertions.assertFalse(usersCursor.isOpen());
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/Mapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,6 +19,11 @@ import org.apache.ibatis.cursor.Cursor;
 
 public interface Mapper {
 
-  Cursor<User> getAllUsers();
+  Cursor<User> getAllUsersSqlOrderedResultOrdered();
 
+  Cursor<User> getAllUsersSqlOrderedResultUnordered();
+
+  Cursor<User> getAllUsersSqlUnorderedResultOrdered();
+
+  Cursor<User> getAllUsersSqlUnorderedResultUnordered();
 }

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2019 the original author or authors.
+       Copyright 2009-2020 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -22,8 +22,20 @@
 
 <mapper namespace="org.apache.ibatis.submitted.cursor_nested.Mapper">
 
-    <select id="getAllUsers" resultMap="results" resultOrdered="true">
+    <select id="getAllUsersSqlOrderedResultOrdered" resultMap="results" resultOrdered="true">
         select * from users order by id
+    </select>
+
+    <select id="getAllUsersSqlOrderedResultUnordered" resultMap="results" resultOrdered="false">
+        select * from users order by id
+    </select>
+
+    <select id="getAllUsersSqlUnorderedResultOrdered" resultMap="results" resultOrdered="true">
+        select * from users
+    </select>
+
+    <select id="getAllUsersSqlUnorderedResultUnordered" resultMap="results" resultOrdered="false">
+        select * from users
     </select>
 
     <resultMap type="org.apache.ibatis.submitted.cursor_nested.User" id="results">


### PR DESCRIPTION
# MyBatis version
3.5.4

# Problem
https://www.javadoc.io/doc/org.mybatis/mybatis/latest/org/apache/ibatis/cursor/Cursor.html
The javadoc of `Cursor` has the following constraint:
>If you use collections in resultMaps then cursor SQL queries must be ordered (resultOrdered="true") using the id columns of the resultMap.

However, there is no validation during query execution, which may result in uncertain outcomes.
And it is not clearly stated in the documentation neither.

# Test case or example project
Added in `CursorNestedTest` in this PR.

# Steps to reproduce
1. Create a database with unordered data.
2. Execute nested resultMap cursor queries and iterate the cursor with ordered/unordered SQL queries and `resultOrdered` true/false. See results below.

# Actual result
See `CursorNestedTest` in eb4fe9aa73a8b6660f9fa699b0c773704a34d158 for the results

Case | SQL query ordered? | resultOrdered? | Outcome
----- | ----- | ----- | -----
1 | Y | Y | Correct(and memory efficient)
2 | Y | N | May have missing elements in collection during iteration, but execution appears to have no error.
3 | N | Y | New rows of an already mapped ID becomes new elements in the cursor due to the wrong resultOrdered assumption. Hard to check but it is caller's fault. 
4 | N | N | Seems to be correct given that memory is enough, but it violates Cursor javadoc anyway.

# Expected result
- MyBatis should inform callers about the constraint violation in case 2 and 4 mentioned in Cursor's javadoc rather than producing uncertain result.
- The mentioned constraint should also be stated in documentation.

# Fix
- `BaseExecutor#queryCursor` throws `ExecutorException` if `MappedStatement` has nested result maps but is not result ordered
  - It may be controversial that this may be a breaking change because existing users having implementation similar to case 2 and 4 will crash something after the fix.
But it is preferred to give users an error rather than a result which may be false positive.
(For my case, I misused it without being noticed, and brought it to production code for a days...But luckily the impact was just minor.)
Comments are welcome if a non-breaking alternative is preferred or suggested.
- Update English and Japanese documentation regarding to `resultOrdered` configuration
  - Sorry that I don't know all languages