### PR TITLE
changed initial value assignment location

### DIFF
--- a/src/main/java/org/apache/ibatis/mapping/Environment.java
+++ b/src/main/java/org/apache/ibatis/mapping/Environment.java
@@ -33,11 +33,11 @@ public final class Environment {
     }
     if (transactionFactory == null) {
       throw new IllegalArgumentException("Parameter 'transactionFactory' must not be null");
-    }
-    this.id = id;
+    } 
     if (dataSource == null) {
       throw new IllegalArgumentException("Parameter 'dataSource' must not be null");
     }
+    this.id = id;
     this.transactionFactory = transactionFactory;
     this.dataSource = dataSource;
   }


### PR DESCRIPTION
If I write the new Envinroment(); command in the catch block, the id of the envinroment object may have been initially assigned.
