### PR TITLE
Update XMLConfigBuilder.java

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -106,8 +106,8 @@ public class XMLConfigBuilder extends BaseBuilder {
       propertiesElement(root.evalNode("properties"));
       Properties settings = settingsAsProperties(root.evalNode("settings"));
       loadCustomVfs(settings);
-      loadCustomLogImpl(settings);
       typeAliasesElement(root.evalNode("typeAliases"));
+      loadCustomLogImpl(settings);
       pluginElement(root.evalNode("plugins"));
       objectFactoryElement(root.evalNode("objectFactory"));
       objectWrapperFactoryElement(root.evalNode("objectWrapperFactory"));


### PR DESCRIPTION
The TypeAliasRegistry is relied upon when the log adapter is loaded [loadCustomLogImpl()] , I defined my own log adapter, and setting it with an alias will cause an error because the alias has not been registered at this time
For Example
<configuration>
   <settings>
        <setting name="logImpl" value="myLogAdapter"/>
    </settings>

    <typeAliases>
        <typeAlias type="com.learning.mybatis.log.MyMybatisLog" alias="myLogAdapter"/>
    </typeAliases>
</configuration>