### PR TITLE
fix the description of set tag in dynamic-sql.xml doc

### DIFF
--- a/src/site/es/xdoc/dynamic-sql.xml
+++ b/src/site/es/xdoc/dynamic-sql.xml
@@ -137,7 +137,7 @@ AND title like ‘someTitle’]]></source>
 </update>]]></source>
   <p>En este caso, el elemento set  prefijará dinámicamente el valor SET y además eliminará todas las comas sobrantes que pudieran quedar tras las asignaciones de valor después de que se hayan aplicado las condiciones.</p>
   <p>Si tienes curiosidad de qué aspecto tendría el elemento trim equivalente, aquí lo tienes:</p>
-  <source><![CDATA[<trim prefix="SET" suffixOverrides=",">
+  <source><![CDATA[<trim prefix="SET" prefixOverrides="," suffixOverrides=",">
   ...
 </trim>]]></source>
   <p>Fíjate que en este caso estamos sobrescribiendo un sufijo y añadiendo un prefijo.</p>

--- a/src/site/ja/xdoc/dynamic-sql.xml
+++ b/src/site/ja/xdoc/dynamic-sql.xml
@@ -143,7 +143,7 @@ AND title like ‘someTitle’]]></source>
 </update>]]></source>
   <p><em>set</em> 要素は、動的に SET キーワードを付加し、余分な末尾のカンマを削除します。</p>
   <p>疑問に思った方のために、これと同じ処理を行う trim 要素は次のようになります。</p>
-  <source><![CDATA[<trim prefix="SET" suffixOverrides=",">
+  <source><![CDATA[<trim prefix="SET" prefixOverrides="," suffixOverrides=",">
   ...
 </trim>]]></source>
   <p>prefix を追加している点は前の例と同じですが、今回は suffix をオーバーライドしている点に注意してください。</p>

--- a/src/site/ko/xdoc/dynamic-sql.xml
+++ b/src/site/ko/xdoc/dynamic-sql.xml
@@ -164,7 +164,7 @@ AND title like ‘someTitle’]]></source>
 </update>]]></source>
         <p>여기서 set 엘리먼트는 동적으로 SET 키워드를 붙히고 필요없는 콤마를 제거한다.</p>
         <p>아마도 trim 엘리먼트로 처리한다면 아래와 같을 것이다.</p>
-        <source><![CDATA[<trim prefix="SET" suffixOverrides=",">
+        <source><![CDATA[<trim prefix="SET" prefixOverrides="," suffixOverrides=",">
   ...
 </trim>]]></source>
         <p>이 경우 접두사는 추가하고 접미사를 오버라이딩 한다.</p>

--- a/src/site/xdoc/dynamic-sql.xml
+++ b/src/site/xdoc/dynamic-sql.xml
@@ -136,7 +136,7 @@ AND title like ‘someTitle’]]></source>
 </update>]]></source>
   <p>Here, the <em>set</em> element will dynamically prepend the SET keyword, and also eliminate any extraneous commas that might trail the value assignments after the conditions are applied.</p>
   <p>If you’re curious about what the equivalent <em>trim</em> element would look like, here it is:</p>
-  <source><![CDATA[<trim prefix="SET" suffixOverrides=",">
+  <source><![CDATA[<trim prefix="SET" prefixOverrides="," suffixOverrides=",">
   ...
 </trim>]]></source>
   <p>Notice that in this case we’re overriding a suffix, while we’re still appending a prefix.</p>

--- a/src/site/zh/xdoc/dynamic-sql.xml
+++ b/src/site/zh/xdoc/dynamic-sql.xml
@@ -140,7 +140,7 @@ AND title like ‘someTitle’]]></source>
 </update>]]></source>
         <p>这个例子中，<em>set</em> 元素会动态地在行首插入 SET 关键字，并会删掉额外的逗号（这些逗号是在使用条件语句给列赋值时引入的）。</p>
         <p>来看看与 <em>set</em> 元素等价的自定义 <em>trim</em> 元素吧：</p>
-        <source><![CDATA[<trim prefix="SET" suffixOverrides=",">
+        <source><![CDATA[<trim prefix="SET" prefixOverrides="," suffixOverrides=",">
   ...
 </trim>]]></source>
         <p>注意，我们覆盖了后缀值设置，并且自定义了前缀值。</p>


### PR DESCRIPTION
in the fact, `<set>`  is equal to `<trim prefix="set" prefixOverrides="," suffixOverrides=",">`

ref: https://github.com/mybatis/mybatis-3/commit/95166a683c11e35273769c7edf15f7925a5f4006#diff-df20f6a8f86025feb42cead35070d7689a4f04afc051008c93a2f38250bf53afR31