### PR TITLE
Support the syntax of "in (#{xxx})"

### DIFF
--- a/src/main/java/org/apache/ibatis/scripting/xmltags/TextSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/TextSqlNode.java
@@ -42,7 +42,12 @@ public class TextSqlNode implements SqlNode {
     DynamicCheckerTokenParser checker = new DynamicCheckerTokenParser();
     GenericTokenParser parser = createParser(checker);
     parser.parse(text);
-    return checker.isDynamic();
+		if (checker.isDynamic) return true;
+
+		// Use regularity to determine whether the string of in (#{xxx}) is contained in sql, and if so, process it as dynamic sql
+		Pattern pattern = Pattern.compile("\\s+in\\s+\\(\\s*#\\{\\s*\\S+\\s*\\}\\s*\\)", Pattern.CASE_INSENSITIVE);
+		Matcher matcher = pattern.matcher(text);
+		return matcher.find();
   }
 
   @Override


### PR DESCRIPTION
In Hibernate, "IN" query only needs to write " in (:xxx) ". And MyBatis needs to use cumbersome <foreach> script. We made the following changes to make MyBatis support the syntax of "in (#{xxx})" . For example, "select * from user where dept_id in (#{ids})" .After testing on our project, it has no negative impact on existing expressions.