### PR TITLE
bugfix: Document site's TOC is not work

### DIFF
--- a/src/site/xdoc/sqlmap-xml.xml
+++ b/src/site/xdoc/sqlmap-xml.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2019 the original author or authors.
+       Copyright 2009-2020 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -249,7 +249,7 @@ ps.setInt(1,id);]]></source>
         </table>
       </subsection>
 
-      <subsection name="insert, update and delete">
+      <subsection name="insert update and delete">
         <p>The data modification statements insert, update and delete are very similar in their implementation:
         </p>
 


### PR DESCRIPTION
I read [this page](https://mybatis.org/mybatis-3/sqlmap-xml.html) in your web site. But this insert_update_and_delete toc is not working to moving that heading.
Like this picture..
<img width="914" alt="스크린샷 2020-08-22 오후 12 16 21" src="https://user-images.githubusercontent.com/17822723/90947504-55ca9a80-e471-11ea-8910-5ab9cf4cac2c.png">
So, I fixed sqlmap-xml.xml's Insert subsection name.  That TOC function worked well in my local...
