### PR TITLE
tostring() may result in the creation of a sqlsession

### DIFF
--- a/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
@@ -344,6 +344,11 @@ public class SqlSessionManager implements SqlSessionFactory, SqlSession {
 
     @Override
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+
+       if (args == null && "toString".equals(method.getName())){
+           return Arrays.toString(proxy.getClass().getInterfaces());
+       }
+
       final SqlSession sqlSession = SqlSessionManager.this.localSqlSession.get();
       if (sqlSession != null) {
         try {


### PR DESCRIPTION
https://github.com/mybatis/mybatis-3/blob/master/src/main/java/org/apache/ibatis/session/SqlSessionManager.java#L346-L366

During ide breakpoint debugging, the ``tostring()`` method is called because the IDE will display the value of the method parameter proxy, which may lead to the creation of ``Sqlsession``