### PR TITLE
[ci] Java 17 GA and 18-ea

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [8, 11, 16, 17-ea]
-        distribution: ['adopt']
+        java: [8, 11, 16, 17, 18-ea]
+        distribution: ['zulu']
       fail-fast: false
       max-parallel: 4
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}
@@ -45,7 +45,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-m2
       - name: Set argLine command line option
-        if: ${{ matrix.java != '8' }}
+        if: ${{ matrix.java == '11' || matrix.java == '16' }}
         run: echo 'ARG_LINE=-D"argLine=--illegal-access=permit"' >> $GITHUB_ENV
       - name: Set env command line option
         if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -54,8 +54,8 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
         run: ./mvnw test -B -D"license.skip=true" -D"jacoco.skip=true" $ENV_TRAVIS $ARG_LINE 
       - name: Test with Maven
-        if: ${{ matrix.os == 'windows-latest' && matrix.java == '8' }}
+        if: ${{ matrix.os == 'windows-latest' && (matrix.java != '11' && matrix.java != '16')}}
         run: ./mvnw test -B -D"license.skip=true" -D"jacoco.skip=true"
       - name: Test with Maven
-        if: ${{ matrix.os == 'windows-latest' && matrix.java != '8' }}
+        if: ${{ matrix.os == 'windows-latest' && (matrix.java == '11' || matrix.java == '16') }}
         run: ./mvnw test -B -D"license.skip=true" -D"jacoco.skip=true" -D"argLine=--illegal-access=permit"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,6 +47,12 @@ jobs:
       - name: Set argLine command line option
         if: ${{ matrix.java == '11' || matrix.java == '16' }}
         run: echo 'ARG_LINE=-D"argLine=--illegal-access=permit"' >> $GITHUB_ENV
+      - name: Skip tests that require illegal reflective access
+        if: ${{ matrix.os == 'ubuntu-latest' && (matrix.java == '17' || matrix.java == '18-ea' )}}
+        run: echo 'ARG_LINE=-D"excludedGroups=RequireIllegalAccess"' >> $GITHUB_ENV
+      - name: Skip tests that require illegal reflective access
+        if: ${{ matrix.os != 'ubuntu-latest' && (matrix.java == '17' || matrix.java == '18-ea' )}}
+        run: echo 'ARG_LINE=-D"excludedGroups=TestcontainersTests,RequireIllegalAccess"' >> $GITHUB_ENV
       - name: Set env command line option
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: echo 'ENV_TRAVIS="-Denv.TRAVIS"' >> $GITHUB_ENV
@@ -54,8 +60,11 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
         run: ./mvnw test -B -D"license.skip=true" -D"jacoco.skip=true" $ENV_TRAVIS $ARG_LINE 
       - name: Test with Maven
-        if: ${{ matrix.os == 'windows-latest' && (matrix.java != '11' && matrix.java != '16')}}
+        if: ${{ matrix.os == 'windows-latest' && (matrix.java == '8')}}
         run: ./mvnw test -B -D"license.skip=true" -D"jacoco.skip=true"
       - name: Test with Maven
         if: ${{ matrix.os == 'windows-latest' && (matrix.java == '11' || matrix.java == '16') }}
         run: ./mvnw test -B -D"license.skip=true" -D"jacoco.skip=true" -D"argLine=--illegal-access=permit"
+      - name: Test with Maven
+        if: ${{ matrix.os == 'windows-latest' && (matrix.java == '17' || matrix.java == '18-ea') }}
+        run: ./mvnw test -B -D"license.skip=true" -D"jacoco.skip=true" -D"excludedGroups=TestcontainersTests,RequireIllegalAccess"

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -64,6 +64,7 @@ import org.apache.ibatis.type.EnumTypeHandler;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 class XmlConfigBuilderTest {
@@ -162,6 +163,7 @@ class XmlConfigBuilderTest {
     assertArrayEquals(MyEnum.values(), ((EnumOrderTypeHandler<MyEnum>) typeHandler).constants);
   }
 
+  @Tag("RequireIllegalAccess")
   @Test
   void shouldSuccessfullyLoadXMLConfigFile() throws Exception {
     String resource = "org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml";

--- a/src/test/java/org/apache/ibatis/executor/loader/CglibProxyTest.java
+++ b/src/test/java/org/apache/ibatis/executor/loader/CglibProxyTest.java
@@ -30,8 +30,10 @@ import org.apache.ibatis.reflection.factory.DefaultObjectFactory;
 import org.apache.ibatis.session.Configuration;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+@Tag("RequireIllegalAccess")
 class CglibProxyTest extends SerializableProxyTest {
 
   @BeforeAll

--- a/src/test/java/org/apache/ibatis/submitted/lazy_properties/LazyPropertiesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazy_properties/LazyPropertiesTest.java
@@ -31,6 +31,7 @@ import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 class LazyPropertiesTest {
@@ -156,6 +157,7 @@ class LazyPropertiesTest {
     shoulInvokingSetterInvalidateLazyLoading(new JavassistProxyFactory());
   }
 
+  @Tag("RequireIllegalAccess")
   @Test
   void shouldInvokingSetterInvalidateLazyLoading_Cglib() {
     shoulInvokingSetterInvalidateLazyLoading(new CglibProxyFactory());

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/CglibLazyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/CglibLazyTest.java
@@ -15,6 +15,9 @@
  */
 package org.apache.ibatis.submitted.lazyload_proxyfactory_comparison;
 
+import org.junit.jupiter.api.Tag;
+
+@Tag("RequireIllegalAccess")
 class CglibLazyTest extends AbstractLazyTest {
   @Override
   protected String getConfiguration() {

--- a/src/test/java/org/apache/ibatis/submitted/ognl_enum/EnumWithOgnlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognl_enum/EnumWithOgnlTest.java
@@ -26,6 +26,7 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.apache.ibatis.submitted.ognl_enum.Person.Type;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 class EnumWithOgnlTest {
@@ -60,6 +61,7 @@ class EnumWithOgnlTest {
     }
   }
 
+  @Tag("RequireIllegalAccess")
   @Test
   void testEnumWithOgnlDirectorNameAttribute() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/ognlstatic/OgnlStaticTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognlstatic/OgnlStaticTest.java
@@ -24,6 +24,7 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 class OgnlStaticTest {
@@ -63,6 +64,7 @@ class OgnlStaticTest {
     }
   }
 
+  @Tag("RequireIllegalAccess")
   @Test // see issue #61 (gh)
   void shouldGetAUserWithIfNode() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {


### PR DESCRIPTION
Some tests that require  `--illegal-access=permit` are skipped on 17 and 18-ea (the option was removed in 17 GA).
I added a new tag `@Tag("RequireIllegalAccess")` to those tests.
Regarding CGLIB, this issue tracks the 17/18 support, I think : https://github.com/cglib/cglib/issues/191

I changed the `distribution` because AdoptOpenJDK is [moved to Eclipse Adoptium](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/) and 18-ea is (was?) only available in zulu.