### PR TITLE
Enrich debug log of PreparedStatement

### DIFF
--- a/src/main/java/org/apache/ibatis/logging/jdbc/PreparedStatementLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/PreparedStatementLogger.java
@@ -50,6 +50,7 @@ public final class PreparedStatementLogger extends BaseJdbcLogger implements Inv
       if (EXECUTE_METHODS.contains(method.getName())) {
         if (isDebugEnabled()) {
           debug("Parameters: " + getParameterValueString(), true);
+          debug("PreparedStatement: " + statement, true);
         }
         clearColumnInfo();
         if ("executeQuery".equals(method.getName())) {

--- a/src/test/java/org/apache/ibatis/logging/jdbc/PreparedStatementLoggerTest.java
+++ b/src/test/java/org/apache/ibatis/logging/jdbc/PreparedStatementLoggerTest.java
@@ -79,6 +79,20 @@ class PreparedStatementLoggerTest {
   }
 
   @Test
+  void shouldPrintPreparedStatement() throws SQLException {
+    when(log.isDebugEnabled()).thenReturn(true);
+    when(preparedStatement.executeQuery(anyString())).thenReturn(resultSet);
+    when(preparedStatement.toString()).thenReturn("DummyStatement: select 1 limit 10");
+
+    ps.setInt(1, 10);
+    ResultSet rs = ps.executeQuery("select 1 limit ?");
+
+    verify(log).debug(contains("PreparedStatement: DummyStatement: select 1 limit 10"));
+    Assertions.assertNotNull(rs);
+    Assertions.assertNotSame(resultSet, rs);
+  }
+
+  @Test
   void shouldNotPrintLog() throws SQLException {
     ps.getResultSet();
     ps.getParameterMetaData();


### PR DESCRIPTION
When debugging SQL, developers may enable the DEBUG level log to see the detail of statement which is prepared for executing. I know that MyBatis provides a user friendly log which contains SQL with placeholders and parameters. However, user have to combine the parameters and SQL together before they execute the complete SQL in their database. Some of the JDBC driver (like MySQL CJ) implements `PreparedStatement` with a `toString()` method which can prompt developers the complete SQL with all placeholders replaced by actual parameters. This pull request aims to print out the this sort of debugging information via `PreparedStatementLogger`.