### PR TITLE
Add @Test annotation to shouldGetResultNullFromCallableStatement() in BooleanTypeHandlerTest

### DIFF
--- a/src/test/java/org/apache/ibatis/type/BooleanTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/BooleanTypeHandlerTest.java
@@ -74,6 +74,7 @@ class BooleanTypeHandlerTest extends BaseTypeHandlerTest {
   }
 
   @Override
+  @Test
   public void shouldGetResultNullFromCallableStatement() throws Exception {
     when(cs.getBoolean(1)).thenReturn(false);
     when(cs.wasNull()).thenReturn(true);


### PR DESCRIPTION
We are investigating mock objects in test suites over different benchmarks, and we believe this one is missing the @Test annotation.