### PR TITLE
fix issues 1960

### DIFF
--- a/src/main/java/org/apache/ibatis/mapping/MappedStatement.java
+++ b/src/main/java/org/apache/ibatis/mapping/MappedStatement.java
@@ -259,7 +259,7 @@ public final class MappedStatement {
   }
 
   public boolean isUseCache() {
-    return useCache;
+    return useCache && !flushCacheRequired;
   }
 
   public boolean isResultOrdered() {


### PR DESCRIPTION
The underlying problem,MappedStatement#isUseCache, does not consider the actual scenario working with flushCacheRequired

	1. When useCach=true, consider the following scenario
		
		when flushCacheRequired = Flushcachepolicy.DEFAULT:「L2 cahce should be checked」

		when flushCacheRequired = Flushcachepolicy.false:「L2 cahce should be checked」

		when flushCacheRequired = Flushcachepolicy.true:「There is no need to check L2 cache」

	2. When useCach=true, ignore

The above changes are the most reasonable

It only affects the MappedStatement#isUseCache method, and it is only used in CachingExecutor#query

The MappedStatement#isFlushCacheRequired method will not be affected, and the cache clearance will not be affected

Although you can change the value of useCache when the MapperAnnotationBuilder#parseStatement parses the @options annotation, it is recommended to make it more intuitive by using &&

I hope to adopt