### PR TITLE
Support preventing and reporting feature for SQL injection

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/BaseBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/BaseBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2019 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -47,6 +47,9 @@ public abstract class BaseBuilder {
   }
 
   protected Pattern parseExpression(String regex, String defaultValue) {
+    if (regex == null && defaultValue == null) {
+      return null;
+    }
     return Pattern.compile(regex == null ? defaultValue : regex);
   }
 
@@ -148,4 +151,5 @@ public abstract class BaseBuilder {
   protected <T> Class<? extends T> resolveAlias(String alias) {
     return typeAliasRegistry.resolveAlias(alias);
   }
+
 }

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -39,6 +39,7 @@ import org.apache.ibatis.reflection.MetaClass;
 import org.apache.ibatis.reflection.ReflectorFactory;
 import org.apache.ibatis.reflection.factory.ObjectFactory;
 import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
+import org.apache.ibatis.scripting.xmltags.DynamicSqlBehavior;
 import org.apache.ibatis.session.AutoMappingBehavior;
 import org.apache.ibatis.session.AutoMappingUnknownColumnBehavior;
 import org.apache.ibatis.session.Configuration;
@@ -270,6 +271,8 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setConfigurationFactory(resolveClass(props.getProperty("configurationFactory")));
     configuration.setShrinkWhitespacesInSql(booleanValueOf(props.getProperty("shrinkWhitespacesInSql"), false));
     configuration.setDefaultSqlProviderType(resolveClass(props.getProperty("defaultSqlProviderType")));
+    configuration.setDynamicSqlBehavior(DynamicSqlBehavior.valueOf(props.getProperty("dynamicSqlBehavior", "ALLOW")));
+    configuration.setSqlInjectionAllowPattern(parseExpression(props.getProperty("sqlInjectionAllowPattern"), null));
   }
 
   private void environmentsElement(XNode context) throws Exception {

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -272,7 +272,7 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setShrinkWhitespacesInSql(booleanValueOf(props.getProperty("shrinkWhitespacesInSql"), false));
     configuration.setDefaultSqlProviderType(resolveClass(props.getProperty("defaultSqlProviderType")));
     configuration.setDynamicSqlBehavior(DynamicSqlBehavior.valueOf(props.getProperty("dynamicSqlBehavior", "ALLOW")));
-    configuration.setSqlInjectionAllowPattern(parseExpression(props.getProperty("sqlInjectionAllowPattern"), null));
+    configuration.setStringSubstitutionFilterPattern(parseExpression(props.getProperty("stringSubstitutionFilterPattern"), null));
   }
 
   private void environmentsElement(XNode context) throws Exception {

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/DynamicSqlBehavior.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/DynamicSqlBehavior.java
@@ -1,0 +1,80 @@
+/**
+ *    Copyright 2009-2020 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.scripting.xmltags;
+
+import org.apache.ibatis.executor.ErrorContext;
+import org.apache.ibatis.logging.Log;
+import org.apache.ibatis.logging.LogFactory;
+import org.apache.ibatis.scripting.ScriptingException;
+
+/**
+ * Specify the behavior when detects a dynamic sql.
+ *
+ * @since 3.5.6
+ * @author Kazuki Shimizu
+ */
+public enum DynamicSqlBehavior {
+
+  /**
+   * Allow the dynamic sql (Default).
+   */
+  ALLOW {
+    @Override
+    public void doAction(String content) {
+      // do nothing
+    }
+  },
+
+  /**
+   * Allow the dynamic sql and output warning log.
+   * Note: The log level of {@code 'org.apache.ibatis.scripting.xmltags.DynamicSqlBehavior'} must be set to {@code WARN}.
+   */
+  WARNING {
+    @Override
+    public void doAction(String content) {
+      DynamicSqlBehavior.LogHolder.log.warn(buildMessage(content));
+    }
+  },
+
+  /**
+   * Deny the dynamic sql.
+   * Note: throw {@link ScriptingException}.
+   */
+  DENY {
+    @Override
+    public void doAction(String content) {
+      throw new ScriptingException(buildMessage(content));
+    }
+  };
+
+  /**
+   * Perform the action when detects a dynamic sql.
+   * @param content a dynamic content
+   */
+  public abstract void doAction(String content);
+
+  /**
+   * build error message.
+   */
+  private static String buildMessage(String content) {
+      return "Dynamic sql is detected. dynamic content : " + content;
+  }
+
+  private static class LogHolder {
+    private static final Log log = LogFactory.getLog(DynamicSqlBehavior.class);
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/TextSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/TextSqlNode.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2019 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -76,13 +76,14 @@ public class TextSqlNode implements SqlNode {
       }
       Object value = OgnlCache.getValue(content, context.getBindings());
       String srtValue = value == null ? "" : String.valueOf(value); // issue #274 return "" instead of "null"
-      checkInjection(srtValue);
+      checkInjection(srtValue, content);
       return srtValue;
     }
 
-    private void checkInjection(String value) {
+    private void checkInjection(String value, String expression) {
       if (injectionFilter != null && !injectionFilter.matcher(value).matches()) {
-        throw new ScriptingException("Invalid input. Please conform to regex" + injectionFilter.pattern());
+        throw new ScriptingException("Detect an invalid injection value[" + value + "] at expression[" + expression + "]." +
+          " The valid injection pattern is '" + injectionFilter.pattern() + "'.");
       }
     }
   }

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
@@ -53,7 +53,7 @@ public class XMLLanguageDriver implements LanguageDriver {
     } else {
       // issue #127
       script = PropertyParser.parse(script, configuration.getVariables());
-      TextSqlNode textSqlNode = new TextSqlNode(script, configuration.getSqlInjectionAllowPattern());
+      TextSqlNode textSqlNode = new TextSqlNode(script, configuration.getStringSubstitutionFilterPattern());
       if (textSqlNode.isDynamic()) {
         configuration.getDynamicSqlBehavior().doAction(script);
         return new DynamicSqlSource(configuration, textSqlNode);

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2015 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -53,8 +53,9 @@ public class XMLLanguageDriver implements LanguageDriver {
     } else {
       // issue #127
       script = PropertyParser.parse(script, configuration.getVariables());
-      TextSqlNode textSqlNode = new TextSqlNode(script);
+      TextSqlNode textSqlNode = new TextSqlNode(script, configuration.getSqlInjectionAllowPattern());
       if (textSqlNode.isDynamic()) {
+        configuration.getDynamicSqlBehavior().doAction(script);
         return new DynamicSqlSource(configuration, textSqlNode);
       } else {
         return new RawSqlSource(configuration, script, parameterType);

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -81,7 +81,7 @@ public class XMLScriptBuilder extends BaseBuilder {
       XNode child = node.newXNode(children.item(i));
       if (child.getNode().getNodeType() == Node.CDATA_SECTION_NODE || child.getNode().getNodeType() == Node.TEXT_NODE) {
         String data = child.getStringBody("");
-        TextSqlNode textSqlNode = new TextSqlNode(data, configuration.getSqlInjectionAllowPattern());
+        TextSqlNode textSqlNode = new TextSqlNode(data, configuration.getStringSubstitutionFilterPattern());
         if (textSqlNode.isDynamic()) {
           configuration.getDynamicSqlBehavior().doAction(data);
           contents.add(textSqlNode);

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2019 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -81,8 +81,9 @@ public class XMLScriptBuilder extends BaseBuilder {
       XNode child = node.newXNode(children.item(i));
       if (child.getNode().getNodeType() == Node.CDATA_SECTION_NODE || child.getNode().getNodeType() == Node.TEXT_NODE) {
         String data = child.getStringBody("");
-        TextSqlNode textSqlNode = new TextSqlNode(data);
+        TextSqlNode textSqlNode = new TextSqlNode(data, configuration.getSqlInjectionAllowPattern());
         if (textSqlNode.isDynamic()) {
+          configuration.getDynamicSqlBehavior().doAction(data);
           contents.add(textSqlNode);
           isDynamic = true;
         } else {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -131,7 +131,7 @@ public class Configuration {
   protected AutoMappingBehavior autoMappingBehavior = AutoMappingBehavior.PARTIAL;
   protected AutoMappingUnknownColumnBehavior autoMappingUnknownColumnBehavior = AutoMappingUnknownColumnBehavior.NONE;
   protected DynamicSqlBehavior dynamicSqlBehavior = DynamicSqlBehavior.ALLOW;
-  protected Pattern sqlInjectionAllowPattern;
+  protected Pattern stringSubstitutionFilterPattern;
 
   protected Properties variables = new Properties();
   protected ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
@@ -407,25 +407,25 @@ public class Configuration {
   }
 
   /**
-   * Gets a regex pattern that allow sql injection using substitution variable(${...}).
+   * Gets a regex pattern that allow substitution to an sql text using substitution variable({@code ${...}}).
    * <p>
    * The default value is none (this mean is allowing all value).
    * </p>
-   * @return a regex pattern that allow sql injection
+   * @return a regex pattern that allow substitution
    * @since 3.5.6
    */
-  public Pattern getSqlInjectionAllowPattern() {
-    return sqlInjectionAllowPattern;
+  public Pattern getStringSubstitutionFilterPattern() {
+    return stringSubstitutionFilterPattern;
   }
 
   /**
-   * Sets a regex pattern that allow sql injection using substitution variable(${...}).
+   * Sets a regex pattern that allow substitution to an sql text using substitution variable({@code ${...}}).
    *
-   * @param sqlInjectionAllowPattern a regex pattern that allow sql injection
+   * @param stringSubstitutionFilterPattern a regex pattern that allow substitution
    * @since 3.5.6
    */
-  public void setSqlInjectionAllowPattern(Pattern sqlInjectionAllowPattern) {
-    this.sqlInjectionAllowPattern = sqlInjectionAllowPattern;
+  public void setStringSubstitutionFilterPattern(Pattern stringSubstitutionFilterPattern) {
+    this.stringSubstitutionFilterPattern = stringSubstitutionFilterPattern;
   }
 
   public boolean isLazyLoadingEnabled() {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiFunction;
+import java.util.regex.Pattern;
 
 import org.apache.ibatis.binding.MapperRegistry;
 import org.apache.ibatis.builder.CacheRefResolver;
@@ -86,6 +87,7 @@ import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
 import org.apache.ibatis.scripting.LanguageDriver;
 import org.apache.ibatis.scripting.LanguageDriverRegistry;
 import org.apache.ibatis.scripting.defaults.RawLanguageDriver;
+import org.apache.ibatis.scripting.xmltags.DynamicSqlBehavior;
 import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
 import org.apache.ibatis.transaction.Transaction;
 import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
@@ -128,6 +130,8 @@ public class Configuration {
   protected ExecutorType defaultExecutorType = ExecutorType.SIMPLE;
   protected AutoMappingBehavior autoMappingBehavior = AutoMappingBehavior.PARTIAL;
   protected AutoMappingUnknownColumnBehavior autoMappingUnknownColumnBehavior = AutoMappingUnknownColumnBehavior.NONE;
+  protected DynamicSqlBehavior dynamicSqlBehavior = DynamicSqlBehavior.ALLOW;
+  protected Pattern sqlInjectionAllowPattern;
 
   protected Properties variables = new Properties();
   protected ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
@@ -380,6 +384,48 @@ public class Configuration {
    */
   public void setAutoMappingUnknownColumnBehavior(AutoMappingUnknownColumnBehavior autoMappingUnknownColumnBehavior) {
     this.autoMappingUnknownColumnBehavior = autoMappingUnknownColumnBehavior;
+  }
+
+  /**
+   * Gets the dynamic sql behavior(allow or deny).
+   *
+   * @return the dynamic sql behavior
+   * @since 3.5.6
+   */
+  public DynamicSqlBehavior getDynamicSqlBehavior() {
+    return dynamicSqlBehavior;
+  }
+
+  /**
+   * Sets the dynamic sql detecting behavior(allow or deny).
+   *
+   * @param dynamicSqlBehavior the dynamic sql behavior
+   * @since 3.5.6
+   */
+  public void setDynamicSqlBehavior(DynamicSqlBehavior dynamicSqlBehavior) {
+    this.dynamicSqlBehavior = dynamicSqlBehavior;
+  }
+
+  /**
+   * Gets a regex pattern that allow sql injection using substitution variable(${...}).
+   * <p>
+   * The default value is none (this mean is allowing all value).
+   * </p>
+   * @return a regex pattern that allow sql injection
+   * @since 3.5.6
+   */
+  public Pattern getSqlInjectionAllowPattern() {
+    return sqlInjectionAllowPattern;
+  }
+
+  /**
+   * Sets a regex pattern that allow sql injection using substitution variable(${...}).
+   *
+   * @param sqlInjectionAllowPattern a regex pattern that allow sql injection
+   * @since 3.5.6
+   */
+  public void setSqlInjectionAllowPattern(Pattern sqlInjectionAllowPattern) {
+    this.sqlInjectionAllowPattern = sqlInjectionAllowPattern;
   }
 
   public boolean isLazyLoadingEnabled() {

--- a/src/test/java/log4j.properties
+++ b/src/test/java/log4j.properties
@@ -1,5 +1,5 @@
 #
-#    Copyright 2009-2016 the original author or authors.
+#    Copyright 2009-2020 the original author or authors.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -20,11 +20,13 @@ log4j.rootLogger=ERROR, stdout
 ### Uncomment for MyBatis logging
 log4j.logger.org.apache.ibatis=ERROR
 
-log4j.logger.org.apache.ibatis.session.AutoMappingUnknownColumnBehavior=WARN, lastEventSavedAppender
+log4j.logger.org.apache.ibatis.session.AutoMappingUnknownColumnBehavior=WARN, autoMappingUnknownColumnBehaviorLastEventSavedAppender
+log4j.logger.org.apache.ibatis.scripting.xmltags.DynamicSqlBehavior=WARN, dynamicSqlBehaviorLastEventSavedAppender
 
 ### Console output...
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n
 
-log4j.appender.lastEventSavedAppender=org.apache.ibatis.session.AutoMappingUnknownColumnBehaviorTest$LastEventSavedAppender
+log4j.appender.autoMappingUnknownColumnBehaviorLastEventSavedAppender=org.apache.ibatis.session.AutoMappingUnknownColumnBehaviorTest$LastEventSavedAppender
+log4j.appender.dynamicSqlBehaviorLastEventSavedAppender=org.apache.ibatis.builder.AnnotationMapperBuilderTest$LastEventSavedAppender

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -56,6 +56,8 @@
     <setting name="defaultEnumTypeHandler" value="org.apache.ibatis.type.EnumOrdinalTypeHandler"/>
     <setting name="shrinkWhitespacesInSql" value="true"/>
     <setting name="defaultSqlProviderType" value="org.apache.ibatis.builder.XmlConfigBuilderTest$MySqlProvider"/>
+    <setting name="sqlInjectionAllowPattern" value="^[a-zA-Z_]$"/>
+    <setting name="dynamicSqlBehavior" value="DENY"/>
   </settings>
 
   <typeAliases>

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -56,7 +56,7 @@
     <setting name="defaultEnumTypeHandler" value="org.apache.ibatis.type.EnumOrdinalTypeHandler"/>
     <setting name="shrinkWhitespacesInSql" value="true"/>
     <setting name="defaultSqlProviderType" value="org.apache.ibatis.builder.XmlConfigBuilderTest$MySqlProvider"/>
-    <setting name="sqlInjectionAllowPattern" value="^[a-zA-Z_]$"/>
+    <setting name="stringSubstitutionFilterPattern" value="^[a-zA-Z_]$"/>
     <setting name="dynamicSqlBehavior" value="DENY"/>
   </settings>
 

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -103,7 +103,7 @@ class XmlConfigBuilderTest {
       assertThat(config.getTypeHandlerRegistry().getTypeHandler(RoundingMode.class)).isInstanceOf(EnumTypeHandler.class);
       assertThat(config.isShrinkWhitespacesInSql()).isFalse();
       assertThat(config.getDefaultSqlProviderType()).isNull();
-      assertThat(config.getSqlInjectionAllowPattern()).isNull();
+      assertThat(config.getStringSubstitutionFilterPattern()).isNull();
       assertThat(config.getDynamicSqlBehavior()).isEqualTo(DynamicSqlBehavior.ALLOW);
     }
   }
@@ -201,7 +201,7 @@ class XmlConfigBuilderTest {
       assertThat(config.getConfigurationFactory().getName()).isEqualTo(String.class.getName());
       assertThat(config.isShrinkWhitespacesInSql()).isTrue();
       assertThat(config.getDefaultSqlProviderType().getName()).isEqualTo(MySqlProvider.class.getName());
-      assertThat(config.getSqlInjectionAllowPattern().pattern()).isEqualTo("^[a-zA-Z_]$");
+      assertThat(config.getStringSubstitutionFilterPattern().pattern()).isEqualTo("^[a-zA-Z_]$");
       assertThat(config.getDynamicSqlBehavior()).isEqualTo(DynamicSqlBehavior.DENY);
 
       assertThat(config.getTypeAliasRegistry().getTypeAliases().get("blogauthor")).isEqualTo(Author.class);

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -51,6 +51,7 @@ import org.apache.ibatis.logging.slf4j.Slf4jImpl;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.mapping.ResultSetType;
 import org.apache.ibatis.scripting.defaults.RawLanguageDriver;
+import org.apache.ibatis.scripting.xmltags.DynamicSqlBehavior;
 import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
 import org.apache.ibatis.session.AutoMappingBehavior;
 import org.apache.ibatis.session.AutoMappingUnknownColumnBehavior;
@@ -102,6 +103,8 @@ class XmlConfigBuilderTest {
       assertThat(config.getTypeHandlerRegistry().getTypeHandler(RoundingMode.class)).isInstanceOf(EnumTypeHandler.class);
       assertThat(config.isShrinkWhitespacesInSql()).isFalse();
       assertThat(config.getDefaultSqlProviderType()).isNull();
+      assertThat(config.getSqlInjectionAllowPattern()).isNull();
+      assertThat(config.getDynamicSqlBehavior()).isEqualTo(DynamicSqlBehavior.ALLOW);
     }
   }
 
@@ -198,6 +201,8 @@ class XmlConfigBuilderTest {
       assertThat(config.getConfigurationFactory().getName()).isEqualTo(String.class.getName());
       assertThat(config.isShrinkWhitespacesInSql()).isTrue();
       assertThat(config.getDefaultSqlProviderType().getName()).isEqualTo(MySqlProvider.class.getName());
+      assertThat(config.getSqlInjectionAllowPattern().pattern()).isEqualTo("^[a-zA-Z_]$");
+      assertThat(config.getDynamicSqlBehavior()).isEqualTo(DynamicSqlBehavior.DENY);
 
       assertThat(config.getTypeAliasRegistry().getTypeAliases().get("blogauthor")).isEqualTo(Author.class);
       assertThat(config.getTypeAliasRegistry().getTypeAliases().get("blog")).isEqualTo(Blog.class);


### PR DESCRIPTION
I will try to fix the gh-1941 by following changes:

* Add 'dynamicSqlBehavior' that specify whether allow or deny the dynamic sql feature(=substitution variable) in sql text node
* Add 'stringSubstitutionFilterPattern' that specify allowing value pattern of substitution

WDYT?

## About 'dynamicSqlBehavior'
This option is control whether allow or not to use the dynamic sql(substitution variable) in SQL template.

e.g:

```sql
SELECT * FROM ${table} WHERE ... -- ${table} is "substitution variable"
```
 
I've defined a three options.

* `ALLOW` (default) : Allow the dynamic sql(substitution variable) in SQL template
* `WARNING` : Allow the dynamic sql, However output a warning log for reporting
* `DENY` : Throw an exception for deny the dynamic sql 


## About 'stringSubstitutionFilterPattern'

This option specify allowing value pattern(regex) at substitution variable(`${...}`). Default is not set(this mean is allow all values). 

**Note:**

The `TextSqlNode` has the filter feature for substitution value, but it not use until current version. I've change to use it in this change. I think there is case that can be prevent the SQL injection problem by this feature.  Of course, I propose not use the substitution variable for user input value.

