### PR TITLE
Prevent errors when accessing the cache concurrently

### DIFF
--- a/src/main/java/org/apache/ibatis/cache/decorators/WeakCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/WeakCache.java
@@ -72,9 +72,11 @@ public class WeakCache implements Cache {
       if (result == null) {
         delegate.removeObject(key);
       } else {
-        hardLinksToAvoidGarbageCollection.addFirst(result);
-        if (hardLinksToAvoidGarbageCollection.size() > numberOfHardLinks) {
-          hardLinksToAvoidGarbageCollection.removeLast();
+        synchronized (hardLinksToAvoidGarbageCollection) {
+          hardLinksToAvoidGarbageCollection.addFirst(result);
+          if (hardLinksToAvoidGarbageCollection.size() > numberOfHardLinks) {
+            hardLinksToAvoidGarbageCollection.removeLast();
+          }
         }
       }
     }
@@ -89,7 +91,9 @@ public class WeakCache implements Cache {
 
   @Override
   public void clear() {
-    hardLinksToAvoidGarbageCollection.clear();
+    synchronized (hardLinksToAvoidGarbageCollection) {
+      hardLinksToAvoidGarbageCollection.clear();
+    }
     removeGarbageCollectedItems();
     delegate.clear();
   }


### PR DESCRIPTION
Just like SoftCache, getObject() or clear() function in WeakCache need synchronized.
Because LinkedList is not synchronized， and a structural modification is any operation that adds or deletes one or more elements in .