### PR TITLE
Updated Error Messages for Method Parsing Exceptions

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -15,50 +15,9 @@
  */
 package org.apache.ibatis.builder.annotation;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Array;
-import java.lang.reflect.GenericArrayType;
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.apache.ibatis.annotations.Arg;
-import org.apache.ibatis.annotations.CacheNamespace;
-import org.apache.ibatis.annotations.CacheNamespaceRef;
-import org.apache.ibatis.annotations.Case;
-import org.apache.ibatis.annotations.Delete;
-import org.apache.ibatis.annotations.DeleteProvider;
-import org.apache.ibatis.annotations.Insert;
-import org.apache.ibatis.annotations.InsertProvider;
-import org.apache.ibatis.annotations.Lang;
-import org.apache.ibatis.annotations.MapKey;
-import org.apache.ibatis.annotations.Options;
-import org.apache.ibatis.annotations.Options.FlushCachePolicy;
-import org.apache.ibatis.annotations.Property;
-import org.apache.ibatis.annotations.Result;
+import org.apache.ibatis.annotations.*;
 import org.apache.ibatis.annotations.ResultMap;
-import org.apache.ibatis.annotations.ResultType;
-import org.apache.ibatis.annotations.Results;
-import org.apache.ibatis.annotations.Select;
-import org.apache.ibatis.annotations.SelectKey;
-import org.apache.ibatis.annotations.SelectProvider;
-import org.apache.ibatis.annotations.TypeDiscriminator;
-import org.apache.ibatis.annotations.Update;
-import org.apache.ibatis.annotations.UpdateProvider;
+import org.apache.ibatis.annotations.Options.FlushCachePolicy;
 import org.apache.ibatis.binding.MapperMethod.ParamMap;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.builder.CacheRefResolver;
@@ -71,15 +30,7 @@ import org.apache.ibatis.executor.keygen.KeyGenerator;
 import org.apache.ibatis.executor.keygen.NoKeyGenerator;
 import org.apache.ibatis.executor.keygen.SelectKeyGenerator;
 import org.apache.ibatis.io.Resources;
-import org.apache.ibatis.mapping.Discriminator;
-import org.apache.ibatis.mapping.FetchType;
-import org.apache.ibatis.mapping.MappedStatement;
-import org.apache.ibatis.mapping.ResultFlag;
-import org.apache.ibatis.mapping.ResultMapping;
-import org.apache.ibatis.mapping.ResultSetType;
-import org.apache.ibatis.mapping.SqlCommandType;
-import org.apache.ibatis.mapping.SqlSource;
-import org.apache.ibatis.mapping.StatementType;
+import org.apache.ibatis.mapping.*;
 import org.apache.ibatis.parsing.PropertyParser;
 import org.apache.ibatis.reflection.TypeParameterResolver;
 import org.apache.ibatis.scripting.LanguageDriver;
@@ -89,6 +40,14 @@ import org.apache.ibatis.session.RowBounds;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.UnknownTypeHandler;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.*;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * @author Clinton Begin
@@ -126,7 +85,15 @@ public class MapperAnnotationBuilder {
         }
         if (getAnnotationWrapper(method, false, Select.class, SelectProvider.class).isPresent()
             && method.getAnnotation(ResultMap.class) == null) {
-          parseResultMap(method);
+          try {
+            parseResultMap(method);
+          } catch (Exception e) {
+            Class<?> declaringClass = method.getDeclaringClass();
+            String fullyQualifiedClassName = declaringClass.getCanonicalName() != null ? declaringClass.getCanonicalName() : declaringClass.getName();
+            String parameterTypes = Arrays.stream(method.getParameterTypes()).map(Class::getSimpleName).collect(Collectors.joining(","));
+            String canonicalMethodName = fullyQualifiedClassName + "#" + method.getName() + "(" + parameterTypes + ")";
+            throw new BuilderException("Error occurred while parsing mapper method " + canonicalMethodName, e);
+          }
         }
         try {
           parseStatement(method);

--- a/src/main/java/org/apache/ibatis/mapping/ResultMapping.java
+++ b/src/main/java/org/apache/ibatis/mapping/ResultMapping.java
@@ -15,15 +15,15 @@
  */
 package org.apache.ibatis.mapping;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 
 /**
  * @author Clinton Begin
@@ -143,17 +143,19 @@ public class ResultMapping {
 
     private void validate() {
       // Issue #697: cannot define both nestedQueryId and nestedResultMapId
-      if (resultMapping.nestedQueryId != null && resultMapping.nestedResultMapId != null) {
-        throw new IllegalStateException("Cannot define both nestedQueryId and nestedResultMapId in property " + resultMapping.property);
-      }
+      String propertyAlias = resultMapping.property != null ? resultMapping.property : resultMapping.column;
+      String propertyAliasType = resultMapping.property != null ? "property" : "column";
+      if (resultMapping.nestedQueryId != null && resultMapping.nestedResultMapId != null)
+        throw new IllegalStateException("Cannot define both nestedQueryId and nestedResultMapId for " + propertyAliasType + " '" + propertyAlias + "' ");
+
       // Issue #5: there should be no mappings without typehandler
-      if (resultMapping.nestedQueryId == null && resultMapping.nestedResultMapId == null && resultMapping.typeHandler == null) {
-        throw new IllegalStateException("No typehandler found for property " + resultMapping.property);
-      }
+      if (resultMapping.nestedQueryId == null && resultMapping.nestedResultMapId == null && resultMapping.typeHandler == null)
+        throw new IllegalStateException("No typehandler found for " + propertyAliasType + " '" + propertyAlias + "' ");
+
       // Issue #4 and GH #39: column is optional only in nested resultmaps but not in the rest
-      if (resultMapping.nestedResultMapId == null && resultMapping.column == null && resultMapping.composites.isEmpty()) {
-        throw new IllegalStateException("Mapping is missing column attribute for property " + resultMapping.property);
-      }
+      if (resultMapping.nestedResultMapId == null && resultMapping.column == null && resultMapping.composites.isEmpty())
+        throw new IllegalStateException("Mapping is missing column attribute for  " + propertyAliasType + " '" + propertyAlias + "' ");
+
       if (resultMapping.getResultSet() != null) {
         int numColumns = 0;
         if (resultMapping.column != null) {

--- a/src/test/java/org/apache/ibatis/builder/AnnotationMapperBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/AnnotationMapperBuilderTest.java
@@ -15,18 +15,17 @@
  */
 package org.apache.ibatis.builder;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.apache.ibatis.annotations.Insert;
-import org.apache.ibatis.annotations.Options;
-import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.*;
 import org.apache.ibatis.builder.annotation.MapperAnnotationBuilder;
 import org.apache.ibatis.executor.keygen.Jdbc3KeyGenerator;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.mapping.ResultSetType;
 import org.apache.ibatis.mapping.StatementType;
 import org.apache.ibatis.session.Configuration;
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class AnnotationMapperBuilderTest {
 
@@ -94,6 +93,19 @@ class AnnotationMapperBuilderTest {
     assertThat(mappedStatement.getResultSetType()).isEqualTo(ResultSetType.DEFAULT);
   }
 
+  @Test
+  void withJavaTypeWhenMissingTypeHandler() {
+    Assert.assertThrows(BuilderException.class, () -> {
+      Configuration configuration = new Configuration();
+      MapperAnnotationBuilder builder = new MapperAnnotationBuilder(configuration, Mapper.class);
+      builder.parse();
+    });
+  }
+
+  public static class InvalidJavaTestType {}
+
+  public static class TestResponseType {}
+
   interface Mapper {
 
     @Insert("insert into test (name) values(#{name})")
@@ -110,6 +122,10 @@ class AnnotationMapperBuilderTest {
 
     @Select("select * from test")
     String selectWithoutOptions(Integer id);
+
+    @Select("SELECT col FROM test")
+    @ConstructorArgs({@Arg(column = "col", javaType = InvalidJavaTestType.class)})
+    TestResponseType getTestResponseType(int a, String b);
 
   }
 


### PR DESCRIPTION
- Updated `parse()` method to add more context when a parsing exception occurs while parsing a mapper method. The declaring class's canonical name (if local/anonymous class, class name is used), method name, and method parameter types are printed in the error message. 
- Updated the `validate()` method to default to column name if the property name is null. Since "property" is not required in the `Arg` annotation, I have defaulted to displaying the SQL column name when applying constructor args.