### PR TITLE
A temporary workaround for Java 8 specific ConcurrentHashMap issue JDK-8161372

### DIFF
--- a/src/main/java/org/apache/ibatis/binding/MapperProxy.java
+++ b/src/main/java/org/apache/ibatis/binding/MapperProxy.java
@@ -91,6 +91,14 @@ public class MapperProxy<T> implements InvocationHandler, Serializable {
 
   private MapperMethodInvoker cachedInvoker(Method method) throws Throwable {
     try {
+      // A workaround for https://bugs.openjdk.java.net/browse/JDK-8161372
+      // It should be removed once the fix is backported to Java 8 or
+      // MyBatis drops Java 8 support. See gh-1929
+      MapperMethodInvoker invoker = methodCache.get(method);
+      if (invoker != null) {
+        return invoker;
+      }
+
       return methodCache.computeIfAbsent(method, m -> {
         if (m.isDefault()) {
           try {


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8161372
Should be reverted once the fix is backported or MyBatis drops Java 8 support.
Should fix #1929