### PR TITLE
Update ParamNameResolver.java

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
@@ -84,10 +84,54 @@ public class SqlSourceBuilder extends BaseBuilder {
 
     @Override
     public String handleToken(String content) {
+      Object params = metaParameters.getValue("_parameter");
+			if (params != null && params instanceof Map) {
+				String token = handleCollectionParam(content, (Map<String, Object>) params);
+				if (token != null) return token;
+			}
+
       parameterMappings.add(buildParameterMapping(content));
       return "?";
     }
 
+    // Expand the collection variable into multiple placeholders
+		@SuppressWarnings("rawtypes")
+		private String handleCollectionParam(String content, Map<String, Object> params) {
+			if (!params.containsKey(content)) return null;
+
+			Object data = params.get(content);
+			if (data == null) return null;
+
+			// 数组转成集合, 然后统一处理
+			if (data instanceof Object[]) {
+				data = Arrays.asList((Object[]) data);
+			}
+
+			// 统一处理集合
+			if (data instanceof Collection) {
+				int idx = 0;
+				StringBuilder sb = new StringBuilder();
+
+				Collection vals = (Collection) data;
+				for (Object val : vals) {
+					String bindName = content + "_" + idx;
+					if (params.containsKey(bindName)) {
+						bindName += "_" + params.size();
+					}
+
+					params.put(bindName, val);
+					parameterMappings.add(buildParameterMapping(bindName));
+
+					if (idx > 0) sb.append(",");
+					sb.append("?");
+					idx++;
+				}
+				return sb.toString();
+			}
+
+			return null;
+		}
+    
     private ParameterMapping buildParameterMapping(String content) {
       Map<String, String> propertiesMap = parseParameterMapping(content);
       String property = propertiesMap.get("property");

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/TextSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/TextSqlNode.java
@@ -42,7 +42,12 @@ public class TextSqlNode implements SqlNode {
     DynamicCheckerTokenParser checker = new DynamicCheckerTokenParser();
     GenericTokenParser parser = createParser(checker);
     parser.parse(text);
-    return checker.isDynamic();
+		if (checker.isDynamic) return true;
+
+		// Use regularity to determine whether the string of in (#{xxx}) is contained in sql, and if so, process it as dynamic sql
+		Pattern pattern = Pattern.compile("\\s+in\\s+\\(\\s*#\\{\\s*\\S+\\s*\\}\\s*\\)", Pattern.CASE_INSENSITIVE);
+		Matcher matcher = pattern.matcher(text);
+		return matcher.find();
   }
 
   @Override


### PR DESCRIPTION
When the method in the Mapper interface has only one Map parameter, the variable is resolved correctly. If the method has other parameters, the Map variable must specify @Param("prefix"), but the variable name in the SQL script must be in the format of the #{prefix.xxx} The purpose of this improvement is to simplify writing, and if the @Param ("") is empty, the variable name in the script can omit the prefix