### PR TITLE
Enable ability to provide custom configuration to XMLConfigBuilder

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -67,7 +67,11 @@ public class XMLConfigBuilder extends BaseBuilder {
   }
 
   public XMLConfigBuilder(Reader reader, String environment, Properties props) {
-    this(new XPathParser(reader, true, props, new XMLMapperEntityResolver()), environment, props);
+    this(new Configuration(), reader, environment, props);
+  }
+
+  public XMLConfigBuilder(Configuration configuration, Reader reader, String environment, Properties props) {
+    this(configuration, new XPathParser(reader, true, props, new XMLMapperEntityResolver()), environment, props);
   }
 
   public XMLConfigBuilder(InputStream inputStream) {
@@ -79,11 +83,15 @@ public class XMLConfigBuilder extends BaseBuilder {
   }
 
   public XMLConfigBuilder(InputStream inputStream, String environment, Properties props) {
-    this(new XPathParser(inputStream, true, props, new XMLMapperEntityResolver()), environment, props);
+    this(new Configuration(), inputStream, environment, props);
   }
 
-  private XMLConfigBuilder(XPathParser parser, String environment, Properties props) {
-    super(new Configuration());
+  public XMLConfigBuilder(Configuration configuration, InputStream inputStream, String environment, Properties props) {
+    this(configuration, new XPathParser(inputStream, true, props, new XMLMapperEntityResolver()), environment, props);
+  }
+
+  private XMLConfigBuilder(Configuration configuration, XPathParser parser, String environment, Properties props) {
+    super(configuration);
     ErrorContext.instance().resource("SQL Mapper Configuration");
     this.configuration.setVariables(props);
     this.parsed = false;

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -67,11 +67,11 @@ public class XMLConfigBuilder extends BaseBuilder {
   }
 
   public XMLConfigBuilder(Reader reader, String environment, Properties props) {
-    this(new Configuration(), reader, environment, props);
+    this(Configuration.class, reader, environment, props);
   }
 
-  public XMLConfigBuilder(Configuration configuration, Reader reader, String environment, Properties props) {
-    this(configuration, new XPathParser(reader, true, props, new XMLMapperEntityResolver()), environment, props);
+  public XMLConfigBuilder(Class<? extends Configuration> configClass, Reader reader, String environment, Properties props) {
+    this(configClass, new XPathParser(reader, true, props, new XMLMapperEntityResolver()), environment, props);
   }
 
   public XMLConfigBuilder(InputStream inputStream) {
@@ -83,15 +83,15 @@ public class XMLConfigBuilder extends BaseBuilder {
   }
 
   public XMLConfigBuilder(InputStream inputStream, String environment, Properties props) {
-    this(new Configuration(), inputStream, environment, props);
+    this(Configuration.class, inputStream, environment, props);
   }
 
-  public XMLConfigBuilder(Configuration configuration, InputStream inputStream, String environment, Properties props) {
-    this(configuration, new XPathParser(inputStream, true, props, new XMLMapperEntityResolver()), environment, props);
+  public XMLConfigBuilder(Class<? extends Configuration> configClass, InputStream inputStream, String environment, Properties props) {
+    this(configClass, new XPathParser(inputStream, true, props, new XMLMapperEntityResolver()), environment, props);
   }
 
-  private XMLConfigBuilder(Configuration configuration, XPathParser parser, String environment, Properties props) {
-    super(configuration);
+  private XMLConfigBuilder(Class<? extends Configuration> configClass, XPathParser parser, String environment, Properties props) {
+    super(newConfig(configClass));
     ErrorContext.instance().resource("SQL Mapper Configuration");
     this.configuration.setVariables(props);
     this.parsed = false;
@@ -412,6 +412,14 @@ public class XMLConfigBuilder extends BaseBuilder {
       throw new BuilderException("Environment requires an id attribute.");
     }
     return environment.equals(id);
+  }
+
+  private static Configuration newConfig(Class<? extends Configuration> configClass) {
+    try {
+      return configClass.getDeclaredConstructor().newInstance();
+    } catch (Exception ex) {
+      throw new BuilderException("Failed to create a new Configuration instance.", ex);
+    }
   }
 
 }

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -19,6 +19,7 @@ import static com.googlecode.catchexception.apis.BDDCatchException.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -65,6 +66,7 @@ import org.apache.ibatis.type.EnumTypeHandler;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -325,15 +327,32 @@ class XmlConfigBuilderTest {
     String resource = "org/apache/ibatis/builder/MinimalMapperConfig.xml";
     try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
       XMLConfigBuilder builder = new XMLConfigBuilder(
-              new MyConfiguration(), inputStream, null, null);
+              MyConfiguration.class, inputStream, null, null);
       Configuration config = builder.parse();
 
       assertThat(config).isInstanceOf(MyConfiguration.class);
     }
   }
 
-  private static class MyConfiguration extends Configuration {
+  @Test
+  void noDefaultConstructorForSubclassedConfiguration() throws IOException {
+    String resource = "org/apache/ibatis/builder/MinimalMapperConfig.xml";
+    try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+      Exception exception = Assertions.assertThrows(Exception.class, () -> new XMLConfigBuilder(
+              BadConfiguration.class, inputStream, null, null));
+      assertEquals("Failed to create a new Configuration instance.", exception.getMessage());
+    }
+  }
+
+  public static class MyConfiguration extends Configuration {
     // only using to check configuration was used
+  }
+
+  public static class BadConfiguration extends Configuration {
+
+    public BadConfiguration(String parameter) {
+        // should have a default constructor
+    }
   }
 
 }

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.math.RoundingMode;
@@ -114,7 +115,7 @@ class XmlConfigBuilderTest {
 
   public static class EnumOrderTypeHandler<E extends Enum<E>> extends BaseTypeHandler<E> {
 
-    private E[] constants;
+    private final E[] constants;
 
     public EnumOrderTypeHandler(Class<E> javaType) {
       constants = javaType.getEnumConstants();
@@ -317,6 +318,22 @@ class XmlConfigBuilderTest {
     public static String provideSql() {
       return "SELECT 1";
     }
+  }
+
+  @Test
+  void shouldAllowSubclassedConfiguration() throws IOException {
+    String resource = "org/apache/ibatis/builder/MinimalMapperConfig.xml";
+    try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+      XMLConfigBuilder builder = new XMLConfigBuilder(
+              new MyConfiguration(), inputStream, null, null);
+      Configuration config = builder.parse();
+
+      assertThat(config).isInstanceOf(MyConfiguration.class);
+    }
+  }
+
+  private static class MyConfiguration extends Configuration {
+    // only using to check configuration was used
   }
 
 }


### PR DESCRIPTION
Supported via the InputStream/Reader constructors

Default constructors will keep using a new configuration