### PR TITLE
Fix utf-8 bom and add future representation for license header

### DIFF
--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,0 +1,13 @@
+   Copyright ${license.git.copyrightYears} the original author or authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/site/xdoc/getting-started.xml
+++ b/src/site/xdoc/getting-started.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2019 the original author or authors.
+       Copyright 2009-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.

--- a/src/site/xdoc/getting-started.xml
+++ b/src/site/xdoc/getting-started.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
 
        Copyright 2009-2019 the original author or authors.


### PR DESCRIPTION
next parent will use LICENSE_HEADER as more appropriate naming for the license header.  The older file will be removed then.