### PR TITLE
Minor optimization for GenericTokenParser

### DIFF
--- a/src/main/java/org/apache/ibatis/parsing/GenericTokenParser.java
+++ b/src/main/java/org/apache/ibatis/parsing/GenericTokenParser.java
@@ -79,7 +79,7 @@ public class GenericTokenParser {
         }
       }
       start = text.indexOf(openToken, offset);
-    }while (start > -1);
+    } while (start > -1);
     if (offset < src.length) {
       builder.append(src, offset, src.length - offset);
     }

--- a/src/main/java/org/apache/ibatis/parsing/GenericTokenParser.java
+++ b/src/main/java/org/apache/ibatis/parsing/GenericTokenParser.java
@@ -43,7 +43,7 @@ public class GenericTokenParser {
     int offset = 0;
     final StringBuilder builder = new StringBuilder();
     StringBuilder expression = null;
-    while (start > -1) {
+    do {
       if (start > 0 && src[start - 1] == '\\') {
         // this open token is escaped. remove the backslash and continue.
         builder.append(src, offset, start - offset - 1).append(openToken);
@@ -79,7 +79,7 @@ public class GenericTokenParser {
         }
       }
       start = text.indexOf(openToken, offset);
-    }
+    }while (start > -1);
     if (offset < src.length) {
       builder.append(src, offset, src.length - offset);
     }


### PR DESCRIPTION
Before `while (start > -1) `,   existing judgment  `if (start == -1)`, so I suggest to adjust `while do` to `do while`,which can reduce redundant judgment.


