### PR TITLE
Argument name based constructor auto-mapping

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -269,6 +269,7 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setLogPrefix(props.getProperty("logPrefix"));
     configuration.setConfigurationFactory(resolveClass(props.getProperty("configurationFactory")));
     configuration.setShrinkWhitespacesInSql(booleanValueOf(props.getProperty("shrinkWhitespacesInSql"), false));
+    configuration.setArgNameBasedConstructorAutoMapping(booleanValueOf(props.getProperty("argNameBasedConstructorAutoMapping"), false));
     configuration.setDefaultSqlProviderType(resolveClass(props.getProperty("defaultSqlProviderType")));
   }
 

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -525,6 +525,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
     if (autoMapping == null) {
       autoMapping = new ArrayList<>();
       final List<String> unmappedColumnNames = rsw.getUnmappedColumnNames(resultMap, columnPrefix);
+      // Remove the entry to release the memory
       List<String> mappedInConstructorAutoMapping = constructorAutoMappingColumns.remove(mapKey);
       if (mappedInConstructorAutoMapping != null) {
         unmappedColumnNames.removeAll(mappedInConstructorAutoMapping);

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -774,8 +774,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
       Param paramAnno = param.getAnnotation(Param.class);
       String paramName = paramAnno == null ? param.getName() : paramAnno.value();
       for (String columnName : rsw.getColumnNames()) {
-        if (paramName.equalsIgnoreCase(
-            configuration.isMapUnderscoreToCamelCase() ? columnName.replace("_", "") : columnName)) {
+        if (columnMatchesParam(columnName, paramName, columnPrefix)) {
           Class<?> paramType = param.getType();
           TypeHandler<?> typeHandler = rsw.getTypeHandler(paramType, columnName);
           Object value = typeHandler.getResult(rsw.getResultSet(), columnName);
@@ -803,6 +802,17 @@ public class DefaultResultSetHandler implements ResultSetHandler {
           missingArgs, constructor, rsw.getColumnNames(), configuration.isMapUnderscoreToCamelCase()));
     }
     return foundValues;
+  }
+
+  private boolean columnMatchesParam(String columnName, String paramName, String columnPrefix) {
+    if (columnPrefix != null) {
+      if (!columnName.toUpperCase(Locale.ENGLISH).startsWith(columnPrefix)) {
+        return false;
+      }
+      columnName = columnName.substring(columnPrefix.length());
+    }
+    return paramName
+        .equalsIgnoreCase(configuration.isMapUnderscoreToCamelCase() ? columnName.replace("_", "") : columnName);
   }
 
   private Object createPrimitiveResultObject(ResultSetWrapper rsw, ResultMap resultMap, String columnPrefix) throws SQLException {

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -782,7 +782,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
           constructorArgs.add(value);
           final String mapKey = resultMap.getId() + ":" + columnPrefix;
           if (!autoMappingsCache.containsKey(mapKey)) {
-            constructorAutoMappingColumns.computeIfAbsent(mapKey, k -> new ArrayList<>()).add(columnName);
+            MapUtil.computeIfAbsent(constructorAutoMappingColumns, mapKey, k -> new ArrayList<>()).add(columnName);
           }
           columnNotFound = false;
           foundValues = value != null || foundValues;

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2020 the original author or authors.
+ *    Copyright 2009-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -114,6 +114,7 @@ public class Configuration {
   protected boolean useActualParamName = true;
   protected boolean returnInstanceForEmptyRow;
   protected boolean shrinkWhitespacesInSql;
+  protected boolean argNameBasedConstructorAutoMapping;
 
   protected String logPrefix;
   protected Class<? extends Log> logImpl;
@@ -295,6 +296,14 @@ public class Configuration {
 
   public void setShrinkWhitespacesInSql(boolean shrinkWhitespacesInSql) {
     this.shrinkWhitespacesInSql = shrinkWhitespacesInSql;
+  }
+
+  public boolean isArgNameBasedConstructorAutoMapping() {
+    return argNameBasedConstructorAutoMapping;
+  }
+
+  public void setArgNameBasedConstructorAutoMapping(boolean argNameBasedConstructorAutoMapping) {
+    this.argNameBasedConstructorAutoMapping = argNameBasedConstructorAutoMapping;
   }
 
   public String getDatabaseId() {

--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2021 the original author or authors.
+       Copyright 2009-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -596,7 +596,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 argNameBasedConstructorAutoMapping
               </td>
               <td>
-                When applying constructor auto-mapping, argument name is used to search the column to map instead of relying on the column order. (Since 3.5.7)
+                When applying constructor auto-mapping, argument name is used to search the column to map instead of relying on the column order. (Since 3.5.10)
               </td>
               <td>
                 true | false

--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -575,6 +575,20 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
                 Not set
+              </td>
+            </tr>
+            <tr>
+              <td>
+                argNameBasedConstructorAutoMapping
+              </td>
+              <td>
+                When applying constructor auto-mapping, argument name is used to search the column to map instead of relying on the column order. (Since 3.5.7)
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
               </td>
             </tr>
           </tbody>

--- a/src/site/ja/xdoc/configuration.xml
+++ b/src/site/ja/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2021 the original author or authors.
+       Copyright 2009-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/site/ja/xdoc/configuration.xml
+++ b/src/site/ja/xdoc/configuration.xml
@@ -620,7 +620,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 argNameBasedConstructorAutoMapping
               </td>
               <td>
-                引数を受け取るコンストラクタに対して自動マッピングを適用する際、引数名に一致する列をマップ対象にします。<code>false</code> の場合は列の順序依存となります。 (導入されたバージョン: 3.5.7）
+                引数を受け取るコンストラクタに対して自動マッピングを適用する際、引数名に一致する列をマップ対象にします。<code>false</code> の場合は列の順序依存となります。 (導入されたバージョン: 3.5.10）
               </td>
               <td>
                 true | false

--- a/src/site/ja/xdoc/configuration.xml
+++ b/src/site/ja/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -599,6 +599,20 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
                 未指定
+              </td>
+            </tr>
+            <tr>
+              <td>
+                argNameBasedConstructorAutoMapping
+              </td>
+              <td>
+                引数を受け取るコンストラクタに対して自動マッピングを適用する際、引数名に一致する列をマップ対象にします。<code>false</code> の場合は列の順序依存となります。 (導入されたバージョン: 3.5.7）
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
               </td>
             </tr>
           </tbody>

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2021 the original author or authors.
+       Copyright 2009-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -603,7 +603,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 argNameBasedConstructorAutoMapping
               </td>
               <td>
-                When applying constructor auto-mapping, argument name is used to search the column to map instead of relying on the column order. (Since 3.5.7)
+                When applying constructor auto-mapping, argument name is used to search the column to map instead of relying on the column order. (Since 3.5.10)
               </td>
               <td>
                 true | false

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -582,6 +582,20 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
                 설정하지 않음
+              </td>
+            </tr>
+            <tr>
+              <td>
+                argNameBasedConstructorAutoMapping
+              </td>
+              <td>
+                When applying constructor auto-mapping, argument name is used to search the column to map instead of relying on the column order. (Since 3.5.7)
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
               </td>
             </tr>
           </tbody>

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2021 the original author or authors.
+       Copyright 2009-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -683,7 +683,7 @@ SqlSessionFactory factory =
                 argNameBasedConstructorAutoMapping
               </td>
               <td>
-                When applying constructor auto-mapping, argument name is used to search the column to map instead of relying on the column order. (Since 3.5.7)
+                When applying constructor auto-mapping, argument name is used to search the column to map instead of relying on the column order. (Since 3.5.10)
               </td>
               <td>
                 true | false

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -662,6 +662,20 @@ SqlSessionFactory factory =
               </td>
               <td>
                 Not set
+              </td>
+            </tr>
+            <tr>
+              <td>
+                argNameBasedConstructorAutoMapping
+              </td>
+              <td>
+                When applying constructor auto-mapping, argument name is used to search the column to map instead of relying on the column order. (Since 3.5.7)
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
               </td>
             </tr>
           </tbody>

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2021 the original author or authors.
+       Copyright 2009-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -614,7 +614,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 argNameBasedConstructorAutoMapping
               </td>
               <td>
-                When applying constructor auto-mapping, argument name is used to search the column to map instead of relying on the column order. (Since 3.5.7)
+                When applying constructor auto-mapping, argument name is used to search the column to map instead of relying on the column order. (Since 3.5.10)
               </td>
               <td>
                 true | false

--- a/src/site/zh/xdoc/configuration.xml
+++ b/src/site/zh/xdoc/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -593,6 +593,20 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
                 Not set
+              </td>
+            </tr>
+            <tr>
+              <td>
+                argNameBasedConstructorAutoMapping
+              </td>
+              <td>
+                When applying constructor auto-mapping, argument name is used to search the column to map instead of relying on the column order. (Since 3.5.7)
+              </td>
+              <td>
+                true | false
+              </td>
+              <td>
+                false
               </td>
             </tr>
           </tbody>

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2021 the original author or authors.
+       Copyright 2009-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@
     <setting name="configurationFactory" value="java.lang.String"/>
     <setting name="defaultEnumTypeHandler" value="org.apache.ibatis.type.EnumOrdinalTypeHandler"/>
     <setting name="shrinkWhitespacesInSql" value="true"/>
+    <setting name="argNameBasedConstructorAutoMapping" value="true"/>
     <setting name="defaultSqlProviderType" value="org.apache.ibatis.builder.XmlConfigBuilderTest$MySqlProvider"/>
   </settings>
 

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2020 the original author or authors.
+ *    Copyright 2009-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -101,6 +101,7 @@ class XmlConfigBuilderTest {
       assertNull(config.getConfigurationFactory());
       assertThat(config.getTypeHandlerRegistry().getTypeHandler(RoundingMode.class)).isInstanceOf(EnumTypeHandler.class);
       assertThat(config.isShrinkWhitespacesInSql()).isFalse();
+      assertThat(config.isArgNameBasedConstructorAutoMapping()).isFalse();
       assertThat(config.getDefaultSqlProviderType()).isNull();
     }
   }
@@ -197,6 +198,7 @@ class XmlConfigBuilderTest {
       assertThat(config.getVfsImpl().getName()).isEqualTo(JBoss6VFS.class.getName());
       assertThat(config.getConfigurationFactory().getName()).isEqualTo(String.class.getName());
       assertThat(config.isShrinkWhitespacesInSql()).isTrue();
+      assertThat(config.isArgNameBasedConstructorAutoMapping()).isTrue();
       assertThat(config.getDefaultSqlProviderType().getName()).isEqualTo(MySqlProvider.class.getName());
 
       assertThat(config.getTypeAliasRegistry().getTypeAliases().get("blogauthor")).isEqualTo(Author.class);

--- a/src/test/java/org/apache/ibatis/builder/xsd/CustomizedSettingsMapperConfig.xml
+++ b/src/test/java/org/apache/ibatis/builder/xsd/CustomizedSettingsMapperConfig.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2020 the original author or authors.
+       Copyright 2009-2021 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@
     <setting name="vfsImpl" value="org.apache.ibatis.io.JBoss6VFS"/>
     <setting name="configurationFactory" value="java.lang.String"/>
     <setting name="shrinkWhitespacesInSql" value="true"/>
+    <setting name="argNameBasedConstructorAutoMapping" value="true"/>
   </settings>
 
   <typeAliases>

--- a/src/test/java/org/apache/ibatis/builder/xsd/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/xsd/XmlConfigBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2020 the original author or authors.
+ *    Copyright 2009-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@ class XmlConfigBuilderTest {
       assertNull(config.getLogImpl());
       assertNull(config.getConfigurationFactory());
       assertFalse(config.isShrinkWhitespacesInSql());
+      assertFalse(config.isArgNameBasedConstructorAutoMapping());
     } finally {
       // System.clearProperty(XPathParser.KEY_USE_XSD);
     }
@@ -123,6 +124,7 @@ class XmlConfigBuilderTest {
       assertEquals(JBoss6VFS.class.getName(), config.getVfsImpl().getName());
       assertEquals(String.class.getName(), config.getConfigurationFactory().getName());
       assertTrue(config.isShrinkWhitespacesInSql());
+      assertTrue(config.isArgNameBasedConstructorAutoMapping());
 
       assertEquals(Author.class, config.getTypeAliasRegistry().getTypeAliases().get("blogauthor"));
       assertEquals(Blog.class, config.getTypeAliasRegistry().getTypeAliases().get("blog"));

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/ArgNameBasedConstructorAutoMappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/ArgNameBasedConstructorAutoMappingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2009-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/ArgNameBasedConstructorAutoMappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/ArgNameBasedConstructorAutoMappingTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -121,6 +121,18 @@ class ArgNameBasedConstructorAutoMappingTest {
       User2 user = mapper.selectUserIdAndUserNameUnderscore(1);
       assertEquals(Integer.valueOf(1), user.getUserId());
       assertEquals("User1", user.getName());
+    }
+  }
+
+  @Test
+  void shouldApplyColumnPrefix() {
+    sqlSessionFactory.getConfiguration().setMapUnderscoreToCamelCase(true);
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      Task task = mapper.selectTask(11);
+      assertEquals(Integer.valueOf(1), task.getAssignee().getId());
+      assertEquals("User1!", task.getAssignee().getName());
+      assertEquals(99, task.getAssignee().getTeam());
     }
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/ArgNameBasedConstructorAutoMappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/ArgNameBasedConstructorAutoMappingTest.java
@@ -53,7 +53,7 @@ class ArgNameBasedConstructorAutoMappingTest {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = mapper.selectNameAndId(1);
       assertEquals(Integer.valueOf(1), user.getId());
-      assertEquals("User1", user.getName());
+      assertEquals("User1!", user.getName());
     }
   }
 
@@ -65,7 +65,7 @@ class ArgNameBasedConstructorAutoMappingTest {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = mapper.selectNameAndIdWithBogusLabel(1);
       assertEquals(Integer.valueOf(1), user.getId());
-      assertEquals("User1", user.getName());
+      assertEquals("User1!", user.getName());
     } finally {
       sqlSessionFactory.getConfiguration().setUseColumnLabel(true);
     }
@@ -76,7 +76,7 @@ class ArgNameBasedConstructorAutoMappingTest {
     // This test requires -parameters compiler option
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
-      User user = mapper.selectNameAndIdWithBogusLabel(1);
+      mapper.selectNameAndIdWithBogusLabel(1);
       fail("Exception should be thrown");
     } catch (PersistenceException e) {
       ExecutorException ex = (ExecutorException) e.getCause();
@@ -96,7 +96,7 @@ class ArgNameBasedConstructorAutoMappingTest {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = mapper.selectNameTeamAndId(1);
       assertEquals(Integer.valueOf(1), user.getId());
-      assertEquals("User1", user.getName());
+      assertEquals("User1!", user.getName());
       assertEquals(99, user.getTeam());
     }
   }

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/ArgNameBasedConstructorAutoMappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/ArgNameBasedConstructorAutoMappingTest.java
@@ -1,0 +1,126 @@
+/**
+ *    Copyright 2009-2021 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.arg_name_baesd_constructor_automapping;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.Reader;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.exceptions.PersistenceException;
+import org.apache.ibatis.executor.ExecutorException;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ArgNameBasedConstructorAutoMappingTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+    sqlSessionFactory.getConfiguration().setArgNameBasedConstructorAutoMapping(true);
+    // populate in-memory database
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+        "org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/CreateDB.sql");
+  }
+
+  @Test
+  void shouldFindResultsInDifferentOrder() {
+    // This test requires -parameters compiler option
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.selectNameAndId(1);
+      assertEquals(Integer.valueOf(1), user.getId());
+      assertEquals("User1", user.getName());
+    }
+  }
+
+  @Test
+  void shouldRespectUseColumnLabelSetting() {
+    // This test requires -parameters compiler option
+    sqlSessionFactory.getConfiguration().setUseColumnLabel(false);
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.selectNameAndIdWithBogusLabel(1);
+      assertEquals(Integer.valueOf(1), user.getId());
+      assertEquals("User1", user.getName());
+    } finally {
+      sqlSessionFactory.getConfiguration().setUseColumnLabel(true);
+    }
+  }
+
+  @Test
+  void shouldErrorMessageBeHelpful() {
+    // This test requires -parameters compiler option
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.selectNameAndIdWithBogusLabel(1);
+      fail("Exception should be thrown");
+    } catch (PersistenceException e) {
+      ExecutorException ex = (ExecutorException) e.getCause();
+      assertEquals(
+          "Constructor auto-mapping of 'public org.apache.ibatis.submitted.arg_name_baesd_constructor_automapping."
+              + "User(java.lang.Integer,java.lang.String)' failed "
+              + "because '[id]' were not found in the result set; "
+              + "Available columns are '[NAME, BAR]' and mapUnderscoreToCamelCase is 'true'.",
+          ex.getMessage());
+    }
+  }
+
+  @Test
+  void shouldWorkWithExtraColumns() {
+    // This test requires -parameters compiler option
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.selectNameTeamAndId(1);
+      assertEquals(Integer.valueOf(1), user.getId());
+      assertEquals("User1", user.getName());
+      assertEquals(99, user.getTeam());
+    }
+  }
+
+  @Test
+  void shouldRespectParamAnnotation() {
+    // This test requires -parameters compiler option
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User2 user = mapper.selectUserIdAndUserName(1);
+      assertEquals(Integer.valueOf(1), user.getUserId());
+      assertEquals("User1", user.getName());
+    }
+  }
+
+  @Test
+  void shouldRespectMapUnderscoreToCamelCaseSetting() {
+    // This test requires -parameters compiler option
+    sqlSessionFactory.getConfiguration().setMapUnderscoreToCamelCase(true);
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User2 user = mapper.selectUserIdAndUserNameUnderscore(1);
+      assertEquals(Integer.valueOf(1), user.getUserId());
+      assertEquals("User1", user.getName());
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/CreateDB.sql
@@ -1,0 +1,26 @@
+--
+--    Copyright 2009-2021 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       http://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(20),
+  team int
+);
+
+insert into users (id, name, team) values
+(1, 'User1', 99);

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/CreateDB.sql
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/CreateDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2009-2021 the original author or authors.
+--    Copyright 2009-2022 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.
@@ -24,3 +24,14 @@ create table users (
 
 insert into users (id, name, team) values
 (1, 'User1', 99);
+
+drop table tasks if exists;
+
+create table tasks (
+  id int,
+  name varchar(20),
+  assignee_id int
+);
+
+insert into tasks (id, name, assignee_id) values
+(11, 'Task1', 1);

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/Mapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2009-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/Mapper.java
@@ -1,0 +1,36 @@
+/**
+ *    Copyright 2009-2021 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.arg_name_baesd_constructor_automapping;
+
+import org.apache.ibatis.annotations.Select;
+
+public interface Mapper {
+
+  @Select("select name, id from users where id = #{id}")
+  User selectNameAndId(Integer id);
+
+  @Select("select name, id bar from users where id = #{id}")
+  User selectNameAndIdWithBogusLabel(Integer id);
+
+  @Select("select name, team, id from users where id = #{id}")
+  User selectNameTeamAndId(Integer id);
+
+  @Select("select name userName, id userId from users where id = #{id}")
+  User2 selectUserIdAndUserName(Integer id);
+
+  @Select("select name user_name, id user_id from users where id = #{id}")
+  User2 selectUserIdAndUserNameUnderscore(Integer id);
+}

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/Mapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/Mapper.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2022 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper
+  namespace="org.apache.ibatis.submitted.arg_name_baesd_constructor_automapping.Mapper">
+
+  <resultMap
+    type="org.apache.ibatis.submitted.arg_name_baesd_constructor_automapping.Task"
+    id="taskRM">
+    <association property="assignee" resultMap="userRM"
+      columnPrefix="u_" />
+  </resultMap>
+
+  <resultMap autoMapping="true"
+    type="org.apache.ibatis.submitted.arg_name_baesd_constructor_automapping.User"
+    id="userRM">
+  </resultMap>
+
+  <select id="selectTask" resultMap="taskRM"><![CDATA[
+    select t.id, t.name, u.name u_name, u.team u_team, u.id u_id
+    from tasks t left join users u on u.id = t.assignee_id
+    where t.id = #{id}
+  ]]></select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/Task.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/Task.java
@@ -15,24 +15,32 @@
  */
 package org.apache.ibatis.submitted.arg_name_baesd_constructor_automapping;
 
-import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Param;
 
-public interface Mapper {
+public class Task {
+  private final Integer id;
+  private final String name;
+  private User assignee;
 
-  @Select("select name, id from users where id = #{id}")
-  User selectNameAndId(Integer id);
+  public Task(@Param("id") Integer id, @Param("name") String name) {
+    super();
+    this.id = id;
+    this.name = name;
+  }
 
-  @Select("select name, id bar from users where id = #{id}")
-  User selectNameAndIdWithBogusLabel(Integer id);
+  public Integer getId() {
+    return id;
+  }
 
-  @Select("select name, team, id from users where id = #{id}")
-  User selectNameTeamAndId(Integer id);
+  public String getName() {
+    return name;
+  }
 
-  @Select("select name userName, id userId from users where id = #{id}")
-  User2 selectUserIdAndUserName(Integer id);
+  public User getAssignee() {
+    return assignee;
+  }
 
-  @Select("select name user_name, id user_id from users where id = #{id}")
-  User2 selectUserIdAndUserNameUnderscore(Integer id);
-
-  Task selectTask(Integer id);
+  public void setAssignee(User assignee) {
+    this.assignee = assignee;
+  }
 }

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2009-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User.java
@@ -24,7 +24,7 @@ public class User {
   public User(Integer id, String name) {
     super();
     this.id = id;
-    this.name = name;
+    this.name = name + "!";
   }
 
   public Integer getId() {

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User.java
@@ -1,0 +1,45 @@
+/**
+ *    Copyright 2009-2021 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.arg_name_baesd_constructor_automapping;
+
+public class User {
+
+  private Integer id;
+  private String name;
+  private Long team;
+
+  public User(Integer id, String name) {
+    super();
+    this.id = id;
+    this.name = name;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setTeam(Long team) {
+    this.team = team;
+  }
+
+  public Long getTeam() {
+    return team;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User2.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User2.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User2.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User2.java
@@ -1,4 +1,4 @@
-/**
+/*
  *    Copyright 2009-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User2.java
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/User2.java
@@ -1,0 +1,38 @@
+/**
+ *    Copyright 2009-2021 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.arg_name_baesd_constructor_automapping;
+
+import org.apache.ibatis.annotations.Param;
+
+public class User2 {
+
+  private Integer userId;
+  private String name;
+
+  public User2(Integer userId, @Param("userName") String name) {
+    super();
+    this.userId = userId;
+    this.name = name;
+  }
+
+  public Integer getUserId() {
+    return userId;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/mybatis-config.xml
+++ b/src/test/java/org/apache/ibatis/submitted/arg_name_baesd_constructor_automapping/mybatis-config.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2021 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "http://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url"
+          value="jdbc:hsqldb:mem:argNameBasedConstructorAutoMapping" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper
+      class="org.apache.ibatis.submitted.arg_name_baesd_constructor_automapping.Mapper" />
+  </mappers>
+</configuration>


### PR DESCRIPTION
An attempt at fixing #2192 

- A new option `argNameBasedConstructorAutoMapping` is added.
- When enabled, MyBatis searches a column that matches the constructor argument name.

Compared to the current (=column order based) constructor auto-mapping, name-based auto-mapping is more lenient.

- The column order is irrelevant.
- The number of columns can be greater than the number of arguments (but cannot be less).
- The columns used in constructor auto-mapping are not used in property mapping. This prevents unintuitive behavior like #2207 .

Cc: @h3adache 