### PR TITLE
Add `affectData` attribute to `@Select`, `@SelectProvider` and `<select />`

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/Select.java
+++ b/src/main/java/org/apache/ibatis/annotations/Select.java
@@ -56,6 +56,15 @@ public @interface Select {
   String databaseId() default "";
 
   /**
+   * Returns whether this select affects DB data.<br>
+   * e.g. RETURNING of PostgreSQL or OUTPUT of MS SQL Server.
+   *
+   * @return {@code true} if this select affects DB data; {@code false} if otherwise
+   * @since 3.5.12
+   */
+  boolean affectData() default false;
+
+  /**
    * The container annotation for {@link Select}.
    * @author Kazuki Shimizu
    * @since 3.5.5

--- a/src/main/java/org/apache/ibatis/annotations/SelectProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/SelectProvider.java
@@ -100,6 +100,15 @@ public @interface SelectProvider {
   String databaseId() default "";
 
   /**
+   * Returns whether this select affects DB data.<br>
+   * e.g. RETURNING of PostgreSQL or OUTPUT of MS SQL Server.
+   *
+   * @return {@code true} if this select affects DB data; {@code false} if otherwise
+   * @since 3.5.12
+   */
+  boolean affectData() default false;
+
+  /**
    * The container annotation for {@link SelectProvider}.
    * @author Kazuki Shimizu
    * @since 3.5.5

--- a/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
+++ b/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
@@ -261,7 +261,8 @@ public class MapperBuilderAssistant extends BaseBuilder {
       String keyColumn,
       String databaseId,
       LanguageDriver lang,
-      String resultSets) {
+      String resultSets,
+      boolean dirtySelect) {
 
     if (unresolvedCacheRef) {
       throw new IncompleteElementException("Cache-ref not yet resolved");
@@ -285,7 +286,8 @@ public class MapperBuilderAssistant extends BaseBuilder {
         .resultSetType(resultSetType)
         .flushCacheRequired(flushCache)
         .useCache(useCache)
-        .cache(currentCache);
+        .cache(currentCache)
+        .dirtySelect(dirtySelect);
 
     ParameterMap statementParameterMap = getStatementParameterMap(parameterMap, parameterType, id);
     if (statementParameterMap != null) {
@@ -344,12 +346,24 @@ public class MapperBuilderAssistant extends BaseBuilder {
       SqlCommandType sqlCommandType, Integer fetchSize, Integer timeout, String parameterMap, Class<?> parameterType,
       String resultMap, Class<?> resultType, ResultSetType resultSetType, boolean flushCache, boolean useCache,
       boolean resultOrdered, KeyGenerator keyGenerator, String keyProperty, String keyColumn, String databaseId,
-      LanguageDriver lang) {
+      LanguageDriver lang, String resultSets) {
     return addMappedStatement(
       id, sqlSource, statementType, sqlCommandType, fetchSize, timeout,
       parameterMap, parameterType, resultMap, resultType, resultSetType,
       flushCache, useCache, resultOrdered, keyGenerator, keyProperty,
-      keyColumn, databaseId, lang, null);
+      keyColumn, databaseId, lang, null, false);
+  }
+
+  public MappedStatement addMappedStatement(String id, SqlSource sqlSource, StatementType statementType,
+      SqlCommandType sqlCommandType, Integer fetchSize, Integer timeout, String parameterMap, Class<?> parameterType,
+      String resultMap, Class<?> resultType, ResultSetType resultSetType, boolean flushCache, boolean useCache,
+      boolean resultOrdered, KeyGenerator keyGenerator, String keyProperty, String keyColumn, String databaseId,
+      LanguageDriver lang) {
+    return addMappedStatement(
+        id, sqlSource, statementType, sqlCommandType, fetchSize, timeout,
+        parameterMap, parameterType, resultMap, resultType, resultSetType,
+        flushCache, useCache, resultOrdered, keyGenerator, keyProperty,
+        keyColumn, databaseId, lang, null);
   }
 
   private <T> T valueOrDefault(T value, T defaultValue) {

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -378,7 +378,8 @@ public class MapperAnnotationBuilder {
           statementAnnotation.getDatabaseId(),
           languageDriver,
           // ResultSets
-          options != null ? nullOrEmpty(options.resultSets()) : null);
+          options != null ? nullOrEmpty(options.resultSets()) : null,
+          statementAnnotation.isDirtySelect());
     });
   }
 
@@ -604,7 +605,7 @@ public class MapperAnnotationBuilder {
 
     assistant.addMappedStatement(id, sqlSource, statementType, sqlCommandType, fetchSize, timeout, parameterMap, parameterTypeClass, resultMap, resultTypeClass, resultSetTypeEnum,
         flushCache, useCache, false,
-        keyGenerator, keyProperty, keyColumn, databaseId, languageDriver, null);
+        keyGenerator, keyProperty, keyColumn, databaseId, languageDriver, null, false);
 
     id = assistant.applyCurrentNamespace(id, false);
 
@@ -672,6 +673,7 @@ public class MapperAnnotationBuilder {
     private final Annotation annotation;
     private final String databaseId;
     private final SqlCommandType sqlCommandType;
+    private boolean dirtySelect;
 
     AnnotationWrapper(Annotation annotation) {
       super();
@@ -679,6 +681,7 @@ public class MapperAnnotationBuilder {
       if (annotation instanceof Select) {
         databaseId = ((Select) annotation).databaseId();
         sqlCommandType = SqlCommandType.SELECT;
+        dirtySelect = ((Select) annotation).affectData();
       } else if (annotation instanceof Update) {
         databaseId = ((Update) annotation).databaseId();
         sqlCommandType = SqlCommandType.UPDATE;
@@ -691,6 +694,7 @@ public class MapperAnnotationBuilder {
       } else if (annotation instanceof SelectProvider) {
         databaseId = ((SelectProvider) annotation).databaseId();
         sqlCommandType = SqlCommandType.SELECT;
+        dirtySelect = ((SelectProvider) annotation).affectData();
       } else if (annotation instanceof UpdateProvider) {
         databaseId = ((UpdateProvider) annotation).databaseId();
         sqlCommandType = SqlCommandType.UPDATE;
@@ -722,6 +726,10 @@ public class MapperAnnotationBuilder {
 
     String getDatabaseId() {
       return databaseId;
+    }
+
+    boolean isDirtySelect() {
+      return dirtySelect;
     }
   }
 }

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
@@ -109,11 +109,12 @@ public class XMLStatementBuilder extends BaseBuilder {
     String keyProperty = context.getStringAttribute("keyProperty");
     String keyColumn = context.getStringAttribute("keyColumn");
     String resultSets = context.getStringAttribute("resultSets");
+    boolean dirtySelect = context.getBooleanAttribute("affectData", Boolean.FALSE);
 
     builderAssistant.addMappedStatement(id, sqlSource, statementType, sqlCommandType,
         fetchSize, timeout, parameterMap, parameterTypeClass, resultMap, resultTypeClass,
         resultSetTypeEnum, flushCache, useCache, resultOrdered,
-        keyGenerator, keyProperty, keyColumn, databaseId, langDriver, resultSets);
+        keyGenerator, keyProperty, keyColumn, databaseId, langDriver, resultSets, dirtySelect);
   }
 
   private void processSelectKeyNodes(String id, Class<?> parameterTypeClass, LanguageDriver langDriver) {
@@ -160,7 +161,7 @@ public class XMLStatementBuilder extends BaseBuilder {
     builderAssistant.addMappedStatement(id, sqlSource, statementType, sqlCommandType,
         fetchSize, timeout, parameterMap, parameterTypeClass, resultMap, resultTypeClass,
         resultSetTypeEnum, flushCache, useCache, resultOrdered,
-        keyGenerator, keyProperty, keyColumn, databaseId, langDriver, null);
+        keyGenerator, keyProperty, keyColumn, databaseId, langDriver, null, false);
 
     id = builderAssistant.applyCurrentNamespace(id, false);
 

--- a/src/main/java/org/apache/ibatis/mapping/MappedStatement.java
+++ b/src/main/java/org/apache/ibatis/mapping/MappedStatement.java
@@ -56,6 +56,7 @@ public final class MappedStatement {
   private Log statementLog;
   private LanguageDriver lang;
   private String[] resultSets;
+  private boolean dirtySelect;
 
   MappedStatement() {
     // constructor disabled
@@ -174,6 +175,11 @@ public final class MappedStatement {
       return this;
     }
 
+    public Builder dirtySelect(boolean dirtySelect) {
+      mappedStatement.dirtySelect = dirtySelect;
+      return this;
+    }
+
     /**
      * Resul sets.
      *
@@ -288,6 +294,10 @@ public final class MappedStatement {
 
   public String[] getResultSets() {
     return resultSets;
+  }
+
+  public boolean isDirtySelect() {
+    return dirtySelect;
   }
 
   /**

--- a/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSession.java
+++ b/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSession.java
@@ -120,6 +120,7 @@ public class DefaultSqlSession implements SqlSession {
   public <T> Cursor<T> selectCursor(String statement, Object parameter, RowBounds rowBounds) {
     try {
       MappedStatement ms = configuration.getMappedStatement(statement);
+      dirty |= ms.isDirtySelect();
       Cursor<T> cursor = executor.queryCursor(ms, wrapCollection(parameter), rowBounds);
       registerCursor(cursor);
       return cursor;

--- a/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSession.java
+++ b/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSession.java
@@ -148,6 +148,7 @@ public class DefaultSqlSession implements SqlSession {
   private <E> List<E> selectList(String statement, Object parameter, RowBounds rowBounds, ResultHandler handler) {
     try {
       MappedStatement ms = configuration.getMappedStatement(statement);
+      dirty |= ms.isDirtySelect();
       return executor.query(ms, wrapCollection(parameter), rowBounds, handler);
     } catch (Exception e) {
       throw ExceptionFactory.wrapException("Error querying database.  Cause: " + e, e);

--- a/src/main/resources/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
+++ b/src/main/resources/org/apache/ibatis/builder/xml/mybatis-3-mapper.dtd
@@ -184,6 +184,7 @@ databaseId CDATA #IMPLIED
 lang CDATA #IMPLIED
 resultOrdered (true|false) #IMPLIED
 resultSets CDATA #IMPLIED 
+affectData (true|false) #IMPLIED
 >
 
 <!ELEMENT insert (#PCDATA | selectKey | include | trim | where | set | foreach | choose | if | bind)*>

--- a/src/site/es/xdoc/java-api.xml
+++ b/src/site/es/xdoc/java-api.xml
@@ -245,13 +245,13 @@ public interface ResultHandler<T> {
   <p>There is method for flushing(executing) batch update statements that stored in a JDBC driver class at any timing. This method can be used when you use the <code>ExecutorType.BATCH</code> as <code>ExecutorType</code>.</p>
   <source><![CDATA[List<BatchResult> flushStatements()]]></source>
 
-  <h5>Métodos de control de transacción</h5>
+  <h5 id="transaction-control-methods">Métodos de control de transacción</h5>
   <p>El parámetro ResultContext te da acceso al objeto resultado en sí mismo, un contador del número de objetos creados y un método booleano stop() que te permite indicar a MyBatis que pare la carga de datos.</p>
   <source>void commit()
 void commit(boolean force)
 void rollback()
 void rollback(boolean force)</source>
-  <p>Por defecto MyBatis no hace un commit a no ser que haya detectado que la base de datos ha sido modificada por una insert, update o delete. Si has realizado cambios sin llamar a estos métodos, entonces puedes pasar true en al método de commit() y rollback() para asegurar que se realiza el commit (ten en cuenta que aun así no puedes forzar el commit() en modo auto-commit o cuando se usa un gestor de transacciones externo). La mayoría de las veces no tendrás que llamar a rollback() dado que MyBatis lo hará por ti en caso de que no hayas llamado a commit(). Sin embargo, si necesitas un control más fino sobre la sesión, donde puede que haya varios commits, tienes esta opción para hacerlo posible.</p>
+  <p>Por defecto MyBatis no hace un commit a no ser que haya detectado que la base de datos ha sido modificada por una insert, update, delete o select con <code>affectData</code> habilitado. Si has realizado cambios sin llamar a estos métodos, entonces puedes pasar true en al método de commit() y rollback() para asegurar que se realiza el commit (ten en cuenta que aun así no puedes forzar el commit() en modo auto-commit o cuando se usa un gestor de transacciones externo). La mayoría de las veces no tendrás que llamar a rollback() dado que MyBatis lo hará por ti en caso de que no hayas llamado a commit(). Sin embargo, si necesitas un control más fino sobre la sesión, donde puede que haya varios commits, tienes esta opción para hacerlo posible.</p>
   <p><span class="label important">NOTA</span> MyBatis-Spring y MyBatis-Guice proporcionan gestión de transacción declarativa. Por tanto si estás usando MyBatis con Spring o Guice consulta sus manuales específicos.</p>
 
   <h5>Local Cache</h5>

--- a/src/site/es/xdoc/sqlmap-xml.xml
+++ b/src/site/es/xdoc/sqlmap-xml.xml
@@ -201,6 +201,11 @@ ps.setInt(1,id);]]></source>
                 <code>false</code>.
               </td>
             </tr>
+            <tr>
+              <td><code>affectData</code></td>
+              <td>Set this to true when writing a INSERT, UPDATE or DELETE statement that returns data so that the transaction is controlled properly. Also see <a href="./java-api.html#transaction-control-methods">Transaction Control Method</a>. Default: <code>false</code> (since 3.5.12)
+              </td>
+            </tr>
           </tbody>
         </table>
       </subsection>
@@ -405,6 +410,18 @@ Por ejemplo, si la columna id de la tabla Author del ejemplo siguiente fuera aut
             </tr>
           </tbody>
         </table>
+
+        <p>
+          As an irregular case, some databases allow INSERT, UPDATE or DELETE statement to return result set (e.g. <code>RETURNING</code> clause of PostgreSQL and MariaDB or <code>OUTPUT</code> clause of MS SQL Server). This type of statement must be written as <code><![CDATA[<select>]]></code> to map the returned data.
+        </p>
+
+        <source><![CDATA[<select id="insertAndGetAuthor" resultType="domain.blog.Author"
+      affectData="true" flushCache="true">
+  insert into Author (username, password, email, bio)
+  values (#{username}, #{password}, #{email}, #{bio})
+  returning id, username, password, email, bio
+</select>]]></source>
+
       </subsection>
 
       <subsection name="sql">

--- a/src/site/ja/xdoc/java-api.xml
+++ b/src/site/ja/xdoc/java-api.xml
@@ -249,13 +249,13 @@ public interface ResultHandler<T> {
   <p>バッチ更新用に JDBC ドライバ内に蓄積されたステートメントを任意のタイミングでデータベースへフラッシュ(実行)するメソッドがあります。このメソッドは、 <code>ExecutorType</code> として <code>ExecutorType.BATCH</code> を使用している場合に使用することができます。</p>
   <source><![CDATA[List<BatchResult> flushStatements()]]></source>
 
-  <h5>トランザクションを制御するメソッド</h5>
+  <h5 id="transaction-control-methods">トランザクションを制御するメソッド</h5>
   <p>トランザクションのスコープを制御するメソッドは４つあります。当然ですが、auto-commit を使用する場合や、外部のトランザクションマネージャーを使っている場合、これらのメソッドは効果がありません。しかし、Connection のインスタンスによって管理されている JDBC トランザクションマネージャーを利用している場合は便利なメソッドです。</p>
   <source>void commit()
 void commit(boolean force)
 void rollback()
 void rollback(boolean force)</source>
-  <p>デフォルトでは、データベースが insert, update, delete メソッドの実行によって変更されない限り MyBatis は commit を実行しません。何らかの理由でこれらのメソッドを使わずにデータを変更した場合は確実にコミットされるように commit メソッドに引数 true を渡してください（ただし、auto-commit モードのセッションや外部のトランザクションマネージャーを使っている場合は true を渡してもコミットされません）。commit が実行されない場合、MyBatis がロールバックを実行するので、通常明示的に rollback() メソッドを呼び出す必要はありません。しかし、一つのセッションの中で複数のコミットやロールバックが必要とされるようなケースでは、rollback() メソッドを使ってより細かい制御を行うことが可能です。</p>
+  <p>デフォルトでは、データベースの変更を伴うメソッド insert, update, delete, <code>affectData</code> を有効化した select が実行されない限り MyBatis は commit を実行しません。何らかの理由でこれらのメソッドを使わずにデータを変更した場合は確実にコミットされるように commit メソッドに引数 true を渡してください（ただし、auto-commit モードのセッションや外部のトランザクションマネージャーを使っている場合は true を渡してもコミットされません）。commit が実行されない場合、MyBatis がロールバックを実行するので、通常明示的に rollback() メソッドを呼び出す必要はありません。しかし、一つのセッションの中で複数のコミットやロールバックが必要とされるようなケースでは、rollback() メソッドを使ってより細かい制御を行うことが可能です。</p>
   <p><span class="label important">NOTE</span> Mybatis-Spring と MyBatis-Guice では宣言的トランザクションがサポートされています。詳細は各サブプロジェクトのドキュメントを参照してください。</p>
 
   <h5>ローカルキャッシュ</h5>

--- a/src/site/ja/xdoc/sqlmap-xml.xml
+++ b/src/site/ja/xdoc/sqlmap-xml.xml
@@ -233,6 +233,11 @@ ps.setInt(1,id);]]></source>
               <td>複数の ResultSet を利用する場合にのみ有効です。ステートメントが返す ResultSet にそれぞれ任意の名前を付けてリストアップします。名前はカンマで区切ります。
               </td>
             </tr>
+            <tr>
+              <td><code>affectData</code></td>
+              <td>ResultSet を返す INSERT, UPDATE, DELETE 文を記述する場合に true をセットします。これによりトランザクション制御が正しく実行されるようになります。<a href="./java-api.html#transaction-control-methods">トランザクションを制御するメソッド</a> も参照してください。 デフォルト： <code>false</code> （3.5.12 以降）
+              </td>
+            </tr>
           </tbody>
         </table>
       </subsection>
@@ -453,6 +458,18 @@ ps.setInt(1,id);]]></source>
             </tr>
           </tbody>
         </table>
+
+        <p>
+          例外として、INSERT, UPDATE, DELETE 文から ResultSet を返す SQL 文（PostgreSQL, MariaDB の <code>RETURNING</code> , MS SQL Server の <code>OUTPUT</code> など）で結果をマップするためには <code><![CDATA[<select />]]></code> を使用する必要があります。
+        </p>
+
+        <source><![CDATA[<select id="insertAndGetAuthor" resultType="domain.blog.Author"
+      affectData="true" flushCache="true">
+  insert into Author (username, password, email, bio)
+  values (#{username}, #{password}, #{email}, #{bio})
+  returning id, username, password, email, bio
+</select>]]></source>
+
       </subsection>
 
       <subsection name="sql">

--- a/src/site/ko/xdoc/java-api.xml
+++ b/src/site/ko/xdoc/java-api.xml
@@ -316,7 +316,7 @@ public interface ResultHandler<T> {
   이 방법은 <code>ExecutorType</code>을 <code>ExecutorType.BATCH</code>로 설정한 경우 사용가능하다. </p>
   <source><![CDATA[List<BatchResult> flushStatements()]]></source>
 
-  <h5>트랙잭션 제어 메소드</h5>
+  <h5 id="transaction-control-methods">트랙잭션 제어 메소드</h5>
   <p>트랜잭션을 제어하기 위해 4개의 메소드가 있다.
   물론 자동커밋을 선택하였거나 외부 트랜잭션 관리자를 사용하면 영향이 없다.
   어쨌든 Connection인스턴스에 의해 관리되고 JDBC 트랜잭션 관리자를 사용하면 이 4개의 메소드를 사용할 수 있다.</p>
@@ -324,7 +324,7 @@ public interface ResultHandler<T> {
 void commit(boolean force)
 void rollback()
 void rollback(boolean force)</source>
-  <p>기본적으로 마이바티스는 insert, update 또는 delete 를 호출하여 데이터베이스가 변경된 것으로 감지하지 않는 한 실제로 커밋하지 않는다.
+  <p>기본적으로 마이바티스는 insert, update, delete 또는 <code>affectData</code>가 활성화된select 를 호출하여 데이터베이스가 변경된 것으로 감지하지 않는 한 실제로 커밋하지 않는다.
   이러한 메소드 호출없이 변경되면 커밋된 것으로 보장하기 위해 commit 와 rollback 메소드에 true 값을 전달한다.</p>
   <p><span class="label important">참고</span> MyBatis-Spring 과 MyBatis-Guice는 선언적인 트랜잭션 관리기법을 제공한다.
   그래서 스프링이나 쥬스와 함께 마이바티스를 사용한다면 해당되는 메뉴얼을 꼭 참고하길 바란다. </p>

--- a/src/site/ko/xdoc/sqlmap-xml.xml
+++ b/src/site/ko/xdoc/sqlmap-xml.xml
@@ -188,6 +188,11 @@ ps.setInt(1,id);]]></source>
               디폴트값은 <code>false</code> 이다.
               </td>
             </tr>
+            <tr>
+              <td><code>affectData</code></td>
+              <td>Set this to true when writing a INSERT, UPDATE or DELETE statement that returns data so that the transaction is controlled properly. Also see <a href="./java-api.html#transaction-control-methods">Transaction Control Method</a>. Default: <code>false</code> (since 3.5.12)
+              </td>
+            </tr>
           </tbody>
         </table>
       </subsection>
@@ -392,6 +397,18 @@ ps.setInt(1,id);]]></source>
             </tr>
           </tbody>
         </table>
+
+        <p>
+          As an irregular case, some databases allow INSERT, UPDATE or DELETE statement to return result set (e.g. <code>RETURNING</code> clause of PostgreSQL and MariaDB or <code>OUTPUT</code> clause of MS SQL Server). This type of statement must be written as <code><![CDATA[<select>]]></code> to map the returned data.
+        </p>
+
+        <source><![CDATA[<select id="insertAndGetAuthor" resultType="domain.blog.Author"
+      affectData="true" flushCache="true">
+  insert into Author (username, password, email, bio)
+  values (#{username}, #{password}, #{email}, #{bio})
+  returning id, username, password, email, bio
+</select>]]></source>
+
       </subsection>
 
       <subsection name="sql">

--- a/src/site/xdoc/java-api.xml
+++ b/src/site/xdoc/java-api.xml
@@ -251,13 +251,13 @@ public interface ResultHandler<T> {
   <p>There is method for flushing (executing) batch update statements that are stored in a JDBC driver class at any time. This method can be used when the <code>ExecutorType</code> is <code>ExecutorType.BATCH</code>.</p>
   <source><![CDATA[List<BatchResult> flushStatements()]]></source>
 
-  <h5>Transaction Control Methods</h5>
+  <h5 id="transaction-control-methods">Transaction Control Methods</h5>
   <p>There are four methods for controlling the scope of a transaction. Of course, these have no effect if you've chosen to use auto-commit or if you're using an external transaction manager. However, if you're using the JDBC transaction manager, managed by the <code>Connection</code> instance, then the four methods that will come in handy are:</p>
   <source>void commit()
 void commit(boolean force)
 void rollback()
 void rollback(boolean force)</source>
-  <p>By default MyBatis does not actually commit unless it detects that the database has been changed by a call to <code>insert</code>, <code>update</code> or <code>delete</code>. If you've somehow made changes without calling these methods, then you can pass <code>true</code> into the <code>commit</code> and <code>rollback</code> methods to guarantee that they will be committed (note, you still can't force a session in auto-commit mode, or one that is using an external transaction manager). Most of the time you won't have to call <code>rollback()</code>, as MyBatis will do that for you if you don't call commit. However, if you need more fine-grained control over a session where multiple commits and rollbacks are possible, you have the rollback option there to make that possible.</p>
+  <p>By default MyBatis does not actually commit unless it detects that the database has been changed by a call to <code>insert</code>, <code>update</code>, <code>delete</code> or <code>select</code> with <code>affectData</code> enabled. If you've somehow made changes without calling these methods, then you can pass <code>true</code> into the <code>commit</code> and <code>rollback</code> methods to guarantee that they will be committed (note, you still can't force a session in auto-commit mode, or one that is using an external transaction manager). Most of the time you won't have to call <code>rollback()</code>, as MyBatis will do that for you if you don't call commit. However, if you need more fine-grained control over a session where multiple commits and rollbacks are possible, you have the rollback option there to make that possible.</p>
   <p><span class="label important">NOTE</span> MyBatis-Spring and MyBatis-Guice provide declarative transaction handling. So if you are using MyBatis with Spring or Guice please refer to their specific manuals.</p>
 
   <h5>Local Cache</h5>

--- a/src/site/xdoc/sqlmap-xml.xml
+++ b/src/site/xdoc/sqlmap-xml.xml
@@ -245,6 +245,11 @@ ps.setInt(1,id);]]></source>
                 be returned by the statement and gives a name to each one. Names are separated by commas.
               </td>
             </tr>
+            <tr>
+              <td><code>affectData</code></td>
+              <td>Set this to true when writing a INSERT, UPDATE or DELETE statement that returns data so that the transaction is controlled properly. Also see <a href="./java-api.html#transaction-control-methods">Transaction Control Method</a>. Default: <code>false</code> (since 3.5.12)
+              </td>
+            </tr>
           </tbody>
         </table>
       </subsection>
@@ -491,6 +496,18 @@ ps.setInt(1,id);]]></source>
             </tr>
           </tbody>
         </table>
+
+        <p>
+          As an irregular case, some databases allow INSERT, UPDATE or DELETE statement to return result set (e.g. <code>RETURNING</code> clause of PostgreSQL and MariaDB or <code>OUTPUT</code> clause of MS SQL Server). This type of statement must be written as <code><![CDATA[<select>]]></code> to map the returned data.
+        </p>
+
+        <source><![CDATA[<select id="insertAndGetAuthor" resultType="domain.blog.Author"
+      affectData="true" flushCache="true">
+  insert into Author (username, password, email, bio)
+  values (#{username}, #{password}, #{email}, #{bio})
+  returning id, username, password, email, bio
+</select>]]></source>
+
       </subsection>
 
       <subsection name="sql">

--- a/src/site/zh/xdoc/java-api.xml
+++ b/src/site/zh/xdoc/java-api.xml
@@ -245,7 +245,7 @@ public interface ResultHandler<T> {
   <p>当你将 <code>ExecutorType</code> 设置为 <code>ExecutorType.BATCH</code> 时，可以使用这个方法清除（执行）缓存在 JDBC 驱动类中的批量更新语句。</p>
   <source><![CDATA[List<BatchResult> flushStatements()]]></source>
 
-  <h5>事务控制方法</h5>
+  <h5 id="transaction-control-methods">事务控制方法</h5>
   <p>
     有四个方法用来控制事务作用域。当然，如果你已经设置了自动提交或你使用了外部事务管理器，这些方法就没什么作用了。然而，如果你正在使用由 Connection 实例控制的 JDBC 事务管理器，那么这四个方法就会派上用场：
   </p>
@@ -253,7 +253,7 @@ public interface ResultHandler<T> {
 void commit(boolean force)
 void rollback()
 void rollback(boolean force)</source>
-  <p>默认情况下 MyBatis 不会自动提交事务，除非它侦测到调用了插入、更新或删除方法改变了数据库。如果你没有使用这些方法提交修改，那么你可以在 commit 和 rollback 方法参数中传入 true 值，来保证事务被正常提交（注意，在自动提交模式或者使用了外部事务管理器的情况下，设置 force 值对 session 无效）。大部分情况下你无需调用 rollback()，因为 MyBatis 会在你没有调用 commit 时替你完成回滚操作。不过，当你要在一个可能多次提交或回滚的 session 中详细控制事务，回滚操作就派上用场了。</p>
+  <p>默认情况下 MyBatis 不会自动提交事务，除非它侦测到调用了插入、更新、删除或 select with <code>affectData</code> enabled 方法改变了数据库。如果你没有使用这些方法提交修改，那么你可以在 commit 和 rollback 方法参数中传入 true 值，来保证事务被正常提交（注意，在自动提交模式或者使用了外部事务管理器的情况下，设置 force 值对 session 无效）。大部分情况下你无需调用 rollback()，因为 MyBatis 会在你没有调用 commit 时替你完成回滚操作。不过，当你要在一个可能多次提交或回滚的 session 中详细控制事务，回滚操作就派上用场了。</p>
   <p><span class="label important">提示</span> MyBatis-Spring 和 MyBatis-Guice 提供了声明式事务处理，所以如果你在使用 Mybatis 的同时使用了 Spring 或者 Guice，请参考它们的手册以获取更多的内容。</p>
 
 <h5>本地缓存</h5>

--- a/src/site/zh/xdoc/sqlmap-xml.xml
+++ b/src/site/zh/xdoc/sqlmap-xml.xml
@@ -233,6 +233,11 @@ ps.setInt(1,id);]]></source>
                 这个设置仅适用于多结果集的情况。它将列出语句执行后返回的结果集并赋予每个结果集一个名称，多个名称之间以逗号分隔。
               </td>
             </tr>
+            <tr>
+              <td><code>affectData</code></td>
+              <td>Set this to true when writing a INSERT, UPDATE or DELETE statement that returns data so that the transaction is controlled properly. Also see <a href="./java-api.html#transaction-control-methods">Transaction Control Method</a>. Default: <code>false</code> (since 3.5.12)
+              </td>
+            </tr>
           </tbody>
         </table>
       </subsection>
@@ -461,6 +466,18 @@ ps.setInt(1,id);]]></source>
             </tr>
           </tbody>
         </table>
+
+        <p>
+          As an irregular case, some databases allow INSERT, UPDATE or DELETE statement to return result set (e.g. <code>RETURNING</code> clause of PostgreSQL and MariaDB or <code>OUTPUT</code> clause of MS SQL Server). This type of statement must be written as <code><![CDATA[<select>]]></code> to map the returned data.
+        </p>
+
+        <source><![CDATA[<select id="insertAndGetAuthor" resultType="domain.blog.Author"
+      affectData="true" flushCache="true">
+  insert into Author (username, password, email, bio)
+  values (#{username}, #{password}, #{email}, #{bio})
+  returning id, username, password, email, bio
+</select>]]></source>
+
       </subsection>
 
       <subsection name="sql">

--- a/src/test/java/org/apache/ibatis/submitted/dirty_select/DirtySelectTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dirty_select/DirtySelectTest.java
@@ -1,0 +1,104 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.dirty_select;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.mapping.Environment;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.apache.ibatis.testcontainers.PgContainer;
+import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag("TestcontainersTests")
+class DirtySelectTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    Configuration configuration = new Configuration();
+    Environment environment = new Environment("development", new JdbcTransactionFactory(),
+        PgContainer.getUnpooledDataSource());
+    configuration.setEnvironment(environment);
+    configuration.addMapper(Mapper.class);
+    sqlSessionFactory = new SqlSessionFactoryBuilder().build(configuration);
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+        "org/apache/ibatis/submitted/dirty_select/CreateDB.sql");
+  }
+
+  @Test
+  void shouldRollbackIfCalled() {
+    Integer id;
+    try (SqlSession sqlSession = sqlSessionFactory.openSession(false)) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.insertReturn("Jimmy");
+      id = user.getId();
+      assertNotNull(id);
+      assertEquals("Jimmy", user.getName());
+      sqlSession.rollback();
+    }
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.selectById(id);
+      assertNull(user);
+    }
+  }
+
+  @Test
+  void shouldRollbackIfCalled_Xml() {
+    Integer id;
+    try (SqlSession sqlSession = sqlSessionFactory.openSession(false)) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.insertReturnXml("Jimmy");
+      id = user.getId();
+      assertNotNull(id);
+      assertEquals("Jimmy", user.getName());
+      sqlSession.rollback();
+    }
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.selectById(id);
+      assertNull(user);
+    }
+  }
+
+  @Test
+  void shouldRollbackIfCalled_Provider() {
+    Integer id;
+    try (SqlSession sqlSession = sqlSessionFactory.openSession(false)) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.insertReturnProvider("Jimmy");
+      id = user.getId();
+      assertNotNull(id);
+      assertEquals("Jimmy", user.getName());
+      sqlSession.rollback();
+    }
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.selectById(id);
+      assertNull(user);
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/dirty_select/DirtySelectTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dirty_select/DirtySelectTest.java
@@ -17,7 +17,10 @@ package org.apache.ibatis.submitted.dirty_select;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Iterator;
+
 import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.SqlSession;
@@ -102,6 +105,27 @@ class DirtySelectTest {
   }
 
   @Test
+  void shouldRollbackIfCalled_Cursor() throws Exception {
+    Integer id;
+    try (SqlSession sqlSession = sqlSessionFactory.openSession(false)) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      try (Cursor<User> cursor = mapper.insertReturnCursor("Kate")) {
+        Iterator<User> iterator = cursor.iterator();
+        User user = iterator.next();
+        id = user.getId();
+        assertNotNull(id);
+        assertEquals("Kate", user.getName());
+      }
+      sqlSession.rollback();
+    }
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.selectById(id);
+      assertNull(user);
+    }
+  }
+
+  @Test
   void shouldNonDirtySelectNotUnsetDirtyFlag() {
     Integer id;
     try (SqlSession sqlSession = sqlSessionFactory.openSession(false)) {
@@ -115,6 +139,32 @@ class DirtySelectTest {
       assertEquals("Bobby", user.getName());
       // Non-dirty SELECT
       mapper.selectById(id);
+      sqlSession.rollback();
+    }
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.selectById(id);
+      assertNull(user);
+    }
+  }
+
+  @Test
+  void shouldNonDirtySelectNotUnsetDirtyFlag_Cursor() throws Exception {
+    Integer id;
+    try (SqlSession sqlSession = sqlSessionFactory.openSession(false)) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      // INSERT
+      User user = new User();
+      user.setName("Bobby");
+      mapper.insert(user);
+      id = user.getId();
+      assertNotNull(id);
+      assertEquals("Bobby", user.getName());
+      // Non-dirty SELECT
+      try (Cursor<User> cursor = mapper.selectCursorById(id)) {
+        Iterator<User> iterator = cursor.iterator();
+        iterator.next();
+      }
       sqlSession.rollback();
     }
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/dirty_select/DirtySelectTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dirty_select/DirtySelectTest.java
@@ -101,4 +101,27 @@ class DirtySelectTest {
     }
   }
 
+  @Test
+  void shouldNonDirtySelectNotUnsetDirtyFlag() {
+    Integer id;
+    try (SqlSession sqlSession = sqlSessionFactory.openSession(false)) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      // INSERT
+      User user = new User();
+      user.setName("Bobby");
+      mapper.insert(user);
+      id = user.getId();
+      assertNotNull(id);
+      assertEquals("Bobby", user.getName());
+      // Non-dirty SELECT
+      mapper.selectById(id);
+      sqlSession.rollback();
+    }
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.selectById(id);
+      assertNull(user);
+    }
+  }
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/dirty_select/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/dirty_select/Mapper.java
@@ -15,6 +15,8 @@
  */
 package org.apache.ibatis.submitted.dirty_select;
 
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.SelectProvider;
 
@@ -23,13 +25,17 @@ public interface Mapper {
   @Select("select * from users where id = #{id}")
   User selectById(Integer id);
 
-  @Select(value = "insert into users (name) values (#{name}) returning id, name")
+  @Select(value = "insert into users (name) values (#{name}) returning id, name", affectData = true)
   User insertReturn(String name);
 
   User insertReturnXml(String name);
 
-  @SelectProvider(type = MyProvider.class, method = "getSql")
+  @SelectProvider(type = MyProvider.class, method = "getSql", affectData = true)
   User insertReturnProvider(String name);
+
+  @Options(useGeneratedKeys = true, keyProperty = "id", keyColumn = "id")
+  @Insert("insert into users (name) values (#{name}) returning id, name")
+  int insert(User user);
 
   static class MyProvider {
     public static String getSql() {

--- a/src/test/java/org/apache/ibatis/submitted/dirty_select/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/dirty_select/Mapper.java
@@ -19,14 +19,21 @@ import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.SelectProvider;
+import org.apache.ibatis.cursor.Cursor;
 
 public interface Mapper {
 
   @Select("select * from users where id = #{id}")
   User selectById(Integer id);
 
+  @Select("select * from users where id = #{id}")
+  Cursor<User> selectCursorById(Integer id);
+
   @Select(value = "insert into users (name) values (#{name}) returning id, name", affectData = true)
   User insertReturn(String name);
+
+  @Select(value = "insert into users (name) values (#{name}) returning id, name", affectData = true)
+  Cursor<User> insertReturnCursor(String name);
 
   User insertReturnXml(String name);
 

--- a/src/test/java/org/apache/ibatis/submitted/dirty_select/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/dirty_select/Mapper.java
@@ -1,0 +1,39 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.dirty_select;
+
+import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.SelectProvider;
+
+public interface Mapper {
+
+  @Select("select * from users where id = #{id}")
+  User selectById(Integer id);
+
+  @Select(value = "insert into users (name) values (#{name}) returning id, name")
+  User insertReturn(String name);
+
+  User insertReturnXml(String name);
+
+  @SelectProvider(type = MyProvider.class, method = "getSql")
+  User insertReturnProvider(String name);
+
+  static class MyProvider {
+    public static String getSql() {
+      return "insert into users (name) values (#{name}) returning id, name";
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/dirty_select/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/dirty_select/User.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.dirty_select;
+
+public class User {
+
+  private Integer id;
+  private String name;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/resources/org/apache/ibatis/submitted/dirty_select/CreateDB.sql
+++ b/src/test/resources/org/apache/ibatis/submitted/dirty_select/CreateDB.sql
@@ -1,0 +1,20 @@
+--
+--    Copyright 2009-2022 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       https://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+create table users (
+  id serial primary key,
+  name varchar(30)
+);

--- a/src/test/resources/org/apache/ibatis/submitted/dirty_select/CreateDB.sql
+++ b/src/test/resources/org/apache/ibatis/submitted/dirty_select/CreateDB.sql
@@ -14,6 +14,8 @@
 --    limitations under the License.
 --
 
+drop table if exists users;
+
 create table users (
   id serial primary key,
   name varchar(30)

--- a/src/test/resources/org/apache/ibatis/submitted/dirty_select/Mapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/dirty_select/Mapper.xml
@@ -1,9 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2022 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper
   namespace="org.apache.ibatis.submitted.dirty_select.Mapper">
 
-  <select id="insertReturnXml"
+  <select id="insertReturnXml" affectData="true"
     resultType="org.apache.ibatis.submitted.dirty_select.User">
     insert into users (name) values (#{name})
     returning id, name

--- a/src/test/resources/org/apache/ibatis/submitted/dirty_select/Mapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/dirty_select/Mapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper
+  namespace="org.apache.ibatis.submitted.dirty_select.Mapper">
+
+  <select id="insertReturnXml"
+    resultType="org.apache.ibatis.submitted.dirty_select.User">
+    insert into users (name) values (#{name})
+    returning id, name
+  </select>
+
+</mapper>


### PR DESCRIPTION
Some DBs support returning result set from INSERT/UPDATE/DELETE statements. e.g.

- PostgreSQL has `RETURNING`
- MS SQL Server has `OUTPUT`

By using `@Select`, `@SelectProvider` or `<select />`, it is possible to retrieve data from those statements.
The problem is that calling `SqlSession#commit()` or `SqlSession#rollback()`does not work as expected because MyBatis assumes SELECT does not affect DB data [1].

By setting `affectData=true`, users can indicate that the SELECT statement affects DB data.

Related to:

- #1189
- #2156 
- #2363 
- https://groups.google.com/g/mybatis-user/c/1Wn-0IyUi-Q/m/2MUAL4nFBwAJ

Notes:

- The use of `@Select`, `@SelectProvider`, `<select />` might look unintuitive, but changing the INSERT/UPDATE/DELETE behavior requires bigger change. The characteristic of these statement is closer to SELECT from MyBatis' perspective.
- Enabling `affectData` does not automatically activate `flushCache`.

TODO: doc

@emacarron @jeffgbutler @mnesarco @hazendaz  @kazuki43zoo @eddumelendez 
Any input would be appreciated!

[1] An obvious (but not ideal) workaround is to execute another INSERT/UPDATE/DELETE in the same session.
