### PR TITLE
Remove unnecessary null check in ClassLoaderWrapper

### DIFF
--- a/src/main/java/org/apache/ibatis/io/ClassLoaderWrapper.java
+++ b/src/main/java/org/apache/ibatis/io/ClassLoaderWrapper.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2019 the original author or authors.
+ *    Copyright 2009-2020 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/ibatis/io/ClassLoaderWrapper.java
+++ b/src/main/java/org/apache/ibatis/io/ClassLoaderWrapper.java
@@ -185,9 +185,7 @@ public class ClassLoaderWrapper {
 
           Class<?> c = Class.forName(name, true, cl);
 
-          if (null != c) {
-            return c;
-          }
+          return c;
 
         } catch (ClassNotFoundException e) {
           // we'll ignore this until all classloaders fail to locate the class

--- a/src/main/java/org/apache/ibatis/io/ClassLoaderWrapper.java
+++ b/src/main/java/org/apache/ibatis/io/ClassLoaderWrapper.java
@@ -183,9 +183,7 @@ public class ClassLoaderWrapper {
 
         try {
 
-          Class<?> c = Class.forName(name, true, cl);
-
-          return c;
+          return Class.forName(name, true, cl);
 
         } catch (ClassNotFoundException e) {
           // we'll ignore this until all classloaders fail to locate the class


### PR DESCRIPTION
when Class.forName() can not find class, will throw ClassNotFoundException install of null object