### PR TITLE
fix return Type when SubClass is a ParameterizedType with TypeVariable like T

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
+++ b/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
@@ -199,7 +199,12 @@ public class TypeParameterResolver {
       if (declaringClass == parentAsClass) {
         for (int i = 0; i < parentTypeVars.length; i++) {
           if (typeVar.equals(parentTypeVars[i])) {
-            return parentAsType.getActualTypeArguments()[i];
+            Type actualTypeArgument = parentAsType.getActualTypeArguments()[i];
+            if(actualTypeArgument instanceof TypeVariable){
+              return Object.class;
+            }else{
+              return actualTypeArgument;
+            }
           }
         }
       }


### PR DESCRIPTION
here is the code to reproduce the problem：


class classB<T> {
  protected T name;

}

class SubClassB<T> extends classB<T>{}

public class TestTypes {
  public static void main(String[] args) throws Exception {
    SubClassB<Long> aa = new SubClassB<>();

    Field field = classB.class.getDeclaredField("name");

    Type type = TypeParameterResolver.resolveFieldType(field, aa.getClass());

    System.out.println(type);

    System.out.println(type);
    System.out.println(type instanceof TypeVariable);

  }
}


the output is

T
T
true