### PR TITLE
trim, set, where label add notEmpty attr.

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
@@ -264,9 +264,18 @@ prefix CDATA #IMPLIED
 prefixOverrides CDATA #IMPLIED
 suffix CDATA #IMPLIED
 suffixOverrides CDATA #IMPLIED
+notEmpty CDATA #IMPLIED
 >
+
 <!ELEMENT where (#PCDATA | include | trim | where | set | foreach | choose | if | bind)*>
+<!ATTLIST where
+notEmpty CDATA #IMPLIED
+>
+
 <!ELEMENT set (#PCDATA | include | trim | where | set | foreach | choose | if | bind)*>
+<!ATTLIST set
+notEmpty CDATA #IMPLIED
+>
 
 <!ELEMENT foreach (#PCDATA | include | trim | where | set | foreach | choose | if | bind)*>
 <!ATTLIST foreach

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/SetSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/SetSqlNode.java
@@ -28,7 +28,11 @@ public class SetSqlNode extends TrimSqlNode {
   private static final List<String> COMMA = Collections.singletonList(",");
 
   public SetSqlNode(Configuration configuration,SqlNode contents) {
-    super(configuration, contents, "SET", COMMA, null, COMMA);
+    this(configuration, contents, null);
+  }
+
+  public SetSqlNode(Configuration configuration,SqlNode contents, String notEmpty) {
+    super(configuration, contents, "SET", COMMA, null, COMMA, notEmpty);
   }
 
 }

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/WhereSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/WhereSqlNode.java
@@ -28,7 +28,11 @@ public class WhereSqlNode extends TrimSqlNode {
   private static List<String> prefixList = Arrays.asList("AND ","OR ","AND\n", "OR\n", "AND\r", "OR\r", "AND\t", "OR\t");
 
   public WhereSqlNode(Configuration configuration, SqlNode contents) {
-    super(configuration, contents, "WHERE", prefixList, null, null);
+    this(configuration, contents, null);
+  }
+
+  public WhereSqlNode(Configuration configuration, SqlNode contents, String notEmpty) {
+    super(configuration, contents, "WHERE", prefixList, null, null, notEmpty);
   }
 
 }

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -131,7 +131,8 @@ public class XMLScriptBuilder extends BaseBuilder {
       String prefixOverrides = nodeToHandle.getStringAttribute("prefixOverrides");
       String suffix = nodeToHandle.getStringAttribute("suffix");
       String suffixOverrides = nodeToHandle.getStringAttribute("suffixOverrides");
-      TrimSqlNode trim = new TrimSqlNode(configuration, mixedSqlNode, prefix, prefixOverrides, suffix, suffixOverrides);
+      String notEmpty = nodeToHandle.getStringAttribute("notEmpty");
+      TrimSqlNode trim = new TrimSqlNode(configuration, mixedSqlNode, prefix, prefixOverrides, suffix, suffixOverrides, notEmpty);
       targetContents.add(trim);
     }
   }
@@ -144,7 +145,8 @@ public class XMLScriptBuilder extends BaseBuilder {
     @Override
     public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
       MixedSqlNode mixedSqlNode = parseDynamicTags(nodeToHandle);
-      WhereSqlNode where = new WhereSqlNode(configuration, mixedSqlNode);
+      String notEmpty = nodeToHandle.getStringAttribute("notEmpty");
+      WhereSqlNode where = new WhereSqlNode(configuration, mixedSqlNode, notEmpty);
       targetContents.add(where);
     }
   }
@@ -157,7 +159,8 @@ public class XMLScriptBuilder extends BaseBuilder {
     @Override
     public void handleNode(XNode nodeToHandle, List<SqlNode> targetContents) {
       MixedSqlNode mixedSqlNode = parseDynamicTags(nodeToHandle);
-      SetSqlNode set = new SetSqlNode(configuration, mixedSqlNode);
+      String notEmpty = nodeToHandle.getStringAttribute("notEmpty");
+      SetSqlNode set = new SetSqlNode(configuration, mixedSqlNode, notEmpty);
       targetContents.add(set);
     }
   }


### PR DESCRIPTION
trim, set, where label add notEmpty attr. 

When notempty is set, an exception is thrown if the content of the element is empty. The settings here can avoid dangerous SQL.

Example:
```xml
<select id="getUserIfNode" resultType="org.apache.ibatis.submitted.ognlstatic.User">
   select * from users
  <where notEmpty="query criteria cannot be blank">
   <if test="value not in {null, ''}">
   name = #{value}
   </if>
   </where>
</select>

<delete id="deleteAuthor" parameterType="int">
    delete from Author
    <where notEmpty="Dangerous: clear the table!">
    <if test="id!=null">
    id = #{id}
    </if>
    </where>
</delete>
```

If you think OK, I'll add some tests.