### PR TITLE
Call to 'toArray()' with pre-sized array argument 'new String[map.key…

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
@@ -63,12 +63,12 @@ public class MapWrapper extends BaseWrapper {
 
   @Override
   public String[] getGetterNames() {
-    return map.keySet().toArray(new String[map.keySet().size()]);
+    return map.keySet().toArray(new String[0]);
   }
 
   @Override
   public String[] getSetterNames() {
-    return map.keySet().toArray(new String[map.keySet().size()]);
+    return map.keySet().toArray(new String[0]);
   }
 
   @Override


### PR DESCRIPTION
…Set().size()]'

 Inspection info: There are two styles to convert a collection to an array: either using a pre-sized array (like c.toArray(new String[c.size()])) or using an empty array (like c.toArray(new String[0]).
In older Java versions using pre-sized array was recommended, as the reflection call which is necessary to create an array of proper size was quite slow. However since late updates of OpenJDK 6 this call was intrinsified, making the performance of the empty array version the same and sometimes even better, compared to the pre-sized version. Also passing pre-sized array is dangerous for a concurrent or synchronized collection as a data race is possible between the size and toArray call which may result in extra nulls at the end of the array, if the collection was concurrently shrunk during the operation.
This inspection allows to follow the uniform style: either using an empty array (which is recommended in modern Java) or using a pre-sized array (which might be faster in older Java versions or non-HotSpot based JVMs).