### PR TITLE
用户程序更改返回值时导致的本地缓存与数据库不一致

### DIFF
--- a/src/main/java/org/apache/ibatis/cache/impl/PerpetualCache.java
+++ b/src/main/java/org/apache/ibatis/cache/impl/PerpetualCache.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.cache.CacheException;
+import org.apache.ibatis.util.Pair;
 
 /**
  * @author Clinton Begin
@@ -28,7 +29,7 @@ public class PerpetualCache implements Cache {
 
   private final String id;
 
-  private final Map<Object, Object> cache = new HashMap<>();
+  private final Map<Object, Pair<Integer, Object>> cache = new HashMap<>();
 
   public PerpetualCache(String id) {
     this.id = id;
@@ -46,12 +47,17 @@ public class PerpetualCache implements Cache {
 
   @Override
   public void putObject(Object key, Object value) {
-    cache.put(key, value);
+    cache.put(key, new Pair<>(value == null ? 0 : value.hashCode(), value));
   }
 
   @Override
   public Object getObject(Object key) {
-    return cache.get(key);
+    Pair<Integer, Object> cacheValue = cache.get(key);
+    if (cacheValue.getKey() == cacheValue.getValueHashCode()) {
+      return cacheValue.getValue();
+    }
+    this.removeObject(key);
+    return null;
   }
 
   @Override
@@ -87,5 +93,4 @@ public class PerpetualCache implements Cache {
     }
     return getId().hashCode();
   }
-
 }

--- a/src/main/java/org/apache/ibatis/util/Pair.java
+++ b/src/main/java/org/apache/ibatis/util/Pair.java
@@ -1,0 +1,83 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.util;
+
+import java.util.Objects;
+
+/**
+ * describe: A pair of key and value
+ *
+ * @author kfyty725
+ * @date 2022/7/28 15:08
+ * @email kfyty725@hotmail.com
+ */
+public class Pair<K, V> {
+  /**
+   * key
+   */
+  private final K key;
+
+  /**
+   * value
+   */
+  private final V value;
+
+  public Pair(K key, V value) {
+    this.key = key;
+    this.value = value;
+  }
+
+  public K getKey() {
+    return key;
+  }
+
+  public V getValue() {
+    return value;
+  }
+
+  public int getKeyHashCode() {
+    return this.getKey() == null ? 0 : this.getKey().hashCode();
+  }
+
+  public int getValueHashCode() {
+    return this.getValue() == null ? 0 : this.getValue().hashCode();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof Pair)) {
+      return false;
+    }
+    Pair<?, ?> other = (Pair<?, ?>) obj;
+    return Objects.equals(this.getKey(), other.getKey()) && Objects.equals(this.getValue(), other.getValue());
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 1;
+    result = result * 59 + (this.getKey() == null ? 43 : this.getKey().hashCode());
+    result = result * 59 + (this.getValue() == null ? 43 : this.getValue().hashCode());
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return this.getKey() + "=" + this.getValue();
+  }
+}

--- a/src/test/java/org/apache/ibatis/cache/PerpetualCacheTest.java
+++ b/src/test/java/org/apache/ibatis/cache/PerpetualCacheTest.java
@@ -22,6 +22,9 @@ import org.apache.ibatis.cache.decorators.SynchronizedCache;
 import org.apache.ibatis.cache.impl.PerpetualCache;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 class PerpetualCacheTest {
 
   @Test
@@ -74,5 +77,14 @@ class PerpetualCacheTest {
     Cache cache = new PerpetualCache(null);
     assertThrows(CacheException.class, () -> cache.hashCode());
     assertThrows(CacheException.class, () -> cache.equals(new Object()));
+  }
+
+  @Test
+  void showRemoveCacheOnChangeCache() {
+    Cache cache = new PerpetualCache("change-cache");
+    List<Object> value = new ArrayList<>();
+    cache.putObject("key", value);
+    value.add(1);
+    assertNull(cache.getObject("key"));
   }
 }


### PR DESCRIPTION
当用户程序对返回值进行更新值，会破坏本地缓存与数据库数据的一致性，代码示例如下：
```java
    public void dirtyCache() {
        SqlSession sqlSession = new DefaultSqlSession(null, null);       // just test
        List<Object> list = sqlSession.selectList("selectById");         // empty list
        list.add(new Object());                                          // update list
        List<Object> dirtyList = sqlSession.selectList("selectById");    // non empty list !!!
    }
```

解决方案如下：

org.apache.ibatis.cache.impl.PerpetualCache#cache 的 key 使用 Pair<Key, Value> 进行包装，其 key 为缓存值的哈希码，value 为缓存对象。
获取对象时，如果发现 key 和 value 的哈希码不一致，则说明缓存值被用户变更过，此时删除该缓存并返回 null，从数据库重新查询。

测试代码如下：
```java
@Test
  void showRemoveCacheOnChangeCache() {
    Cache cache = new PerpetualCache("change-cache");
    List<Object> value = new ArrayList<>();
    cache.putObject("key", value);
    value.add(1);
    assertNull(cache.getObject("key"));
  }
```