### PR TITLE
Possibility to intercept flushStatements in batch executor mode

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/BatchExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BatchExecutor.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.ibatis.cursor.Cursor;
+import org.apache.ibatis.executor.flush.FlushResultHandler;
 import org.apache.ibatis.executor.keygen.Jdbc3KeyGenerator;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
 import org.apache.ibatis.executor.keygen.NoKeyGenerator;
@@ -150,6 +151,10 @@ public class BatchExecutor extends BaseExecutor {
         }
         results.add(batchResult);
       }
+
+      final FlushResultHandler resultSetHandler = configuration.newFlushHandler(this, results);
+      resultSetHandler.handleResults();
+
       return results;
     } finally {
       for (Statement stmt : statementList) {

--- a/src/main/java/org/apache/ibatis/executor/flush/DefaultFlushResultHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/flush/DefaultFlushResultHandler.java
@@ -1,0 +1,31 @@
+package org.apache.ibatis.executor.flush;
+
+import org.apache.ibatis.executor.BatchResult;
+import org.apache.ibatis.executor.Executor;
+
+import java.util.List;
+
+/**
+ * @author : Daniel Kvasnička
+ * @inheritDoc
+ * @since : 21.01.2021
+ **/
+public class DefaultFlushResultHandler implements FlushResultHandler {
+
+  private final Executor executor;
+  private final List<BatchResult> batchResults;
+
+  public DefaultFlushResultHandler(Executor executor, List<BatchResult> batchResults) {
+    this.executor = executor;
+    this.batchResults = batchResults;
+  }
+
+  public List<BatchResult> handleResults() {
+    return this.batchResults;
+  }
+
+  public Executor getExecutor() {
+    return this.executor;
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/executor/flush/FlushResultHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/flush/FlushResultHandler.java
@@ -1,0 +1,16 @@
+package org.apache.ibatis.executor.flush;
+
+import org.apache.ibatis.executor.BatchResult;
+
+import java.util.List;
+
+/**
+ * @author : Daniel Kvasnička
+ * @inheritDoc
+ * @since : 21.01.2021
+ **/
+public interface FlushResultHandler {
+
+    List<BatchResult> handleResults();
+
+}

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -42,11 +42,9 @@ import org.apache.ibatis.cache.impl.PerpetualCache;
 import org.apache.ibatis.datasource.jndi.JndiDataSourceFactory;
 import org.apache.ibatis.datasource.pooled.PooledDataSourceFactory;
 import org.apache.ibatis.datasource.unpooled.UnpooledDataSourceFactory;
-import org.apache.ibatis.executor.BatchExecutor;
-import org.apache.ibatis.executor.CachingExecutor;
-import org.apache.ibatis.executor.Executor;
-import org.apache.ibatis.executor.ReuseExecutor;
-import org.apache.ibatis.executor.SimpleExecutor;
+import org.apache.ibatis.executor.*;
+import org.apache.ibatis.executor.flush.DefaultFlushResultHandler;
+import org.apache.ibatis.executor.flush.FlushResultHandler;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
 import org.apache.ibatis.executor.loader.ProxyFactory;
 import org.apache.ibatis.executor.loader.cglib.CglibProxyFactory;
@@ -658,6 +656,12 @@ public class Configuration {
     StatementHandler statementHandler = new RoutingStatementHandler(executor, mappedStatement, parameterObject, rowBounds, resultHandler, boundSql);
     statementHandler = (StatementHandler) interceptorChain.pluginAll(statementHandler);
     return statementHandler;
+  }
+
+  public FlushResultHandler newFlushHandler(Executor executor, List<BatchResult> flushResults) {
+    FlushResultHandler flushResultHandler = new DefaultFlushResultHandler(executor, flushResults);
+    flushResultHandler = (FlushResultHandler) interceptorChain.pluginAll(flushResultHandler);
+    return flushResultHandler;
   }
 
   public Executor newExecutor(Transaction transaction) {

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -1700,6 +1700,10 @@ public class ExampleObjectFactory extends DefaultObjectFactory {
             StatementHandler
             (prepare, parameterize, batch, update, query)
           </li>
+          <li>
+            FlushHandler
+            (handleResults)
+          </li>
         </ul>
         <p>
           The details of these classes methods can be discovered by looking


### PR DESCRIPTION
https://groups.google.com/g/mybatis-user/c/IVoEvgKhsq8 is without answer, so I paste it in here...

In our application, we are trying to implement optimistic locking via mybatis interceptor 
feature. 

We want to use mybatis in batch mode (mybatis.executor-type=batch).   

In our business logic we actually simply call update DAO method that call sql UPDATE statement.  

We defined interceptor like this:
@Intercepts({@Signature(type = Executor.class, method = "flushStatements", args = {})})

Executor.flushStatements method is internally called every time the transaction is commited. So there is no need (and we don't want to do it) to call flush method explicitly. When Executor.flushStatements is called internally from Executor.commit then this call is not invoked on proxy (Plugin) and there is no way how to intercept flushStatements method and get results (List<BatchResult>) of our update methods to resolve optimistic locking.

If we call @Flush annotated method explicitly from our business logic, interceptor works right as well as our optimistic locking implementation. But this would mean we have to call dao.flush() method every time we call dao.update() method. And we don't want to .....


Actually we solved the problem adding our custom FlushResultHandler (similar as mybatis ResultSetHandler, StatementHandler, ...) to mybatis.

To Configuration class we add:

 public FlushResultHandler newFlushHandler(Executor executor, List<BatchResult> flushResults) {

    FlushResultHandler flushResultHandler = new DefaultFlushResultHandler(executor, flushResults);

    flushResultHandler = (FlushResultHandler) interceptorChain.pluginAll(flushResultHandler);

    return flushResultHandler;

}

and to doFlushStatements method in BatchExecutor before return line (return results;) we added these lines: 

final FlushResultHandler resultSetHandler = configuration.newFlushHandler(this, results);

resultSetHandler.handleResults();

  

Our Interceptor looks like this:

@Slf4j

@Intercepts({@Signature(type = FlushResultHandler.class, method = "handleResults", args = {})})

public class OptimisticLockingInterceptor implements Interceptor {


Because there is no reply from mybatis community and I did not find any solution how to solve this problem using actual mybatis version, I ask you to add this functionallity to some next of mybatis versions

Thnak you 
Daniel