### PR TITLE
[ISSUE #2509]Fix memory leak

### DIFF
--- a/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
@@ -333,7 +333,7 @@ public class SqlSessionManager implements SqlSessionFactory, SqlSession {
     try {
       sqlSession.close();
     } finally {
-      localSqlSession.set(null);
+      localSqlSession.remove();
     }
   }
 


### PR DESCRIPTION
`set(null)` to remove the value might keep the reference to this pointer in the map, which can cause memory leak in some scenarios. Using remove is safer to avoid this issue.
#2509 