### PR TITLE
add deprecated annotation

### DIFF
--- a/src/main/java/org/apache/ibatis/jdbc/SqlBuilder.java
+++ b/src/main/java/org/apache/ibatis/jdbc/SqlBuilder.java
@@ -20,6 +20,7 @@ package org.apache.ibatis.jdbc;
  *
  * @author Jeff Butler
  */
+@Deprecated
 public class SqlBuilder {
 
   private static final ThreadLocal<SQL> localSQL = new ThreadLocal<>();


### PR DESCRIPTION
The deprecated class should add `@Deprecated` annotation