### PR TITLE
Improvement: multiple-assertions unit tests into parameterized ones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.7.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <version>2.5.1</version>

--- a/src/test/java/org/apache/ibatis/parsing/GenericTokenParserTest.java
+++ b/src/test/java/org/apache/ibatis/parsing/GenericTokenParserTest.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2020 the original author or authors.
+ *    Copyright 2009-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,14 +16,19 @@
 package org.apache.ibatis.parsing;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class GenericTokenParserTest {
 
@@ -40,8 +45,9 @@ class GenericTokenParserTest {
     }
   }
 
-  @Test
-  void shouldDemonstrateGenericTokenReplacement() {
+  @ParameterizedTest
+  @MethodSource("shouldDemonstrateGenericTokenReplacementProvider")
+  void shouldDemonstrateGenericTokenReplacement(String expected, String text) {
     GenericTokenParser parser = new GenericTokenParser("${", "}", new VariableTokenHandler(new HashMap<String, String>() {
       {
         put("first_name", "James");
@@ -51,39 +57,50 @@ class GenericTokenParserTest {
         put("", "");
       }
     }));
-
-    assertEquals("James T Kirk reporting.", parser.parse("${first_name} ${initial} ${last_name} reporting."));
-    assertEquals("Hello captain James T Kirk", parser.parse("Hello captain ${first_name} ${initial} ${last_name}"));
-    assertEquals("James T Kirk", parser.parse("${first_name} ${initial} ${last_name}"));
-    assertEquals("JamesTKirk", parser.parse("${first_name}${initial}${last_name}"));
-    assertEquals("{}JamesTKirk", parser.parse("{}${first_name}${initial}${last_name}"));
-    assertEquals("}JamesTKirk", parser.parse("}${first_name}${initial}${last_name}"));
-
-    assertEquals("}James{{T}}Kirk", parser.parse("}${first_name}{{${initial}}}${last_name}"));
-    assertEquals("}James}T{Kirk", parser.parse("}${first_name}}${initial}{${last_name}"));
-    assertEquals("}James}T{Kirk", parser.parse("}${first_name}}${initial}{${last_name}"));
-    assertEquals("}James}T{Kirk{{}}", parser.parse("}${first_name}}${initial}{${last_name}{{}}"));
-    assertEquals("}James}T{Kirk{{}}", parser.parse("}${first_name}}${initial}{${last_name}{{}}${}"));
-
-    assertEquals("{$$something}JamesTKirk", parser.parse("{$$something}${first_name}${initial}${last_name}"));
-    assertEquals("${", parser.parse("${"));
-    assertEquals("${\\}", parser.parse("${\\}"));
-    assertEquals("Hiya", parser.parse("${var{with\\}brace}"));
-    assertEquals("", parser.parse("${}"));
-    assertEquals("}", parser.parse("}"));
-    assertEquals("Hello ${ this is a test.", parser.parse("Hello ${ this is a test."));
-    assertEquals("Hello } this is a test.", parser.parse("Hello } this is a test."));
-    assertEquals("Hello } ${ this is a test.", parser.parse("Hello } ${ this is a test."));
+    assertEquals(expected, parser.parse(text));
   }
 
-  @Test
-  void shallNotInterpolateSkippedVaiables() {
-    GenericTokenParser parser = new GenericTokenParser("${", "}", new VariableTokenHandler(new HashMap<>()));
+  static Stream<Arguments> shouldDemonstrateGenericTokenReplacementProvider() {
+    return Stream.of(
+      arguments("James T Kirk reporting.", "${first_name} ${initial} ${last_name} reporting."),
+      arguments("Hello captain James T Kirk", "Hello captain ${first_name} ${initial} ${last_name}"),
+      arguments("James T Kirk", "${first_name} ${initial} ${last_name}"),
+      arguments("JamesTKirk", "${first_name}${initial}${last_name}"),
+      arguments("{}JamesTKirk", "{}${first_name}${initial}${last_name}"),
+      arguments("}JamesTKirk", "}${first_name}${initial}${last_name}"),
 
-    assertEquals("${skipped} variable", parser.parse("\\${skipped} variable"));
-    assertEquals("This is a ${skipped} variable", parser.parse("This is a \\${skipped} variable"));
-    assertEquals("null ${skipped} variable", parser.parse("${skipped} \\${skipped} variable"));
-    assertEquals("The null is ${skipped} variable", parser.parse("The ${skipped} is \\${skipped} variable"));
+      arguments("}James{{T}}Kirk", "}${first_name}{{${initial}}}${last_name}"),
+      arguments("}James}T{Kirk", "}${first_name}}${initial}{${last_name}"),
+      arguments("}James}T{Kirk", "}${first_name}}${initial}{${last_name}"),
+      arguments("}James}T{Kirk{{}}", "}${first_name}}${initial}{${last_name}{{}}"),
+      arguments("}James}T{Kirk{{}}", "}${first_name}}${initial}{${last_name}{{}}${}"),
+
+      arguments("{$$something}JamesTKirk", "{$$something}${first_name}${initial}${last_name}"),
+      arguments("${", "${"),
+      arguments("${\\}", "${\\}"),
+      arguments("Hiya", "${var{with\\}brace}"),
+      arguments("", "${}"),
+      arguments("}", "}"),
+      arguments("Hello ${ this is a test.", "Hello ${ this is a test."),
+      arguments("Hello } this is a test.", "Hello } this is a test."),
+      arguments("Hello } ${ this is a test.", "Hello } ${ this is a test.")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("shallNotInterpolateSkippedVariablesProvider")
+  void shallNotInterpolateSkippedVariables(String expected, String text) {
+    GenericTokenParser parser = new GenericTokenParser("${", "}", new VariableTokenHandler(new HashMap<>()));
+    assertEquals(expected, parser.parse(text));
+  }
+
+  static Stream<Arguments> shallNotInterpolateSkippedVariablesProvider() {
+    return Stream.of(
+      arguments("${skipped} variable", "\\${skipped} variable"),
+      arguments("This is a ${skipped} variable", "This is a \\${skipped} variable"),
+      arguments("null ${skipped} variable", "${skipped} \\${skipped} variable"),
+      arguments("The null is ${skipped} variable", "The ${skipped} is \\${skipped} variable")
+    );
   }
 
   @Disabled("Because it randomly fails on Travis CI. It could be useful during development.")


### PR DESCRIPTION
**Problem:**
A test method with many individual assertions stops being executed on the first failed assertion, which prevents the remaining ones' execution. In the refactored methods, the difference between the assertions lies in different arguments only.

**Solution:**
Parameterized tests make it possible to run a test multiple times, with different arguments, as individual and independent tests. This way, we were able to make 2 original tests become 24 independent ones. In this refactoring, no original assertion parameter was changed.

**Additional change:**
Maven dependency concerning the JUnit params library was also added.