### PR TITLE
optimize: reduce put value to TypeHandlerRegistry.typeHandlerMap mult…

### DIFF
--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -267,8 +267,13 @@ public final class TypeHandlerRegistry {
       } else {
         jdbcHandlerMap = getJdbcHandlerMapForSuperclass(clazz);
       }
+      if (jdbcHandlerMap != null) {
+        typeHandlerMap.put(type, jdbcHandlerMap);
+      }
     }
-    typeHandlerMap.put(type, jdbcHandlerMap == null ? NULL_TYPE_HANDLER_MAP : jdbcHandlerMap);
+    if (jdbcHandlerMap == null) {
+      typeHandlerMap.put(type, NULL_TYPE_HANDLER_MAP);
+    }
     return jdbcHandlerMap;
   }
 


### PR DESCRIPTION
reduce put value to TypeHandlerRegistry.typeHandlerMap multi times
typeHandlerMap is ConcurrentHashMap, which put may cause thread blocked