### PR TITLE
Fixed cache invalidation caused by deleting key and then querying

### DIFF
--- a/src/main/java/org/apache/ibatis/cache/decorators/LruCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/LruCache.java
@@ -75,6 +75,7 @@ public class LruCache implements Cache {
 
   @Override
   public Object removeObject(Object key) {
+    keyMap.remove(key);
     return delegate.removeObject(key);
   }
 

--- a/src/test/java/org/apache/ibatis/cache/LruCacheTest.java
+++ b/src/test/java/org/apache/ibatis/cache/LruCacheTest.java
@@ -58,4 +58,15 @@ class LruCacheTest {
     assertNull(cache.getObject(4));
   }
 
+  @Test
+  void shouldDemonstrateWhenQueryAfterKeyWasRemoved() {
+    LruCache lruCache = new LruCache(new PerpetualCache("default"));
+    lruCache.setSize(2);
+    lruCache.putObject(2, 2);
+    lruCache.putObject(1, 1);
+    lruCache.removeObject(2);
+    lruCache.getObject(2);
+    lruCache.putObject(3, 3);
+    assertNotNull(lruCache.getObject(1));
+  }
 }


### PR DESCRIPTION
Querying again after deleting the key may invalidate other key caches