### PR TITLE
it's better to use final decorate field in ParameterMappingTokenHandler class

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
@@ -68,9 +68,9 @@ public class SqlSourceBuilder extends BaseBuilder {
 
   private static class ParameterMappingTokenHandler extends BaseBuilder implements TokenHandler {
 
-    private List<ParameterMapping> parameterMappings = new ArrayList<>();
-    private Class<?> parameterType;
-    private MetaObject metaParameters;
+    private final List<ParameterMapping> parameterMappings = new ArrayList<>();
+    private final Class<?> parameterType;
+    private final MetaObject metaParameters;
 
     public ParameterMappingTokenHandler(Configuration configuration, Class<?> parameterType, Map<String, Object> additionalParameters) {
       super(configuration);


### PR DESCRIPTION
it's much better to use final decorate field in ParameterMappingTokenHandler class