### PR TITLE
Constructor id arguments don't need to be listed first

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
@@ -61,7 +61,7 @@ extends CDATA #IMPLIED
 autoMapping (true|false) #IMPLIED
 >
 
-<!ELEMENT constructor (idArg*,arg*)>
+<!ELEMENT constructor ((idArg|arg)*)>
 
 <!ELEMENT id EMPTY>
 <!ATTLIST id

--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-mapper.xsd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-mapper.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2021 the original author or authors.
+       Copyright 2009-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -108,7 +108,7 @@
   </xs:element>
   <xs:element name="constructor">
     <xs:complexType>
-      <xs:choice minOccurs="0" maxOccurs="unbounded">
+      <xs:choice minOccurs="1" maxOccurs="unbounded">
         <xs:element ref="idArg"/>
         <xs:element ref="arg"/>
       </xs:choice>

--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-mapper.xsd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-mapper.xsd
@@ -108,10 +108,10 @@
   </xs:element>
   <xs:element name="constructor">
     <xs:complexType>
-      <xs:sequence>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="idArg"/>
-        <xs:element minOccurs="0" maxOccurs="unbounded" ref="arg"/>
-      </xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element ref="idArg"/>
+        <xs:element ref="arg"/>
+      </xs:choice>
     </xs:complexType>
   </xs:element>
   <xs:element name="id">


### PR DESCRIPTION
Fixes #2541 