### PR TITLE
Update link to Java Logging documentation

### DIFF
--- a/src/site/es/xdoc/logging.xml
+++ b/src/site/es/xdoc/logging.xml
@@ -86,7 +86,7 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
           <a href="http://logging.apache.org/log4j/">Apache Log4j 1.x y 2.x</a>
         </li>
         <li>
-          <a href="http://java.sun.com/j2se/1.4.1/docs/guide/util/logging/">JDK Logging API</a>
+          <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/logging/overview.html">JDK Logging API</a>
         </li>
       </ul>
       <subsection name="Configuración">

--- a/src/site/ja/xdoc/logging.xml
+++ b/src/site/ja/xdoc/logging.xml
@@ -83,7 +83,7 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
           <a href="http://logging.apache.org/log4j/">Apache Log4j</a>
         </li>
         <li>
-          <a href="http://java.sun.com/j2se/1.4.1/docs/guide/util/logging/">JDK Logging API</a>
+          <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/logging/overview.html">JDK Logging API</a>
         </li>
       </ul>
       <subsection name="Logging Configuration">

--- a/src/site/ko/xdoc/logging.xml
+++ b/src/site/ko/xdoc/logging.xml
@@ -88,7 +88,7 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
           <a href="http://logging.apache.org/log4j/">Apache Log4j</a>
         </li>
         <li>
-          <a href="http://java.sun.com/j2se/1.4.1/docs/guide/util/logging/">JDK Logging API</a>
+          <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/logging/overview.html">JDK Logging API</a>
         </li>
       </ul>
       <subsection name="Logging Configuration">

--- a/src/site/xdoc/logging.xml
+++ b/src/site/xdoc/logging.xml
@@ -113,7 +113,7 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
           <a href="http://logging.apache.org/log4j/">Apache Log4j 1.x and 2.x</a>
         </li>
         <li>
-          <a href="http://java.sun.com/j2se/1.4.1/docs/guide/util/logging/">JDK Logging API</a>
+          <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/logging/overview.html">JDK Logging API</a>
         </li>
       </ul>
       <subsection name="Logging Configuration">

--- a/src/site/zh/xdoc/logging.xml
+++ b/src/site/zh/xdoc/logging.xml
@@ -75,7 +75,7 @@ org.apache.ibatis.logging.LogFactory.useStdOutLogging();]]></source>
           <a href="http://logging.apache.org/log4j/">Apache Log4j 1.x and 2.x</a>
         </li>
         <li>
-          <a href="http://java.sun.com/j2se/1.4.1/docs/guide/util/logging/">JDK Logging API</a>
+          <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/logging/overview.html">JDK Logging API</a>
         </li>
       </ul>
       <subsection name="日志配置">


### PR DESCRIPTION
the link in logging.xml document for [JDK Logging API](http://java.sun.com/j2se/1.4.1/docs/guide/util/logging/) is no long available, change it to [https://docs.oracle.com/javase/8/docs/technotes/guides/logging/overview.html](https://docs.oracle.com/javase/8/docs/technotes/guides/logging/overview.html)