### PR TITLE
fix bug in file org.apache.ibatis.scripting.xmltags.TrimSqlNode

### DIFF
--- a/src/main/java/org/apache/ibatis/scripting/xmltags/TrimSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/TrimSqlNode.java
@@ -84,8 +84,9 @@ public class TrimSqlNode implements SqlNode {
     }
 
     public void applyAll() {
-      sqlBuffer = new StringBuilder(sqlBuffer.toString().trim());
-      String trimmedUppercaseSql = sqlBuffer.toString().toUpperCase(Locale.ENGLISH);
+      String trimmedSql = sqlBuffer.toString().trim();
+      sqlBuffer = new StringBuilder(trimmedSql);
+      String trimmedUppercaseSql = trimmedSql.toUpperCase(Locale.ENGLISH);
       if (trimmedUppercaseSql.length() > 0) {
         applyPrefix(sqlBuffer, trimmedUppercaseSql);
         applySuffix(sqlBuffer, trimmedUppercaseSql);
@@ -136,22 +137,23 @@ public class TrimSqlNode implements SqlNode {
       }
     }
 
-    private void applySuffix(StringBuilder sql, String trimmedUppercaseSql) {
+    private void applySuffix(StringBuilder sqlSB, String trimmedUppercaseSql) {
       if (!suffixApplied) {
         suffixApplied = true;
         if (suffixesToOverride != null) {
           for (String toRemove : suffixesToOverride) {
-            if (trimmedUppercaseSql.endsWith(toRemove) || trimmedUppercaseSql.endsWith(toRemove.trim())) {
-              int start = sql.length() - toRemove.trim().length();
-              int end = sql.length();
-              sql.delete(start, end);
+	    String trimmedToRemove = toRemove.trim();
+            if (sqlSB.length() >= trimedToRemove.length() && trimmedUppercaseSql.endsWith(trimmedToRemove)) {
+              int start = sqlSB.length() - trimmedToRemove.length();
+              int end = sqlSB.length();
+              sqlSB.delete(start, end);
               break;
             }
           }
         }
         if (suffix != null) {
-          sql.append(" ");
-          sql.append(suffix);
+          sqlSB.append(" ");
+          sqlSB.append(suffix);
         }
       }
     }

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/TrimSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/TrimSqlNode.java
@@ -142,7 +142,7 @@ public class TrimSqlNode implements SqlNode {
         suffixApplied = true;
         if (suffixesToOverride != null) {
           for (String toRemove : suffixesToOverride) {
-	    String trimmedToRemove = toRemove.trim();
+            String trimmedToRemove = toRemove.trim();
             if (sqlSB.length() >= trimedToRemove.length() && trimmedUppercaseSql.endsWith(trimmedToRemove)) {
               int start = sqlSB.length() - trimmedToRemove.length();
               int end = sqlSB.length();

--- a/src/test/java/org/apache/ibatis/submitted/basetest/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/basetest/Mapper.xml
@@ -22,8 +22,28 @@
 
 <mapper namespace="org.apache.ibatis.submitted.basetest.Mapper">
 
+    <baseWhere>
+        <trim suffixOverrides="AND">
+          <if test="id != null">
+	     id = #{id} AND
+          </if>
+          <if test="name != null">
+	     name = #{name} AND
+          </if>
+        </trim>
+    </baseWhere>
     <select id="getUser" resultType="org.apache.ibatis.submitted.basetest.User">
-        select * from users where id = #{id}
+        select * 
+        from users
+        <where>
+          <trim prefixOverrides="AND" suffixOverrides="AND">
+            <include refid="baseWhere" />
+            AND
+            <if test="likeName != null">
+	       name like concat('%',#{likeName},'%') AND
+            </if>
+          </trim>
+        </where>
     </select>
 
     <insert id="insertUser">


### PR DESCRIPTION
when prefixesToOverride equals suffixesToOverride, for example "AND", and sql is "AND", it will delete "AND" twice

exception log:
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -3
        at java.lang.AbstractStringBuilder.delete(AbstractStringBuilder.java:756)
        at java.lang.StringBuilder.delete(StringBuilder.java:244)
        at org.apache.ibatis.scripting.xmltags.TrimSqlNode$FilteredDynamicContext.applySuffix(TrimSqlNode.java:147)
        at org.apache.ibatis.scripting.xmltags.TrimSqlNode$FilteredDynamicContext.applyAll(TrimSqlNode.java:91)
        at org.apache.ibatis.scripting.xmltags.TrimSqlNode.apply(TrimSqlNode.java:56)
        at org.apache.ibatis.scripting.xmltags.MixedSqlNode.apply(MixedSqlNode.java:33)
        at org.apache.ibatis.scripting.xmltags.TrimSqlNode.apply(TrimSqlNode.java:55)
        at org.apache.ibatis.scripting.xmltags.MixedSqlNode.apply(MixedSqlNode.java:33)
        at org.apache.ibatis.scripting.xmltags.DynamicSqlSource.getBoundSql(DynamicSqlSource.java:41)