### PR TITLE
A problem in executing SQL scripts

### DIFF
--- a/src/main/java/org/apache/ibatis/jdbc/ScriptRunner.java
+++ b/src/main/java/org/apache/ibatis/jdbc/ScriptRunner.java
@@ -18,7 +18,12 @@ package org.apache.ibatis.jdbc;
 import java.io.BufferedReader;
 import java.io.PrintWriter;
 import java.io.Reader;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.Statement;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 


### PR DESCRIPTION
The reason why I raise this problem is that I encounter a business scenario in the company. I use mysql. I need to execute the SQL script during the running of the program. The SQL script creates databases, tables, stored procedures, functions and views, but errors often occur during the execution. The main reason is that the splitters cannot be handled uniformly when parsing SQL, Here I give an example.


![微信图片_20210814191007](https://user-images.githubusercontent.com/8363919/129444480-39661536-9ddd-4f99-9260-c9aa6d070196.png)

Let's take a look at this example. At present, the default separator is ";", This is effective for the above operations such as creating a database, but it is not allowed to execute the following stored procedure. Therefore, I added an attribute to expand its function. After testing, after setting this attribute, the program can execute the whole SQL script normally. If this attribute is not set, there will be no impact on the original function. Thank you