### PR TITLE
[modernize] Use standard charsets

### DIFF
--- a/src/main/java/org/apache/ibatis/io/DefaultVFS.java
+++ b/src/main/java/org/apache/ibatis/io/DefaultVFS.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLEncoder;
@@ -269,7 +270,7 @@ public class DefaultVFS extends VFS {
         // File name might be URL-encoded
         if (!file.exists()) {
           try {
-            file = new File(URLEncoder.encode(jarUrl.toString(), "UTF-8"));
+            file = new File(URLEncoder.encode(jarUrl.toString(), StandardCharsets.UTF_8.name()));
           } catch (UnsupportedEncodingException e) {
             throw new RuntimeException("Unsupported encoding?  UTF-8?  That's impossible.");
           }

--- a/src/test/java/org/apache/ibatis/io/ExternalResourcesTest.java
+++ b/src/test/java/org/apache/ibatis/io/ExternalResourcesTest.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
unfortunately if > jdk 16 uses with current project needs, the detection can be a bit off.  So this is not entirely ideal until we are on higher jdks and stop using static for searching when we already have it.  For now this is better.