### PR TITLE
Fix the issue #2302, bug when namespace starts with a space.

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
+++ b/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
@@ -391,7 +391,7 @@ public class MapperBuilderAssistant extends BaseBuilder {
       String[] resultMapNames = resultMap.split(",");
       for (String resultMapName : resultMapNames) {
         try {
-          resultMaps.add(configuration.getResultMap(resultMapName.trim()));
+          resultMaps.add(configuration.getResultMap(resultMapName));
         } catch (IllegalArgumentException e) {
           throw new IncompleteElementException("Could not find result map '" + resultMapName + "' referenced from '" + statementId + "'", e);
         }


### PR DESCRIPTION
When we use the method `MapperBuilderAssistant#getStatementResultMaps`, the name is trimmed . But in the method `Configuration#AddResultMap`, there is no trim operation. These asymmetrical operations will lead to this happening.

Perhaps, we can throw an error directly in the build phase when Namespace begins with a space. Just like this in method `XMLMapperBuilder#configurationElement`.
```java
private void configurationElement(XNode context) {
    try {
      String namespace = context.getStringAttribute("namespace");
      if (namespace == null || namespace.isEmpty()) {
        throw new BuilderException("Mapper's namespace cannot be empty");
      }
      // like this
      if (namespace.startsWith(" ")) {
        throw new BuilderException("Mapper's namespace cannot start with whitespace.");
      }
     
        ...
    } catch (Exception e) {
      throw new BuilderException("Error parsing Mapper XML. The XML location is '" + resource + "'. Cause: " + e, e);
    }
  }
```