### PR TITLE
Pooled connection timeout in pingConnection method

### DIFF
--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -1847,6 +1847,8 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
           </li>
           <li><code>poolPingConnectionsNotUsedFor</code> – Configura la frecuencia con la que se ejecutará la sentencia poolPingQuery. Normalmente se iguala al timeout de la conexión de base de datos para evitar pings innecesarios. Por defecto: 0 (todas las conexiones se testean continuamente – solo si se ha habilitado poolPingEnabled).
           </li>
+          <li><code>networkPingTimeout</code> – Configura un timeout (en milisegundos) a nivel de la conexión para la query de ping. En caso de que pase este tiempo, la conexión sera inválida. En caso de que un firewall o un problema de red descarte los paquetes, las conexiones no esperaran indefinidamente una respuesta. Por defecto:  0 (inactivo).
+        </li>
         </ul>
         <p>
           <strong>JNDI</strong>

--- a/src/site/xdoc/configuration.xml
+++ b/src/site/xdoc/configuration.xml
@@ -2153,6 +2153,10 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, propert
             Default: 0 (i.e. all connections are pinged every time – but only
             if poolPingEnabled is true of course).
           </li>
+          <li><code>networkPingTimeout</code> – This configures a timeout (in milliseconds) at the connection level for
+            the ping query. If this time passes, the connection will be invalid. In the event that a firewall or network
+            problem drops packets, connections will not wait indefinitely for a response. Default: 0 (inactive)
+          </li>
         </ul>
         <p>
           <strong>JNDI</strong>


### PR DESCRIPTION
If the firewall drops packets or they are lost on the network, the pingConnection method in X ms drops this connection and gets a new one, and does not wait indefinitely the response. The time will be configured in networkPingTimeout property (in milliseconds).
To reproduce this execute this in the database machine:
 sudo iptables -D INPUT -p tcp --sport $i -j DROP; sudo iptables -D OUTPUT -p tcp --dport $i -j DROP
 $i -> port of the connections