### PR TITLE
Support annotation that allow annotated property to be used when reading and writing Enum to DB

### DIFF
--- a/src/main/java/org/apache/ibatis/type/DbValue.java
+++ b/src/main/java/org/apache/ibatis/type/DbValue.java
@@ -1,0 +1,30 @@
+package org.apache.ibatis.type;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The annotation that specify property of enum to be used for database I/O.
+ * See also: {@link EnumTypeHandler}
+ * <p>
+ * <b>How to use:</b>
+ * <pre>
+ * public enum ExampleEnum {
+ *   EX1,EX2;
+ *
+ *  {@literal @DbValue}
+ *   public String getDbCode() {
+ *     return this.name().toLowerCase();
+ *   }
+ * }
+ * </pre>
+ * @author umbum
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface DbValue {
+}

--- a/src/main/java/org/apache/ibatis/type/EnumTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/EnumTypeHandler.java
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2009-2017 the original author or authors.
+ *    Copyright 2009-2021 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,49 +15,100 @@
  */
 package org.apache.ibatis.type;
 
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Member;
+import java.lang.reflect.Method;
 import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * @author Clinton Begin
+ * @author umbum
  */
 public class EnumTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E> {
 
-  private final Class<E> type;
+  private final Map<String, E> enumConstantDirectory;
+  private final Field fieldAnnotatedByDbValue;
+  private final Method methodAnnotatedByDbValue;
 
   public EnumTypeHandler(Class<E> type) {
     if (type == null) {
       throw new IllegalArgumentException("Type argument cannot be null");
     }
-    this.type = type;
+
+    E[] universe = type.getEnumConstants();
+    if (universe == null) {
+      throw new IllegalArgumentException(type.getSimpleName() + " is not an enum type");
+    }
+
+    List<Field> fieldsAnnotatedByDbValue = getAnnotatedMembers(type.getDeclaredFields());
+    List<Method> methodsAnnotatedByDbValue = getAnnotatedMembers(type.getDeclaredMethods());
+
+    if (methodsAnnotatedByDbValue.size() + fieldsAnnotatedByDbValue.size() > 1) {
+      throw new IllegalArgumentException(type.getSimpleName() + ": Multiple '@DbValue' properties defined.");
+    }
+
+    fieldAnnotatedByDbValue =
+      (fieldsAnnotatedByDbValue.size() == 1) ? fieldsAnnotatedByDbValue.get(0) : null;
+    methodAnnotatedByDbValue =
+      (methodsAnnotatedByDbValue.size() == 1) ? methodsAnnotatedByDbValue.get(0) : null;
+
+    if (fieldAnnotatedByDbValue != null) {
+      fieldAnnotatedByDbValue.setAccessible(true);
+    }
+
+    enumConstantDirectory = Arrays.stream(universe)
+      .collect(Collectors.toMap(e -> getDbValue(e), e -> e));
+  }
+
+  private <T extends Member & AnnotatedElement> List<T> getAnnotatedMembers(T[] members) {
+    return Arrays.stream(members)
+      .filter(field -> field.isAnnotationPresent(DbValue.class))
+      .collect(Collectors.toList());
+  }
+
+  private String getDbValue(E e) {
+    try {
+      return fieldAnnotatedByDbValue != null ? (String)fieldAnnotatedByDbValue.get(e)
+        : methodAnnotatedByDbValue != null ? (String)methodAnnotatedByDbValue.invoke(e)
+        : e.name();
+    } catch (IllegalAccessException | InvocationTargetException ex) {
+      throw new IllegalStateException("Unexpected reflection exception", ex);
+    }
   }
 
   @Override
   public void setNonNullParameter(PreparedStatement ps, int i, E parameter, JdbcType jdbcType) throws SQLException {
     if (jdbcType == null) {
-      ps.setString(i, parameter.name());
+      ps.setString(i, getDbValue(parameter));
     } else {
-      ps.setObject(i, parameter.name(), jdbcType.TYPE_CODE); // see r3589
+      ps.setObject(i, getDbValue(parameter), jdbcType.TYPE_CODE); // see r3589
     }
   }
 
   @Override
   public E getNullableResult(ResultSet rs, String columnName) throws SQLException {
     String s = rs.getString(columnName);
-    return s == null ? null : Enum.valueOf(type, s);
+    return s == null ? null : enumConstantDirectory.get(s);
   }
 
   @Override
   public E getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
     String s = rs.getString(columnIndex);
-    return s == null ? null : Enum.valueOf(type, s);
+    return s == null ? null : enumConstantDirectory.get(s);
   }
 
   @Override
   public E getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
     String s = cs.getString(columnIndex);
-    return s == null ? null : Enum.valueOf(type, s);
+    return s == null ? null : enumConstantDirectory.get(s);
   }
 }


### PR DESCRIPTION
Do you have any plans to support specific property of Enum to be used as DB input/output values instead of `Enum.name()`?

Since there is no predefined feature support(like annotation), each developer who wants to these feature have to implement it by themselves.

Because property name of App layer should not affect attribute name of DB layer and vice versa, I think a lot of people might want this feature.

Although I've include it in EnumTypeHandler, it would be also good to be provided as another builtin EnumTypeHandler, or make it as an example.