### PR TITLE
add transaction close

### DIFF
--- a/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSessionFactory.java
+++ b/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSessionFactory.java
@@ -104,6 +104,7 @@ public class DefaultSqlSessionFactory implements SqlSessionFactory {
   }
 
   private SqlSession openSessionFromConnection(ExecutorType execType, Connection connection) {
+    Transaction tx = null;
     try {
       boolean autoCommit;
       try {
@@ -115,10 +116,11 @@ public class DefaultSqlSessionFactory implements SqlSessionFactory {
       }
       final Environment environment = configuration.getEnvironment();
       final TransactionFactory transactionFactory = getTransactionFactoryFromEnvironment(environment);
-      final Transaction tx = transactionFactory.newTransaction(connection);
+      tx = transactionFactory.newTransaction(connection);
       final Executor executor = configuration.newExecutor(tx, execType);
       return new DefaultSqlSession(configuration, executor, autoCommit);
     } catch (Exception e) {
+      closeTransaction(tx);
       throw ExceptionFactory.wrapException("Error opening session.  Cause: " + e, e);
     } finally {
       ErrorContext.instance().reset();


### PR DESCRIPTION
The private SqlSession openSessionFromDataSource(ExecutorType execType, TransactionIsolationLevel level, boolean autoCommit) method closes the transaction when an error occurs.

However, it does not close the private SqlSession openSessionFromConnection(ExecutorType execType, Connection connection) method.

If it wasn't closed on purpose, can you tell me why?