### PR TITLE
Do not try logging implementations when one is provided.

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -29,6 +29,7 @@ import org.apache.ibatis.executor.loader.ProxyFactory;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.io.VFS;
 import org.apache.ibatis.logging.Log;
+import org.apache.ibatis.logging.LogFactory;
 import org.apache.ibatis.mapping.DatabaseIdProvider;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.parsing.XNode;
@@ -106,7 +107,7 @@ public class XMLConfigBuilder extends BaseBuilder {
       propertiesElement(root.evalNode("properties"));
       Properties settings = settingsAsProperties(root.evalNode("settings"));
       loadCustomVfs(settings);
-      loadCustomLogImpl(settings);
+      loadLogImpl(settings);
       typeAliasesElement(root.evalNode("typeAliases"));
       pluginElement(root.evalNode("plugins"));
       objectFactoryElement(root.evalNode("objectFactory"));
@@ -149,6 +150,14 @@ public class XMLConfigBuilder extends BaseBuilder {
           configuration.setVfsImpl(vfsImpl);
         }
       }
+    }
+  }
+
+  private void loadLogImpl(Properties settings) {
+    loadCustomLogImpl(settings);
+
+    if(LogFactory.hasNoImplementation()) {
+      LogFactory.tryKnownImplementations();
     }
   }
 

--- a/src/main/java/org/apache/ibatis/logging/LogFactory.java
+++ b/src/main/java/org/apache/ibatis/logging/LogFactory.java
@@ -28,9 +28,13 @@ public final class LogFactory {
    */
   public static final String MARKER = "MYBATIS";
 
-  private static Constructor<? extends Log> logConstructor;
+  protected static Constructor<? extends Log> logConstructor;
 
-  static {
+  private LogFactory() {
+    // disable construction
+  }
+
+  public static void tryKnownImplementations() {
     tryImplementation(LogFactory::useSlf4jLogging);
     tryImplementation(LogFactory::useCommonsLogging);
     tryImplementation(LogFactory::useLog4J2Logging);
@@ -39,8 +43,8 @@ public final class LogFactory {
     tryImplementation(LogFactory::useNoLogging);
   }
 
-  private LogFactory() {
-    // disable construction
+  public static boolean hasNoImplementation() {
+    return logConstructor == null;
   }
 
   public static Log getLog(Class<?> clazz) {

--- a/src/test/java/org/apache/ibatis/logging/LogFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/logging/LogFactoryTest.java
@@ -15,9 +15,8 @@
  */
 package org.apache.ibatis.logging;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.io.Reader;
+import java.lang.reflect.Constructor;
 
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.logging.commons.JakartaCommonsLoggingImpl;
@@ -29,6 +28,8 @@ import org.apache.ibatis.logging.slf4j.Slf4jImpl;
 import org.apache.ibatis.logging.stdout.StdOutImpl;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 class LogFactoryTest {
 
@@ -86,6 +87,25 @@ class LogFactoryTest {
     Log log = LogFactory.getLog(Object.class);
     logSomething(log);
     assertEquals(log.getClass().getName(), NoLoggingImpl.class.getName());
+  }
+
+  @Test
+  void hasImplementation() {
+    LogFactory.useCommonsLogging();
+    assertFalse(LogFactory.hasNoImplementation());
+  }
+
+  @Test
+  void hasNoImplementation() {
+    LogFactory.logConstructor = null;
+    assertTrue(LogFactory.hasNoImplementation());
+  }
+
+  @Test
+  void mustNotOverwriteCustomImplementation() throws NoSuchMethodException {
+    LogFactory.useCustomLogging(JakartaCommonsLoggingImpl.class);
+    LogFactory.tryKnownImplementations();
+    assertEquals(LogFactory.logConstructor, JakartaCommonsLoggingImpl.class.getConstructor(String.class));
   }
 
   @Test


### PR DESCRIPTION
When setting configuration option
`<setting name="logImpl" value="LOG4J2"/>`
I still see output from trying different implementations, like
```
log4j:WARN No appenders could be found for logger (org.apache.ibatis.logging.LogFactory).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
```
which is unexpected. If a concrete implementation is requested there is no need to test for others.