### PR TITLE
remove a redundant Chinese character '的'

### DIFF
--- a/src/site/zh/xdoc/sqlmap-xml.xml
+++ b/src/site/zh/xdoc/sqlmap-xml.xml
@@ -1091,7 +1091,7 @@ public class User {
 
         <p>
           为了将结果注入构造方法，MyBatis 需要通过某种方式定位相应的构造方法。
-          在下面的例子中，MyBatis 搜索一个声明了三个形参的的构造方法，参数类型以
+          在下面的例子中，MyBatis 搜索一个声明了三个形参的构造方法，参数类型以
           <code>java.lang.Integer</code>, <code>java.lang.String</code> 和
           <code>int</code> 的顺序给出。
         </p>


### PR DESCRIPTION
There seems to be a redundant Chinese character '的' which was deleted by me.(shown in the following pic)

![image](https://user-images.githubusercontent.com/3983683/80867060-b23c5b00-8cc4-11ea-8f47-eaaa00e7873c.png)

Search "的的" [here](https://mybatis.org/mybatis-3/zh/sqlmap-xml.html), and you will see it. (shown in the following pic)
![image](https://user-images.githubusercontent.com/3983683/80867210-7d7cd380-8cc5-11ea-844d-ec938ba8aaec.png)


