### PR TITLE
Added SQL_SERVER_SNAPSHOT value to TransactionIsolationLevel enum

### DIFF
--- a/src/main/java/org/apache/ibatis/session/TransactionIsolationLevel.java
+++ b/src/main/java/org/apache/ibatis/session/TransactionIsolationLevel.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2018 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,9 +27,9 @@ public enum TransactionIsolationLevel {
   REPEATABLE_READ(Connection.TRANSACTION_REPEATABLE_READ),
   SERIALIZABLE(Connection.TRANSACTION_SERIALIZABLE),
   /**
-  * A non-standard isolation level for Microsoft SQL Server. Defined in
-  * the SQL Server JDBC driver {@link com.microsoft.sqlserver.jdbc.ISQLServerConnection}
-  */
+   * A non-standard isolation level for Microsoft SQL Server.
+   * Defined in the SQL Server JDBC driver {@link com.microsoft.sqlserver.jdbc.ISQLServerConnection}
+   */
   SQL_SERVER_SNAPSHOT(0x1000);
 
   private final int level;

--- a/src/main/java/org/apache/ibatis/session/TransactionIsolationLevel.java
+++ b/src/main/java/org/apache/ibatis/session/TransactionIsolationLevel.java
@@ -29,6 +29,8 @@ public enum TransactionIsolationLevel {
   /**
    * A non-standard isolation level for Microsoft SQL Server.
    * Defined in the SQL Server JDBC driver {@link com.microsoft.sqlserver.jdbc.ISQLServerConnection}
+   *
+   * @since 3.5.6
    */
   SQL_SERVER_SNAPSHOT(0x1000);
 

--- a/src/main/java/org/apache/ibatis/session/TransactionIsolationLevel.java
+++ b/src/main/java/org/apache/ibatis/session/TransactionIsolationLevel.java
@@ -25,7 +25,12 @@ public enum TransactionIsolationLevel {
   READ_COMMITTED(Connection.TRANSACTION_READ_COMMITTED),
   READ_UNCOMMITTED(Connection.TRANSACTION_READ_UNCOMMITTED),
   REPEATABLE_READ(Connection.TRANSACTION_REPEATABLE_READ),
-  SERIALIZABLE(Connection.TRANSACTION_SERIALIZABLE);
+  SERIALIZABLE(Connection.TRANSACTION_SERIALIZABLE),
+  /**
+  * A non-standard isolation level for Microsoft SQL Server. Defined in
+  * the SQL Server JDBC driver {@link com.microsoft.sqlserver.jdbc.ISQLServerConnection}
+  */
+  SQL_SERVER_SNAPSHOT(0x1000);
 
   private final int level;
 


### PR DESCRIPTION
Sql Server supports a non-standard transaction isolation level called "SNAPSHOT" whose JDBC value is 0x1000 (4096). The new enum value adds support for this isolation level.

The name "SQL_SERVER_SNAPSHOT" was chosen to reflect the fact that it is unique to SQL Server to avoid confusion. See #1969 