### PR TITLE
Support global configuration for applying sql provider type when omit on annotation

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/ProviderSqlSource.java
@@ -100,7 +100,7 @@ public class ProviderSqlSource implements SqlSource {
       this.mapperMethod = mapperMethod;
       Lang lang = mapperMethod == null ? null : mapperMethod.getAnnotation(Lang.class);
       this.languageDriver = configuration.getLanguageDriver(lang == null ? null : lang.value());
-      this.providerType = getProviderType(provider, mapperMethod);
+      this.providerType = getProviderType(configuration, provider, mapperMethod);
       candidateProviderMethodName = (String) provider.annotationType().getMethod("method").invoke(provider);
 
       if (candidateProviderMethodName.length() == 0 && ProviderMethodResolver.class.isAssignableFrom(this.providerType)) {
@@ -235,11 +235,14 @@ public class ProviderSqlSource implements SqlSource {
     return sql != null ? sql.toString() : null;
   }
 
-  private Class<?> getProviderType(Annotation providerAnnotation, Method mapperMethod)
+  private Class<?> getProviderType(Configuration configuration, Annotation providerAnnotation, Method mapperMethod)
       throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
     Class<?> type = (Class<?>) providerAnnotation.annotationType().getMethod("type").invoke(providerAnnotation);
     Class<?> value = (Class<?>) providerAnnotation.annotationType().getMethod("value").invoke(providerAnnotation);
     if (value == void.class && type == void.class) {
+      if (configuration.getDefaultSqlProviderType() != null) {
+        return configuration.getDefaultSqlProviderType();
+      }
       throw new BuilderException("Please specify either 'value' or 'type' attribute of @"
           + providerAnnotation.annotationType().getSimpleName()
           + " at the '" + mapperMethod.toString() + "'.");

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -269,6 +269,7 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setLogPrefix(props.getProperty("logPrefix"));
     configuration.setConfigurationFactory(resolveClass(props.getProperty("configurationFactory")));
     configuration.setShrinkWhitespacesInSql(booleanValueOf(props.getProperty("shrinkWhitespacesInSql"), false));
+    configuration.setDefaultSqlProviderType(resolveClass(props.getProperty("defaultSqlProviderType")));
   }
 
   private void environmentsElement(XNode context) throws Exception {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -118,6 +118,7 @@ public class Configuration {
   protected String logPrefix;
   protected Class<? extends Log> logImpl;
   protected Class<? extends VFS> vfsImpl;
+  protected Class<?> defaultSqlProviderType;
   protected LocalCacheScope localCacheScope = LocalCacheScope.SESSION;
   protected JdbcType jdbcTypeForNull = JdbcType.OTHER;
   protected Set<String> lazyLoadTriggerMethods = new HashSet<>(Arrays.asList("equals", "clone", "hashCode", "toString"));
@@ -241,6 +242,27 @@ public class Configuration {
       this.vfsImpl = vfsImpl;
       VFS.addImplClass(this.vfsImpl);
     }
+  }
+
+  /**
+   * GEt an applying type when omit a type on sql provider annotation(e.g. {@link org.apache.ibatis.annotations.SelectProvider}).
+   *
+   * @return the default type for sql provider annotation
+   * @since 3.5.6
+   */
+  public Class<?> getDefaultSqlProviderType() {
+    return defaultSqlProviderType;
+  }
+
+  /**
+   * Sets an applying type when omit a type on sql provider annotation(e.g. {@link org.apache.ibatis.annotations.SelectProvider}).
+   *
+   * @param defaultSqlProviderType
+   *          the default type for sql provider annotation
+   * @since 3.5.6
+   */
+  public void setDefaultSqlProviderType(Class<?> defaultSqlProviderType) {
+    this.defaultSqlProviderType = defaultSqlProviderType;
   }
 
   public boolean isCallSettersOnNulls() {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -245,7 +245,7 @@ public class Configuration {
   }
 
   /**
-   * GEt an applying type when omit a type on sql provider annotation(e.g. {@link org.apache.ibatis.annotations.SelectProvider}).
+   * Gets an applying type when omit a type on sql provider annotation(e.g. {@link org.apache.ibatis.annotations.SelectProvider}).
    *
    * @return the default type for sql provider annotation
    * @since 3.5.6

--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -561,6 +561,22 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 false
               </td>
             </tr>
+            <tr>
+              <td>
+                defaultSqlProviderType
+              </td>
+              <td>
+                Specifies an sql provider class that holds provider method (Since 3.5.6).
+                This class apply to the <code>type</code>(or <code>value</code>) attribute on sql provider annotation(e.g. <code>@SelectProvider</code>),
+                when these attribute was omitted.
+              </td>
+              <td>
+                A type alias or fully qualified class name
+              </td>
+              <td>
+                Not set
+              </td>
+            </tr>
           </tbody>
         </table>
         <p>

--- a/src/site/es/xdoc/java-api.xml
+++ b/src/site/es/xdoc/java-api.xml
@@ -480,7 +480,8 @@ void rollback(boolean force)</source>
           via the <code>ProviderContext</code>(available since MyBatis 3.4.5 or later) as method argument.(In MyBatis 3.4 or later, it's allow multiple parameters)
           Atributos: value, type y method.
           El atributo value y type es el nombre completamente cualificado de una clase
-          (The <code>type</code> attribute is alias for <code>value</code>, you must be specify either one).
+          (The <code>type</code> attribute is alias for <code>value</code>, you must be specify either one.
+          But both attributes can be omit when specify the <code>defaultSqlProviderType</code> as global configuration).
           El method es el nombre un método de dicha clase
           (Since 3.5.1, you can omit <code>method</code> attribute, the MyBatis will resolve a target method via the
           <code>ProviderMethodResolver</code> interface.
@@ -633,6 +634,29 @@ class UserSqlProvider implements ProviderMethodResolver {
       ORDER_BY("id");
     }}.toString();
   }
+}]]></source>
+
+    <p>This example shows usage that share an sql provider class to all mapper methods using global configuration(Available since 3.5.6):</p>
+    <source><![CDATA[
+Configuration configuration = new Configuration();
+configuration.setDefaultSqlProviderType(TemplateFilePathProvider.class); // Specify an sql provider class for sharing on all mapper methods
+// ...]]></source>
+    <source><![CDATA[
+// Can omit the type/value attribute on sql provider annotation
+// If omit it, the MyBatis apply the class that specified on defaultSqlProviderType.
+public interface UserMapper {
+
+  @SelectProvider // Same with @SelectProvider(TemplateFilePathProvider.class)
+  User findUser(int id);
+
+  @InsertProvider // Same with @InsertProvider(TemplateFilePathProvider.class)
+  void createUser(User user);
+
+  @UpdateProvider // Same with @UpdateProvider(TemplateFilePathProvider.class)
+  void updateUser(User user);
+
+  @DeleteProvider // Same with @DeleteProvider(TemplateFilePathProvider.class)
+  void deleteUser(int id);
 }]]></source>
 
     <p>This example shows usage the default implementation of <code>ProviderMethodResolver</code>(available since MyBatis 3.5.1 or later):</p>

--- a/src/site/ja/xdoc/configuration.xml
+++ b/src/site/ja/xdoc/configuration.xml
@@ -586,6 +586,21 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 false
               </td>
             </tr>
+            <tr>
+              <td>
+                defaultSqlProviderType
+              </td>
+              <td>
+                SQLを提供するメソッドを保持するSQLプロバイダクラスを指定します(導入されたバージョン: 3.5.6)。
+                ここで指定したクラスは、SQLプロバイダアノテーション(例: <code>@SelectProvider</code>)の<code>type</code>(または <code>value</code>) 属性を省略した際に適用されます。
+              </td>
+              <td>
+                タイプエイリアスまたは完全修飾クラス名
+              </td>
+              <td>
+                未指定
+              </td>
+            </tr>
           </tbody>
         </table>
         <p>

--- a/src/site/ja/xdoc/java-api.xml
+++ b/src/site/ja/xdoc/java-api.xml
@@ -491,7 +491,8 @@ void rollback(boolean force)</source>
         なお、メソッド引数にはMapperメソッドの引数に渡したオブジェクトに加え、<code>ProviderContext</code>(MyBatis 3.4.5以降で利用可能)を介して「Mapperインタフェースの型」「Mapperメソッド」「データベースID」を渡すことができます。(MyBatis 3.4以降では、複数の引数を渡すことができます)
         キー: <code>value</code>, <code>type</code>, <code>method</code>.
         <code>value</code> と <code>type</code> にはクラスオブジェクトを指定します
-        (<code>type</code> は <code>value</code> の別名で、どちらか一方を指定する必要があります)。
+        (<code>type</code> は <code>value</code> の別名で、どちらか一方を指定する必要があります。
+        ただし、グローバル設定として<code>defaultSqlProviderType</code>を指定している場合は両方とも省略することができます)。
         <code>method</code> にはメソッド名を指定します
         (MyBatis 3.5.1以降では、<code>method</code> 属性を省略することができます。その際MyBatisは、<code>ProviderMethodResolver</code> インタフェースを介して対象メソッドの解決を試み、
         対象メソッドが解決できない場合は、<code>provideSql</code>という名前のメソッドを代替メソッドとして利用します)。
@@ -617,6 +618,29 @@ class UserSqlBuilder {
       ORDER_BY(orderByColumn);
     }}.toString();
   }
+}]]></source>
+
+    <p>次のコードは、グローバル設定を利用して全てのマッパーメソッドで同じSQLプロバイダクラスを利用する例です。(3.5.6以降で利用可能)</p>
+    <source><![CDATA[
+Configuration configuration = new Configuration();
+configuration.setDefaultSqlProviderType(TemplateFilePathProvider.class); // 全てのマッパーメソッドで利用するSQLプロバイダクラスを指定する
+// ...]]></source>
+    <source><![CDATA[
+// 各メソッドのSQLプロバイダアノテーションの type または value 属性は省略することができ、
+// 省略した場合はMyBaitsはグローバル設定の defaultSqlProviderType に指定されているクラスを適用する
+public interface UserMapper {
+
+  @SelectProvider // @SelectProvider(TemplateFilePathProvider.class) と同義
+  User findUser(int id);
+
+  @InsertProvider // @InsertProvider(TemplateFilePathProvider.class) と同義
+  void createUser(User user);
+
+  @UpdateProvider // @UpdateProvider(TemplateFilePathProvider.class) と同義
+  void updateUser(User user);
+
+  @DeleteProvider // @DeleteProvider(TemplateFilePathProvider.class) と同義
+  void deleteUser(int id);
 }]]></source>
 
     <p>次のコードは、<code>ProviderMethodResolver</code>(MyBatis 3.5.1以降で利用可能)のデフォルト実装の利用例です。</p>

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -569,6 +569,22 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 false
               </td>
             </tr>
+            <tr>
+              <td>
+                defaultSqlProviderType
+              </td>
+              <td>
+                Specifies an sql provider class that holds provider method (Since 3.5.6).
+                This class apply to the <code>type</code>(or <code>value</code>) attribute on sql provider annotation(e.g. <code>@SelectProvider</code>),
+                when these attribute was omitted.
+              </td>
+              <td>
+                A type alias or fully qualified class name
+              </td>
+              <td>
+                Not set
+              </td>
+            </tr>
           </tbody>
         </table>
         <p>위 설정을 모두 사용한 setting 엘리먼트의 예제이다:</p>

--- a/src/site/ko/xdoc/java-api.xml
+++ b/src/site/ko/xdoc/java-api.xml
@@ -605,7 +605,8 @@ void rollback(boolean force)</source>
 		매핑된 구문을 실행할 때 마이바티스는 클래스의 인스턴스를 만들고 메소드를 실행한다.
     Mapper 메서드의 인수인 "Mapper interface type" and "Database ID" 과 <code>ProviderContext</code>(Mybatis 3.4.5 부터) 를 이용한 "Mapper method" 로 전달 된 객체를 메서드 매개변수로 전달할 수 있다.(마이바티스 3.4이상에서는 복수 파라미터를 허용한다.)
 		사용가능한 속성들 : value, type, method.
-		value and type 속성은 클래스 (The <code>type</code> attribute is alias for <code>value</code>, you must be specify either one).
+		value and type 속성은 클래스 (The <code>type</code> attribute is alias for <code>value</code>, you must be specify either one.
+    But both attributes can be omit when specify the <code>defaultSqlProviderType</code> as global configuration).
 		method 속성은 메소드명이다
     (Since 3.5.1, you can omit <code>method</code> attribute, the MyBatis will resolve a target method via the
     <code>ProviderMethodResolver</code> interface.
@@ -747,6 +748,29 @@ class UserSqlBuilder {
       ORDER_BY(orderByColumn);
     }}.toString();
   }
+}]]></source>
+
+    <p>This example shows usage that share an sql provider class to all mapper methods using global configuration(Available since 3.5.6):</p>
+    <source><![CDATA[
+Configuration configuration = new Configuration();
+configuration.setDefaultSqlProviderType(TemplateFilePathProvider.class); // Specify an sql provider class for sharing on all mapper methods
+// ...]]></source>
+    <source><![CDATA[
+// Can omit the type/value attribute on sql provider annotation
+// If omit it, the MyBatis apply the class that specified on defaultSqlProviderType.
+public interface UserMapper {
+
+  @SelectProvider // Same with @SelectProvider(TemplateFilePathProvider.class)
+  User findUser(int id);
+
+  @InsertProvider // Same with @InsertProvider(TemplateFilePathProvider.class)
+  void createUser(User user);
+
+  @UpdateProvider // Same with @UpdateProvider(TemplateFilePathProvider.class)
+  void updateUser(User user);
+
+  @DeleteProvider // Same with @DeleteProvider(TemplateFilePathProvider.class)
+  void deleteUser(int id);
 }]]></source>
 
     <p>This example shows usage the default implementation of <code>ProviderMethodResolver</code>(available since MyBatis 3.5.1 or later):</p>

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -648,6 +648,22 @@ SqlSessionFactory factory =
                 false
               </td>
             </tr>
+            <tr>
+              <td>
+                defaultSqlProviderType
+              </td>
+              <td>
+                Specifies an sql provider class that holds provider method (Since 3.5.6).
+                This class apply to the <code>type</code>(or <code>value</code>) attribute on sql provider annotation(e.g. <code>@SelectProvider</code>),
+                when these attribute was omitted.
+              </td>
+              <td>
+                A type alias or fully qualified class name
+              </td>
+              <td>
+                Not set
+              </td>
+            </tr>
           </tbody>
         </table>
         <p>

--- a/src/site/xdoc/java-api.xml
+++ b/src/site/xdoc/java-api.xml
@@ -525,7 +525,8 @@ void rollback(boolean force)</source>
         (In MyBatis 3.4 or later, it's allow multiple parameters)
         Attributes: <code>value</code>, <code>type</code>, <code>method</code> and <code>databaseId</code>.
         The <code>value</code> and <code>type</code> attribute is a class
-        (The <code>type</code> attribute is alias for <code>value</code>, you must be specify either one).
+        (The <code>type</code> attribute is alias for <code>value</code>, you must be specify either one.
+        But both attributes can be omit when specify the <code>defaultSqlProviderType</code> as global configuration).
         The <code>method</code> is the name of the method on that class
         (Since 3.5.1, you can omit <code>method</code> attribute, the MyBatis will resolve a target method via the
         <code>ProviderMethodResolver</code> interface.
@@ -672,6 +673,29 @@ class UserSqlBuilder {
   }
 }]]></source>
 
+    <p>This example shows usage that share an sql provider class to all mapper methods using global configuration(Available since 3.5.6):</p>
+    <source><![CDATA[
+Configuration configuration = new Configuration();
+configuration.setDefaultSqlProviderType(TemplateFilePathProvider.class); // Specify an sql provider class for sharing on all mapper methods
+// ...]]></source>
+    <source><![CDATA[
+// Can omit the type/value attribute on sql provider annotation
+// If omit it, the MyBatis apply the class that specified on defaultSqlProviderType.
+public interface UserMapper {
+
+  @SelectProvider // Same with @SelectProvider(TemplateFilePathProvider.class)
+  User findUser(int id);
+
+  @InsertProvider // Same with @InsertProvider(TemplateFilePathProvider.class)
+  void createUser(User user);
+
+  @UpdateProvider // Same with @UpdateProvider(TemplateFilePathProvider.class)
+  void updateUser(User user);
+
+  @DeleteProvider // Same with @DeleteProvider(TemplateFilePathProvider.class)
+  void deleteUser(int id);
+}]]></source>
+
     <p>This example shows usage the default implementation of <code>ProviderMethodResolver</code>(available since MyBatis 3.5.1 or later):</p>
     <source><![CDATA[@SelectProvider(UserSqlProvider.class)
 List<User> getUsersByName(String name);
@@ -690,6 +714,7 @@ class UserSqlProvider implements ProviderMethodResolver {
     }}.toString();
   }
 }]]></source>
+
 
     <p>This example shows usage the <code>databaseId</code> attribute on the statement annotation(Available since 3.5.5):</p>
     <source><![CDATA[

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -579,6 +579,22 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 false
               </td>
             </tr>
+            <tr>
+              <td>
+                defaultSqlProviderType
+              </td>
+              <td>
+                Specifies an sql provider class that holds provider method (Since 3.5.6).
+                This class apply to the <code>type</code>(or <code>value</code>) attribute on sql provider annotation(e.g. <code>@SelectProvider</code>),
+                when these attribute was omitted.
+              </td>
+              <td>
+                A type alias or fully qualified class name
+              </td>
+              <td>
+                Not set
+              </td>
+            </tr>
           </tbody>
         </table>
         <p>

--- a/src/site/zh/xdoc/java-api.xml
+++ b/src/site/zh/xdoc/java-api.xml
@@ -464,7 +464,12 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
 </ul>
         </td>
         <td>
-        允许构建动态 SQL。这些备选的 SQL 注解允许你指定返回 SQL 语句的类和方法，以供运行时执行。（从 MyBatis 3.4.6 开始，可以使用 <code>CharSequence</code> 代替 <code>String</code> 来作为返回类型）。当执行映射语句时，MyBatis 会实例化注解指定的类，并调用注解指定的方法。你可以通过 <code>ProviderContext</code> 传递映射方法接收到的参数、"Mapper interface type" 和 "Mapper method"（仅在 MyBatis 3.4.5 以上支持）作为参数。（MyBatis 3.4 以上支持传入多个参数）属性：<code>type</code>、<code>method</code>。<code>type</code> 属性用于指定类名。<code>method</code> 用于指定该类的方法名（从版本 3.5.1 开始，可以省略 <code>method</code> 属性，MyBatis 将会使用 <code>ProviderMethodResolver</code> 接口解析方法的具体实现。如果解析失败，MyBatis 将会使用名为 <code>provideSql</code> 的降级实现）。<span class="label important">提示</span> 接下来的“SQL 语句构建器”一章将会讨论该话题，以帮助你以更清晰、更便于阅读的方式构建动态 SQL。
+        允许构建动态 SQL。这些备选的 SQL 注解允许你指定返回 SQL 语句的类和方法，以供运行时执行。（从 MyBatis 3.4.6 开始，可以使用 <code>CharSequence</code> 代替 <code>String</code> 来作为返回类型）。当执行映射语句时，MyBatis 会实例化注解指定的类，并调用注解指定的方法。你可以通过 <code>ProviderContext</code> 传递映射方法接收到的参数、"Mapper interface type" 和 "Mapper method"（仅在 MyBatis 3.4.5 以上支持）作为参数。（MyBatis 3.4 以上支持传入多个参数）
+        属性：<code>value</code>、<code>type</code>、<code>method</code>、<code>databaseId</code>。
+        <code>value</code> and <code>type</code> 属性用于指定类名
+        (The <code>type</code> attribute is alias for <code>value</code>, you must be specify either one.
+        But both attributes can be omit when specify the <code>defaultSqlProviderType</code> as global configuration)。
+        <code>method</code> 用于指定该类的方法名（从版本 3.5.1 开始，可以省略 <code>method</code> 属性，MyBatis 将会使用 <code>ProviderMethodResolver</code> 接口解析方法的具体实现。如果解析失败，MyBatis 将会使用名为 <code>provideSql</code> 的降级实现）。<span class="label important">提示</span> 接下来的“SQL 语句构建器”一章将会讨论该话题，以帮助你以更清晰、更便于阅读的方式构建动态 SQL。
         The <code>databaseId</code>(Available since 3.5.5), in case there is a configured <code>DatabaseIdProvider</code>,
         the MyBatis will use a provider method with no <code>databaseId</code> attribute or with a <code>databaseId</code>
         that matches the current one. If found with and without the <code>databaseId</code> the latter will be discarded.
@@ -579,6 +584,29 @@ class UserSqlBuilder {
       ORDER_BY(orderByColumn);
     }}.toString();
   }
+}]]></source>
+
+    <p>This example shows usage that share an sql provider class to all mapper methods using global configuration(Available since 3.5.6):</p>
+    <source><![CDATA[
+Configuration configuration = new Configuration();
+configuration.setDefaultSqlProviderType(TemplateFilePathProvider.class); // Specify an sql provider class for sharing on all mapper methods
+// ...]]></source>
+    <source><![CDATA[
+// Can omit the type/value attribute on sql provider annotation
+// If omit it, the MyBatis apply the class that specified on defaultSqlProviderType.
+public interface UserMapper {
+
+  @SelectProvider // Same with @SelectProvider(TemplateFilePathProvider.class)
+  User findUser(int id);
+
+  @InsertProvider // Same with @InsertProvider(TemplateFilePathProvider.class)
+  void createUser(User user);
+
+  @UpdateProvider // Same with @UpdateProvider(TemplateFilePathProvider.class)
+  void updateUser(User user);
+
+  @DeleteProvider // Same with @DeleteProvider(TemplateFilePathProvider.class)
+  void deleteUser(int id);
 }]]></source>
 
     <p>以下例子展示了 <code>ProviderMethodResolver</code>（3.5.1 后可用）的默认实现使用方法：

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -55,6 +55,7 @@
     <setting name="configurationFactory" value="java.lang.String"/>
     <setting name="defaultEnumTypeHandler" value="org.apache.ibatis.type.EnumOrdinalTypeHandler"/>
     <setting name="shrinkWhitespacesInSql" value="true"/>
+    <setting name="defaultSqlProviderType" value="org.apache.ibatis.builder.XmlConfigBuilderTest$MySqlProvider"/>
   </settings>
 
   <typeAliases>

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -101,6 +101,7 @@ class XmlConfigBuilderTest {
       assertNull(config.getConfigurationFactory());
       assertThat(config.getTypeHandlerRegistry().getTypeHandler(RoundingMode.class)).isInstanceOf(EnumTypeHandler.class);
       assertThat(config.isShrinkWhitespacesInSql()).isFalse();
+      assertThat(config.getDefaultSqlProviderType()).isNull();
     }
   }
 
@@ -196,6 +197,7 @@ class XmlConfigBuilderTest {
       assertThat(config.getVfsImpl().getName()).isEqualTo(JBoss6VFS.class.getName());
       assertThat(config.getConfigurationFactory().getName()).isEqualTo(String.class.getName());
       assertThat(config.isShrinkWhitespacesInSql()).isTrue();
+      assertThat(config.getDefaultSqlProviderType().getName()).isEqualTo(MySqlProvider.class.getName());
 
       assertThat(config.getTypeAliasRegistry().getTypeAliases().get("blogauthor")).isEqualTo(Author.class);
       assertThat(config.getTypeAliasRegistry().getTypeAliases().get("blog")).isEqualTo(Blog.class);
@@ -302,6 +304,13 @@ class XmlConfigBuilderTest {
     when(builder::parse);
     then(caughtException()).isInstanceOf(BuilderException.class)
       .hasMessageContaining("The properties element cannot specify both a URL and a resource based property file reference.  Please specify one or the other.");
+  }
+
+  static class MySqlProvider {
+    @SuppressWarnings("unused")
+    public static String provideSql() {
+      return "SELECT 1";
+    }
   }
 
 }


### PR DESCRIPTION
I propose to support a global configuration for applying sql provider type when omit `type` attribute on sql provider annotation(such as `@SelectProvider`, etc).
We has been supported the mechanism that use a shared sql provider class on all mapper methods, however developer need to specify explicitly the type on all mapper methods as follow:

**mapper methods (on current version):**
```java
public interface MyMapper {
  @SelectProvider(SharedSqlProvider.class)
  String select(int id);
  @UpdateProvider(SharedSqlProvider.class)
  void insert(String name);
  @UpdateProvider(SharedSqlProvider.class)
  void update(int id, String name);
  @DeleteProvider(SharedSqlProvider.class)
  void delete(int id);
}
```

There is case that  I feel it's redundant. As this changes, developer can be omit the type attribute on all mapper methods as follow:

**mapper methods:**
```java
public interface MyMapper {
  @SelectProvider
  String select(int id);
  @UpdateProvider
  void insert(String name);
  @UpdateProvider
  void update(int id, String name);
  @DeleteProvider
  void delete(int id);
}
```

**global configuration:**
```java
Configuration configuration = new Configuration();
configuration.setDefaultSqlProviderType(SharedSqlProvider.class);
// ...
```

## Note

The mybatis-thymeleaf and mybaits-freemarker provids the sql provider class(TemplateFilePathProvider) that can be use on all mapper methods. I want to use this mechanism when use these class.

* https://mybatis.org/thymeleaf-scripting/user-guide.html#_templatefilepathprovider
* http://mybatis.org/freemarker-scripting/#TemplateFilePathProvider

