### PR TITLE
style: Use the typeAliasRegistry field in BaseBuilder to avoid ambiguity

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -162,7 +162,7 @@ public class XMLConfigBuilder extends BaseBuilder {
       for (XNode child : parent.getChildren()) {
         if ("package".equals(child.getName())) {
           String typeAliasPackage = child.getStringAttribute("name");
-          configuration.getTypeAliasRegistry().registerAliases(typeAliasPackage);
+          typeAliasRegistry.registerAliases(typeAliasPackage);
         } else {
           String alias = child.getStringAttribute("alias");
           String type = child.getStringAttribute("type");


### PR DESCRIPTION
The field of TypeAliasRegistry has been defined in the BaseBuilder class, so it can be used directly instead of getting it from the Configuration object. This is a bit weird, so adjust to use the TypeAliasRegistry type field in BaseBuilder directly