### PR TITLE
Fix a race condition caused by other threads calling mapper methods while mappedStatements are being constructed

### DIFF
--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 
 import org.apache.ibatis.binding.MapperRegistry;
@@ -998,7 +999,7 @@ public class Configuration {
     }
   }
 
-  protected static class StrictMap<V> extends HashMap<String, V> {
+  protected static class StrictMap<V> extends ConcurrentHashMap<String, V> {
 
     private static final long serialVersionUID = -4950446264854982944L;
     private final String name;
@@ -1053,6 +1054,15 @@ public class Configuration {
         }
       }
       return super.put(key, value);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+      if (key == null) {
+        return false;
+      }
+
+      return super.get(key) != null;
     }
 
     @Override


### PR DESCRIPTION
In projects using the Spring framework, we often use `@PostConstruct` to perform some operations after bean initialization. In some scenarios, we will create asynchronous thread to perform some time-consuming SQL operations to avoid blocking the application startup process. We observed that the use of mappers in asynchronous thread may broken due to the `resize` of the underlying `StrictMap` of `mappedStatements`.

Example code for using `@PostConstruct` with asynchronous thread, [MybatisRaceConditionApplication.java](https://github.com/tianshuang/mybatis-race-condition/blob/main/src/main/java/me/tianshuang/MybatisRaceConditionApplication.java#L19-L45):

```java
@Autowired
private Mapper1 mapper1;

private volatile boolean applicationReady;

@PostConstruct
public void raceConditionTest() {
    new Thread(() -> {
        int successfulCalls = 0;
        while (!applicationReady) {
            try {
                mapper1.select1();
                successfulCalls++;
            } catch (Exception e) {
                System.err.println("Number of successful calls before application ready: " + successfulCalls);
                e.printStackTrace();
                return;
            }
        }
    }).start();
}

@EventListener(ApplicationReadyEvent.class)
public void doSomethingAfterStartup() {
    applicationReady = true;
    System.out.println("Context Ready Event received.");
}
```

In this scenario, the main thread is still building the mapper of other beans, that is, it keeps putting `mappedStatement` to `mappedStatements`, and in this asynchronous thread, it keeps getting `mappedStatement` from `mappedStatements` , because `StrictMap` inherits from `HashMap`, when the underlying `HashMap` performs the `resize` operation, before the old array element migration is completed and the asynchronous thread obtains the latest `table` reference, At this time, the `mappedStatement` that has been put before cannot be obtained from `mappedStatements`.

This is the source code of `HashMap#resize` in JDK8:
```java
transient Node<K,V>[] table;

final Node<K,V>[] resize() {
    Node<K,V>[] oldTab = table;

    // omit newCap calculation

    Node<K,V>[] newTab = (Node<K,V>[])new Node[newCap];
    table = newTab;
    if (oldTab != null) {
        for (int j = 0; j < oldCap; ++j) {
            // omit elements reference copy
        }
    }
    return newTab;
}
```

In the source code, a new array `newTab` is allocated first, and the empty array `newTab` reference is assigned to `table`. Before the element migration is completed, the asynchronous thread calling `mappedStatements.get(id)` may not be able to get it `mappedStatement`(**depends on seeing the latest `table` reference, note that `table` does not contain the `volatile` modifier. however, it can be obtained normally before and after resize**), instead throws the following exception:

```text
org.mybatis.spring.MyBatisSystemException: nested exception is org.apache.ibatis.exceptions.PersistenceException: 
### Error querying database.  Cause: java.lang.IllegalArgumentException: Mapped Statements collection does not contain value for me.tianshuang.mapper.Mapper1.select1
### Cause: java.lang.IllegalArgumentException: Mapped Statements collection does not contain value for me.tianshuang.mapper.Mapper1.select1
	at org.mybatis.spring.MyBatisExceptionTranslator.translateExceptionIfPossible(MyBatisExceptionTranslator.java:96)
	at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:441)
	at com.sun.proxy.$Proxy47.selectOne(Unknown Source)
	at org.mybatis.spring.SqlSessionTemplate.selectOne(SqlSessionTemplate.java:160)
	at org.apache.ibatis.binding.MapperMethod.execute(MapperMethod.java:87)
	at org.apache.ibatis.binding.MapperProxy$PlainMethodInvoker.invoke(MapperProxy.java:145)
	at org.apache.ibatis.binding.MapperProxy.invoke(MapperProxy.java:86)
	at com.sun.proxy.$Proxy50.select1(Unknown Source)
	at me.tianshuang.MybatisRaceConditionApplication.lambda$raceConditionTest$0(MybatisRaceConditionApplication.java:25)
	at java.lang.Thread.run(Thread.java:750)
Caused by: org.apache.ibatis.exceptions.PersistenceException: 
### Error querying database.  Cause: java.lang.IllegalArgumentException: Mapped Statements collection does not contain value for me.tianshuang.mapper.Mapper1.select1
### Cause: java.lang.IllegalArgumentException: Mapped Statements collection does not contain value for me.tianshuang.mapper.Mapper1.select1
	at org.apache.ibatis.exceptions.ExceptionFactory.wrapException(ExceptionFactory.java:30)
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:153)
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:145)
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:140)
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectOne(DefaultSqlSession.java:76)
	at sun.reflect.GeneratedMethodAccessor34.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.mybatis.spring.SqlSessionTemplate$SqlSessionInterceptor.invoke(SqlSessionTemplate.java:427)
	... 8 more
Caused by: java.lang.IllegalArgumentException: Mapped Statements collection does not contain value for me.tianshuang.mapper.Mapper1.select1
	at org.apache.ibatis.session.Configuration$StrictMap.get(Configuration.java:1054)
	at org.apache.ibatis.session.Configuration.getMappedStatement(Configuration.java:844)
	at org.apache.ibatis.session.Configuration.getMappedStatement(Configuration.java:837)
	at org.apache.ibatis.session.defaults.DefaultSqlSession.selectList(DefaultSqlSession.java:150)
	... 15 more
```

The root cause of this problem is that multiple threads access `mappedStatements` concurrently, and the main thread has made structural modifications to `mappedStatements`, which does not conform to the usage specification of `HashMap`, so in order to solve this problem, we should make `StrictMap` inherited from `ConcurrentHashMap`, at the same time, in order to be compatible with the changes of the `containsKey` method and adapt to the NULL key, I rewrote the `containsKey` method.

This project can reproduce the race condition: [GitHub - tianshuang/mybatis-race-condition](https://github.com/tianshuang/mybatis-race-condition)

Reference:
[java - HashMap resize() while single thread writing and multiple threads reading - Stack Overflow](https://stackoverflow.com/questions/71557222/hashmap-resize-while-single-thread-writing-and-multiple-threads-reading)

#### Unit Test
All unit tests pass.