### PR TITLE
Allow custom ognl for XMLLanguageDriver

### DIFF
--- a/src/main/java/org/apache/ibatis/scripting/xmltags/ForEachSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/ForEachSqlNode.java
@@ -37,7 +37,11 @@ public class ForEachSqlNode implements SqlNode {
   private final Configuration configuration;
 
   public ForEachSqlNode(Configuration configuration, SqlNode contents, String collectionExpression, String index, String item, String open, String close, String separator) {
-    this.evaluator = new ExpressionEvaluator();
+    this(new XMLLanguageDriver(), configuration, contents, collectionExpression, index, item, open, close, separator);
+  }
+
+  public ForEachSqlNode(XMLLanguageDriver xmlLanguageDriver, Configuration configuration, SqlNode contents, String collectionExpression, String index, String item, String open, String close, String separator) {
+    this.evaluator = xmlLanguageDriver.newExpressionEvaluator();
     this.collectionExpression = collectionExpression;
     this.contents = contents;
     this.open = open;

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/IfSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/IfSqlNode.java
@@ -24,9 +24,13 @@ public class IfSqlNode implements SqlNode {
   private final SqlNode contents;
 
   public IfSqlNode(SqlNode contents, String test) {
+    this(new XMLLanguageDriver(), contents, test);
+  }
+
+  public IfSqlNode(XMLLanguageDriver xmlLanguageDriver, SqlNode contents, String test) {
     this.test = test;
     this.contents = contents;
-    this.evaluator = new ExpressionEvaluator();
+    this.evaluator = xmlLanguageDriver.newExpressionEvaluator();
   }
 
   @Override

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
@@ -15,6 +15,8 @@
  */
 package org.apache.ibatis.scripting.xmltags;
 
+import java.util.Map;
+
 import org.apache.ibatis.builder.xml.XMLMapperEntityResolver;
 import org.apache.ibatis.executor.parameter.ParameterHandler;
 import org.apache.ibatis.mapping.BoundSql;
@@ -40,7 +42,7 @@ public class XMLLanguageDriver implements LanguageDriver {
 
   @Override
   public SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType) {
-    XMLScriptBuilder builder = new XMLScriptBuilder(configuration, script, parameterType);
+    XMLScriptBuilder builder = new XMLScriptBuilder(this, configuration, script, parameterType);
     return builder.parseScriptNode();
   }
 
@@ -53,13 +55,21 @@ public class XMLLanguageDriver implements LanguageDriver {
     } else {
       // issue #127
       script = PropertyParser.parse(script, configuration.getVariables());
-      TextSqlNode textSqlNode = new TextSqlNode(script);
+      TextSqlNode textSqlNode = new TextSqlNode(this, script, null);
       if (textSqlNode.isDynamic()) {
         return new DynamicSqlSource(configuration, textSqlNode);
       } else {
         return new RawSqlSource(configuration, script, parameterType);
       }
     }
+  }
+
+  protected Object getOgnlValue(String expression, Map<String, Object> bindings) {
+    return OgnlCache.getValue(expression, bindings);
+  }
+
+  protected ExpressionEvaluator newExpressionEvaluator() {
+    return new ExpressionEvaluator();
   }
 
 }

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -37,14 +37,16 @@ public class XMLScriptBuilder extends BaseBuilder {
   private final XNode context;
   private boolean isDynamic;
   private final Class<?> parameterType;
+  private final XMLLanguageDriver xmlLanguageDriver;
   private final Map<String, NodeHandler> nodeHandlerMap = new HashMap<>();
 
   public XMLScriptBuilder(Configuration configuration, XNode context) {
-    this(configuration, context, null);
+    this(new XMLLanguageDriver(), configuration, context, null);
   }
 
-  public XMLScriptBuilder(Configuration configuration, XNode context, Class<?> parameterType) {
+  public XMLScriptBuilder(XMLLanguageDriver xmlLanguageDriver, Configuration configuration, XNode context, Class<?> parameterType) {
     super(configuration);
+    this.xmlLanguageDriver = xmlLanguageDriver;
     this.context = context;
     this.parameterType = parameterType;
     initNodeHandlerMap();
@@ -81,7 +83,7 @@ public class XMLScriptBuilder extends BaseBuilder {
       XNode child = node.newXNode(children.item(i));
       if (child.getNode().getNodeType() == Node.CDATA_SECTION_NODE || child.getNode().getNodeType() == Node.TEXT_NODE) {
         String data = child.getStringBody("");
-        TextSqlNode textSqlNode = new TextSqlNode(data);
+        TextSqlNode textSqlNode = new TextSqlNode(xmlLanguageDriver, data, null);
         if (textSqlNode.isDynamic()) {
           contents.add(textSqlNode);
           isDynamic = true;
@@ -114,7 +116,7 @@ public class XMLScriptBuilder extends BaseBuilder {
     public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
       final String name = nodeToHandle.getStringAttribute("name");
       final String expression = nodeToHandle.getStringAttribute("value");
-      final VarDeclSqlNode node = new VarDeclSqlNode(name, expression);
+      final VarDeclSqlNode node = new VarDeclSqlNode(xmlLanguageDriver, name, expression);
       targetContents.add(node);
     }
   }
@@ -176,7 +178,7 @@ public class XMLScriptBuilder extends BaseBuilder {
       String open = nodeToHandle.getStringAttribute("open");
       String close = nodeToHandle.getStringAttribute("close");
       String separator = nodeToHandle.getStringAttribute("separator");
-      ForEachSqlNode forEachSqlNode = new ForEachSqlNode(configuration, mixedSqlNode, collection, index, item, open, close, separator);
+      ForEachSqlNode forEachSqlNode = new ForEachSqlNode(xmlLanguageDriver, configuration, mixedSqlNode, collection, index, item, open, close, separator);
       targetContents.add(forEachSqlNode);
     }
   }
@@ -190,7 +192,7 @@ public class XMLScriptBuilder extends BaseBuilder {
     public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
       MixedSqlNode mixedSqlNode = parseDynamicTags(nodeToHandle);
       String test = nodeToHandle.getStringAttribute("test");
-      IfSqlNode ifSqlNode = new IfSqlNode(mixedSqlNode, test);
+      IfSqlNode ifSqlNode = new IfSqlNode(xmlLanguageDriver, mixedSqlNode, test);
       targetContents.add(ifSqlNode);
     }
   }

--- a/src/test/java/org/apache/ibatis/submitted/language/CustomLanguageMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/language/CustomLanguageMapper.java
@@ -13,28 +13,12 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.scripting.xmltags;
+package org.apache.ibatis.submitted.language;
 
-/**
- * @author Frank D. Martinez [mnesarco]
- */
-public class VarDeclSqlNode implements SqlNode {
+import java.util.List;
 
-  private final XMLLanguageDriver xmlLanguageDriver;
-  private final String name;
-  private final String expression;
+public interface CustomLanguageMapper {
 
-  public VarDeclSqlNode(XMLLanguageDriver xmlLanguageDriver, String var, String exp) {
-    this.xmlLanguageDriver = xmlLanguageDriver;
-    name = var;
-    expression = exp;
-  }
-
-  @Override
-  public boolean apply(DynamicContext context) {
-    final Object value = xmlLanguageDriver.getOgnlValue(expression, context.getBindings());
-    context.bind(name, value);
-    return true;
-  }
+  List<Long> select();
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/language/CustomLanguageMapper.xml
+++ b/src/test/java/org/apache/ibatis/submitted/language/CustomLanguageMapper.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2019 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.language.CustomLanguageMapper">
+
+  <select id="select" resultType="long">
+    SELECT 1
+    FROM dual
+    <where>
+      <if test="a != null">
+        and 'a' = 'a'
+      </if>
+      <if test="b != null">
+        and 'b' in
+        <foreach item="item" collection="b" separator="," open="(" close=")">
+          #{item}
+        </foreach>
+      </if>
+      and 'c' = ${c}
+    </where>
+  </select>
+
+</mapper>

--- a/src/test/java/org/apache/ibatis/submitted/language/CustomLanguageTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/language/CustomLanguageTest.java
@@ -1,0 +1,84 @@
+package org.apache.ibatis.submitted.language;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.scripting.xmltags.ExpressionEvaluator;
+import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
+import org.apache.ibatis.session.Configuration;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Liu Dongmiao
+ */
+public class CustomLanguageTest {
+
+  @Test
+  public void checkXml() throws IOException {
+    Configuration configuration1 = new Configuration();
+    Map<String, Object> parameter = new LinkedHashMap<>();
+    parameter.put("a", "a");
+    parameter.put("b", Collections.singletonList("0"));
+    parameter.put("c", "1");
+    String sql1 = getSql(configuration1, parameter);
+
+    Configuration configuration2 = new Configuration();
+    configuration2.getLanguageRegistry().setDefaultDriverClass(CustomXMLLanguageDriver.class);
+    CustomXMLLanguageDriver.resetDollars();
+    String sql2 = getSql(configuration2, null);
+    Set<String> dollars = CustomXMLLanguageDriver.getDollars();
+    Assert.assertTrue(dollars.contains("c"));
+    Assert.assertEquals(sql1, sql2);
+  }
+
+  protected String getSql(Configuration configuration, Object parameter) throws IOException {
+    try (InputStream inputStream = Resources.getResourceAsStream("org/apache/ibatis/submitted/language/CustomLanguageMapper.xml")) {
+      XMLMapperBuilder xmlMapperBuilder = new XMLMapperBuilder(inputStream, configuration, "CustomLanguageMapper.xml", configuration.getSqlFragments());
+      xmlMapperBuilder.parse();
+    }
+    return configuration.getMappedStatement("select").getBoundSql(parameter).getSql();
+  }
+
+  public static class CustomXMLLanguageDriver extends XMLLanguageDriver {
+
+    static final ThreadLocal<Set<String>> DOLLARS = ThreadLocal.withInitial(LinkedHashSet::new);
+
+    public CustomXMLLanguageDriver() {
+      super();
+    }
+
+    static void resetDollars() {
+      DOLLARS.get().clear();
+    }
+
+    static Set<String> getDollars() {
+      return DOLLARS.get();
+    }
+
+    protected Object getOgnlValue(String expression, Map<String, Object> bindings) {
+      DOLLARS.get().add(expression);
+      return "1";
+    }
+
+    protected ExpressionEvaluator newExpressionEvaluator() {
+      return new ExpressionEvaluator() {
+        @Override
+        public boolean evaluateBoolean(String expression, Object parameterObject) {
+          return true;
+        }
+
+        public Iterable<?> evaluateIterable(String expression, Object parameterObject) {
+          return Collections.singletonList("0");
+        }
+      };
+    }
+  }
+}


### PR DESCRIPTION
There is a default XMLLanguageDriver for xml, and actually it's ognl.

However, it's impossible to custom, as following method is hard coded:
- `OgnlCache.getValue`
- `new ExpressionEvaluator()`

In our cases, we'd like to solve problem like this:
- analysis the dynamic sql in mybatis' xml
- check unsafe `$` usage

In this pull request, we allow custom `OgnlCache.getValue` and `new ExpressionEvaluator()`, so we can:
- check `$`
- custom test (like `if` / `when`)
- custom foreach

In our cases, we use strategy like this (may change):
- parse the condition try to make it true
   - use constant value in condition, dynamic adjust parameter value, try make first condition always true
- always return one item for sql
Then we can get the sql, and analysis.