### PR TITLE
[pom] Move from log4j1 to reload4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,9 +163,9 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>1.2.18.0</version>
       <optional>true</optional>
     </dependency>
     <dependency>


### PR DESCRIPTION
see https://reload4j.qos.ch/ for rational.  This resolves current vulnerabilities with inclusion of support for log4j1 still and apache declined to reopen to fix anything with log4j1 so its now with slf4j/logback team.