### PR TITLE
polish the tips in issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,10 +1,10 @@
 <!--
 ❌ 不要在这里问问题❗️
-⭕️ 请将您的问题发送到邮件列表
-請用英文寫
+⭕️ 请使用英文将您的问题发送到邮件列表： 
 https://groups.google.com/group/mybatis-user
-或
+或在 Stack Overflow 进行提问，并带上 'mybatis' 标签：
 https://stackoverflow.com/questions/ask?tags=mybatis
+在这里的提问将会被直接关闭。
 
 Question?
 ======================


### PR DESCRIPTION
I reviewed the history of commits. I found that the Chinese tips are mainly for users in Mainland China. If not, I will revert the PR.
I do sth. as follows:
1. unify the characters to Simplified Chinese.
2. add some translations to improve readability.