### PR TITLE
Code style

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/SystemMetaObject.java
+++ b/src/main/java/org/apache/ibatis/reflection/SystemMetaObject.java
@@ -27,7 +27,8 @@ public final class SystemMetaObject {
 
   public static final ObjectFactory DEFAULT_OBJECT_FACTORY = new DefaultObjectFactory();
   public static final ObjectWrapperFactory DEFAULT_OBJECT_WRAPPER_FACTORY = new DefaultObjectWrapperFactory();
-  public static final MetaObject NULL_META_OBJECT = MetaObject.forObject(new NullObject(), DEFAULT_OBJECT_FACTORY, DEFAULT_OBJECT_WRAPPER_FACTORY, new DefaultReflectorFactory());
+  public static final ReflectorFactory DEFAULT_REFLECTOR_FACTORY = new DefaultReflectorFactory();
+  public static final MetaObject NULL_META_OBJECT = MetaObject.forObject(new NullObject(), DEFAULT_OBJECT_FACTORY, DEFAULT_OBJECT_WRAPPER_FACTORY, DEFAULT_REFLECTOR_FACTORY);
 
   private SystemMetaObject() {
     // Prevent Instantiation of Static Class
@@ -37,7 +38,7 @@ public final class SystemMetaObject {
   }
 
   public static MetaObject forObject(Object object) {
-    return MetaObject.forObject(object, DEFAULT_OBJECT_FACTORY, DEFAULT_OBJECT_WRAPPER_FACTORY, new DefaultReflectorFactory());
+    return MetaObject.forObject(object, DEFAULT_OBJECT_FACTORY, DEFAULT_OBJECT_WRAPPER_FACTORY, DEFAULT_REFLECTOR_FACTORY);
   }
 
 }


### PR DESCRIPTION
Modify DefaultReflectorFactory to be consistent with DefaultObjectFactory and DefaultObjectFactory. On the one hand, the code style is guaranteed to be unified, and on the other hand, the performance of org.apache.ibatis.reflection. SystemMetaObject #forObject method is improved, avoiding the need for new DefaultReflectorFactory () for each call.