### PR TITLE
Introduced optional settings to disable print prepare statement in log.

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -272,6 +272,7 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setArgNameBasedConstructorAutoMapping(booleanValueOf(props.getProperty("argNameBasedConstructorAutoMapping"), false));
     configuration.setDefaultSqlProviderType(resolveClass(props.getProperty("defaultSqlProviderType")));
     configuration.setNullableOnForEach(booleanValueOf(props.getProperty("nullableOnForEach"), false));
+    configuration.setPrintPrepareStatement(booleanValueOf(props.getProperty("printPrepareStatement"), true));
   }
 
   private void environmentsElement(XNode context) throws Exception {

--- a/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
@@ -336,7 +336,7 @@ public abstract class BaseExecutor implements Executor {
   protected Connection getConnection(Log statementLog) throws SQLException {
     Connection connection = transaction.getConnection();
     if (statementLog.isDebugEnabled()) {
-      return ConnectionLogger.newInstance(connection, statementLog, queryStack);
+      return ConnectionLogger.newInstance(connection, statementLog, queryStack, configuration);
     } else {
       return connection;
     }

--- a/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import org.apache.ibatis.builder.SqlSourceBuilder;
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.reflection.ArrayUtil;
+import org.apache.ibatis.session.Configuration;
 
 /**
  * Base class for proxies to do logging.
@@ -50,6 +51,7 @@ public abstract class BaseJdbcLogger {
 
   protected final Log statementLog;
   protected final int queryStack;
+
 
   /*
    * Default constructor

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -116,6 +116,8 @@ public class Configuration {
   protected boolean shrinkWhitespacesInSql;
   protected boolean nullableOnForEach;
   protected boolean argNameBasedConstructorAutoMapping;
+  protected boolean printPrepareStatement;
+
 
   protected String logPrefix;
   protected Class<? extends Log> logImpl;
@@ -420,6 +422,16 @@ public class Configuration {
 
   public void setLazyLoadingEnabled(boolean lazyLoadingEnabled) {
     this.lazyLoadingEnabled = lazyLoadingEnabled;
+  }
+
+  public boolean isPrintPrepareStatement()
+  {
+    return printPrepareStatement;
+  }
+
+  public void setPrintPrepareStatement(boolean printPrepareStatement)
+  {
+    this.printPrepareStatement = printPrepareStatement;
   }
 
   public ProxyFactory getProxyFactory() {

--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -638,6 +638,7 @@ A continuación se muestra un ejemplo del elemento settings al completo:
   <setting name="vfsImpl" value="org.mybatis.example.YourselfVfsImpl"/>
   <setting name="useActualParamName" value="true"/>
   <setting name="configurationFactory" value="org.mybatis.example.ConfigurationFactory"/>
+  <setting name="printPrepareStatement" value="true"/>
 </settings>]]></source>
 
       </subsection>


### PR DESCRIPTION
SQL statements are logged at the DEBUG level. However, in many cases, the statement that is logged is repeated several times identical in the log file, generating space: in these cases, for the purpose of a practical reconstruction of the query, what you really need is the parameter log of the statement. Since there is no log level that allows you to print only the parameters of the statement, I thought of introducing a setting, for now global, that allows you to optionally print only the parameters of the statement.