### PR TITLE
mybatis-config.xml parseConfiguration - The environment is already specified. Just break out of the loop

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -287,6 +287,7 @@ public class XMLConfigBuilder extends BaseBuilder {
               .transactionFactory(txFactory)
               .dataSource(dataSource);
           configuration.setEnvironment(environmentBuilder.build());
+          break;
         }
       }
     }


### PR DESCRIPTION
In the context of parsing mybatis-config.xml -> environments element；if the environment was found, just break out of the loop