### PR TITLE
[modernize] Use standard charsets utf-8

### DIFF
--- a/src/main/java/org/apache/ibatis/io/DefaultVFS.java
+++ b/src/main/java/org/apache/ibatis/io/DefaultVFS.java
@@ -21,7 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -268,11 +268,7 @@ public class DefaultVFS extends VFS {
 
         // File name might be URL-encoded
         if (!file.exists()) {
-          try {
-            file = new File(URLEncoder.encode(jarUrl.toString(), "UTF-8"));
-          } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException("Unsupported encoding?  UTF-8?  That's impossible.");
-          }
+          file = new File(URLEncoder.encode(jarUrl.toString(), StandardCharsets.UTF_8));
         }
 
         if (file.exists()) {

--- a/src/test/java/org/apache/ibatis/io/ExternalResourcesTest.java
+++ b/src/test/java/org/apache/ibatis/io/ExternalResourcesTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,7 +83,7 @@ class ExternalResourcesTest {
   void testGetConfiguredTemplate() {
     String templateName = "";
 
-    try (FileWriter fileWriter = new FileWriter(tempFile)) {
+    try (FileWriter fileWriter = new FileWriter(tempFile, StandardCharsets.UTF_8)) {
       fileWriter.append("new_command.template=templates/col_new_template_migration.sql");
       fileWriter.flush();
       templateName = ExternalResources.getConfiguredTemplate(tempFile.getAbsolutePath(), "new_command.template");


### PR DESCRIPTION
- replacing source hard coded value for utf-8 which is likely somewhat costly along with removal of try no longer needed
- adding missing utf-8 charset for unit test