### PR TITLE
add CacheNamespace useCacheGlobally

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/CacheNamespace.java
+++ b/src/main/java/org/apache/ibatis/annotations/CacheNamespace.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -99,5 +99,12 @@ public @interface CacheNamespace {
    * @since 3.4.2
    */
   Property[] properties() default {};
+
+  /**
+   * Returns whether all method use cache or not.
+   *
+   * @return {@code true} if all method use cache; {@code false} if otherwise
+   */
+  boolean useCacheGlobally() default true;
 
 }

--- a/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
+++ b/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
 
+import org.apache.ibatis.annotations.CacheNamespace;
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.cache.decorators.LruCache;
 import org.apache.ibatis.cache.impl.PerpetualCache;
@@ -58,6 +59,13 @@ public class MapperBuilderAssistant extends BaseBuilder {
   private final String resource;
   private Cache currentCache;
   private boolean unresolvedCacheRef; // issue #676
+
+  /**
+   * use Cache globally.
+   *
+   * @see CacheNamespace#useCacheGlobally()
+   */
+  private boolean useCacheGlobally = true;
 
   public MapperBuilderAssistant(Configuration configuration, String resource) {
     super(configuration);
@@ -127,6 +135,7 @@ public class MapperBuilderAssistant extends BaseBuilder {
       Integer size,
       boolean readWrite,
       boolean blocking,
+      boolean useCacheGlobally,
       Properties props) {
     Cache cache = new CacheBuilder(currentNamespace)
         .implementation(valueOrDefault(typeClass, PerpetualCache.class))
@@ -139,6 +148,7 @@ public class MapperBuilderAssistant extends BaseBuilder {
         .build();
     configuration.addCache(cache);
     currentCache = cache;
+    this.useCacheGlobally = useCacheGlobally;
     return cache;
   }
 
@@ -557,4 +567,7 @@ public class MapperBuilderAssistant extends BaseBuilder {
     return javaType;
   }
 
+  public boolean isUseCacheGlobally() {
+    return useCacheGlobally;
+  }
 }

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -187,7 +187,7 @@ public class MapperAnnotationBuilder {
       Integer size = cacheDomain.size() == 0 ? null : cacheDomain.size();
       Long flushInterval = cacheDomain.flushInterval() == 0 ? null : cacheDomain.flushInterval();
       Properties props = convertToProperties(cacheDomain.properties());
-      assistant.useNewCache(cacheDomain.implementation(), cacheDomain.eviction(), flushInterval, size, cacheDomain.readWrite(), cacheDomain.blocking(), props);
+      assistant.useNewCache(cacheDomain.implementation(), cacheDomain.eviction(), flushInterval, size, cacheDomain.readWrite(), cacheDomain.blocking(), cacheDomain.useCacheGlobally(), props);
     }
   }
 
@@ -329,14 +329,14 @@ public class MapperAnnotationBuilder {
       ResultSetType resultSetType = configuration.getDefaultResultSetType();
       boolean isSelect = sqlCommandType == SqlCommandType.SELECT;
       boolean flushCache = !isSelect;
-      boolean useCache = isSelect;
+      boolean useCache = isSelect && assistant.isUseCacheGlobally();
       if (options != null) {
         if (FlushCachePolicy.TRUE.equals(options.flushCache())) {
           flushCache = true;
         } else if (FlushCachePolicy.FALSE.equals(options.flushCache())) {
           flushCache = false;
         }
-        useCache = options.useCache();
+        useCache = options.useCache() && assistant.isUseCacheGlobally();
         fetchSize = options.fetchSize() > -1 || options.fetchSize() == Integer.MIN_VALUE ? options.fetchSize() : null; //issue #348
         timeout = options.timeout() > -1 ? options.timeout() : null;
         statementType = options.statementType();

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -210,7 +210,8 @@ public class XMLMapperBuilder extends BaseBuilder {
       boolean readWrite = !context.getBooleanAttribute("readOnly", false);
       boolean blocking = context.getBooleanAttribute("blocking", false);
       Properties props = context.getChildrenAsProperties();
-      builderAssistant.useNewCache(typeClass, evictionClass, flushInterval, size, readWrite, blocking, props);
+      boolean useCacheGlobally = context.getBooleanAttribute("useCacheGlobally", true);
+      builderAssistant.useNewCache(typeClass, evictionClass, flushInterval, size, readWrite, blocking, useCacheGlobally, props);
     }
   }
 

--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
@@ -34,6 +34,7 @@ flushInterval CDATA #IMPLIED
 size CDATA #IMPLIED
 readOnly CDATA #IMPLIED
 blocking CDATA #IMPLIED
+useCacheGlobally CDATA #IMPLIED
 >
 
 <!ELEMENT parameterMap (parameter+)?>

--- a/src/main/java/org/apache/ibatis/builder/xml/mybatis-mapper.xsd
+++ b/src/main/java/org/apache/ibatis/builder/xml/mybatis-mapper.xsd
@@ -53,6 +53,7 @@
       <xs:attribute name="size"/>
       <xs:attribute name="readOnly"/>
       <xs:attribute name="blocking"/>
+      <xs:attribute name="useCacheGlobally"/>
     </xs:complexType>
   </xs:element>
   <xs:element name="parameterMap">

--- a/src/test/java/org/apache/ibatis/builder/AnnotationMapperBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/AnnotationMapperBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.builder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.apache.ibatis.annotations.CacheNamespace;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
@@ -94,6 +95,24 @@ class AnnotationMapperBuilderTest {
     assertThat(mappedStatement.getResultSetType()).isEqualTo(ResultSetType.DEFAULT);
   }
 
+  @Test
+  void testSelectWithCache() {
+    Configuration configuration = new Configuration();
+    MapperAnnotationBuilder builder = new MapperAnnotationBuilder(configuration, NoUseCacheMapper.class);
+    builder.parse();
+    MappedStatement mappedStatement = configuration.getMappedStatement("selectWithCache");
+    assertThat(mappedStatement.isUseCache()).isTrue();
+  }
+
+  @Test
+  void testSelectWithNoCache() {
+    Configuration configuration = new Configuration();
+    MapperAnnotationBuilder builder = new MapperAnnotationBuilder(configuration, NoUseCacheMapper.class);
+    builder.parse();
+    MappedStatement mappedStatement = configuration.getMappedStatement("selectWithNoCache");
+    assertThat(mappedStatement.isUseCache()).isFalse();
+  }
+
   interface Mapper {
 
     @Insert("insert into test (name) values(#{name})")
@@ -111,6 +130,18 @@ class AnnotationMapperBuilderTest {
     @Select("select * from test")
     String selectWithoutOptions(Integer id);
 
+  }
+
+  @CacheNamespace(useCacheGlobally = true)
+  interface NoUseCacheMapper {
+
+    @Select("select * from test")
+    @Options(useCache = true)
+    String selectWithCache(Integer id);
+
+    @Select("select * from test")
+    @Options(useCache = false)
+    String selectWithNoCache(Integer id);
   }
 
 }

--- a/src/test/java/org/apache/ibatis/builder/CachedAuthorMapper.java
+++ b/src/test/java/org/apache/ibatis/builder/CachedAuthorMapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,4 +23,6 @@ public interface CachedAuthorMapper {
     void insertAuthor(Author author);
     boolean updateAuthor(Author author);
     boolean deleteAuthor(int id);
+    Author selectAllAuthorsNoUseCache();
+    Author selectAllAuthorsUseCache();
 }

--- a/src/test/java/org/apache/ibatis/builder/CachedAuthorMapper.xml
+++ b/src/test/java/org/apache/ibatis/builder/CachedAuthorMapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2016 the original author or authors.
+       Copyright 2009-2022 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
 
 <mapper namespace="org.apache.ibatis.builder.CachedAuthorMapper">
 
-  <cache readOnly="true"/>
+  <cache readOnly="true" useCacheGlobally="true"/>
 
   <select id="selectAllAuthors"
           resultType="org.apache.ibatis.domain.blog.Author">
@@ -52,5 +52,15 @@
           parameterType="int">
     delete from Author where id = #{id}
   </delete>
+
+  <select id="selectAllAuthorsUseCache"
+          resultType="org.apache.ibatis.domain.blog.Author" useCache="true">
+    select * from author
+  </select>
+
+  <select id="selectAllAuthorsNoUseCache"
+          resultType="org.apache.ibatis.domain.blog.Author" useCache="false">
+    select * from author
+  </select>
 
 </mapper>

--- a/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
+++ b/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2021 the original author or authors.
+ *    Copyright 2009-2022 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -475,6 +475,36 @@ class SqlSessionTest extends BaseDataTest {
     int second;
     try (SqlSession session = sqlMapper.openSession()) {
       List<Author> authors = session.selectList("org.apache.ibatis.domain.blog.mappers.AuthorMapper.selectAllAuthors");
+      second = System.identityHashCode(authors);
+    }
+    assertTrue(first != second);
+  }
+
+  @Test
+  void shouldNotUseCacheForTestUseCacheGlobally() {
+    int first;
+    try (SqlSession session = sqlMapper.openSession()) {
+      List<Author> authors = session.selectList("org.apache.ibatis.builder.CachedAuthorMapper.selectAllAuthorsUseCache");
+      first = System.identityHashCode(authors);
+    }
+    int second;
+    try (SqlSession session = sqlMapper.openSession()) {
+      List<Author> authors = session.selectList("org.apache.ibatis.builder.CachedAuthorMapper.selectAllAuthorsUseCache");
+      second = System.identityHashCode(authors);
+    }
+    assertEquals(first, second);
+  }
+
+  @Test
+  void shouldUseCacheForTestUseCacheGlobally() {
+    int first;
+    try (SqlSession session = sqlMapper.openSession()) {
+      List<Author> authors = session.selectList("org.apache.ibatis.builder.CachedAuthorMapper.selectAllAuthorsNoUseCache");
+      first = System.identityHashCode(authors);
+    }
+    int second;
+    try (SqlSession session = sqlMapper.openSession()) {
+      List<Author> authors = session.selectList("org.apache.ibatis.builder.CachedAuthorMapper.selectAllAuthorsNoUseCache");
       second = System.identityHashCode(authors);
     }
     assertTrue(first != second);


### PR DESCRIPTION
Hi, as described in this issure https://github.com/mybatis/mybatis-3/issues/2633

The current problem is:

CacheNamespace defaults to using Cache for all methods under the current Mapper, which only makes sense when Options.useCache=false.
If you want to specify a specific method to use Cache, you must use subtraction to exclude all methods that do not use cache with Options.useCache=false, which is more complicated for developers in some aspects.

My train of thought:
1. Add the useCacheGlobally option to CacheNamespace, the default is true, which satisfies the current implementation idea
2. Developers can choose useCacheGlobally = false in Mapper. At this time, whether the method uses cache is completely handled by Options.useCache