### PR TITLE
Revert workarounds for JaCoCo issue with JDK 15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,11 @@
 language: java
 
-matrix:
-  include:
-    - jdk: openjdk15
-      env: JACOCO_SKIP="-Djacoco.skip=true"
-    - jdk: openjdk14
-    - jdk: openjdk11
-    - jdk: openjdk8
-
-script:
-  - ./mvnw test -B $JACOCO_SKIP
+jdk:
+  - openjdk15
+  - openjdk14
+  - openjdk13
+  - openjdk11
+  - openjdk8
 
 services:
   - docker

--- a/pom.xml
+++ b/pom.xml
@@ -139,9 +139,6 @@
     <osgi.import>*;resolution:=optional</osgi.import>
     <osgi.dynamicImport>*</osgi.dynamicImport>
     <spotbugs.onlyAnalyze>org.apache.ibatis.*</spotbugs.onlyAnalyze>
-
-    <!-- Remove after parent 32 (support for jdk 13on) -->
-    <jacoco.version>0.8.5</jacoco.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
JaCoCo 0.8.6 is released.

@hazendaz ,
We should do this, right?