### PR TITLE
Change the cast targets

### DIFF
--- a/src/main/java/org/apache/ibatis/cache/decorators/SoftCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/SoftCache.java
@@ -65,8 +65,8 @@ public class SoftCache implements Cache {
   @Override
   public Object getObject(Object key) {
     Object result = null;
-    @SuppressWarnings("unchecked") // assumed delegate cache is totally managed by this cache
-    SoftReference<Object> softReference = (SoftReference<Object>) delegate.getObject(key);
+    // assumed delegate cache is totally managed by this cache
+    SoftEntry softReference = (SoftEntry) delegate.getObject(key);
     if (softReference != null) {
       result = softReference.get();
       if (result == null) {
@@ -87,8 +87,7 @@ public class SoftCache implements Cache {
   @Override
   public Object removeObject(Object key) {
     removeGarbageCollectedItems();
-    @SuppressWarnings("unchecked")
-    SoftReference<Object> softReference = (SoftReference<Object>) delegate.removeObject(key);
+    SoftEntry softReference = (SoftEntry) delegate.removeObject(key);
     return softReference == null ? null : softReference.get();
   }
 

--- a/src/main/java/org/apache/ibatis/cache/decorators/WeakCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/WeakCache.java
@@ -65,8 +65,8 @@ public class WeakCache implements Cache {
   @Override
   public Object getObject(Object key) {
     Object result = null;
-    @SuppressWarnings("unchecked") // assumed delegate cache is totally managed by this cache
-    WeakReference<Object> weakReference = (WeakReference<Object>) delegate.getObject(key);
+    // assumed delegate cache is totally managed by this cache
+    WeakEntry weakReference = (WeakEntry) delegate.getObject(key);
     if (weakReference != null) {
       result = weakReference.get();
       if (result == null) {
@@ -86,8 +86,7 @@ public class WeakCache implements Cache {
   @Override
   public Object removeObject(Object key) {
     removeGarbageCollectedItems();
-    @SuppressWarnings("unchecked")
-    WeakReference<Object> weakReference = (WeakReference<Object>) delegate.removeObject(key);
+    WeakEntry weakReference = (WeakEntry) delegate.removeObject(key);
     return weakReference == null ? null : weakReference.get();
   }
 


### PR DESCRIPTION
- Change the cast target from `WeakReference<Object>` to `WeakEntry` in `WeakCache.class`.
- Change the cast target from `SoftReference<Object>` to `SoftEntry` in `SoftCache.class`.

Because I don't think it's necessary to convert `delegate.get(key)` to `WeakReference` or `SoftReference` and then suppress the warning with `@SuppressWarnings("unchecked")`.
If my idea is wrong, please point it out.
Thanks!