### PR TITLE
New enum type handler for saving concrete string value in database

### DIFF
--- a/src/main/java/org/apache/ibatis/type/EnumAlias.java
+++ b/src/main/java/org/apache/ibatis/type/EnumAlias.java
@@ -1,0 +1,32 @@
+package org.apache.ibatis.type;
+
+/**
+ * Interface for enums that specify alias - string value which will be saved in database instead of <code>name()</code>
+ * <p>
+ * <b>Usage:</b>
+ * <pre>
+ *  enum MyEnum implements EnumAlias {
+ *     JavaScript("JS"),
+ *     TypeScript("TS"),
+ *     Kubernetes("K8S");
+ *
+ *     private final String fullName;
+ *
+ *     //...
+ *
+ *     &#064;Override
+ *     public String getAlias() {
+ *       return fullName;
+ *     }
+ *   }
+ *   </pre>
+ * </p>
+ *
+ * @author Konstantin Parakhin
+ */
+public interface EnumAlias {
+  /**
+   * @return alias for enum value which will be saved in DB
+   */
+  String getAlias();
+}

--- a/src/main/java/org/apache/ibatis/type/EnumAliasTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/EnumAliasTypeHandler.java
@@ -1,0 +1,63 @@
+package org.apache.ibatis.type;
+
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+
+/**
+ * Type handler for subclasses of {@link EnumAlias}
+ *
+ * @author Konstantin Parakhin
+ */
+public class EnumAliasTypeHandler<TMnemonic extends Enum<TMnemonic> & EnumAlias> extends BaseTypeHandler<TMnemonic> {
+
+  public static final String UNKNOWN_ENUM_NAME = "UNKNOWN";
+
+  private final Class<TMnemonic> type;
+
+  public EnumAliasTypeHandler(Class<TMnemonic> type) {
+    this.type = type;
+  }
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, TMnemonic parameter, JdbcType jdbcType) throws SQLException {
+    ps.setString(i, parameter.getAlias());
+  }
+
+  @Override
+  public TMnemonic getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    String s = rs.getString(columnName);
+    if (s == null && rs.wasNull()) {
+      return null;
+    }
+    return asAlias(s);
+  }
+
+  @Override
+  public TMnemonic getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    String s = rs.getString(columnIndex);
+    if (s == null && rs.wasNull()) {
+      return null;
+    }
+    return asAlias(s);
+  }
+
+  @Override
+  public TMnemonic getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    String s = cs.getString(columnIndex);
+    if (s == null && cs.wasNull()) {
+      return null;
+    }
+    return asAlias(s);
+  }
+
+  private TMnemonic asAlias(final String value) {
+    return Arrays.stream(type.getEnumConstants())
+      .filter(x -> x.getAlias().equalsIgnoreCase(value))
+      .findFirst()
+      .orElse(null);
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/EnumAliasTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/EnumAliasTypeHandlerTest.java
@@ -1,0 +1,84 @@
+package org.apache.ibatis.type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EnumAliasTypeHandlerTest extends BaseTypeHandlerTest {
+
+  enum MyEnum implements EnumAlias {
+    JavaScript("JS"),
+    TypeScript("TS"),
+    Kubernetes("K8S");
+
+    private final String fullName;
+
+    MyEnum(String fullName) {
+      this.fullName = fullName;
+    }
+
+    @Override
+    public String getAlias() {
+      return fullName;
+    }
+  }
+
+  private static final TypeHandler<MyEnum> TYPE_HANDLER =
+    new EnumAliasTypeHandler<>(MyEnum.class);
+
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, MyEnum.JavaScript, null);
+    verify(ps).setString(1, MyEnum.JavaScript.getAlias());
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, null, JdbcType.VARCHAR);
+    verify(ps).setNull(1, JdbcType.VARCHAR.TYPE_CODE);
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getString("column")).thenReturn("JS");
+    assertEquals(MyEnum.JavaScript, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getString(1)).thenReturn("JS");
+    assertEquals(MyEnum.JavaScript, TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getString(1)).thenReturn(null);
+    when(rs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getString(1)).thenReturn("JS");
+    assertEquals(MyEnum.JavaScript, TYPE_HANDLER.getResult(cs, 1));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getString(1)).thenReturn(null);
+    when(cs.wasNull()).thenReturn(true);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+
+}


### PR DESCRIPTION
EnumAliasTypeHandler allows us to specify particular string values which we want to save in our database