### PR TITLE
Add ListTypeHandler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,11 @@
       <version>3.3.0</version>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.13.4.2</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,7 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.13.4.2</version>
+      <optional>true</optional>
     </dependency>
 
     <!-- Test dependencies -->

--- a/src/main/java/org/apache/ibatis/builder/ResultMapResolver.java
+++ b/src/main/java/org/apache/ibatis/builder/ResultMapResolver.java
@@ -17,6 +17,7 @@ package org.apache.ibatis.builder;
 
 import java.util.List;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.mapping.Discriminator;
 import org.apache.ibatis.mapping.ResultMap;
 import org.apache.ibatis.mapping.ResultMapping;
@@ -27,13 +28,23 @@ import org.apache.ibatis.mapping.ResultMapping;
 public class ResultMapResolver {
   private final MapperBuilderAssistant assistant;
   private final String id;
-  private final Class<?> type;
+  private final ResolvedType type;
   private final String extend;
   private final Discriminator discriminator;
   private final List<ResultMapping> resultMappings;
   private final Boolean autoMapping;
 
   public ResultMapResolver(MapperBuilderAssistant assistant, String id, Class<?> type, String extend, Discriminator discriminator, List<ResultMapping> resultMappings, Boolean autoMapping) {
+    this.assistant = assistant;
+    this.id = id;
+    this.type = assistant.getConfiguration().constructType(type);
+    this.extend = extend;
+    this.discriminator = discriminator;
+    this.resultMappings = resultMappings;
+    this.autoMapping = autoMapping;
+  }
+
+  public ResultMapResolver(MapperBuilderAssistant assistant, String id, ResolvedType type, String extend, Discriminator discriminator, List<ResultMapping> resultMappings, Boolean autoMapping) {
     this.assistant = assistant;
     this.id = id;
     this.type = type;

--- a/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
@@ -101,7 +101,7 @@ public class SqlSourceBuilder extends BaseBuilder {
       ResolvedType propertyType;
       if (metaParameters.hasGetter(property)) { // issue #448 get type from additional params
         propertyType = metaParameters.getGetterResolvedType(property);
-      } else if (typeHandlerRegistry.hasTypeHandler(parameterType)) {
+      } else if (parameterTypeToPropertyType(property)) {
         propertyType = parameterType;
       } else if (JdbcType.CURSOR.name().equals(propertiesMap.get("jdbcType"))) {
         propertyType = resolvedTypeFactory.getResultSetType();
@@ -156,6 +156,14 @@ public class SqlSourceBuilder extends BaseBuilder {
       } catch (Exception ex) {
         throw new BuilderException("Parsing error was found in mapping #{" + content + "}.  Check syntax #{property|(expression), var1=value1, var2=value2, ...} ", ex);
       }
+    }
+
+    private boolean parameterTypeToPropertyType(String property) {
+      if (parameterType.hasContentType() && PropertyTokenizer.isIndexAccess(property)) {
+        // TypeHandlerRegistry has ListTypeHandler, skip list[0] indexAccess
+        return false;
+      }
+      return typeHandlerRegistry.hasTypeHandler(parameterType);
     }
 
     private ResolvedType resolveParamTypeByProperty(ResolvedType type, String property) {

--- a/src/main/java/org/apache/ibatis/builder/StaticSqlSource.java
+++ b/src/main/java/org/apache/ibatis/builder/StaticSqlSource.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.ParameterMapping;
 import org.apache.ibatis.mapping.SqlSource;
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.session.Configuration;
 
 /**
@@ -29,6 +30,7 @@ public class StaticSqlSource implements SqlSource {
 
   private final String sql;
   private final List<ParameterMapping> parameterMappings;
+  private final ResolvedType parameterObjectType;
   private final Configuration configuration;
 
   public StaticSqlSource(Configuration configuration, String sql) {
@@ -39,11 +41,19 @@ public class StaticSqlSource implements SqlSource {
     this.sql = sql;
     this.parameterMappings = parameterMappings;
     this.configuration = configuration;
+    this.parameterObjectType = null;
+  }
+
+  public StaticSqlSource(Configuration configuration, String sql, List<ParameterMapping> parameterMappings, ResolvedType parameterObjectType) {
+    this.sql = sql;
+    this.parameterMappings = parameterMappings;
+    this.configuration = configuration;
+    this.parameterObjectType = parameterObjectType;
   }
 
   @Override
   public BoundSql getBoundSql(Object parameterObject) {
-    return new BoundSql(configuration, sql, parameterMappings, parameterObject);
+    return new BoundSql(configuration, sql, parameterMappings, parameterObject, parameterObjectType);
   }
 
 }

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -93,11 +93,11 @@ public class MapperAnnotationBuilder {
           InsertProvider.class, DeleteProvider.class)
       .collect(Collectors.toSet());
 
-  private final Configuration configuration;
-  private final MapperBuilderAssistant assistant;
-  private final ResolvedTypeFactory resolvedTypeFactory;
-  private final Class<?> type;
-  private final ResolvedType resolvedType;
+  protected final Configuration configuration;
+  protected final MapperBuilderAssistant assistant;
+  protected final ResolvedTypeFactory resolvedTypeFactory;
+  protected final Class<?> type;
+  protected final ResolvedType resolvedType;
 
   public MapperAnnotationBuilder(Configuration configuration, Class<?> type) {
     String resource = type.getName().replace('.', '/') + ".java (best guess)";
@@ -135,12 +135,12 @@ public class MapperAnnotationBuilder {
     parsePendingMethods();
   }
 
-  private boolean canHaveStatement(Method method) {
+  protected boolean canHaveStatement(Method method) {
     // issue #237
     return !method.isBridge() && !method.isDefault();
   }
 
-  private void parsePendingMethods() {
+  protected void parsePendingMethods() {
     Collection<MethodResolver> incompleteMethods = configuration.getIncompleteMethods();
     synchronized (incompleteMethods) {
       Iterator<MethodResolver> iter = incompleteMethods.iterator();
@@ -155,7 +155,7 @@ public class MapperAnnotationBuilder {
     }
   }
 
-  private void loadXmlResource() {
+  protected void loadXmlResource() {
     // Spring may not know the real resource name so we check a flag
     // to prevent loading again a resource twice
     // this flag is set at XMLMapperBuilder#bindMapperForNamespace
@@ -178,7 +178,7 @@ public class MapperAnnotationBuilder {
     }
   }
 
-  private void parseCache() {
+  protected void parseCache() {
     CacheNamespace cacheDomain = type.getAnnotation(CacheNamespace.class);
     if (cacheDomain != null) {
       Integer size = cacheDomain.size() == 0 ? null : cacheDomain.size();
@@ -200,7 +200,7 @@ public class MapperAnnotationBuilder {
     return props;
   }
 
-  private void parseCacheRef() {
+  protected void parseCacheRef() {
     CacheNamespaceRef cacheDomainRef = type.getAnnotation(CacheNamespaceRef.class);
     if (cacheDomainRef != null) {
       Class<?> refType = cacheDomainRef.value();
@@ -220,7 +220,7 @@ public class MapperAnnotationBuilder {
     }
   }
 
-  private String parseResultMap(ResolvedMethod resolvedMethod) {
+  protected String parseResultMap(ResolvedMethod resolvedMethod) {
     Method method = resolvedMethod.getMethod();
     ResolvedType returnType = getReturnType(resolvedMethod);
     Arg[] args = method.getAnnotationsByType(Arg.class);
@@ -291,7 +291,7 @@ public class MapperAnnotationBuilder {
     return null;
   }
 
-  void parseStatement(ResolvedMethod resolvedMethod) {
+  protected void parseStatement(ResolvedMethod resolvedMethod) {
     Method method = resolvedMethod.getMethod();
     final ResolvedType parameterTypeClass = resolvedMethod.namedParamsType(configuration);
     final LanguageDriver languageDriver = getLanguageDriver(method);
@@ -391,7 +391,7 @@ public class MapperAnnotationBuilder {
     return configuration.getLanguageDriver(langClass);
   }
 
-  private ResolvedType getReturnType(ResolvedMethod resolvedMethod) {
+  protected ResolvedType getReturnType(ResolvedMethod resolvedMethod) {
     return assistant.getReturnType(resolvedMethod);
   }
 
@@ -567,7 +567,7 @@ public class MapperAnnotationBuilder {
   }
 
   @SafeVarargs
-  private final Optional<AnnotationWrapper> getAnnotationWrapper(Method method, boolean errorIfNoMatch,
+  protected final Optional<AnnotationWrapper> getAnnotationWrapper(Method method, boolean errorIfNoMatch,
       Class<? extends Annotation>... targetTypes) {
     return getAnnotationWrapper(method, errorIfNoMatch, Arrays.asList(targetTypes));
   }

--- a/src/main/java/org/apache/ibatis/builder/annotation/MethodResolver.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MethodResolver.java
@@ -17,14 +17,23 @@ package org.apache.ibatis.builder.annotation;
 
 import java.lang.reflect.Method;
 
+import org.apache.ibatis.reflection.type.ResolvedMethod;
+
 /**
  * @author Eduardo Macarron
  */
 public class MethodResolver {
   private final MapperAnnotationBuilder annotationBuilder;
-  private final Method method;
+  private final ResolvedMethod method;
 
+  @Deprecated
   public MethodResolver(MapperAnnotationBuilder annotationBuilder, Method method) {
+    this.annotationBuilder = annotationBuilder;
+    this.method = annotationBuilder.configuration.constructType(method.getDeclaringClass())
+      .resolveMethod(method);
+  }
+
+  public MethodResolver(MapperAnnotationBuilder annotationBuilder, ResolvedMethod method) {
     this.annotationBuilder = annotationBuilder;
     this.method = method;
   }

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -56,7 +56,7 @@ public class XMLConfigBuilder extends BaseBuilder {
   private boolean parsed;
   private final XPathParser parser;
   private String environment;
-  private final ReflectorFactory localReflectorFactory = new DefaultReflectorFactory();
+  private final ReflectorFactory localReflectorFactory = new DefaultReflectorFactory(resolvedTypeFactory);
 
   public XMLConfigBuilder(Reader reader) {
     this(reader, null, null);

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
@@ -45,6 +45,7 @@ import org.apache.ibatis.mapping.ResultMapping;
 import org.apache.ibatis.parsing.XNode;
 import org.apache.ibatis.parsing.XPathParser;
 import org.apache.ibatis.reflection.MetaClass;
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
@@ -218,7 +219,7 @@ public class XMLMapperBuilder extends BaseBuilder {
     for (XNode parameterMapNode : list) {
       String id = parameterMapNode.getStringAttribute("id");
       String type = parameterMapNode.getStringAttribute("type");
-      Class<?> parameterClass = resolveClass(type);
+      ResolvedType parameterClass = resolveResolvedType(type);
       List<XNode> parameterNodes = parameterMapNode.evalNodes("parameter");
       List<ParameterMapping> parameterMappings = new ArrayList<>();
       for (XNode parameterNode : parameterNodes) {
@@ -230,10 +231,10 @@ public class XMLMapperBuilder extends BaseBuilder {
         String typeHandler = parameterNode.getStringAttribute("typeHandler");
         Integer numericScale = parameterNode.getIntAttribute("numericScale");
         ParameterMode modeEnum = resolveParameterMode(mode);
-        Class<?> javaTypeClass = resolveClass(javaType);
+        ResolvedType resolvedJavaType = resolveResolvedType(javaType);
         JdbcType jdbcTypeEnum = resolveJdbcType(jdbcType);
         Class<? extends TypeHandler<?>> typeHandlerClass = resolveClass(typeHandler);
-        ParameterMapping parameterMapping = builderAssistant.buildParameterMapping(parameterClass, property, javaTypeClass, jdbcTypeEnum, resultMap, modeEnum, typeHandlerClass, numericScale);
+        ParameterMapping parameterMapping = builderAssistant.buildParameterMapping(parameterClass, property, resolvedJavaType, jdbcTypeEnum, resultMap, modeEnum, typeHandlerClass, numericScale);
         parameterMappings.add(parameterMapping);
       }
       builderAssistant.addParameterMap(id, parameterClass, parameterMappings);

--- a/src/main/java/org/apache/ibatis/executor/resultset/ResultSetWrapper.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/ResultSetWrapper.java
@@ -29,6 +29,7 @@ import java.util.Set;
 
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.mapping.ResultMap;
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.ObjectTypeHandler;
@@ -46,7 +47,7 @@ public class ResultSetWrapper {
   private final List<String> columnNames = new ArrayList<>();
   private final List<String> classNames = new ArrayList<>();
   private final List<JdbcType> jdbcTypes = new ArrayList<>();
-  private final Map<String, Map<Class<?>, TypeHandler<?>>> typeHandlerMap = new HashMap<>();
+  private final Map<String, Map<ResolvedType, TypeHandler<?>>> typeHandlerMap = new HashMap<>();
   private final Map<String, List<String>> mappedColumnNamesMap = new HashMap<>();
   private final Map<String, List<String>> unMappedColumnNamesMap = new HashMap<>();
 
@@ -100,8 +101,12 @@ public class ResultSetWrapper {
    * @return the type handler
    */
   public TypeHandler<?> getTypeHandler(Class<?> propertyType, String columnName) {
+    return getTypeHandler(typeHandlerRegistry.getResolvedTypeFactory().constructType(propertyType), columnName);
+  }
+
+  public TypeHandler<?> getTypeHandler(ResolvedType propertyType, String columnName) {
     TypeHandler<?> handler = null;
-    Map<Class<?>, TypeHandler<?>> columnHandlers = typeHandlerMap.get(columnName);
+    Map<ResolvedType, TypeHandler<?>> columnHandlers = typeHandlerMap.get(columnName);
     if (columnHandlers == null) {
       columnHandlers = new HashMap<>();
       typeHandlerMap.put(columnName, columnHandlers);

--- a/src/main/java/org/apache/ibatis/mapping/BoundSql.java
+++ b/src/main/java/org/apache/ibatis/mapping/BoundSql.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.property.PropertyTokenizer;
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.session.Configuration;
 
 /**
@@ -38,6 +39,7 @@ public class BoundSql {
   private final String sql;
   private final List<ParameterMapping> parameterMappings;
   private final Object parameterObject;
+  private final ResolvedType parameterObjectType;
   private final Map<String, Object> additionalParameters;
   private final MetaObject metaParameters;
 
@@ -47,6 +49,16 @@ public class BoundSql {
     this.parameterObject = parameterObject;
     this.additionalParameters = new HashMap<>();
     this.metaParameters = configuration.newMetaObject(additionalParameters);
+    this.parameterObjectType = null;
+  }
+
+  public BoundSql(Configuration configuration, String sql, List<ParameterMapping> parameterMappings, Object parameterObject, ResolvedType parameterObjectType) {
+    this.sql = sql;
+    this.parameterMappings = parameterMappings;
+    this.parameterObject = parameterObject;
+    this.additionalParameters = new HashMap<>();
+    this.metaParameters = configuration.newMetaObject(additionalParameters);
+    this.parameterObjectType = parameterObjectType;
   }
 
   public String getSql() {
@@ -55,6 +67,10 @@ public class BoundSql {
 
   public List<ParameterMapping> getParameterMappings() {
     return parameterMappings;
+  }
+
+  public ResolvedType getParameterObjectType() {
+    return parameterObjectType;
   }
 
   public Object getParameterObject() {

--- a/src/main/java/org/apache/ibatis/mapping/MappedStatement.java
+++ b/src/main/java/org/apache/ibatis/mapping/MappedStatement.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.executor.keygen.Jdbc3KeyGenerator;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
@@ -71,7 +72,7 @@ public final class MappedStatement {
       mappedStatement.sqlSource = sqlSource;
       mappedStatement.statementType = StatementType.PREPARED;
       mappedStatement.resultSetType = ResultSetType.DEFAULT;
-      mappedStatement.parameterMap = new ParameterMap.Builder(configuration, "defaultParameterMap", null, new ArrayList<>()).build();
+      mappedStatement.parameterMap = new ParameterMap.Builder(configuration, "defaultParameterMap", (ResolvedType) null, new ArrayList<>()).build();
       mappedStatement.resultMaps = new ArrayList<>();
       mappedStatement.sqlCommandType = sqlCommandType;
       mappedStatement.keyGenerator = configuration.isUseGeneratedKeys() && SqlCommandType.INSERT.equals(sqlCommandType) ? Jdbc3KeyGenerator.INSTANCE : NoKeyGenerator.INSTANCE;
@@ -315,7 +316,7 @@ public final class MappedStatement {
     BoundSql boundSql = sqlSource.getBoundSql(parameterObject);
     List<ParameterMapping> parameterMappings = boundSql.getParameterMappings();
     if (parameterMappings == null || parameterMappings.isEmpty()) {
-      boundSql = new BoundSql(configuration, boundSql.getSql(), parameterMap.getParameterMappings(), parameterObject);
+      boundSql = new BoundSql(configuration, boundSql.getSql(), parameterMap.getParameterMappings(), parameterObject, boundSql.getParameterObjectType());
     }
 
     // check for nested result maps in parameter mappings (issue #30)

--- a/src/main/java/org/apache/ibatis/mapping/ParameterMap.java
+++ b/src/main/java/org/apache/ibatis/mapping/ParameterMap.java
@@ -18,7 +18,9 @@ package org.apache.ibatis.mapping;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.reflection.type.ResolvedTypeUtil;
 
 /**
  * @author Clinton Begin
@@ -26,7 +28,7 @@ import org.apache.ibatis.session.Configuration;
 public class ParameterMap {
 
   private String id;
-  private Class<?> type;
+  private ResolvedType type;
   private List<ParameterMapping> parameterMappings;
 
   private ParameterMap() {
@@ -37,12 +39,18 @@ public class ParameterMap {
 
     public Builder(Configuration configuration, String id, Class<?> type, List<ParameterMapping> parameterMappings) {
       parameterMap.id = id;
+      parameterMap.type = configuration.constructType(type);
+      parameterMap.parameterMappings = parameterMappings;
+    }
+
+    public Builder(Configuration configuration, String id, ResolvedType type, List<ParameterMapping> parameterMappings) {
+      parameterMap.id = id;
       parameterMap.type = type;
       parameterMap.parameterMappings = parameterMappings;
     }
 
     public Class<?> type() {
-      return parameterMap.type;
+      return ResolvedTypeUtil.getRawClass(parameterMap.type);
     }
 
     public ParameterMap build() {
@@ -57,6 +65,10 @@ public class ParameterMap {
   }
 
   public Class<?> getType() {
+    return ResolvedTypeUtil.getRawClass(type);
+  }
+
+  public ResolvedType getResolvedType() {
     return type;
   }
 

--- a/src/main/java/org/apache/ibatis/mapping/ResultMap.java
+++ b/src/main/java/org/apache/ibatis/mapping/ResultMap.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.logging.Log;
@@ -38,7 +39,7 @@ public class ResultMap {
   private Configuration configuration;
 
   private String id;
-  private Class<?> type;
+  private ResolvedType type;
   private List<ResultMapping> resultMappings;
   private List<ResultMapping> idResultMappings;
   private List<ResultMapping> constructorResultMappings;
@@ -62,7 +63,19 @@ public class ResultMap {
       this(configuration, id, type, resultMappings, null);
     }
 
+    public Builder(Configuration configuration, String id, ResolvedType type, List<ResultMapping> resultMappings) {
+      this(configuration, id, type, resultMappings, null);
+    }
+
     public Builder(Configuration configuration, String id, Class<?> type, List<ResultMapping> resultMappings, Boolean autoMapping) {
+      resultMap.configuration = configuration;
+      resultMap.id = id;
+      resultMap.type = configuration.constructType(type);
+      resultMap.resultMappings = resultMappings;
+      resultMap.autoMapping = autoMapping;
+    }
+
+    public Builder(Configuration configuration, String id, ResolvedType type, List<ResultMapping> resultMappings, Boolean autoMapping) {
       resultMap.configuration = configuration;
       resultMap.id = id;
       resultMap.type = type;
@@ -76,7 +89,7 @@ public class ResultMap {
     }
 
     public Class<?> type() {
-      return resultMap.type;
+      return resultMap.type.getRawClass();
     }
 
     public ResultMap build() {
@@ -146,7 +159,7 @@ public class ResultMap {
     }
 
     private List<String> argNamesOfMatchingConstructor(List<String> constructorArgNames) {
-      Constructor<?>[] constructors = resultMap.type.getDeclaredConstructors();
+      Constructor<?>[] constructors = resultMap.type.getRawClass().getDeclaredConstructors();
       for (Constructor<?> constructor : constructors) {
         Class<?>[] paramTypes = constructor.getParameterTypes();
         if (constructorArgNames.size() == paramTypes.length) {
@@ -219,6 +232,10 @@ public class ResultMap {
   }
 
   public Class<?> getType() {
+    return type.getRawClass();
+  }
+
+  public ResolvedType getResolvedType() {
     return type;
   }
 

--- a/src/main/java/org/apache/ibatis/reflection/MetaObject.java
+++ b/src/main/java/org/apache/ibatis/reflection/MetaObject.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.ibatis.reflection.factory.ObjectFactory;
 import org.apache.ibatis.reflection.property.PropertyTokenizer;
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.reflection.wrapper.BeanWrapper;
 import org.apache.ibatis.reflection.wrapper.CollectionWrapper;
 import org.apache.ibatis.reflection.wrapper.MapWrapper;
@@ -97,8 +98,16 @@ public class MetaObject {
     return objectWrapper.getSetterType(name);
   }
 
+  public ResolvedType getSetterResolvedType(String name) {
+    return objectWrapper.getSetterResolvedType(name);
+  }
+
   public Class<?> getGetterType(String name) {
     return objectWrapper.getGetterType(name);
+  }
+
+  public ResolvedType getGetterResolvedType(String name) {
+    return objectWrapper.getGetterResolvedType(name);
   }
 
   public boolean hasSetter(String name) {

--- a/src/main/java/org/apache/ibatis/reflection/PropertiesDescriptor.java
+++ b/src/main/java/org/apache/ibatis/reflection/PropertiesDescriptor.java
@@ -13,18 +13,17 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.builder;
+package org.apache.ibatis.reflection;
 
-import org.apache.ibatis.reflection.DefaultReflectorFactory;
-import org.apache.ibatis.reflection.type.ResolvedTypeFactory;
-import org.apache.ibatis.reflection.type.ResolvedTypeUtil;
+import org.apache.ibatis.reflection.type.ResolvedType;
 
-public class CustomReflectorFactory extends DefaultReflectorFactory {
-  public CustomReflectorFactory() {
-    this(ResolvedTypeUtil.getResolvedTypeFactory());
-  }
+/**
+ * Interface for get Class or Map properties types
+ */
+public interface PropertiesDescriptor {
 
-  public CustomReflectorFactory(ResolvedTypeFactory resolvedTypeFactory) {
-    super(resolvedTypeFactory);
-  }
+  boolean hasGetter(String name);
+
+  ResolvedType getGetterResolvedType(String name);
+
 }

--- a/src/main/java/org/apache/ibatis/reflection/ReflectorFactory.java
+++ b/src/main/java/org/apache/ibatis/reflection/ReflectorFactory.java
@@ -15,11 +15,18 @@
  */
 package org.apache.ibatis.reflection;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
+import org.apache.ibatis.reflection.type.ResolvedTypeFactory;
+
 public interface ReflectorFactory {
 
   boolean isClassCacheEnabled();
 
   void setClassCacheEnabled(boolean classCacheEnabled);
 
+  ResolvedTypeFactory getResolvedTypeFactory();
+
   Reflector findForClass(Class<?> type);
+
+  Reflector findForType(ResolvedType type);
 }

--- a/src/main/java/org/apache/ibatis/reflection/SystemMetaObject.java
+++ b/src/main/java/org/apache/ibatis/reflection/SystemMetaObject.java
@@ -19,6 +19,7 @@ import org.apache.ibatis.reflection.factory.DefaultObjectFactory;
 import org.apache.ibatis.reflection.factory.ObjectFactory;
 import org.apache.ibatis.reflection.wrapper.DefaultObjectWrapperFactory;
 import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
+import org.apache.ibatis.reflection.type.ResolvedTypeUtil;
 
 /**
  * @author Clinton Begin
@@ -27,7 +28,7 @@ public final class SystemMetaObject {
 
   public static final ObjectFactory DEFAULT_OBJECT_FACTORY = new DefaultObjectFactory();
   public static final ObjectWrapperFactory DEFAULT_OBJECT_WRAPPER_FACTORY = new DefaultObjectWrapperFactory();
-  public static final MetaObject NULL_META_OBJECT = MetaObject.forObject(new NullObject(), DEFAULT_OBJECT_FACTORY, DEFAULT_OBJECT_WRAPPER_FACTORY, new DefaultReflectorFactory());
+  public static final MetaObject NULL_META_OBJECT = MetaObject.forObject(new NullObject(), DEFAULT_OBJECT_FACTORY, DEFAULT_OBJECT_WRAPPER_FACTORY, new DefaultReflectorFactory(ResolvedTypeUtil.getResolvedTypeFactory()));
 
   private SystemMetaObject() {
     // Prevent Instantiation of Static Class
@@ -37,7 +38,7 @@ public final class SystemMetaObject {
   }
 
   public static MetaObject forObject(Object object) {
-    return MetaObject.forObject(object, DEFAULT_OBJECT_FACTORY, DEFAULT_OBJECT_WRAPPER_FACTORY, new DefaultReflectorFactory());
+    return MetaObject.forObject(object, DEFAULT_OBJECT_FACTORY, DEFAULT_OBJECT_WRAPPER_FACTORY, new DefaultReflectorFactory(ResolvedTypeUtil.getResolvedTypeFactory()));
   }
 
 }

--- a/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
+++ b/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 /**
  * @author Iwao AVE!
  */
+@Deprecated
 public class TypeParameterResolver {
 
   /**

--- a/src/main/java/org/apache/ibatis/reflection/property/PropertyTokenizer.java
+++ b/src/main/java/org/apache/ibatis/reflection/property/PropertyTokenizer.java
@@ -73,4 +73,17 @@ public class PropertyTokenizer implements Iterator<PropertyTokenizer> {
   public void remove() {
     throw new UnsupportedOperationException("Remove is not supported, as it has no meaning in the context of properties.");
   }
+
+  public static boolean isIndexAccess(String propertyName) {
+    if (propertyName == null) {
+      return false;
+    }
+    int i = propertyName.indexOf("[");
+    if (i != -1) {
+      // skip list[0]
+      return propertyName.indexOf("]") > i;
+    }
+    return false;
+  }
+
 }

--- a/src/main/java/org/apache/ibatis/reflection/type/BaseResolvedType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/BaseResolvedType.java
@@ -1,0 +1,127 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author FlyInWind
+ */
+public abstract class BaseResolvedType<T, F extends ResolvedTypeFactory> implements ResolvedType {
+  protected final F resolvedTypeFactory;
+  protected final T type;
+
+  protected BaseResolvedType(T type, F resolvedTypeFactory) {
+    Objects.requireNonNull(type);
+    this.resolvedTypeFactory = resolvedTypeFactory;
+    this.type = type;
+  }
+
+  protected abstract ResolvedType toResolvedType(T type);
+
+  protected ResolvedType[] toResolvedTypes(T[] types) {
+    int size = types.length;
+    if (size == 0) {
+      return ResolvedTypeUtil.EMPTY_TYPE_ARRAY;
+    }
+    ResolvedType[] result = new ResolvedType[size];
+    for (int i = 0; i < size; i++) {
+      T inf = types[i];
+      result[i] = toResolvedType(inf);
+    }
+    return result;
+  }
+
+  protected ResolvedType[] toResolvedTypes(List<T> types) {
+    int size = types.size();
+    if (size == 0) {
+      return ResolvedTypeUtil.EMPTY_TYPE_ARRAY;
+    }
+    ResolvedType[] result = new ResolvedType[size];
+    for (int i = 0; i < size; i++) {
+      T inf = types.get(i);
+      result[i] = toResolvedType(inf);
+    }
+    return result;
+  }
+
+  @Override
+  public ResolvedMethod findMapperMethod(String name) {
+    Method[] methods = getRawClass().getMethods();
+    Method foundMethod = null;
+    for (Method method : methods) {
+      if (method.getName().equals(name) && !method.isBridge() && !method.isDefault()) {
+        foundMethod = method;
+        break;
+      }
+    }
+    if (foundMethod != null) {
+      return this.resolveMethod(foundMethod);
+    }
+    return null;
+  }
+
+  @Override
+  public ResolvedMethod resolveMethod(String name, Class<?>... parameterTypes) {
+    try {
+      Method method = getRawClass().getMethod(name, parameterTypes);
+      return resolveMethod(method);
+    } catch (NoSuchMethodException e) {
+      return null;
+    }
+  }
+
+  @Override
+  public ResolvedMethod resolveMethod(Method method) {
+    return new DefaultResolvedMethod(this, method);
+  }
+
+  @Override
+  public ResolvedTypeFactory getResolvedTypeFactory() {
+    return resolvedTypeFactory;
+  }
+
+  @Override
+  public ResolvedType[] getTypeParameters() {
+    return findTypeParameters(getRawClass());
+  }
+
+  @Override
+  public ResolvedType resolveFieldType(Field field) {
+    return findSuperType(field.getDeclaringClass()).resolveMemberType(field.getGenericType());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(getClass().isInstance(o))) return false;
+    return type.equals(((BaseResolvedType<?, ?>) o).type);
+  }
+
+  @Override
+  public int hashCode() {
+    return type.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return type.toString();
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/BuildInJacksonBaseResolvedType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/BuildInJacksonBaseResolvedType.java
@@ -1,0 +1,154 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * @author FlyInWind
+ */
+public class BuildInJacksonBaseResolvedType extends BaseResolvedType<JavaType, BuildInJacksonBaseResolvedTypeFactory> {
+
+  public BuildInJacksonBaseResolvedType(JavaType type, BuildInJacksonBaseResolvedTypeFactory resolvedTypeFactory) {
+    super(type, resolvedTypeFactory);
+  }
+
+  @Override
+  protected ResolvedType toResolvedType(JavaType javaType) {
+    if (javaType == null) {
+      return null;
+    }
+    return resolvedTypeFactory.toResolvedType(javaType);
+  }
+
+  @Override
+  public Class<?> getRawClass() {
+    return type.getRawClass();
+  }
+
+  @Override
+  public boolean isPrimitive() {
+    return type.isPrimitive();
+  }
+
+  @Override
+  public boolean isArrayType() {
+    return type.isArrayType();
+  }
+
+  @Override
+  public boolean isEnumType() {
+    return type.isEnumType();
+  }
+
+  @Override
+  public boolean isRecordType() {
+    return type.isRecordType();
+  }
+
+  @Override
+  public boolean isInterface() {
+    return type.isInterface();
+  }
+
+  @Override
+  public boolean isTypeOrSubTypeOf(Class<?> clazz) {
+    return type.isTypeOrSubTypeOf(clazz);
+  }
+
+  @Override
+  public boolean isTypeOrSuperTypeOf(Class<?> clazz) {
+    return type.isTypeOrSuperTypeOf(clazz);
+  }
+
+  @Override
+  public boolean isJavaLangObject() {
+    return type.isJavaLangObject();
+  }
+
+  @Override
+  public boolean hasRawClass(Class<?> clazz) {
+    return type.hasRawClass(clazz);
+  }
+
+  @Override
+  public boolean hasContentType() {
+    return type.hasContentType();
+  }
+
+  @Override
+  public ResolvedType findSuperType(Class<?> clazz) {
+    return toResolvedType(type.findSuperType(clazz));
+  }
+
+  @Override
+  public ResolvedType[] getInterfaces() {
+    List<JavaType> interfaces = type.getInterfaces();
+    return toResolvedTypes(interfaces);
+  }
+
+  @Override
+  public ResolvedType getSuperclass() {
+    JavaType superClass = type.getSuperClass();
+    if (superClass == null) {
+      return null;
+    }
+    return toResolvedType(superClass);
+  }
+
+  @Override
+  public ResolvedType getContentType() {
+    return toResolvedType(type.getContentType());
+  }
+
+  @Override
+  public ResolvedType[] findTypeParameters(Class<?> clazz) {
+    JavaType[] types = type.findTypeParameters(clazz);
+    return toResolvedTypes(types);
+  }
+
+  @Override
+  public ResolvedType resolveMemberType(Type type) {
+    JavaType javaType = resolvedTypeFactory.typeFactory.resolveMemberType(type, this.type.getBindings());
+    return toResolvedType(javaType);
+  }
+
+  @Override
+  public String toCanonical() {
+    return type.toCanonical();
+  }
+
+  @Override
+  public String toString() {
+    return type.toCanonical();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof BuildInJacksonBaseResolvedType)) return false;
+    return type.equals(((BuildInJacksonBaseResolvedType) o).type);
+  }
+
+  @Override
+  public int hashCode() {
+    return type.hashCode();
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/BuildInJacksonBaseResolvedTypeFactory.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/BuildInJacksonBaseResolvedTypeFactory.java
@@ -1,0 +1,124 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import org.apache.ibatis.binding.MapperMethod.ParamMap;
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+import org.apache.ibatis.reflection.type.jackson.databind.type.TypeFactory;
+import org.apache.ibatis.type.TypeReference;
+
+import java.lang.reflect.Type;
+import java.sql.ResultSet;
+import java.util.Map;
+
+/**
+ * @author FlyInWind
+ */
+public class BuildInJacksonBaseResolvedTypeFactory implements ResolvedTypeFactory {
+  protected final TypeFactory typeFactory;
+
+  protected final ResolvedType objectType;
+  protected final ResolvedType integerType;
+  protected final ResolvedType longType;
+  protected final ResolvedType resultSetType;
+  protected final ResolvedType mapType;
+  protected final ResolvedType paramMapType;
+
+  public BuildInJacksonBaseResolvedTypeFactory() {
+    this(TypeFactory.defaultInstance());
+  }
+
+  public BuildInJacksonBaseResolvedTypeFactory(TypeFactory typeFactory) {
+    this.typeFactory = typeFactory;
+    this.objectType = constructType(Object.class);
+    this.integerType = constructType(Integer.class);
+    this.longType = constructType(Long.class);
+    this.resultSetType = constructType(ResultSet.class);
+    this.mapType = constructType(Map.class);
+    this.paramMapType = constructType(ParamMap.class);
+  }
+
+  public ResolvedType toResolvedType(JavaType javaType) {
+    return new BuildInJacksonBaseResolvedType(javaType, this);
+  }
+
+  @Override
+  public ResolvedType constructType(Type type) {
+    if (type == null) {
+      return null;
+    } else if (type instanceof ResolvedType) {
+      return (ResolvedType) type;
+    }
+    return toResolvedType(typeFactory.constructType(type));
+  }
+
+  @Override
+  public ResolvedType constructType(Class<?> clazz) {
+    if (clazz == null) {
+      return null;
+    }
+    return toResolvedType(typeFactory.constructType(clazz));
+  }
+
+  @Override
+  public <T> ResolvedType constructType(TypeReference<T> typeReference) {
+    return constructType(typeReference.getClass()).findTypeParameters(TypeReference.class)[0];
+  }
+
+  @Override
+  public ResolvedType constructParametricType(Class<?> rawClass, Class<?>... typeParameters) {
+    return toResolvedType(typeFactory.constructParametricType(rawClass, typeParameters));
+  }
+
+  @Override
+  public ResolvedType constructFromCanonical(String canonical) {
+    if (canonical == null || canonical.isEmpty()) {
+      return null;
+    }
+    return toResolvedType(typeFactory.constructFromCanonical(canonical));
+  }
+
+  @Override
+  public ResolvedType getObjectType() {
+    return objectType;
+  }
+
+  @Override
+  public ResolvedType getIntegerType() {
+    return integerType;
+  }
+
+  @Override
+  public ResolvedType getLongType() {
+    return longType;
+  }
+
+  @Override
+  public ResolvedType getMapType() {
+    return mapType;
+  }
+
+  @Override
+  public ResolvedType getResultSetType() {
+    return resultSetType;
+  }
+
+  @Override
+  public ResolvedType getParamMapType() {
+    return paramMapType;
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/ConstantPropertiesDescriptor.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/ConstantPropertiesDescriptor.java
@@ -1,0 +1,44 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import org.apache.ibatis.reflection.PropertiesDescriptor;
+
+import java.util.Objects;
+
+public class ConstantPropertiesDescriptor implements PropertiesDescriptor {
+  protected final ResolvedType resolvedType;
+
+  public ConstantPropertiesDescriptor(ResolvedType resolvedType) {
+    this.resolvedType = resolvedType;
+  }
+
+  public static ConstantPropertiesDescriptor forContentType(ResolvedType collectionType) {
+    ResolvedType contentType = collectionType.getContentType();
+    Objects.requireNonNull(contentType, () -> String.format("Type %s do not have contentType", contentType.toCanonical()));
+    return new ConstantPropertiesDescriptor(contentType);
+  }
+
+  @Override
+  public boolean hasGetter(String name) {
+    return true;
+  }
+
+  @Override
+  public ResolvedType getGetterResolvedType(String name) {
+    return resolvedType;
+  }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/DefaultResolvedMethod.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/DefaultResolvedMethod.java
@@ -1,0 +1,108 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import org.apache.ibatis.reflection.ParamNameResolver;
+import org.apache.ibatis.session.Configuration;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+
+/**
+ * @author FlyInWind
+ */
+public class DefaultResolvedMethod implements ResolvedMethod {
+  protected final ResolvedTypeFactory resolvedTypeFactory;
+  protected final ResolvedType implementationType;
+  protected final Method method;
+  protected ResolvedType[] parameterTypes;
+
+  protected DefaultResolvedMethod(ResolvedType implementationType, Method method) {
+    this.resolvedTypeFactory = implementationType.getResolvedTypeFactory();
+    this.implementationType = implementationType;
+    this.method = method;
+  }
+
+  @Override
+  public ResolvedTypeFactory getResolvedTypeFactory() {
+    return resolvedTypeFactory;
+  }
+
+  @Override
+  public ResolvedType getImplementationType() {
+    return implementationType;
+  }
+
+  @Override
+  public Method getMethod() {
+    return method;
+  }
+
+  @Override
+  public int getParameterCount() {
+    return method.getParameterCount();
+  }
+
+  protected ResolvedType getMethodDeclaringType() {
+    return implementationType.findSuperType(method.getDeclaringClass());
+  }
+
+  @Override
+  public ResolvedType[] getParameterTypes() {
+    if (parameterTypes != null) {
+      return parameterTypes;
+    }
+    int count = method.getParameterTypes().length;
+    if (count == 0) {
+      parameterTypes = ResolvedTypeUtil.EMPTY_TYPE_ARRAY;
+    } else {
+      ResolvedType[] types = new ResolvedType[count];
+      ResolvedType superType = getMethodDeclaringType();
+      if (superType == null) {
+        // jackson don't support get superType of String
+        superType = implementationType;
+      }
+      Type[] genericParameterTypes = method.getGenericParameterTypes();
+      for (int i = 0; i < count; i++) {
+        types[i] = superType.resolveMemberType(genericParameterTypes[i]);
+      }
+      parameterTypes = types;
+    }
+    return parameterTypes;
+  }
+
+  @Override
+  public ResolvedType getReturnType() {
+    Type returnType = method.getGenericReturnType();
+    ResolvedType declaringType = getMethodDeclaringType();
+    return declaringType.resolveMemberType(returnType);
+  }
+
+  @Override
+  public ResolvedType namedParamsType(Configuration configuration) {
+    return ParamNameResolver.namedParamsType(configuration, this);
+  }
+
+  @Override
+  public String getName() {
+    return method.getName();
+  }
+
+  @Override
+  public String toString() {
+    return method.toString();
+  }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/DelegatedResolvedType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/DelegatedResolvedType.java
@@ -1,0 +1,170 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+
+public class DelegatedResolvedType implements ResolvedType {
+
+  protected final ResolvedType delegate;
+
+  public DelegatedResolvedType(ResolvedType delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Class<?> getRawClass() {
+    return delegate.getRawClass();
+  }
+
+  @Override
+  public boolean isPrimitive() {
+    return delegate.isPrimitive();
+  }
+
+  @Override
+  public boolean isArrayType() {
+    return delegate.isArrayType();
+  }
+
+  @Override
+  public boolean isEnumType() {
+    return delegate.isEnumType();
+  }
+
+  @Override
+  public boolean isRecordType() {
+    return delegate.isRecordType();
+  }
+
+  @Override
+  public boolean isInterface() {
+    return delegate.isInterface();
+  }
+
+  @Override
+  public boolean isTypeOrSubTypeOf(Class<?> clazz) {
+    return delegate.isTypeOrSubTypeOf(clazz);
+  }
+
+  @Override
+  public boolean isTypeOrSuperTypeOf(Class<?> clazz) {
+    return delegate.isTypeOrSuperTypeOf(clazz);
+  }
+
+  @Override
+  public boolean isJavaLangObject() {
+    return delegate.isJavaLangObject();
+  }
+
+  @Override
+  public boolean hasRawClass(Class<?> clazz) {
+    return delegate.hasRawClass(clazz);
+  }
+
+  @Override
+  public boolean hasContentType() {
+    return delegate.hasContentType();
+  }
+
+  @Override
+  public ResolvedType findSuperType(Class<?> clazz) {
+    return delegate.findSuperType(clazz);
+  }
+
+  @Override
+  public ResolvedType[] getInterfaces() {
+    return delegate.getInterfaces();
+  }
+
+  @Override
+  public ResolvedType getSuperclass() {
+    return delegate.getSuperclass();
+  }
+
+  @Override
+  public ResolvedType getContentType() {
+    return delegate.getContentType();
+  }
+
+  @Override
+  public ResolvedType[] findTypeParameters(Class<?> rawClass) {
+    return delegate.findTypeParameters(rawClass);
+  }
+
+  @Override
+  public ResolvedType[] getTypeParameters() {
+    return delegate.getTypeParameters();
+  }
+
+  @Override
+  public ResolvedMethod findMapperMethod(String name) {
+    return delegate.findMapperMethod(name);
+  }
+
+  @Override
+  public ResolvedMethod resolveMethod(String name, Class<?>... parameterTypes) {
+    return delegate.resolveMethod(name, parameterTypes);
+  }
+
+  @Override
+  public ResolvedMethod resolveMethod(Method method) {
+    return delegate.resolveMethod(method);
+  }
+
+  @Override
+  public ResolvedType resolveMemberType(Type type) {
+    return this.delegate.resolveMemberType(type);
+  }
+
+  @Override
+  public ResolvedType resolveFieldType(Field field) {
+    return delegate.resolveFieldType(field);
+  }
+
+  @Override
+  public ResolvedTypeFactory getResolvedTypeFactory() {
+    return delegate.getResolvedTypeFactory();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    return delegate.equals(o);
+  }
+
+  @Override
+  public int hashCode() {
+    return delegate.hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return delegate.toString();
+  }
+
+  @Override
+  public String toCanonical() {
+    return delegate.toCanonical();
+  }
+
+  @Override
+  public String getTypeName() {
+    return delegate.getTypeName();
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/JacksonResolvedType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/JacksonResolvedType.java
@@ -1,0 +1,151 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import com.fasterxml.jackson.databind.JavaType;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * @author FlyInWind
+ */
+public class JacksonResolvedType extends BaseResolvedType<JavaType, JacksonResolvedTypeFactory> {
+
+  public JacksonResolvedType(JavaType type, JacksonResolvedTypeFactory resolvedTypeFactory) {
+    super(type, resolvedTypeFactory);
+  }
+
+  @Override
+  protected ResolvedType toResolvedType(JavaType javaType) {
+    return resolvedTypeFactory.toResolvedType(javaType);
+  }
+
+  @Override
+  public Class<?> getRawClass() {
+    return type.getRawClass();
+  }
+
+  @Override
+  public boolean isPrimitive() {
+    return type.isPrimitive();
+  }
+
+  @Override
+  public boolean isArrayType() {
+    return type.isArrayType();
+  }
+
+  @Override
+  public boolean isEnumType() {
+    return type.isEnumType();
+  }
+
+  @Override
+  public boolean isRecordType() {
+    return type.isRecordType();
+  }
+
+  @Override
+  public boolean isInterface() {
+    return type.isInterface();
+  }
+
+  @Override
+  public boolean isTypeOrSubTypeOf(Class<?> clazz) {
+    return type.isTypeOrSubTypeOf(clazz);
+  }
+
+  @Override
+  public boolean isTypeOrSuperTypeOf(Class<?> clazz) {
+    return type.isTypeOrSuperTypeOf(clazz);
+  }
+
+  @Override
+  public boolean isJavaLangObject() {
+    return type.isJavaLangObject();
+  }
+
+  @Override
+  public boolean hasRawClass(Class<?> clazz) {
+    return type.hasRawClass(clazz);
+  }
+
+  @Override
+  public boolean hasContentType() {
+    return type.hasContentType();
+  }
+
+  @Override
+  public ResolvedType findSuperType(Class<?> clazz) {
+    return toResolvedType(type.findSuperType(clazz));
+  }
+
+  @Override
+  public ResolvedType[] getInterfaces() {
+    List<JavaType> interfaces = type.getInterfaces();
+    return toResolvedTypes(interfaces);
+  }
+
+  @Override
+  public ResolvedType getSuperclass() {
+    JavaType superClass = type.getSuperClass();
+    if (superClass == null) {
+      return null;
+    }
+    return toResolvedType(superClass);
+  }
+
+  @Override
+  public ResolvedType getContentType() {
+    return toResolvedType(type.getContentType());
+  }
+
+  @Override
+  public ResolvedType[] findTypeParameters(Class<?> clazz) {
+    JavaType[] types = type.findTypeParameters(clazz);
+    return toResolvedTypes(types);
+  }
+
+  @Override
+  public ResolvedType resolveMemberType(Type type) {
+    JavaType javaType = resolvedTypeFactory.typeFactory.resolveMemberType(type, this.type.getBindings());
+    return toResolvedType(javaType);
+  }
+
+  @Override
+  public String toCanonical() {
+    return type.toCanonical();
+  }
+
+  @Override
+  public String toString() {
+    return type.toCanonical();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (!(o instanceof JacksonResolvedType)) return false;
+    return type.equals(((JacksonResolvedType) o).type);
+  }
+
+  @Override
+  public int hashCode() {
+    return type.hashCode();
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/JacksonResolvedTypeFactory.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/JacksonResolvedTypeFactory.java
@@ -1,0 +1,123 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import org.apache.ibatis.binding.MapperMethod.ParamMap;
+import org.apache.ibatis.type.TypeReference;
+
+import java.lang.reflect.Type;
+import java.sql.ResultSet;
+import java.util.Map;
+
+/**
+ * @author FlyInWind
+ */
+public class JacksonResolvedTypeFactory implements ResolvedTypeFactory {
+  protected final TypeFactory typeFactory;
+
+  protected final ResolvedType objectType;
+  protected final ResolvedType integerType;
+  protected final ResolvedType longType;
+  protected final ResolvedType resultSetType;
+  protected final ResolvedType mapType;
+  protected final ResolvedType paramMapType;
+
+  public JacksonResolvedTypeFactory(TypeFactory typeFactory) {
+    this.typeFactory = typeFactory;
+    this.objectType = constructType(Object.class);
+    this.integerType = constructType(Integer.class);
+    this.longType = constructType(Long.class);
+    this.resultSetType = constructType(ResultSet.class);
+    this.mapType = constructType(Map.class);
+    this.paramMapType = constructType(ParamMap.class);
+  }
+
+  public ResolvedType toResolvedType(JavaType javaType) {
+    if (javaType == null) {
+      return null;
+    }
+    return new JacksonResolvedType(javaType, this);
+  }
+
+  @Override
+  public ResolvedType constructType(Type type) {
+    if (type == null) {
+      return null;
+    } else if (type instanceof ResolvedType) {
+      return (ResolvedType) type;
+    }
+    return toResolvedType(typeFactory.constructType(type));
+  }
+
+  @Override
+  public ResolvedType constructType(Class<?> clazz) {
+    if (clazz == null) {
+      return null;
+    }
+    return toResolvedType(typeFactory.constructType(clazz));
+  }
+
+  @Override
+  public <T> ResolvedType constructType(TypeReference<T> typeReference) {
+    return constructType(typeReference.getClass()).findTypeParameters(TypeReference.class)[0];
+  }
+
+  @Override
+  public ResolvedType constructParametricType(Class<?> rawClass, Class<?>... typeParameters) {
+    return toResolvedType(typeFactory.constructParametricType(rawClass, typeParameters));
+  }
+
+  @Override
+  public ResolvedType constructFromCanonical(String canonical) {
+    if (canonical == null || canonical.isEmpty()) {
+      return null;
+    }
+    return toResolvedType(typeFactory.constructFromCanonical(canonical));
+  }
+
+  @Override
+  public ResolvedType getObjectType() {
+    return objectType;
+  }
+
+  @Override
+  public ResolvedType getIntegerType() {
+    return integerType;
+  }
+
+  @Override
+  public ResolvedType getLongType() {
+    return longType;
+  }
+
+  @Override
+  public ResolvedType getMapType() {
+    return mapType;
+  }
+
+  @Override
+  public ResolvedType getResultSetType() {
+    return resultSetType;
+  }
+
+  @Override
+  public ResolvedType getParamMapType() {
+    return paramMapType;
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/MapDescriptorResolvedType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/MapDescriptorResolvedType.java
@@ -1,0 +1,48 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import org.apache.ibatis.reflection.ReflectionException;
+
+import java.util.Map;
+
+public class MapDescriptorResolvedType extends DelegatedResolvedType implements PropertiesDescriptorResolvedType {
+  protected final Map<String, ResolvedType> typeMap;
+
+  public MapDescriptorResolvedType(ResolvedType resolvedType, Map<String, ResolvedType> typeMap) {
+    super(resolvedType);
+    this.typeMap = typeMap;
+  }
+
+  public static MapDescriptorResolvedType paramMap(ResolvedTypeFactory resolvedTypeFactory, Map<String, ResolvedType> typeMap) {
+    return new MapDescriptorResolvedType(resolvedTypeFactory.getParamMapType(), typeMap);
+  }
+
+  @Override
+  public boolean hasGetter(String name) {
+    return typeMap.containsKey(name);
+  }
+
+  @Override
+  public ResolvedType getGetterResolvedType(String name) {
+    ResolvedType type = typeMap.get(name);
+    if (type == null) {
+      throw new ReflectionException("Parameter '" + name + "' not found. Available parameters are " + typeMap.keySet());
+    }
+    return type;
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/PropertiesDescriptorResolvedType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/PropertiesDescriptorResolvedType.java
@@ -13,18 +13,13 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.builder;
+package org.apache.ibatis.reflection.type;
 
-import org.apache.ibatis.reflection.DefaultReflectorFactory;
-import org.apache.ibatis.reflection.type.ResolvedTypeFactory;
-import org.apache.ibatis.reflection.type.ResolvedTypeUtil;
+import org.apache.ibatis.reflection.PropertiesDescriptor;
 
-public class CustomReflectorFactory extends DefaultReflectorFactory {
-  public CustomReflectorFactory() {
-    this(ResolvedTypeUtil.getResolvedTypeFactory());
-  }
+/**
+ * {@link ResolvedType} with {@link PropertiesDescriptor} support
+ */
+public interface PropertiesDescriptorResolvedType extends PropertiesDescriptor, ResolvedType {
 
-  public CustomReflectorFactory(ResolvedTypeFactory resolvedTypeFactory) {
-    super(resolvedTypeFactory);
-  }
 }

--- a/src/main/java/org/apache/ibatis/reflection/type/ResolvedMethod.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/ResolvedMethod.java
@@ -1,0 +1,71 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import org.apache.ibatis.binding.MapperMethod.ParamMap;
+import org.apache.ibatis.reflection.ParamNameResolver;
+import org.apache.ibatis.session.Configuration;
+
+import java.lang.reflect.Method;
+
+/**
+ * @author FlyInWind
+ */
+public interface ResolvedMethod {
+
+  ResolvedTypeFactory getResolvedTypeFactory();
+
+  /**
+   * @return may be {@link Method#getDeclaringClass()} or the subclass of {@link Method#getDeclaringClass()}
+   */
+  ResolvedType getImplementationType();
+
+  /**
+   * @return the wrapped {@link Method}
+   */
+  Method getMethod();
+
+  /**
+   * @return {@link Method#getParameterCount()}
+   */
+  int getParameterCount();
+
+  /**
+   * @return the resolved {@link Method#getGenericParameterTypes()}
+   */
+  ResolvedType[] getParameterTypes();
+
+  /**
+   * @return the resolved {@link Method#getGenericReturnType()}
+   */
+  ResolvedType getReturnType();
+
+  /**
+   * @return null if no parameter, return the first type if only one parameter, or {@link PropertiesDescriptorResolvedType} if more than one parameter,
+   * the {@link PropertiesDescriptorResolvedType} contains the types of {@link ParamMap} values
+   * @see ParamNameResolver#namedParamsType
+   */
+  ResolvedType namedParamsType(Configuration configuration);
+
+  /**
+   * @return {@link Method#getName}
+   */
+  String getName();
+
+  @Override
+  String toString();
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/ResolvedType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/ResolvedType.java
@@ -1,0 +1,134 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import org.apache.ibatis.builder.annotation.MapperAnnotationBuilder;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Wrap class for {@link Class} with addon ParameterType info
+ *
+ * @author FlyInWind
+ */
+public interface ResolvedType extends Type {
+
+  Class<?> getRawClass();
+
+  /**
+   * @return {@link Class#isPrimitive}
+   */
+  boolean isPrimitive();
+
+  /**
+   * @return {@link Class#isArray}
+   */
+  boolean isArrayType();
+
+  /**
+   * @return {@link Enum}.class.isAssignableFrom({@link #getRawClass})
+   */
+  boolean isEnumType();
+
+  /**
+   * Java14-added new {@code Record} types
+   */
+  boolean isRecordType();
+
+  /**
+   * @return {@link Class#isInterface}
+   */
+  boolean isInterface();
+
+  /**
+   * @return {@code clazz.isAssignedFrom(this)}
+   */
+  boolean isTypeOrSubTypeOf(Class<?> clazz);
+
+  /**
+   * @return {@code this.isAssignedFrom(clazz)}
+   */
+  boolean isTypeOrSuperTypeOf(Class<?> clazz);
+
+  /**
+   * @return {@link #getRawClass()} {@code == Object.class}
+   */
+  boolean isJavaLangObject();
+
+  /**
+   * {@link #getRawClass()} == clazz
+   */
+  boolean hasRawClass(Class<?> clazz);
+
+  /**
+   * Array, {@link Collection}, {@link Map} has content type
+   */
+  boolean hasContentType();
+
+  /**
+   * @param clazz class or super class of {@link #getRawClass()}
+   * @return clazz type with addon ParameterType info
+   */
+  ResolvedType findSuperType(Class<?> clazz);
+
+  ResolvedType[] getInterfaces();
+
+  ResolvedType getSuperclass();
+
+  /**
+   * for {@link Collection}{@code <T>} , {@code T[]} , {@link Map}{@code <K,T>} return T
+   *
+   * @return collection content type
+   */
+  ResolvedType getContentType();
+
+  ResolvedType[] findTypeParameters(Class<?> rawClass);
+
+  ResolvedType[] getTypeParameters();
+
+  /**
+   * find first method may be a mapper method with special name, the method must not bridge or default
+   *
+   * @see MapperAnnotationBuilder#canHaveStatement
+   */
+  ResolvedMethod findMapperMethod(String name);
+
+  ResolvedMethod resolveMethod(String name, Class<?>... parameterTypes);
+
+  ResolvedMethod resolveMethod(Method method);
+
+  ResolvedType resolveMemberType(Type type);
+
+  ResolvedType resolveFieldType(Field field);
+
+  ResolvedTypeFactory getResolvedTypeFactory();
+
+  @Override
+  boolean equals(Object o);
+
+  @Override
+  int hashCode();
+
+  @Override
+  String toString();
+
+  String toCanonical();
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/ResolvedTypeFactory.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/ResolvedTypeFactory.java
@@ -1,0 +1,49 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import org.apache.ibatis.type.TypeReference;
+
+import java.lang.reflect.Type;
+
+/**
+ * @author FlyInWind
+ */
+public interface ResolvedTypeFactory {
+
+  ResolvedType constructType(Type type);
+
+  ResolvedType constructType(Class<?> type);
+
+  <T> ResolvedType constructType(TypeReference<T> typeReference);
+
+  ResolvedType constructParametricType(Class<?> rawClass, Class<?>... typeParameters);
+
+  ResolvedType constructFromCanonical(String canonical);
+
+  ResolvedType getObjectType();
+
+  ResolvedType getIntegerType();
+
+  ResolvedType getLongType();
+
+  ResolvedType getResultSetType();
+
+  ResolvedType getMapType();
+
+  ResolvedType getParamMapType();
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/ResolvedTypeUtil.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/ResolvedTypeUtil.java
@@ -39,7 +39,11 @@ public class ResolvedTypeUtil {
   }
 
   public static ResolvedTypeFactory getResolvedTypeFactory() {
-    return getJacksonTypeFactory();
+    ResolvedTypeFactory resolvedTypeFactory = getJacksonTypeFactory();
+    if (resolvedTypeFactory != null) {
+      return resolvedTypeFactory;
+    }
+    return getBuildInJacksonTypeFactory();
   }
 
   private static class JacksonResolvedTypeFactoryHolder {
@@ -59,4 +63,11 @@ public class ResolvedTypeUtil {
     return JacksonResolvedTypeFactoryHolder.instance;
   }
 
+  private static class BuildInJacksonResolvedTypeFactoryHolder {
+    private static final BuildInJacksonBaseResolvedTypeFactory INSTANCE = new BuildInJacksonBaseResolvedTypeFactory();
+  }
+
+  public static ResolvedTypeFactory getBuildInJacksonTypeFactory() {
+    return BuildInJacksonResolvedTypeFactoryHolder.INSTANCE;
+  }
 }

--- a/src/main/java/org/apache/ibatis/reflection/type/ResolvedTypeUtil.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/ResolvedTypeUtil.java
@@ -1,0 +1,62 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.type;
+
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+/**
+ * @author FlyInWind
+ */
+public class ResolvedTypeUtil {
+
+  public static final ResolvedType[] EMPTY_TYPE_ARRAY = new ResolvedType[0];
+
+  public static Class<?> getRawClass(ResolvedType type) {
+    if (type == null) {
+      return null;
+    }
+    return type.getRawClass();
+  }
+
+  public static boolean isInstance(ResolvedType type, Object obj) {
+    if (type == null) {
+      return false;
+    }
+    return type.getRawClass().isInstance(obj);
+  }
+
+  public static ResolvedTypeFactory getResolvedTypeFactory() {
+    return getJacksonTypeFactory();
+  }
+
+  private static class JacksonResolvedTypeFactoryHolder {
+    private static JacksonResolvedTypeFactory instance;
+
+    static {
+      try {
+        Class.forName("com.fasterxml.jackson.databind.type.TypeFactory");
+        instance = new JacksonResolvedTypeFactory(TypeFactory.defaultInstance());
+      } catch (ClassNotFoundException e) {
+        // ignore
+      }
+    }
+  }
+
+  public static ResolvedTypeFactory getJacksonTypeFactory() {
+    return JacksonResolvedTypeFactoryHolder.instance;
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/core/type/ResolvedType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/core/type/ResolvedType.java
@@ -1,0 +1,168 @@
+package org.apache.ibatis.reflection.type.jackson.core.type;
+
+/**
+ * Type abstraction that represents Java type that has been resolved
+ * (i.e. has all generic information, if any, resolved to concrete
+ * types).
+ * Note that this is an intermediate type, and all concrete instances
+ * MUST be of type <code>JavaType</code> from "databind" bundle -- this
+ * abstraction is only needed so that types can be passed through
+ * {@link com.fasterxml.jackson.core.JsonParser#readValueAs} methods.
+ *
+ * @since 2.0
+ */
+public abstract class ResolvedType
+{
+    /*
+    /**********************************************************
+    /* Public API, simple property accessors
+    /**********************************************************
+     */
+
+    /**
+     * @return Type-erased {@link Class} of resolved type
+     */
+    public abstract Class<?> getRawClass();
+
+    public abstract boolean hasRawClass(Class<?> clz);
+
+    public abstract boolean isAbstract();
+
+    public abstract boolean isConcrete();
+
+    public abstract boolean isThrowable();
+
+    public abstract boolean isArrayType();
+
+    public abstract boolean isEnumType();
+
+    public abstract boolean isInterface();
+
+    public abstract boolean isPrimitive();
+
+    public abstract boolean isFinal();
+
+    public abstract boolean isContainerType();
+
+    public abstract boolean isCollectionLikeType();
+
+    /**
+     * Whether this type is a referential type, meaning that values are
+     * basically pointers to "real" values (or null) and not regular
+     * values themselves. Typical examples include things like
+     * {@link java.util.concurrent.atomic.AtomicReference}, and various
+     * <code>Optional</code> types (in JDK8, Guava).
+     *
+     * @return {@code True} if this is a "referential" type, {@code false} if not
+     *
+     * @since 2.6
+     */
+    public boolean isReferenceType() {
+        return getReferencedType() != null;
+    }
+
+    public abstract boolean isMapLikeType();
+
+    /*
+    /**********************************************************
+    /* Public API, type parameter access
+    /**********************************************************
+     */
+
+    /**
+     * Method that can be used to find out if the type directly declares generic
+     * parameters (for its direct super-class and/or super-interfaces).
+     *
+     * @return {@code True} if this type has generic type parameters, {@code false} if not
+     */
+    public abstract boolean hasGenericTypes();
+
+    /**
+     * @deprecated Since 2.7: does not have meaning as parameters depend on type
+     *    resolved.
+     *
+     * @return Type-erased class of something not usable at this point
+     */
+    @Deprecated // since 2.7
+    public Class<?> getParameterSource() {
+        return null;
+    }
+
+    /**
+     * Method for accessing key type for this type, assuming type
+     * has such a concept (only Map types do)
+     *
+     * @return Key type of this type, if any; {@code null} if none
+     */
+    public abstract ResolvedType getKeyType();
+
+    /**
+     * Method for accessing content type of this type, if type has
+     * such a thing: simple types do not, structured types do
+     * (like arrays, Collections and Maps)
+     *
+     * @return Content type of this type, if any; {@code null} if none
+     */
+    public abstract ResolvedType getContentType();
+
+    /**
+     * Method for accessing type of value that instances of this
+     * type references, if any.
+     *
+     * @return Referenced type, if any; {@code null} if not.
+     *
+     * @since 2.6
+     */
+    public abstract ResolvedType getReferencedType();
+
+    /**
+     * Method for checking how many contained types this type
+     * has. Contained types are usually generic types, so that
+     * generic Maps have 2 contained types.
+     *
+     * @return Number of contained types that may be accessed
+     */
+    public abstract int containedTypeCount();
+
+    /**
+     * Method for accessing definitions of contained ("child")
+     * types.
+     *
+     * @param index Index of contained type to return
+     *
+     * @return Contained type at index, or null if no such type
+     *    exists (no exception thrown)
+     */
+    public abstract ResolvedType containedType(int index);
+
+    /**
+     * Method for accessing name of type variable in indicated
+     * position. If no name is bound, will use placeholders (derived
+     * from 0-based index); if no type variable or argument exists
+     * with given index, null is returned.
+     *
+     * @param index Index of contained type to return
+     *
+     * @return Contained type at index, or null if no such type
+     *    exists (no exception thrown)
+     */
+    public abstract String containedTypeName(int index);
+
+    /*
+    /**********************************************************
+    /* Public API, other
+    /**********************************************************
+     */
+
+    /**
+     * Method that can be used to serialize type into form from which
+     * it can be fully deserialized from at a later point (using
+     * {@code TypeFactory} from mapper package).
+     * For simple types this is same as calling
+     * {@link Class#getName}, but for structured types it may additionally
+     * contain type information about contents.
+     *
+     * @return String representation of the fully resolved type
+     */
+    public abstract String toCanonical();
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/JavaType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/JavaType.java
@@ -1,0 +1,649 @@
+package org.apache.ibatis.reflection.type.jackson.databind;
+
+import org.apache.ibatis.reflection.type.jackson.core.type.ResolvedType;
+import org.apache.ibatis.reflection.type.jackson.databind.type.TypeBindings;
+import org.apache.ibatis.reflection.type.jackson.databind.type.TypeFactory;
+import org.apache.ibatis.reflection.type.jackson.databind.util.ClassUtil;
+
+import java.lang.reflect.Modifier;
+import java.util.List;
+
+/**
+ * Base class for type token classes used both to contain information
+ * and as keys for deserializers.
+ *<p>
+ * Instances can (only) be constructed by
+ * <code>org.apache.ibatis.type.resolved.jackson.databind.type.TypeFactory</code>.
+ *<p>
+ * Since 2.2 this implements {@link java.lang.reflect.Type} to allow
+ * it to be pushed through interfaces that only expose that type.
+ */
+public abstract class JavaType
+    extends ResolvedType
+    implements java.io.Serializable, // 2.1
+        java.lang.reflect.Type // 2.2
+{
+    private static final long serialVersionUID = 1;
+
+    /**
+     * This is the nominal type-erased Class that would be close to the
+     * type represented (but not exactly type, due to type erasure: type
+     * instance may have more information on this).
+     * May be an interface or abstract class, so instantiation
+     * may not be possible.
+     */
+    protected final Class<?> _class;
+
+    protected final int _hash;
+
+    /**
+     * Optional handler (codec) that can be attached to indicate
+     * what to use for handling (serializing, deserializing) values of
+     * this specific type.
+     *<p>
+     * Note: untyped (i.e. caller has to cast) because it is used for
+     * different kinds of handlers, with unrelated types.
+     */
+    protected final Object _valueHandler;
+
+    /**
+     * Optional handler that can be attached to indicate how to handle
+     * additional type metadata associated with this type.
+     *<p>
+     * Note: untyped (i.e. caller has to cast) because it is used for
+     * different kinds of handlers, with unrelated types.
+     */
+    protected final Object _typeHandler;
+
+    /**
+     * Whether entities defined with this type should be handled using
+     * static typing (as opposed to dynamic runtime type) or not.
+     *
+     * @since 2.2
+     */
+    protected final boolean _asStatic;
+
+    /*
+    /**********************************************************************
+    /* Life-cycle: constructors, public mutant factory methods
+    /**********************************************************************
+     */
+
+    /**
+     * Main base constructor for sub-classes to use
+     *
+     * @param raw "Raw" (type-erased) class for this type
+     * @param additionalHash Additional hash code to use, in addition
+     *   to hash code of the class name
+     * @param valueHandler internal handler (serializer/deserializer)
+     *   to apply for this type
+     * @param typeHandler internal type handler (type serializer/deserializer)
+     *   to apply for this type
+     * @param asStatic Whether this type declaration will force specific type
+     *   as opposed to being a base type (usually for serialization typing)
+     */
+    protected JavaType(Class<?> raw, int additionalHash,
+            Object valueHandler, Object typeHandler, boolean asStatic)
+    {
+        _class = raw;
+        _hash = raw.getName().hashCode() + additionalHash;
+        _valueHandler = valueHandler;
+        _typeHandler = typeHandler;
+        _asStatic = asStatic;
+    }
+
+    /**
+     * Copy-constructor used when refining/upgrading type instances.
+     *
+     * @since 2.7
+     */
+    protected JavaType(JavaType base)
+    {
+        _class = base._class;
+        _hash = base._hash;
+        _valueHandler = base._valueHandler;
+        _typeHandler = base._typeHandler;
+        _asStatic = base._asStatic;
+    }
+
+    /**
+     * Mutant factory method that may be called on structured types
+     * that have a so-called content type (element of arrays, value type
+     * of Maps, referenced type of referential types),
+     * and will construct a new instance that is identical to
+     * this instance, except that it has specified content type, instead of current
+     * one. If content type is already set to given type, <code>this</code> is returned.
+     * If type does not have a content type (which is the case with
+     * <code>SimpleType</code>), {@link IllegalArgumentException}
+     * will be thrown.
+     *
+     * @return Newly created type instance
+     *
+     * @since 2.7
+     */
+    public abstract JavaType withContentType(JavaType contentType);
+
+    /**
+     * Method that can be called to get a type instance that indicates
+     * that values of the type should be handled using "static typing" for purposes
+     * of serialization (as opposed to "dynamic" aka runtime typing):
+     * meaning that no runtime information is needed for determining serializers to use.
+     * The main use case is to allow forcing of specific root value serialization type,
+     * and specifically in resolving serializers for contained types (element types
+     * for arrays, Collections and Maps).
+     *
+     * @since 2.2
+     */
+    public abstract JavaType withStaticTyping();
+
+    /*
+    /**********************************************************************
+    /* Internal factory methods for Jackson-databind (not for users)
+    /**********************************************************************
+     */
+
+    /**
+     * Internal method that <b>should not be used by any code outside of
+     * jackson-databind</b>: only used internally by databind.
+     * May be removed from Jackson 3.0.
+     *<p>
+     * This mutant factory method will construct a new instance that is identical to
+     * this instance, except that it will have specified type handler assigned.
+     *
+     * @param h Handler to pass to new instance created
+     * @return Newly created type instance with same type information, specified handler
+     */
+    public abstract JavaType withTypeHandler(Object h);
+
+    /**
+     * Internal method that <b>should not be used by any code outside of
+     * jackson-databind</b>: only used internally by databind.
+     * May be removed from Jackson 3.0.
+     *<p>
+     * This mutant factory method will construct a new instance that is identical to
+     * this instance, except that it will have specified content type (element type
+     * for arrays, value type for Maps and so forth) handler assigned.
+     *
+     * @param h Handler to pass to new instance created
+     * @return Newly created type instance with same type information, specified handler
+     */
+    public abstract JavaType withContentTypeHandler(Object h);
+
+    /**
+     * Internal method that <b>should not be used by any code outside of
+     * jackson-databind</b>: only used internally by databind.
+     * May be removed from Jackson 3.0.
+     *<p>
+     * This mutant factory method will construct a new instance that is identical to
+     * this instance, except that it will have specified value handler assigned.
+     *
+     * @param h Handler to pass to new instance created
+     * @return Newly created type instance with same type information, specified handler
+     */
+    public abstract JavaType withValueHandler(Object h);
+
+    /**
+     * Internal method that <b>should not be used by any code outside of
+     * jackson-databind</b>: only used internally by databind.
+     * May be removed from Jackson 3.0.
+     *<p>
+     * Mutant factory method that will construct a new instance that is identical to
+     * this instance, except that it will have specified content value handler assigned.
+     *
+     * @param h Handler to pass to new instance created
+     * @return Newly created type instance with same type information, specified handler
+     */
+    public abstract JavaType withContentValueHandler(Object h);
+
+    /**
+     * Internal method that <b>should not be used by any code outside of
+     * jackson-databind</b>: only used internally by databind.
+     * May be removed from Jackson 3.0.
+     *<p>
+     * Mutant factory method that will try to copy handlers that the specified
+     * source type instance had, if any; this must be done recursively where
+     * necessary (as content types may be structured).
+     *
+     * @since 2.8.4
+     */
+    public JavaType withHandlersFrom(JavaType src) {
+        JavaType type = this;
+        Object h = src.getTypeHandler();
+        if (h != _typeHandler) {
+            type = type.withTypeHandler(h);
+        }
+        h = src.getValueHandler();
+        if (h != _valueHandler) {
+            type = type.withValueHandler(h);
+        }
+        return type;
+    }
+
+    /*
+    /**********************************************************************
+    /* Type coercion fluent factory methods
+    /**********************************************************************
+     */
+
+    /**
+     * Mutant factory method that will try to create and return a sub-type instance
+     * for known parameterized types; for other types will return `null` to indicate
+     * that no just refinement makes necessary sense, without trying to detect
+     * special status through implemented interfaces.
+     *
+     * @since 2.7
+     */
+    public abstract JavaType refine(Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces);
+
+    /**
+     * Legacy method used for forcing sub-typing of this type into
+     * type specified by specific type erasure.
+     * Deprecated as of 2.7 as such specializations really ought to
+     * go through {@link TypeFactory}, not directly via {@link JavaType}.
+     *
+     * @since 2.7
+     */
+    @Deprecated
+    public JavaType forcedNarrowBy(Class<?> subclass)
+    {
+        if (subclass == _class) { // can still optimize for simple case
+            return this;
+        }
+        return  _narrow(subclass);
+    }
+
+    @Deprecated // since 2.7
+    protected abstract JavaType _narrow(Class<?> subclass);
+
+    /*
+    /**********************************************************************
+    /* Implementation of ResolvedType API
+    /**********************************************************************
+     */
+
+    @Override
+    public final Class<?> getRawClass() { return _class; }
+
+    /**
+     * Method that can be used to check whether this type has
+     * specified Class as its type erasure. Put another way, returns
+     * true if instantiation of this Type is given (type-erased) Class.
+     */
+    @Override
+    public final boolean hasRawClass(Class<?> clz) { return _class == clz; }
+
+    /**
+     * Accessor that allows determining whether {@link #getContentType()} should
+     * return a non-null value (that is, there is a "content type") or not.
+     * True if {@link #isContainerType()} or {@link #isReferenceType()} return true.
+     *
+     * @since 2.8
+     */
+    public boolean hasContentType() {
+        return true;
+    }
+
+    /**
+     * @since 2.6
+     */
+    public final boolean isTypeOrSubTypeOf(Class<?> clz) {
+        return (_class == clz) || clz.isAssignableFrom(_class);
+    }
+
+    /**
+     * @since 2.9
+     */
+    public final boolean isTypeOrSuperTypeOf(Class<?> clz) {
+        return (_class == clz) || _class.isAssignableFrom(clz);
+    }
+
+    @Override
+    public boolean isAbstract() {
+        return Modifier.isAbstract(_class.getModifiers());
+    }
+
+    /**
+     * Convenience method for checking whether underlying Java type
+     * is a concrete class or not: abstract classes and interfaces
+     * are not.
+     */
+    @Override
+    public boolean isConcrete() {
+        int mod = _class.getModifiers();
+        if ((mod & (Modifier.INTERFACE | Modifier.ABSTRACT)) == 0) {
+            return true;
+        }
+        /* 19-Feb-2010, tatus: Holy mackarel; primitive types
+         *    have 'abstract' flag set...
+         */
+        return _class.isPrimitive();
+    }
+
+    @Override
+    public boolean isThrowable() { return Throwable.class.isAssignableFrom(_class); }
+
+    @Override
+    public boolean isArrayType() { return false; }
+
+    /**
+     * Method that basically does equivalent of:
+     *<pre>
+     *  Enum.class.isAssignableFrom(getRawClass())
+     *</pre>
+     * that is, return {@code true} if the underlying type erased class is {@code Enum}
+     * or one its subtypes (Enum implementations).
+     */
+    @Override
+    public final boolean isEnumType() {
+        // 29-Sep-2019, tatu: `Class.isEnum()` not enough to detect custom subtypes.
+        return ClassUtil.isEnumType(_class);
+    }
+
+    /**
+     * Similar to {@link #isEnumType} except does NOT return {@code true}
+     * for {@link Enum} (since that is not Enum implementation type).
+     *
+     * @since 2.11
+     */
+    public final boolean isEnumImplType() {
+        return ClassUtil.isEnumType(_class) && (_class != Enum.class);
+    }
+
+    /**
+     * @since 2.12
+     */
+    public final boolean isRecordType() {
+        return ClassUtil.isRecordType(_class);
+    }
+
+    @Override
+    public final boolean isInterface() { return _class.isInterface(); }
+
+    @Override
+    public final boolean isPrimitive() { return _class.isPrimitive(); }
+
+    @Override
+    public final boolean isFinal() { return Modifier.isFinal(_class.getModifiers()); }
+
+    /**
+     * @return True if type represented is a container type; this includes
+     *    array, Map and Collection types.
+     */
+    @Override
+    public abstract boolean isContainerType();
+
+    /**
+     * @return True if type is either true {@link java.util.Collection} type,
+     *    or something similar (meaning it has at least one type parameter,
+     *    which describes type of contents)
+     */
+    @Override
+    public boolean isCollectionLikeType() { return false; }
+
+    /**
+     * @return True if type is either true {@link java.util.Map} type,
+     *    or something similar (meaning it has at least two type parameter;
+     *    first one describing key type, second value type)
+     */
+    @Override
+    public boolean isMapLikeType() { return false; }
+
+    /**
+     * Convenience method, short-hand for
+     *<code>
+     *   getRawClass() == Object.class
+     *</code>
+     * and used to figure if we basically have "untyped" type object.
+     *
+     * @since 2.5
+     */
+    public final boolean isJavaLangObject() { return _class == Object.class; }
+
+    /**
+     * Accessor for checking whether handlers for dealing with values of
+     * this type should use static typing (as opposed to dynamic typing).
+     * Note that while value of 'true' does mean that static typing is to
+     * be used, value of 'false' may still be overridden by other settings.
+     *
+     * @since 2.2
+     */
+    public final boolean useStaticType() { return _asStatic; }
+
+    /*
+    /**********************************************************************
+    /* Public API, type parameter access; pass-through
+    /**********************************************************************
+     */
+
+    @Override
+    public boolean hasGenericTypes() { return containedTypeCount() > 0; }
+
+    @Override
+    public JavaType getKeyType() { return null; }
+
+    @Override
+    public JavaType getContentType() { return null; }
+
+    @Override // since 2.6
+    public JavaType getReferencedType() { return null; }
+
+    @Override
+    public abstract int containedTypeCount();
+
+    @Override
+    public abstract JavaType containedType(int index);
+
+    @Deprecated // since 2.7
+    @Override
+    public abstract String containedTypeName(int index);
+
+    @Deprecated // since 2.7
+    @Override
+    public Class<?> getParameterSource() {
+        return null;
+    }
+
+    /*
+    /**********************************************************************
+    /* Extended API beyond ResolvedType
+    /**********************************************************************
+     */
+
+    // NOTE: not defined in Resolved type
+    /**
+     * Convenience method that is functionally same as:
+     *<code>
+     * JavaType t = containedType(index);
+     * if (t == null) {
+     *    t = TypeFactory.unknownType();
+     * }
+     *</code>
+     * and typically used to eliminate need for null checks for common case
+     * where we just want to check if containedType is available first; and
+     * if not, use "unknown type" (which translates to <code>java.lang.Object</code>
+     * basically).
+     *
+     * @since 2.5
+     */
+    public JavaType containedTypeOrUnknown(int index) {
+        JavaType t = containedType(index);
+        return (t == null)  ? TypeFactory.unknownType() : t;
+    }
+
+    /**
+     * @since 2.7
+     */
+    public abstract TypeBindings getBindings();
+
+    /**
+     * Method that may be called to find representation of given type
+     * within type hierarchy of this type: either this type (if this
+     * type has given erased type), one of its supertypes that has the
+     * erased types, or null if target is neither this type or any of its
+     * supertypes.
+     *
+     * @since 2.7
+     */
+    public abstract JavaType findSuperType(Class<?> erasedTarget);
+
+    /**
+     * Accessor for finding fully resolved parent class of this type,
+     * if it has one; null if not.
+     *
+     * @since 2.7
+     */
+    public abstract JavaType getSuperClass();
+
+    /**
+     * Accessor for finding fully resolved interfaces this type implements,
+     * if any; empty array if none.
+     *
+     * @since 2.7
+     */
+    public abstract List<JavaType> getInterfaces();
+
+    /**
+     * Method that may be used to find paramaterization this type has for
+     * given type-erased generic target type.
+     *
+     * @since 2.7
+     */
+    public abstract JavaType[] findTypeParameters(Class<?> expType);
+
+    /*
+    /**********************************************************************
+    /* Internal accessors API, accessing handlers
+    /**********************************************************************
+     */
+
+    /**
+     * Internal accessor that <b>should not be used by any code outside of
+     * jackson-databind</b>: only used internally by databind.
+     * May be removed from Jackson 3.0.
+     *
+     * @return Value handler associated with this type, if any.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getValueHandler() { return (T) _valueHandler; }
+
+    /**
+     * Internal accessor that <b>should not be used by any code outside of
+     * jackson-databind</b>: only used internally by databind.
+     * May be removed from Jackson 3.0.
+     *
+     * @return Type handler associated with this type, if any.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getTypeHandler() { return (T) _typeHandler; }
+
+    /**
+     * Internal accessor that <b>should not be used by any code outside of
+     * jackson-databind</b>: only used internally by databind.
+     * May be removed from Jackson 3.0.
+     *
+     * @return Content value handler associated with this type, if any.
+     *
+     * @since 2.7
+     */
+    public Object getContentValueHandler() { return null; }
+
+    /**
+     * Internal accessor that <b>should not be used by any code outside of
+     * jackson-databind</b>: only used internally by databind.
+     * May be removed from Jackson 3.0.
+     *
+     * @return Content type handler associated with this type, if any.
+     *
+     * @since 2.7
+     */
+    public Object getContentTypeHandler() { return null; }
+
+    /**
+     * @since 2.6
+     */
+    public boolean hasValueHandler() { return _valueHandler != null; }
+
+    /**
+     * Helper method that checks whether this type, or its (optional) key
+     * or content type has {@link #getValueHandler} or {@link #getTypeHandler()};
+     * that is, are there any non-standard handlers associated with this
+     * type object.
+     *
+     * @since 2.8
+     */
+    public boolean hasHandlers() {
+        return (_typeHandler != null) || (_valueHandler != null);
+    }
+
+    /*
+    /**********************************************************************
+    /* Support for producing signatures
+    /**********************************************************************
+     */
+
+    //public abstract String toCanonical();
+
+    /**
+     * Method for accessing signature that contains generic
+     * type information, in form compatible with JVM 1.5
+     * as per JLS. It is a superset of {@link #getErasedSignature},
+     * in that generic information can be automatically removed
+     * if necessary (just remove outermost
+     * angle brackets along with content inside)
+     */
+    public String getGenericSignature() {
+        StringBuilder sb = new StringBuilder(40);
+        getGenericSignature(sb);
+        return sb.toString();
+    }
+
+    /**
+     *
+     * @param sb StringBuilder to append signature to
+     *
+     * @return StringBuilder that was passed in; returned to allow
+     * call chaining
+     */
+    public abstract StringBuilder getGenericSignature(StringBuilder sb);
+
+    /**
+     * Method for accessing signature without generic
+     * type information, in form compatible with all versions
+     * of JVM, and specifically used for type descriptions
+     * when generating byte code.
+     */
+    public String getErasedSignature() {
+        StringBuilder sb = new StringBuilder(40);
+        getErasedSignature(sb);
+        return sb.toString();
+    }
+
+    /**
+     * Method for accessing signature without generic
+     * type information, in form compatible with all versions
+     * of JVM, and specifically used for type descriptions
+     * when generating byte code.
+     *
+     * @param sb StringBuilder to append signature to
+     *
+     * @return StringBuilder that was passed in; returned to allow
+     * call chaining
+     */
+    public abstract StringBuilder getErasedSignature(StringBuilder sb);
+
+    /*
+    /**********************************************************************
+    /* Standard methods; let's make them abstract to force override
+    /**********************************************************************
+     */
+
+    @Override
+    public abstract String toString();
+
+    @Override
+    public abstract boolean equals(Object o);
+
+    @Override
+    public final int hashCode() { return _hash; }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/ArrayType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/ArrayType.java
@@ -1,0 +1,236 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.lang.reflect.Array;
+
+/**
+ * Array types represent Java arrays, both primitive and object valued.
+ * Further, Object-valued arrays can have element type of any other
+ * legal {@link JavaType}.
+ */
+public final class ArrayType
+    extends TypeBase
+{
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Type of elements in the array.
+     */
+    protected final JavaType _componentType;
+
+    /**
+     * We will also keep track of shareable instance of empty array,
+     * since it usually needs to be constructed any way; and because
+     * it is essentially immutable and thus can be shared.
+     */
+    protected final Object _emptyArray;
+
+    protected ArrayType(JavaType componentType, TypeBindings bindings, Object emptyInstance,
+            Object valueHandler, Object typeHandler, boolean asStatic)
+    {
+        // No super-class, interfaces, for now
+        super(emptyInstance.getClass(), bindings, null, null,
+                componentType.hashCode(),
+                valueHandler, typeHandler, asStatic);
+        _componentType = componentType;
+        _emptyArray = emptyInstance;
+    }
+
+    public static ArrayType construct(JavaType componentType, TypeBindings bindings) {
+        return construct(componentType, bindings, null, null);
+    }
+
+    public static ArrayType construct(JavaType componentType, TypeBindings bindings,
+            Object valueHandler, Object typeHandler) {
+        // Figuring out raw class for generic array is actually bit tricky...
+        Object emptyInstance = Array.newInstance(componentType.getRawClass(), 0);
+        return new ArrayType(componentType, bindings, emptyInstance, valueHandler, typeHandler, false);
+    }
+
+    @Override
+    public JavaType withContentType(JavaType contentType) {
+        Object emptyInstance = Array.newInstance(contentType.getRawClass(), 0);
+        return new ArrayType(contentType, _bindings, emptyInstance,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public ArrayType withTypeHandler(Object h)
+    {
+        if (h == _typeHandler) {
+            return this;
+        }
+        return new ArrayType(_componentType, _bindings, _emptyArray, _valueHandler, h, _asStatic);
+    }
+
+    @Override
+    public ArrayType withContentTypeHandler(Object h)
+    {
+        if (h == _componentType.<Object>getTypeHandler()) {
+            return this;
+        }
+        return new ArrayType(_componentType.withTypeHandler(h), _bindings, _emptyArray,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public ArrayType withValueHandler(Object h) {
+        if (h == _valueHandler) {
+            return this;
+        }
+        return new ArrayType(_componentType, _bindings, _emptyArray, h, _typeHandler,_asStatic);
+    }
+
+    @Override
+    public ArrayType withContentValueHandler(Object h) {
+        if (h == _componentType.<Object>getValueHandler()) {
+            return this;
+        }
+        return new ArrayType(_componentType.withValueHandler(h), _bindings, _emptyArray,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public ArrayType withStaticTyping() {
+        if (_asStatic) {
+            return this;
+        }
+        return new ArrayType(_componentType.withStaticTyping(), _bindings,
+                _emptyArray, _valueHandler, _typeHandler, true);
+    }
+
+    /*
+    /**********************************************************
+    /* Methods for narrowing conversions
+    /**********************************************************
+     */
+
+    /**
+     * Handling of narrowing conversions for arrays is trickier: for now,
+     * it is not even allowed.
+     */
+    @Override
+    @Deprecated // since 2.7
+    protected JavaType _narrow(Class<?> subclass) {
+        return _reportUnsupported();
+    }
+
+    // Should not be called, as array types in Java are not extensible; but
+    // let's not freak out even if it is called?
+    @Override
+    public JavaType refine(Class<?> contentClass, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces) {
+        return null;
+    }
+
+    private JavaType _reportUnsupported() {
+        throw new UnsupportedOperationException("Cannot narrow or widen array types");
+    }
+
+    /*
+    /**********************************************************
+    /* Overridden methods
+    /**********************************************************
+     */
+
+    @Override
+    public boolean isArrayType() { return true; }
+
+    /**
+     * For some odd reason, modifiers for array classes would
+     * claim they are abstract types. Not so, at least for our
+     * purposes.
+     */
+    @Override
+    public boolean isAbstract() { return false; }
+
+    /**
+     * For some odd reason, modifiers for array classes would
+     * claim they are abstract types. Not so, at least for our
+     * purposes.
+     */
+    @Override
+    public boolean isConcrete() { return true; }
+
+    @Override
+    public boolean hasGenericTypes() {
+        // arrays are not parameterized, but element type may be:
+        return _componentType.hasGenericTypes();
+    }
+
+    /*
+    /**********************************************************
+    /* Public API
+    /**********************************************************
+     */
+
+    @Override
+    public boolean isContainerType() { return true; }
+
+    @Override
+    public JavaType getContentType() { return  _componentType; }
+
+    @Override
+    public Object getContentValueHandler() {
+        return _componentType.getValueHandler();
+    }
+
+    @Override
+    public Object getContentTypeHandler() {
+        return _componentType.getTypeHandler();
+    }
+
+    @Override
+    public boolean hasHandlers() {
+        return super.hasHandlers() || _componentType.hasHandlers();
+    }
+
+    @Override
+    public StringBuilder getGenericSignature(StringBuilder sb) {
+        sb.append('[');
+        return _componentType.getGenericSignature(sb);
+    }
+
+    @Override
+    public StringBuilder getErasedSignature(StringBuilder sb) {
+        sb.append('[');
+        return _componentType.getErasedSignature(sb);
+    }
+
+    /*
+    /**********************************************************
+    /* Extended API
+    /**********************************************************
+     */
+
+    /**
+     * @since 2.12
+     */
+    public Object[] getEmptyArray() {
+        return  (Object[]) _emptyArray;
+    }
+
+    /*
+    /**********************************************************
+    /* Standard methods
+    /**********************************************************
+     */
+
+    @Override
+    public String toString()
+    {
+        return "[array type, component type: "+_componentType+"]";
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == this) return true;
+        if (o == null) return false;
+        if (o.getClass() != getClass()) return false;
+
+        ArrayType other = (ArrayType) o;
+        return _componentType.equals(other._componentType);
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/ClassStack.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/ClassStack.java
@@ -1,0 +1,86 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.util.ArrayList;
+
+/**
+ * Simple helper class used to keep track of 'call stack' for classes being referenced
+ * (as well as unbound variables)
+ *
+ * @since 2.7
+ */
+public final class ClassStack
+{
+    protected final ClassStack _parent;
+    protected final Class<?> _current;
+
+    private ArrayList<ResolvedRecursiveType> _selfRefs;
+
+    public ClassStack(Class<?> rootType) {
+        this(null, rootType);
+    }
+
+    private ClassStack(ClassStack parent, Class<?> curr) {
+        _parent = parent;
+        _current = curr;
+    }
+
+    /**
+     * @return New stack frame, if addition is ok; null if not
+     */
+    public ClassStack child(Class<?> cls) {
+        return new ClassStack(this, cls);
+    }
+
+    /**
+     * Method called to indicate that there is a self-reference from
+     * deeper down in stack pointing into type this stack frame represents.
+     */
+    public void addSelfReference(ResolvedRecursiveType ref)
+    {
+        if (_selfRefs == null) {
+            _selfRefs = new ArrayList<ResolvedRecursiveType>();
+        }
+        _selfRefs.add(ref);
+    }
+
+    /**
+     * Method called when type that this stack frame represents is
+     * fully resolved, allowing self-references to be completed
+     * (if there are any)
+     */
+    public void resolveSelfReferences(JavaType resolved)
+    {
+        if (_selfRefs != null) {
+            for (ResolvedRecursiveType ref : _selfRefs) {
+                ref.setReference(resolved);
+            }
+        }
+    }
+
+    public ClassStack find(Class<?> cls)
+    {
+        if (_current == cls) return this;
+        for (ClassStack curr = _parent; curr != null; curr = curr._parent) {
+            if (curr._current == cls) {
+                return curr;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("[ClassStack (self-refs: ")
+            .append((_selfRefs == null) ? "0" : String.valueOf(_selfRefs.size()))
+            .append(')')
+                    ;
+        for (ClassStack curr = this; curr != null; curr = curr._parent) {
+            sb.append(' ').append(curr._current.getName());
+        }
+        sb.append(']');
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/CollectionLikeType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/CollectionLikeType.java
@@ -1,0 +1,267 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.lang.reflect.TypeVariable;
+import java.util.Collection;
+
+/**
+ * Type that represents things that act similar to {@link Collection};
+ * but may or may not be instances of that interface.
+ * This specifically allows framework to check for configuration and annotation
+ * settings used for Map types, and pass these to custom handlers that may be more
+ * familiar with actual type.
+ */
+public class CollectionLikeType extends TypeBase
+{
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Type of elements in collection
+     */
+    protected final JavaType _elementType;
+
+    /*
+    /**********************************************************
+    /* Life-cycle
+    /**********************************************************
+     */
+
+    protected CollectionLikeType(Class<?> collT, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts, JavaType elemT,
+            Object valueHandler, Object typeHandler, boolean asStatic)
+    {
+        super(collT, bindings, superClass, superInts,
+                elemT.hashCode(), valueHandler, typeHandler, asStatic);
+        _elementType = elemT;
+    }
+
+    /**
+     * @since 2.7
+     */
+    protected CollectionLikeType(TypeBase base, JavaType elemT)
+    {
+        super(base);
+        _elementType = elemT;
+    }
+
+    /**
+     * @since 2.7
+     */
+    public static CollectionLikeType construct(Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts, JavaType elemT) {
+        return new CollectionLikeType(rawType, bindings, superClass, superInts, elemT,
+                null, null, false);
+    }
+
+    /**
+     * @deprecated Since 2.7, use {@link #upgradeFrom} for constructing instances, given
+     *    pre-resolved {@link SimpleType}.
+     */
+    @Deprecated // since 2.7
+    public static CollectionLikeType construct(Class<?> rawType, JavaType elemT) {
+        // First: may need to fabricate TypeBindings (needed for refining into
+        // concrete collection types, as per [databind#1102])
+        TypeVariable<?>[] vars = rawType.getTypeParameters();
+        TypeBindings bindings;
+        if ((vars == null) || (vars.length != 1)) {
+            bindings = TypeBindings.emptyBindings();
+        } else {
+            bindings = TypeBindings.create(rawType, elemT);
+        }
+        return new CollectionLikeType(rawType, bindings,
+                _bogusSuperClass(rawType), null,
+                elemT, null, null, false);
+    }
+
+    /**
+     * Factory method that can be used to "upgrade" a basic type into collection-like
+     * one; usually done via {@link TypeModifier}
+     *
+     * @since 2.7
+     */
+    public static CollectionLikeType upgradeFrom(JavaType baseType, JavaType elementType) {
+        // 19-Oct-2015, tatu: Not sure if and how other types could be used as base;
+        //    will cross that bridge if and when need be
+        if (baseType instanceof TypeBase) {
+            return new CollectionLikeType((TypeBase) baseType, elementType);
+        }
+        throw new IllegalArgumentException("Cannot upgrade from an instance of "+baseType.getClass());
+    }
+
+    @Override
+    @Deprecated // since 2.7
+    protected JavaType _narrow(Class<?> subclass) {
+        return new CollectionLikeType(subclass, _bindings,
+                _superClass, _superInterfaces, _elementType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public JavaType withContentType(JavaType contentType) {
+        if (_elementType == contentType) {
+            return this;
+        }
+        return new CollectionLikeType(_class, _bindings, _superClass, _superInterfaces,
+                contentType, _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public CollectionLikeType withTypeHandler(Object h) {
+        return new CollectionLikeType(_class, _bindings,
+                _superClass, _superInterfaces, _elementType, _valueHandler, h, _asStatic);
+    }
+
+    @Override
+    public CollectionLikeType withContentTypeHandler(Object h)
+    {
+        return new CollectionLikeType(_class, _bindings,
+                _superClass, _superInterfaces, _elementType.withTypeHandler(h),
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public CollectionLikeType withValueHandler(Object h) {
+        return new CollectionLikeType(_class, _bindings,
+                _superClass, _superInterfaces, _elementType, h, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public CollectionLikeType withContentValueHandler(Object h) {
+        return new CollectionLikeType(_class, _bindings,
+                _superClass, _superInterfaces, _elementType.withValueHandler(h),
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public JavaType withHandlersFrom(JavaType src) {
+        JavaType type = super.withHandlersFrom(src);
+        JavaType srcCt = src.getContentType();
+        if (srcCt != null) {
+            JavaType ct = _elementType.withHandlersFrom(srcCt);
+            if (ct != _elementType) {
+                type = type.withContentType(ct);
+            }
+        }
+        return type;
+    }
+
+    @Override
+    public CollectionLikeType withStaticTyping() {
+        if (_asStatic) {
+            return this;
+        }
+        return new CollectionLikeType(_class, _bindings,
+                _superClass, _superInterfaces, _elementType.withStaticTyping(),
+                _valueHandler, _typeHandler, true);
+    }
+
+    @Override
+    public JavaType refine(Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces) {
+        return new CollectionLikeType(rawType, bindings,
+                superClass, superInterfaces, _elementType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    /*
+    /**********************************************************
+    /* Public API
+    /**********************************************************
+     */
+
+    @Override
+    public boolean isContainerType() { return true; }
+
+    @Override
+    public boolean isCollectionLikeType() { return true; }
+
+    @Override
+    public JavaType getContentType() { return _elementType; }
+
+    @Override
+    public Object getContentValueHandler() {
+        return _elementType.getValueHandler();
+    }
+
+    @Override
+    public Object getContentTypeHandler() {
+        return _elementType.getTypeHandler();
+    }
+
+    @Override
+    public boolean hasHandlers() {
+        return super.hasHandlers() || _elementType.hasHandlers();
+    }
+
+    @Override
+    public StringBuilder getErasedSignature(StringBuilder sb) {
+        return _classSignature(_class, sb, true);
+    }
+
+    @Override
+    public StringBuilder getGenericSignature(StringBuilder sb) {
+        _classSignature(_class, sb, false);
+        sb.append('<');
+        _elementType.getGenericSignature(sb);
+        sb.append(">;");
+        return sb;
+    }
+
+    @Override
+    protected String buildCanonicalName() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(_class.getName());
+        // 10-Apr-2021, tatu: [databind#3108] Ensure we have at least nominally
+        //   compatible type declaration (weak guarantee but better than nothing)
+        if ((_elementType != null) && _hasNTypeParameters(1)) {
+            sb.append('<');
+            sb.append(_elementType.toCanonical());
+            sb.append('>');
+        }
+        return sb.toString();
+    }
+
+    /*
+    /**********************************************************
+    /* Extended API
+    /**********************************************************
+     */
+
+    /**
+     * Method that can be used for checking whether this type is a
+     * "real" Collection type; meaning whether it represents a parameterized
+     * subtype of {@link Collection} or just something that acts
+     * like one.
+     *
+     * @deprecated Since 2.12 just use instanceof
+     */
+    @Deprecated // since 2.12 use assignment checks
+    public boolean isTrueCollectionType() {
+        return Collection.class.isAssignableFrom(_class);
+    }
+
+    /*
+    /**********************************************************
+    /* Standard methods
+    /**********************************************************
+     */
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == this) return true;
+        if (o == null) return false;
+        if (o.getClass() != getClass()) return false;
+
+        CollectionLikeType other = (CollectionLikeType) o;
+        return  (_class == other._class) && _elementType.equals(other._elementType);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "[collection-like type; class "+_class.getName()+", contains "+_elementType+"]";
+    }
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/CollectionType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/CollectionType.java
@@ -1,0 +1,136 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.lang.reflect.TypeVariable;
+
+/**
+ * Type that represents Java Collection types (Lists, Sets).
+ */
+public final class CollectionType
+    extends CollectionLikeType
+{
+    private static final long serialVersionUID = 1L;
+
+    /*
+    /**********************************************************
+    /* Life-cycle
+    /**********************************************************
+     */
+
+    private CollectionType(Class<?> collT, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts, JavaType elemT,
+            Object valueHandler, Object typeHandler, boolean asStatic)
+    {
+        super(collT, bindings, superClass, superInts, elemT, valueHandler, typeHandler, asStatic);
+    }
+
+    /**
+     * @since 2.7
+     */
+    protected CollectionType(TypeBase base, JavaType elemT) {
+        super(base, elemT);
+    }
+
+    /**
+     * @since 2.7
+     */
+    public static CollectionType construct(Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts, JavaType elemT) {
+        return new CollectionType(rawType, bindings, superClass, superInts, elemT,
+                null, null, false);
+    }
+
+    /**
+     * @deprecated Since 2.7, remove from 2.9
+     */
+    @Deprecated // since 2.7
+    public static CollectionType construct(Class<?> rawType, JavaType elemT) {
+        // First: may need to fabricate TypeBindings (needed for refining into
+        // concrete collection types, as per [databind#1102])
+        TypeVariable<?>[] vars = rawType.getTypeParameters();
+        TypeBindings bindings;
+        if ((vars == null) || (vars.length != 1)) {
+            bindings = TypeBindings.emptyBindings();
+        } else {
+            bindings = TypeBindings.create(rawType, elemT);
+        }
+        return new CollectionType(rawType, bindings,
+                // !!! TODO: Wrong, does have supertypes, but:
+                _bogusSuperClass(rawType), null, elemT,
+                null, null, false);
+    }
+
+    @Deprecated // since 2.7
+    @Override
+    protected JavaType _narrow(Class<?> subclass) {
+        return new CollectionType(subclass, _bindings,
+                _superClass, _superInterfaces, _elementType, null, null, _asStatic);
+    }
+
+    @Override
+    public JavaType withContentType(JavaType contentType) {
+        if (_elementType == contentType) {
+            return this;
+        }
+        return new CollectionType(_class, _bindings, _superClass, _superInterfaces,
+                contentType, _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public CollectionType withTypeHandler(Object h) {
+        return new CollectionType(_class, _bindings,
+                _superClass, _superInterfaces, _elementType, _valueHandler, h, _asStatic);
+    }
+
+    @Override
+    public CollectionType withContentTypeHandler(Object h)
+    {
+        return new CollectionType(_class, _bindings,
+                _superClass, _superInterfaces, _elementType.withTypeHandler(h),
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public CollectionType withValueHandler(Object h) {
+        return new CollectionType(_class, _bindings,
+                _superClass, _superInterfaces, _elementType, h, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public  CollectionType withContentValueHandler(Object h) {
+        return new CollectionType(_class, _bindings,
+                _superClass, _superInterfaces, _elementType.withValueHandler(h),
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public CollectionType withStaticTyping() {
+        if (_asStatic) {
+            return this;
+        }
+        return new CollectionType(_class, _bindings,
+                _superClass, _superInterfaces, _elementType.withStaticTyping(),
+                _valueHandler, _typeHandler, true);
+    }
+
+    @Override
+    public JavaType refine(Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces) {
+        return new CollectionType(rawType, bindings,
+                superClass, superInterfaces, _elementType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    /*
+    /**********************************************************
+    /* Standard methods
+    /**********************************************************
+     */
+
+    @Override
+    public String toString()
+    {
+        return "[collection type; class "+_class.getName()+", contains "+_elementType+"]";
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/MapLikeType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/MapLikeType.java
@@ -1,0 +1,314 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.lang.reflect.TypeVariable;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Type that represents Map-like types; things that consist of key/value pairs
+ * but that do not necessarily implement {@link Map}, but that do not
+ * have enough introspection functionality to allow for some level of generic
+ * handling. This specifically allows framework to check for configuration and
+ * annotation settings used for Map types, and pass these to custom handlers
+ * that may be more familiar with actual type.
+ */
+public class MapLikeType extends TypeBase {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Type of keys of Map.
+     */
+    protected final JavaType _keyType;
+
+    /**
+     * Type of values of Map.
+     */
+    protected final JavaType _valueType;
+
+    /*
+    /**********************************************************
+    * Life-cycle
+    /**********************************************************
+     */
+
+    protected MapLikeType(Class<?> mapType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts, JavaType keyT,
+            JavaType valueT, Object valueHandler, Object typeHandler,
+            boolean asStatic) {
+        super(mapType, bindings, superClass, superInts, keyT.hashCode()
+                ^ valueT.hashCode(), valueHandler, typeHandler, asStatic);
+        _keyType = keyT;
+        _valueType = valueT;
+    }
+
+    /**
+     * @since 2.7
+     */
+    protected MapLikeType(TypeBase base, JavaType keyT, JavaType valueT) {
+        super(base);
+        _keyType = keyT;
+        _valueType = valueT;
+    }
+
+    /**
+     * Factory method that can be used to "upgrade" a basic type into
+     * collection-like one; usually done via {@link TypeModifier}
+     *
+     * @since 2.7
+     */
+    public static MapLikeType upgradeFrom(JavaType baseType, JavaType keyT,
+            JavaType valueT) {
+        // 19-Oct-2015, tatu: Not sure if and how other types could be used as
+        // base;
+        // will cross that bridge if and when need be
+        if (baseType instanceof TypeBase) {
+            return new MapLikeType((TypeBase) baseType, keyT, valueT);
+        }
+        throw new IllegalArgumentException(
+                "Cannot upgrade from an instance of " + baseType.getClass());
+    }
+
+    @Deprecated
+    // since 2.7; remove from 2.8
+    public static MapLikeType construct(Class<?> rawType, JavaType keyT,
+            JavaType valueT) {
+        // First: may need to fabricate TypeBindings (needed for refining into
+        // concrete collection types, as per [databind#1102])
+        TypeVariable<?>[] vars = rawType.getTypeParameters();
+        TypeBindings bindings;
+        if ((vars == null) || (vars.length != 2)) {
+            bindings = TypeBindings.emptyBindings();
+        } else {
+            bindings = TypeBindings.create(rawType, keyT, valueT);
+        }
+        return new MapLikeType(rawType, bindings, _bogusSuperClass(rawType),
+                null, keyT, valueT, null, null, false);
+    }
+
+    @Deprecated
+    // since 2.7
+    @Override
+    protected JavaType _narrow(Class<?> subclass) {
+        return new MapLikeType(subclass, _bindings, _superClass,
+                _superInterfaces, _keyType, _valueType, _valueHandler,
+                _typeHandler, _asStatic);
+    }
+
+    /**
+     * @since 2.7
+     */
+    public MapLikeType withKeyType(JavaType keyType) {
+        if (keyType == _keyType) {
+            return this;
+        }
+        return new MapLikeType(_class, _bindings, _superClass,
+                _superInterfaces, keyType, _valueType, _valueHandler,
+                _typeHandler, _asStatic);
+    }
+
+    @Override
+    public JavaType withContentType(JavaType contentType) {
+        if (_valueType == contentType) {
+            return this;
+        }
+        return new MapLikeType(_class, _bindings, _superClass,
+                _superInterfaces, _keyType, contentType, _valueHandler,
+                _typeHandler, _asStatic);
+    }
+
+    @Override
+    public MapLikeType withTypeHandler(Object h) {
+        return new MapLikeType(_class, _bindings, _superClass,
+                _superInterfaces, _keyType, _valueType, _valueHandler, h,
+                _asStatic);
+    }
+
+    @Override
+    public MapLikeType withContentTypeHandler(Object h) {
+        return new MapLikeType(_class, _bindings, _superClass,
+                _superInterfaces, _keyType, _valueType.withTypeHandler(h),
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public MapLikeType withValueHandler(Object h) {
+        return new MapLikeType(_class, _bindings, _superClass,
+                _superInterfaces, _keyType, _valueType, h, _typeHandler,
+                _asStatic);
+    }
+
+    @Override
+    public MapLikeType withContentValueHandler(Object h) {
+        return new MapLikeType(_class, _bindings, _superClass,
+                _superInterfaces, _keyType, _valueType.withValueHandler(h),
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public JavaType withHandlersFrom(JavaType src) {
+        JavaType type = super.withHandlersFrom(src);
+        JavaType srcKeyType = src.getKeyType();
+        // "withKeyType()" not part of JavaType, hence must verify:
+        if (type instanceof MapLikeType) {
+            if (srcKeyType != null) {
+                JavaType ct = _keyType.withHandlersFrom(srcKeyType);
+                if (ct != _keyType) {
+                    type = ((MapLikeType) type).withKeyType(ct);
+                }
+            }
+        }
+        JavaType srcCt = src.getContentType();
+        if (srcCt != null) {
+            JavaType ct = _valueType.withHandlersFrom(srcCt);
+            if (ct != _valueType) {
+                type = type.withContentType(ct);
+            }
+        }
+        return type;
+    }
+
+    @Override
+    public MapLikeType withStaticTyping() {
+        if (_asStatic) {
+            return this;
+        }
+        return new MapLikeType(_class, _bindings, _superClass,
+                _superInterfaces, _keyType, _valueType.withStaticTyping(),
+                _valueHandler, _typeHandler, true);
+    }
+
+    @Override
+    public JavaType refine(Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces) {
+        return new MapLikeType(rawType, bindings, superClass, superInterfaces,
+                _keyType, _valueType, _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    protected String buildCanonicalName() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(_class.getName());
+        // 10-Apr-2021, tatu: [databind#3108] Ensure we have at least nominally
+        //   compatible type declaration (weak guarantee but better than nothing)
+        if ((_keyType != null) && _hasNTypeParameters(2)) {
+            sb.append('<');
+            sb.append(_keyType.toCanonical());
+            sb.append(',');
+            sb.append(_valueType.toCanonical());
+            sb.append('>');
+        }
+        return sb.toString();
+    }
+
+    /*
+    /**********************************************************
+    /* Public API
+    /**********************************************************
+     */
+
+    @Override
+    public boolean isContainerType() {
+        return true;
+    }
+
+    @Override
+    public boolean isMapLikeType() {
+        return true;
+    }
+
+    @Override
+    public JavaType getKeyType() {
+        return _keyType;
+    }
+
+    @Override
+    public JavaType getContentType() {
+        return _valueType;
+    }
+
+    @Override
+    public Object getContentValueHandler() {
+        return _valueType.getValueHandler();
+    }
+
+    @Override
+    public Object getContentTypeHandler() {
+        return _valueType.getTypeHandler();
+    }
+
+    @Override
+    public boolean hasHandlers() {
+        return super.hasHandlers() || _valueType.hasHandlers()
+                || _keyType.hasHandlers();
+    }
+
+    @Override
+    public StringBuilder getErasedSignature(StringBuilder sb) {
+        return _classSignature(_class, sb, true);
+    }
+
+    @Override
+    public StringBuilder getGenericSignature(StringBuilder sb) {
+        _classSignature(_class, sb, false);
+        sb.append('<');
+        _keyType.getGenericSignature(sb);
+        _valueType.getGenericSignature(sb);
+        sb.append(">;");
+        return sb;
+    }
+
+    /*
+    /**********************************************************
+    /* Extended API
+    /**********************************************************
+     */
+
+    public MapLikeType withKeyTypeHandler(Object h) {
+        return new MapLikeType(_class, _bindings, _superClass,
+                _superInterfaces, _keyType.withTypeHandler(h), _valueType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    public MapLikeType withKeyValueHandler(Object h) {
+        return new MapLikeType(_class, _bindings, _superClass,
+                _superInterfaces, _keyType.withValueHandler(h), _valueType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    /**
+     * Method that can be used for checking whether this type is a "real"
+     * Collection type; meaning whether it represents a parameterized subtype of
+     * {@link Collection} or just something that acts like one.
+     *
+     * @deprecated Since 2.12 just use instanceof
+     */
+    @Deprecated // since 2.12 use assignment checks
+    public boolean isTrueMapType() {
+        return Map.class.isAssignableFrom(_class);
+    }
+
+    /*
+    /**********************************************************
+    /* Standard methods
+    /**********************************************************
+     */
+
+    @Override
+    public String toString() {
+        return String.format("[map-like type; class %s, %s -> %s]",
+                _class.getName(), _keyType, _valueType);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (o == null) return false;
+        if (o.getClass() != getClass()) return false;
+
+        MapLikeType other = (MapLikeType) o;
+        return (_class == other._class) && _keyType.equals(other._keyType)
+                && _valueType.equals(other._valueType);
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/MapType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/MapType.java
@@ -1,0 +1,163 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.lang.reflect.TypeVariable;
+
+/**
+ * Type that represents "true" Java Map types.
+ */
+public final class MapType extends MapLikeType
+{
+    private static final long serialVersionUID = 1L;
+
+    /*
+    /**********************************************************
+    /* Life-cycle
+    /**********************************************************
+     */
+
+    private MapType(Class<?> mapType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts, JavaType keyT, JavaType valueT,
+            Object valueHandler, Object typeHandler, boolean asStatic) {
+        super(mapType, bindings, superClass, superInts,
+                keyT, valueT, valueHandler, typeHandler, asStatic);
+    }
+
+    /**
+     * @since 2.7
+     */
+    protected MapType(TypeBase base, JavaType keyT, JavaType valueT) {
+        super(base, keyT, valueT);
+    }
+
+    /**
+     * @since 2.7
+     */
+    public static MapType construct(Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts,
+            JavaType keyT, JavaType valueT) {
+        return new MapType(rawType, bindings, superClass, superInts, keyT, valueT, null, null, false);
+    }
+
+    @Deprecated // since 2.7
+    public static MapType construct(Class<?> rawType, JavaType keyT, JavaType valueT)
+    {
+        // First: may need to fabricate TypeBindings (needed for refining into
+        // concrete collection types, as per [databind#1102])
+        TypeVariable<?>[] vars = rawType.getTypeParameters();
+        TypeBindings bindings;
+        if ((vars == null) || (vars.length != 2)) {
+            bindings = TypeBindings.emptyBindings();
+        } else {
+            bindings = TypeBindings.create(rawType, keyT, valueT);
+        }
+        // !!! TODO: Wrong, does have supertypes
+        return new MapType(rawType, bindings, _bogusSuperClass(rawType), null,
+                keyT, valueT, null, null, false);
+    }
+
+    @Deprecated // since 2.7
+    @Override
+    protected JavaType _narrow(Class<?> subclass) {
+        return new MapType(subclass, _bindings,
+                _superClass, _superInterfaces, _keyType, _valueType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public MapType withTypeHandler(Object h) {
+        return new MapType(_class, _bindings,
+                _superClass, _superInterfaces, _keyType, _valueType, _valueHandler, h, _asStatic);
+    }
+
+    @Override
+    public MapType withContentTypeHandler(Object h)
+    {
+        return new MapType(_class, _bindings,
+                _superClass, _superInterfaces, _keyType, _valueType.withTypeHandler(h),
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public MapType withValueHandler(Object h) {
+        return new MapType(_class, _bindings,
+                _superClass, _superInterfaces, _keyType, _valueType, h, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public MapType withContentValueHandler(Object h) {
+        return new MapType(_class, _bindings,
+                _superClass, _superInterfaces, _keyType, _valueType.withValueHandler(h),
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public MapType withStaticTyping() {
+        if (_asStatic) {
+            return this;
+        }
+        return new MapType(_class, _bindings,
+                _superClass, _superInterfaces, _keyType.withStaticTyping(), _valueType.withStaticTyping(),
+                _valueHandler, _typeHandler, true);
+    }
+
+    @Override
+    public JavaType withContentType(JavaType contentType) {
+        if (_valueType == contentType) {
+            return this;
+        }
+        return new MapType(_class, _bindings, _superClass, _superInterfaces,
+                _keyType, contentType, _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public MapType withKeyType(JavaType keyType) {
+        if (keyType == _keyType) {
+            return this;
+        }
+        return new MapType(_class, _bindings, _superClass, _superInterfaces,
+                keyType, _valueType, _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public JavaType refine(Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces) {
+        return new MapType(rawType, bindings,
+                superClass, superInterfaces, _keyType, _valueType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    /*
+    /**********************************************************
+    /* Extended API
+    /**********************************************************
+     */
+
+    @Override
+    public MapType withKeyTypeHandler(Object h)
+    {
+        return new MapType(_class, _bindings,
+                _superClass, _superInterfaces, _keyType.withTypeHandler(h), _valueType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public MapType withKeyValueHandler(Object h) {
+        return new MapType(_class, _bindings,
+                _superClass, _superInterfaces, _keyType.withValueHandler(h), _valueType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    /*
+    /**********************************************************
+    /* Standard methods
+    /**********************************************************
+     */
+
+    @Override
+    public String toString()
+    {
+        return "[map type; class "+_class.getName()+", "+_keyType+" -> "+_valueType+"]";
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/PlaceholderForType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/PlaceholderForType.java
@@ -1,0 +1,110 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+/**
+ * Helper type used when introspecting bindings for already resolved types,
+ * needed for specialization.
+ *
+ * @since 2.8.11
+ */
+public class PlaceholderForType extends TypeBase
+{
+    private static final long serialVersionUID = 1L;
+
+    protected final int _ordinal;
+
+    /**
+     * Type assigned during wildcard resolution (which follows type
+     * structure resolution)
+     */
+    protected JavaType _actualType;
+
+    public PlaceholderForType(int ordinal)
+    {
+        super(Object.class, TypeBindings.emptyBindings(),
+                TypeFactory.unknownType(), null, 1, // super-class, super-interfaces, hashCode
+                null, null, false); // value/type handler, as-static
+        _ordinal = ordinal;
+    }
+
+    public JavaType actualType() { return _actualType; }
+    public void actualType(JavaType t) { _actualType = t; }
+
+    // Override to get better diagnostics
+    @Override
+    protected String buildCanonicalName() {
+        return toString();
+    }
+
+    @Override
+    public StringBuilder getGenericSignature(StringBuilder sb) {
+        return getErasedSignature(sb);
+    }
+
+    @Override
+    public StringBuilder getErasedSignature(StringBuilder sb) {
+        sb.append('$').append(_ordinal+1);
+        return sb;
+    }
+
+    @Override
+    public JavaType withTypeHandler(Object h) {
+        return _unsupported();
+    }
+
+    @Override
+    public JavaType withContentTypeHandler(Object h) {
+        return _unsupported();
+    }
+
+    @Override
+    public JavaType withValueHandler(Object h) {
+        return _unsupported();
+    }
+
+    @Override
+    public JavaType withContentValueHandler(Object h) {
+        return _unsupported();
+    }
+
+    @Override
+    public JavaType withContentType(JavaType contentType) {
+        return _unsupported();
+    }
+
+    @Override
+    public JavaType withStaticTyping() {
+        return _unsupported();
+    }
+
+    @Override
+    public JavaType refine(Class<?> rawType, TypeBindings bindings, JavaType superClass, JavaType[] superInterfaces) {
+        return _unsupported();
+    }
+
+    @Override
+    @Deprecated // since 2.7
+    protected JavaType _narrow(Class<?> subclass) {
+        return _unsupported();
+    }
+
+    @Override
+    public boolean isContainerType() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return getErasedSignature(new StringBuilder()).toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return (o == this);
+    }
+
+    private <T> T _unsupported() {
+        throw new UnsupportedOperationException("Operation should not be attempted on "+getClass().getName());
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/ReferenceType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/ReferenceType.java
@@ -1,0 +1,285 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.util.Objects;
+
+/**
+ * Specialized {@link SimpleType} for types that are referential types,
+ * that is, values that can be dereferenced to another value (or null),
+ * of different type.
+ * Referenced type is accessible using {@link #getContentType()}.
+ *
+ * @since 2.6
+ */
+public class ReferenceType extends SimpleType
+{
+    private static final long serialVersionUID = 1L;
+
+    protected final JavaType _referencedType;
+
+    /**
+     * Essential type used for type ids, for example if type id is needed for
+     * referencing type with polymorphic handling. Typically initialized when
+     * a {@link SimpleType} is upgraded into reference type, but NOT changed
+     * if being sub-classed.
+     *
+     * @since 2.8
+     */
+    protected final JavaType _anchorType;
+
+    protected ReferenceType(Class<?> cls, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts, JavaType refType,
+            JavaType anchorType,
+            Object valueHandler, Object typeHandler, boolean asStatic)
+    {
+        super(cls, bindings, superClass, superInts, Objects.hashCode(refType),
+                valueHandler, typeHandler, asStatic);
+        _referencedType = refType;
+        _anchorType = (anchorType == null) ? this : anchorType;
+    }
+
+    /**
+     * Constructor used when upgrading into this type (via {@link #upgradeFrom},
+     * the usual way for {@link ReferenceType}s to come into existence.
+     * Sets up what is considered the "base" reference type
+     *
+     * @since 2.7
+     */
+    protected ReferenceType(TypeBase base, JavaType refType)
+    {
+        super(base);
+        _referencedType = refType;
+        // we'll establish this as the anchor type
+        _anchorType = this;
+    }
+
+    /**
+     * Factory method that can be used to "upgrade" a basic type into collection-like
+     * one; usually done via {@link TypeModifier}
+     *
+     * @param baseType Resolved non-reference type (usually {@link SimpleType}) that is being upgraded
+     * @param refdType Referenced type; usually the first and only type parameter, but not necessarily
+     *
+     * @since 2.7
+     */
+    public static ReferenceType upgradeFrom(JavaType baseType, JavaType refdType) {
+        if (refdType == null) {
+            throw new IllegalArgumentException("Missing referencedType");
+        }
+        // 19-Oct-2015, tatu: Not sure if and how other types could be used as base;
+        //    will cross that bridge if and when need be
+        if (baseType instanceof TypeBase) {
+            return new ReferenceType((TypeBase) baseType, refdType);
+        }
+        throw new IllegalArgumentException("Cannot upgrade from an instance of "+baseType.getClass());
+    }
+
+    /**
+     * @since 2.7
+     */
+    public static ReferenceType construct(Class<?> cls, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts, JavaType refType)
+    {
+        return new ReferenceType(cls, bindings, superClass, superInts,
+                refType, null, null, null, false);
+    }
+
+    @Deprecated // since 2.7
+    public static ReferenceType construct(Class<?> cls, JavaType refType) {
+        return new ReferenceType(cls, TypeBindings.emptyBindings(),
+                // !!! TODO: missing supertypes
+                null, null, null, refType, null, null, false);
+    }
+
+    @Override
+    public JavaType withContentType(JavaType contentType) {
+        if (_referencedType == contentType) {
+            return this;
+        }
+        return new ReferenceType(_class, _bindings, _superClass, _superInterfaces,
+                contentType, _anchorType, _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public ReferenceType withTypeHandler(Object h)
+    {
+        if (h == _typeHandler) {
+            return this;
+        }
+        return new ReferenceType(_class, _bindings, _superClass, _superInterfaces,
+                _referencedType, _anchorType, _valueHandler, h, _asStatic);
+    }
+
+    @Override
+    public ReferenceType withContentTypeHandler(Object h)
+    {
+        if (h == _referencedType.<Object>getTypeHandler()) {
+            return this;
+        }
+        return new ReferenceType(_class, _bindings, _superClass, _superInterfaces,
+                _referencedType.withTypeHandler(h), _anchorType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public ReferenceType withValueHandler(Object h) {
+        if (h == _valueHandler) {
+            return this;
+        }
+        return new ReferenceType(_class, _bindings,
+                _superClass, _superInterfaces, _referencedType, _anchorType,
+                h, _typeHandler,_asStatic);
+    }
+
+    @Override
+    public ReferenceType withContentValueHandler(Object h) {
+        if (h == _referencedType.<Object>getValueHandler()) {
+            return this;
+        }
+        JavaType refdType = _referencedType.withValueHandler(h);
+        return new ReferenceType(_class, _bindings,
+                _superClass, _superInterfaces, refdType, _anchorType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public ReferenceType withStaticTyping() {
+        if (_asStatic) {
+            return this;
+        }
+        return new ReferenceType(_class, _bindings, _superClass, _superInterfaces,
+                _referencedType.withStaticTyping(), _anchorType,
+                 _valueHandler, _typeHandler, true);
+    }
+
+    @Override
+    public JavaType refine(Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces) {
+        return new ReferenceType(rawType, _bindings,
+                superClass, superInterfaces, _referencedType, _anchorType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    @Override
+    protected String buildCanonicalName()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append(_class.getName());
+        if ((_referencedType != null) && _hasNTypeParameters(1)) {
+            sb.append('<');
+            sb.append(_referencedType.toCanonical());
+            sb.append('>');
+        }
+        return sb.toString();
+    }
+
+    /*
+    /**********************************************************
+    /* Narrow/widen
+    /**********************************************************
+     */
+
+    @Override
+    @Deprecated // since 2.7
+    protected JavaType _narrow(Class<?> subclass)
+    {
+        // Should we check that there is a sub-class relationship?
+        return new ReferenceType(subclass, _bindings,
+                _superClass, _superInterfaces, _referencedType, _anchorType,
+                _valueHandler, _typeHandler, _asStatic);
+    }
+
+    /*
+    /**********************************************************
+    /* Public API overrides
+    /**********************************************************
+     */
+
+    @Override
+    public JavaType getContentType() {
+        return _referencedType;
+    }
+
+    @Override
+    public JavaType getReferencedType() {
+        return _referencedType;
+    }
+
+    @Override
+    public boolean hasContentType() {
+        return true;
+    }
+
+    @Override
+    public boolean isReferenceType() {
+        return true;
+    }
+
+    @Override
+    public StringBuilder getErasedSignature(StringBuilder sb) {
+        return _classSignature(_class, sb, true);
+    }
+
+    @Override
+    public StringBuilder getGenericSignature(StringBuilder sb)
+    {
+        _classSignature(_class, sb, false);
+        sb.append('<');
+        sb = _referencedType.getGenericSignature(sb);
+        sb.append(">;");
+        return sb;
+    }
+
+    /*
+    /**********************************************************
+    /* Extended API
+    /**********************************************************
+     */
+
+    public JavaType getAnchorType() {
+        return _anchorType;
+    }
+
+    /**
+     * Convenience accessor that allows checking whether this is the anchor type
+     * itself; if not, it must be one of supertypes that is also a {@link ReferenceType}
+     */
+    public boolean isAnchorType() {
+        return (_anchorType == this);
+    }
+
+    /*
+    /**********************************************************
+    /* Standard methods
+    /**********************************************************
+     */
+
+    @Override
+    public String toString()
+    {
+        return new StringBuilder(40)
+            .append("[reference type, class ")
+            .append(buildCanonicalName())
+            .append('<')
+            .append(_referencedType)
+            .append('>')
+            .append(']')
+            .toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == this) return true;
+        if (o == null) return false;
+        if (o.getClass() != getClass()) return false;
+
+        ReferenceType other = (ReferenceType) o;
+
+        if (other._class != _class) return false;
+
+        // Otherwise actually mostly worry about referenced type
+        return _referencedType.equals(other._referencedType);
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/ResolvedRecursiveType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/ResolvedRecursiveType.java
@@ -1,0 +1,151 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+/**
+ * Internal placeholder type used for self-references.
+ *
+ * @since 2.7
+ */
+public class ResolvedRecursiveType extends TypeBase
+{
+    private static final long serialVersionUID = 1L;
+
+    protected JavaType _referencedType;
+
+    public ResolvedRecursiveType(Class<?> erasedType, TypeBindings bindings) {
+        super(erasedType, bindings, null, null, 0, null, null, false);
+    }
+
+    public void setReference(JavaType ref)
+    {
+        // sanity check; should not be called multiple times
+        if (_referencedType != null) {
+            throw new IllegalStateException("Trying to re-set self reference; old value = "+_referencedType+", new = "+ref);
+        }
+        _referencedType = ref;
+    }
+
+    @Override
+    public JavaType getSuperClass() {
+        if (_referencedType != null) {
+            return _referencedType.getSuperClass();
+        }
+        return super.getSuperClass();
+    }
+
+    public JavaType getSelfReferencedType() { return _referencedType; }
+
+    // 23-Jul-2019, tatu: [databind#2331] Need to also delegate this...
+    @Override
+    public TypeBindings getBindings() {
+        if (_referencedType != null) { // `null` before resolution [databind#2395]
+            return _referencedType.getBindings();
+        }
+        return super.getBindings();
+    }
+
+    @Override
+    public StringBuilder getGenericSignature(StringBuilder sb) {
+        // 30-Oct-2019, tatu: Alas, need to break recursion, otherwise we'll
+        //    end up in StackOverflowError... two choices; '?' for "not known",
+        //    or erased signature.
+        if (_referencedType != null) {
+//            return _referencedType.getGenericSignature(sb);
+            return _referencedType.getErasedSignature(sb);
+        }
+        return sb.append("?");
+    }
+
+    @Override
+    public StringBuilder getErasedSignature(StringBuilder sb) {
+        if (_referencedType != null) {
+            return _referencedType.getErasedSignature(sb);
+        }
+        return sb;
+    }
+
+    @Override
+    public JavaType withContentType(JavaType contentType) {
+        return this;
+    }
+
+    @Override
+    public JavaType withTypeHandler(Object h) {
+        return this;
+    }
+
+    @Override
+    public JavaType withContentTypeHandler(Object h) {
+        return this;
+    }
+
+    @Override
+    public JavaType withValueHandler(Object h) {
+        return this;
+    }
+
+    @Override
+    public JavaType withContentValueHandler(Object h) {
+        return this;
+    }
+
+    @Override
+    public JavaType withStaticTyping() {
+        return this;
+    }
+
+    @Deprecated // since 2.7
+    @Override
+    protected JavaType _narrow(Class<?> subclass) {
+        return this;
+    }
+
+    @Override
+    public JavaType refine(Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces) {
+        return null;
+    }
+
+    @Override
+    public boolean isContainerType() {
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(40)
+                .append("[recursive type; ");
+        if (_referencedType == null) {
+            sb.append("UNRESOLVED");
+        } else {
+            // [databind#1301]: Typically resolves to a loop so short-cut
+            //   and only include type-erased class
+            sb.append(_referencedType.getRawClass().getName());
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) return true;
+        if (o == null) return false;
+        if (o.getClass() == getClass()) {
+            // 16-Jun-2017, tatu: as per [databind#1658], cannot do recursive call since
+            //    there is likely to be a cycle...
+
+            // but... true or false?
+            return false;
+
+            /*
+            // Do NOT ever match unresolved references
+            if (_referencedType == null) {
+                return false;
+            }
+            return (o.getClass() == getClass()
+                    && _referencedType.equals(((ResolvedRecursiveType) o).getSelfReferencedType()));
+                    */
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/SimpleType.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/SimpleType.java
@@ -1,0 +1,330 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Simple types are defined as anything other than one of recognized
+ * container types (arrays, Collections, Maps). For our needs we
+ * need not know anything further, since we have no way of dealing
+ * with generic types other than Collections and Maps.
+ */
+public class SimpleType // note: until 2.6 was final
+    extends TypeBase
+{
+    private static final long serialVersionUID = 1L;
+
+    /*
+    /**********************************************************
+    /* Life-cycle
+    /**********************************************************
+     */
+
+    /**
+     * Constructor only used by core Jackson databind functionality;
+     * should never be called by application code.
+     *<p>
+     * As with other direct construction that by-passes {@link TypeFactory},
+     * no introspection occurs with respect to super-types; caller must be
+     * aware of consequences if using this method.
+     */
+    protected SimpleType(Class<?> cls) {
+        this(cls, TypeBindings.emptyBindings(), null, null);
+    }
+
+    protected SimpleType(Class<?> cls, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts) {
+        this(cls, bindings, superClass, superInts, null, null, false);
+    }
+
+    /**
+     * Simple copy-constructor, usually used when upgrading/refining a simple type
+     * into more specialized type.
+     *
+     * @since 2.7
+     */
+    protected SimpleType(TypeBase base) {
+        super(base);
+    }
+
+    protected SimpleType(Class<?> cls, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts,
+            Object valueHandler, Object typeHandler, boolean asStatic)
+    {
+        super(cls, bindings, superClass, superInts,
+                0, valueHandler, typeHandler, asStatic);
+    }
+
+    /**
+     * Pass-through constructor used by {@link ReferenceType}.
+     *
+     * @since 2.6
+     */
+    protected SimpleType(Class<?> cls, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInts, int extraHash,
+            Object valueHandler, Object typeHandler, boolean asStatic)
+    {
+        super(cls, bindings, superClass, superInts,
+                extraHash, valueHandler, typeHandler, asStatic);
+    }
+
+    /**
+     * Method used by core Jackson classes: NOT to be used by application code:
+     * it does NOT properly handle inspection of super-types, so neither parent
+     * Classes nor implemented Interfaces are accessible with resulting type
+     * instance.
+     *<p>
+     * NOTE: public only because it is called by <code>ObjectMapper</code> which is
+     * not in same package
+     */
+    public static SimpleType constructUnsafe(Class<?> raw) {
+        return new SimpleType(raw, null,
+                // 18-Oct-2015, tatu: Should be ok to omit possible super-types, right?
+                null, null, null, null, false);
+    }
+
+    /**
+     * Method that should NOT to be used by application code:
+     * it does NOT properly handle inspection of super-types, so neither parent
+     * Classes nor implemented Interfaces are accessible with resulting type
+     * instance. Instead, please use {@link TypeFactory}'s <code>constructType</code>
+     * methods which handle introspection appropriately.
+     *<p>
+     * Note that prior to 2.7, method usage was not limited and would typically
+     * have worked acceptably: the problem comes from inability to resolve super-type
+     * information, for which {@link TypeFactory} is needed.
+     *
+     * @deprecated Since 2.7
+     */
+    @Deprecated
+    public static SimpleType construct(Class<?> cls)
+    {
+        /* Let's add sanity checks, just to ensure no
+         * Map/Collection entries are constructed
+         */
+        if (Map.class.isAssignableFrom(cls)) {
+            throw new IllegalArgumentException("Cannot construct SimpleType for a Map (class: "+cls.getName()+")");
+        }
+        if (Collection.class.isAssignableFrom(cls)) {
+            throw new IllegalArgumentException("Cannot construct SimpleType for a Collection (class: "+cls.getName()+")");
+        }
+        // ... and while we are at it, not array types either
+        if (cls.isArray()) {
+            throw new IllegalArgumentException("Cannot construct SimpleType for an array (class: "+cls.getName()+")");
+        }
+        TypeBindings b = TypeBindings.emptyBindings();
+        return new SimpleType(cls, b,
+                _buildSuperClass(cls.getSuperclass(), b), null, null, null, false);
+    }
+
+    @Override
+    @Deprecated
+    protected JavaType _narrow(Class<?> subclass)
+    {
+        if (_class == subclass) {
+            return this;
+        }
+        // Should we check that there is a sub-class relationship?
+        // 15-Jan-2016, tatu: Almost yes, but there are some complications with
+        //    placeholder values (`Void`, `NoClass`), so cannot quite do yet.
+        // TODO: fix in 2.9
+        if (!_class.isAssignableFrom(subclass)) {
+            /*
+            throw new IllegalArgumentException("Class "+subclass.getName()+" not sub-type of "
+                    +_class.getName());
+                    */
+            return new SimpleType(subclass, _bindings, this, _superInterfaces,
+                    _valueHandler, _typeHandler, _asStatic);
+        }
+        // Otherwise, stitch together the hierarchy. First, super-class
+        Class<?> next = subclass.getSuperclass();
+        if (next == _class) { // straight up parent class? Great.
+            return new SimpleType(subclass, _bindings, this,
+                    _superInterfaces, _valueHandler, _typeHandler, _asStatic);
+        }
+        if ((next != null) && _class.isAssignableFrom(next)) {
+            JavaType superb = _narrow(next);
+            return new SimpleType(subclass, _bindings, superb,
+                    null, _valueHandler, _typeHandler, _asStatic);
+        }
+        // if not found, try a super-interface
+        Class<?>[] nextI = subclass.getInterfaces();
+        for (Class<?> iface : nextI) {
+            if (iface == _class) { // directly implemented
+                return new SimpleType(subclass, _bindings, null,
+                        new JavaType[] { this }, _valueHandler, _typeHandler, _asStatic);
+            }
+            if (_class.isAssignableFrom(iface)) { // indirect, so recurse
+                JavaType superb = _narrow(iface);
+                return new SimpleType(subclass, _bindings, null,
+                        new JavaType[] { superb }, _valueHandler, _typeHandler, _asStatic);
+            }
+        }
+        // should not get here but...
+        throw new IllegalArgumentException("Internal error: Cannot resolve sub-type for Class "+subclass.getName()+" to "
+                +_class.getName());
+    }
+
+    @Override
+    public JavaType withContentType(JavaType contentType) {
+        throw new IllegalArgumentException("Simple types have no content types; cannot call withContentType()");
+    }
+
+    @Override
+    public SimpleType withTypeHandler(Object h) {
+        if (_typeHandler == h) {
+            return this;
+        }
+        return new SimpleType(_class, _bindings, _superClass, _superInterfaces, _valueHandler, h, _asStatic);
+    }
+
+    @Override
+    public JavaType withContentTypeHandler(Object h) {
+        // no content type, so:
+        throw new IllegalArgumentException("Simple types have no content types; cannot call withContenTypeHandler()");
+    }
+
+    @Override
+    public SimpleType withValueHandler(Object h) {
+        if (h == _valueHandler) {
+            return this;
+        }
+        return new SimpleType(_class, _bindings, _superClass, _superInterfaces, h, _typeHandler, _asStatic);
+    }
+
+    @Override
+    public  SimpleType withContentValueHandler(Object h) {
+        // no content type, so:
+        throw new IllegalArgumentException("Simple types have no content types; cannot call withContenValueHandler()");
+    }
+
+    @Override
+    public SimpleType withStaticTyping() {
+        return _asStatic ? this : new SimpleType(_class, _bindings,
+                _superClass, _superInterfaces, _valueHandler, _typeHandler, true);
+    }
+
+    @Override
+    public JavaType refine(Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces) {
+        // SimpleType means something not-specialized, so:
+        return null;
+    }
+
+    @Override
+    protected String buildCanonicalName()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append(_class.getName());
+
+        final int count = _bindings.size();
+
+        // 10-Apr-2021, tatu: [databind#3108] Ensure we have at least nominally
+        //   compatible type declaration (weak guarantee but better than nothing)
+        if ((count > 0) && _hasNTypeParameters(count)) {
+            sb.append('<');
+            for (int i = 0; i < count; ++i) {
+                JavaType t = containedType(i);
+                if (i > 0) {
+                    sb.append(',');
+                }
+                sb.append(t.toCanonical());
+            }
+            sb.append('>');
+        }
+        return sb.toString();
+    }
+
+    /*
+    /**********************************************************
+    /* Public API
+    /**********************************************************
+     */
+
+    @Override
+    public boolean isContainerType() { return false; }
+
+    @Override
+    public boolean hasContentType() { return false; }
+
+    @Override
+    public StringBuilder getErasedSignature(StringBuilder sb) {
+        return _classSignature(_class, sb, true);
+    }
+
+    @Override
+    public StringBuilder getGenericSignature(StringBuilder sb)
+    {
+        _classSignature(_class, sb, false);
+
+        final int count = _bindings.size();
+        if (count > 0) {
+            sb.append('<');
+            for (int i = 0; i < count; ++i) {
+                sb = containedType(i).getGenericSignature(sb);
+            }
+            sb.append('>');
+        }
+        sb.append(';');
+        return sb;
+    }
+
+    /*
+    /**********************************************************
+    /* Internal methods
+    /**********************************************************
+     */
+
+    /**
+     * Helper method we need to recursively build skeletal representations
+     * of superclasses.
+     *
+     * @since 2.7 -- remove when not needed (2.8?)
+     */
+    private static JavaType _buildSuperClass(Class<?> superClass, TypeBindings b)
+    {
+        if (superClass == null) {
+            return null;
+        }
+        if (superClass == Object.class) {
+            return TypeFactory.unknownType();
+        }
+        JavaType superSuper = _buildSuperClass(superClass.getSuperclass(), b);
+        return new SimpleType(superClass, b,
+                superSuper, null, null, null, false);
+    }
+
+    /*
+    /**********************************************************
+    /* Standard methods
+    /**********************************************************
+     */
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder(40);
+        sb.append("[simple type, class ").append(buildCanonicalName()).append(']');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (o == this) return true;
+        if (o == null) return false;
+        if (o.getClass() != getClass()) return false;
+
+        SimpleType other = (SimpleType) o;
+
+        // Classes must be identical...
+        if (other._class != this._class) return false;
+
+        // And finally, generic bindings, if any
+        TypeBindings b1 = _bindings;
+        TypeBindings b2 = other._bindings;
+        return b1.equals(b2);
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/TypeBase.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/TypeBase.java
@@ -1,0 +1,259 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.lang.reflect.TypeVariable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public abstract class TypeBase
+    extends JavaType
+//    implements JsonSerializable
+{
+    private static final long serialVersionUID = 1;
+
+    private final static TypeBindings NO_BINDINGS = TypeBindings.emptyBindings();
+    private final static JavaType[] NO_TYPES = new JavaType[0];
+
+    protected final JavaType _superClass;
+
+    protected final JavaType[] _superInterfaces;
+
+    /**
+     * Bindings in effect for this type instance; possibly empty.
+     * Needed when resolving types declared in members of this type
+     * (if any).
+     *
+     * @since 2.7
+     */
+    protected final TypeBindings _bindings;
+
+    /**
+     * Lazily initialized external representation of the type
+     */
+    volatile transient String _canonicalName;
+
+    /**
+     * Main constructor to use by extending classes.
+     */
+    protected TypeBase(Class<?> raw, TypeBindings bindings, JavaType superClass, JavaType[] superInts,
+            int hash,
+            Object valueHandler, Object typeHandler, boolean asStatic)
+    {
+        super(raw, hash, valueHandler, typeHandler, asStatic);
+        _bindings = (bindings == null) ? NO_BINDINGS : bindings;
+        _superClass = superClass;
+        _superInterfaces = superInts;
+    }
+
+    /**
+     * Copy-constructor used when refining/upgrading type instances.
+     *
+     * @since 2.7
+     */
+    protected TypeBase(TypeBase base) {
+        super(base);
+        _superClass = base._superClass;
+        _superInterfaces = base._superInterfaces;
+        _bindings = base._bindings;
+    }
+
+    @Override
+    public String toCanonical()
+    {
+        String str = _canonicalName;
+        if (str == null) {
+            str = buildCanonicalName();
+        }
+        return str;
+    }
+
+    protected String buildCanonicalName() {
+        return _class.getName();
+    }
+
+    @Override
+    public abstract StringBuilder getGenericSignature(StringBuilder sb);
+
+    @Override
+    public abstract StringBuilder getErasedSignature(StringBuilder sb);
+
+    @Override
+    public TypeBindings getBindings() {
+        return _bindings;
+    }
+
+    @Override
+    public int containedTypeCount() {
+        return _bindings.size();
+    }
+
+    @Override
+    public JavaType containedType(int index) {
+        return _bindings.getBoundType(index);
+    }
+
+    @Override
+    @Deprecated
+    public String containedTypeName(int index) {
+        return _bindings.getBoundName(index);
+    }
+
+    @Override
+    public JavaType getSuperClass() {
+        return _superClass;
+    }
+
+    @Override
+    public List<JavaType> getInterfaces() {
+        if (_superInterfaces == null) {
+            return Collections.emptyList();
+        }
+        switch (_superInterfaces.length) {
+        case 0:
+            return Collections.emptyList();
+        case 1:
+            return Collections.singletonList(_superInterfaces[0]);
+        }
+        return Arrays.asList(_superInterfaces);
+    }
+
+    @Override
+    public final JavaType findSuperType(Class<?> rawTarget)
+    {
+        if (rawTarget == _class) {
+            return this;
+        }
+        // Check super interfaces first:
+        if (rawTarget.isInterface() && (_superInterfaces != null)) {
+            for (int i = 0, count = _superInterfaces.length; i < count; ++i) {
+                JavaType type = _superInterfaces[i].findSuperType(rawTarget);
+                if (type != null) {
+                    return type;
+                }
+            }
+        }
+        // and if not found, super class and its supertypes
+        if (_superClass != null) {
+            JavaType type = _superClass.findSuperType(rawTarget);
+            if (type != null) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public JavaType[] findTypeParameters(Class<?> expType)
+    {
+        JavaType match = findSuperType(expType);
+        if (match == null) {
+            return NO_TYPES;
+        }
+        return match.getBindings().typeParameterArray();
+    }
+
+    /*
+    /**********************************************************
+    /* JsonSerializable base implementation
+    /**********************************************************
+     */
+
+    /*@Override
+    public void serializeWithType(JsonGenerator g, SerializerProvider provider,
+            TypeSerializer typeSer)
+        throws IOException
+    {
+        WritableTypeId typeIdDef = new WritableTypeId(this, JsonToken.VALUE_STRING);
+        typeSer.writeTypePrefix(g, typeIdDef);
+        this.serialize(g, provider);
+        typeSer.writeTypeSuffix(g, typeIdDef);
+    }
+
+    @Override
+    public void serialize(JsonGenerator gen, SerializerProvider provider)
+        throws IOException
+    {
+        gen.writeString(toCanonical());
+    }*/
+
+    /*
+    /**********************************************************
+    /* Methods for sub-classes to use
+    /**********************************************************
+     */
+
+    /**
+     * @param trailingSemicolon Whether to add trailing semicolon for non-primitive
+     *   (reference) types or not
+     */
+    protected static StringBuilder _classSignature(Class<?> cls, StringBuilder sb,
+           boolean trailingSemicolon)
+    {
+        if (cls.isPrimitive()) {
+            if (cls == Boolean.TYPE) {
+                sb.append('Z');
+            } else if (cls == Byte.TYPE) {
+                sb.append('B');
+            }
+            else if (cls == Short.TYPE) {
+                sb.append('S');
+            }
+            else if (cls == Character.TYPE) {
+                sb.append('C');
+            }
+            else if (cls == Integer.TYPE) {
+                sb.append('I');
+            }
+            else if (cls == Long.TYPE) {
+                sb.append('J');
+            }
+            else if (cls == Float.TYPE) {
+                sb.append('F');
+            }
+            else if (cls == Double.TYPE) {
+                sb.append('D');
+            }
+            else if (cls == Void.TYPE) {
+                sb.append('V');
+            } else {
+                throw new IllegalStateException("Unrecognized primitive type: "+cls.getName());
+            }
+        } else {
+            sb.append('L');
+            String name = cls.getName();
+            for (int i = 0, len = name.length(); i < len; ++i) {
+                char c = name.charAt(i);
+                if (c == '.') c = '/';
+                sb.append(c);
+            }
+            if (trailingSemicolon) {
+                sb.append(';');
+            }
+        }
+        return sb;
+    }
+
+    /**
+     * Internal helper method used to figure out nominal super-class for
+     * deprecated factory methods / constructors, where we are not given
+     * properly resolved supertype hierarchy.
+     * Will basically give `JavaType` for `java.lang.Object` for classes
+     * other than `java.lafgn.Object`; null for others.
+     *
+     * @since 2.7
+     */
+    protected static JavaType _bogusSuperClass(Class<?> cls) {
+        Class<?> parent = cls.getSuperclass();
+        if (parent == null) {
+            return null;
+        }
+        return TypeFactory.unknownType();
+    }
+
+    protected boolean _hasNTypeParameters(int count) {
+        TypeVariable<?>[] params = _class.getTypeParameters();
+        return (params.length == count);
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/TypeBindings.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/TypeBindings.java
@@ -1,0 +1,487 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.util.ClassUtil;
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.lang.reflect.TypeVariable;
+import java.util.*;
+
+/**
+ * Helper class used for resolving type parameters for given class
+ */
+public class TypeBindings
+    implements java.io.Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    private final static String[] NO_STRINGS = new String[0];
+
+    private final static JavaType[] NO_TYPES = new JavaType[0];
+
+    private final static TypeBindings EMPTY = new TypeBindings(NO_STRINGS, NO_TYPES, null);
+
+    // // // Pre-resolved instances for minor optimizations
+
+    // // // Actual member information
+
+    /**
+     * Array of type (type variable) names.
+     */
+    private final String[] _names;
+
+    /**
+     * Types matching names
+     */
+    private final JavaType[] _types;
+
+    /**
+     * Names of potentially unresolved type variables.
+     *
+     * @since 2.3
+     */
+    private final String[] _unboundVariables;
+
+    private final int _hashCode;
+
+    /*
+    /**********************************************************************
+    /* Construction
+    /**********************************************************************
+     */
+
+    private TypeBindings(String[] names, JavaType[] types, String[] uvars)
+    {
+        _names = (names == null) ? NO_STRINGS : names;
+        _types = (types == null) ? NO_TYPES : types;
+        if (_names.length != _types.length) {
+            throw new IllegalArgumentException("Mismatching names ("+_names.length+"), types ("+_types.length+")");
+        }
+        int h = 1;
+        for (int i = 0, len = _types.length; i < len; ++i) {
+            h += _types[i].hashCode();
+        }
+        _unboundVariables = uvars;
+        _hashCode = h;
+    }
+
+    public static TypeBindings emptyBindings() {
+        return EMPTY;
+    }
+
+    // Let's just canonicalize serialized EMPTY back to static instance, if need be
+    protected Object readResolve() {
+        if ((_names == null) || (_names.length == 0)) {
+            return EMPTY;
+        }
+        return this;
+    }
+
+    /**
+     * Factory method for constructing bindings for given class using specified type
+     * parameters.
+     */
+    public static TypeBindings create(Class<?> erasedType, List<JavaType> typeList)
+    {
+        JavaType[] types = (typeList == null || typeList.isEmpty()) ?
+                NO_TYPES : typeList.toArray(NO_TYPES);
+        return create(erasedType, types);
+    }
+
+    public static TypeBindings create(Class<?> erasedType, JavaType[] types)
+    {
+        if (types == null) {
+            types = NO_TYPES;
+        } else switch (types.length) {
+        case 1:
+            return create(erasedType, types[0]);
+        case 2:
+            return create(erasedType, types[0], types[1]);
+        }
+        TypeVariable<?>[] vars = erasedType.getTypeParameters();
+        String[] names;
+        if (vars == null || vars.length == 0) {
+            names = NO_STRINGS;
+        } else {
+            int len = vars.length;
+            names = new String[len];
+            for (int i = 0; i < len; ++i) {
+                names[i] = vars[i].getName();
+            }
+        }
+        // Check here to give better error message
+        if (names.length != types.length) {
+            throw new IllegalArgumentException("Cannot create TypeBindings for class "+erasedType.getName()
+                   +" with "+types.length+" type parameter"
+                   +((types.length == 1) ? "" : "s")+": class expects "+names.length);
+        }
+        return new TypeBindings(names, types, null);
+    }
+
+    public static TypeBindings create(Class<?> erasedType, JavaType typeArg1)
+    {
+        // 30-Oct-2015, tatu: Minor optimization for relatively common cases
+        TypeVariable<?>[] vars = TypeParamStash.paramsFor1(erasedType);
+        int varLen = (vars == null) ? 0 : vars.length;
+        if (varLen != 1) {
+            throw new IllegalArgumentException("Cannot create TypeBindings for class "+erasedType.getName()
+                    +" with 1 type parameter: class expects "+varLen);
+        }
+        return new TypeBindings(new String[] { vars[0].getName() },
+                new JavaType[] { typeArg1 }, null);
+    }
+
+    public static TypeBindings create(Class<?> erasedType, JavaType typeArg1, JavaType typeArg2)
+    {
+        // 30-Oct-2015, tatu: Minor optimization for relatively common cases
+        TypeVariable<?>[] vars = TypeParamStash.paramsFor2(erasedType);
+        int varLen = (vars == null) ? 0 : vars.length;
+        if (varLen != 2) {
+            throw new IllegalArgumentException("Cannot create TypeBindings for class "+erasedType.getName()
+                    +" with 2 type parameters: class expects "+varLen);
+        }
+        return new TypeBindings(new String[] { vars[0].getName(), vars[1].getName() },
+                new JavaType[] { typeArg1, typeArg2 }, null);
+    }
+
+    /**
+     * Factory method for constructing bindings given names and associated types.
+     */
+    public static TypeBindings create(List<String> names, List<JavaType> types)
+    {
+        if (names == null || names.isEmpty() || types == null || types.isEmpty()) {
+            return EMPTY;
+        }
+        return new TypeBindings(names.toArray(NO_STRINGS), types.toArray(NO_TYPES), null);
+    }
+
+    /**
+     * Alternate factory method that may be called if it is possible that type
+     * does or does not require type parameters; this is mostly useful for
+     * collection- and map-like types.
+     */
+    public static TypeBindings createIfNeeded(Class<?> erasedType, JavaType typeArg1)
+    {
+        TypeVariable<?>[] vars = erasedType.getTypeParameters();
+        int varLen = (vars == null) ? 0 : vars.length;
+        if (varLen == 0) {
+            return EMPTY;
+        }
+        if (varLen != 1) {
+            throw new IllegalArgumentException("Cannot create TypeBindings for class "+erasedType.getName()
+                    +" with 1 type parameter: class expects "+varLen);
+        }
+        return new TypeBindings(new String[] { vars[0].getName() },
+                new JavaType[] { typeArg1 }, null);
+    }
+
+    /**
+     * Alternate factory method that may be called if it is possible that type
+     * does or does not require type parameters; this is mostly useful for
+     * collection- and map-like types.
+     */
+    public static TypeBindings createIfNeeded(Class<?> erasedType, JavaType[] types)
+    {
+        TypeVariable<?>[] vars = erasedType.getTypeParameters();
+        if (vars == null || vars.length == 0) {
+            return EMPTY;
+        }
+        if (types == null) {
+            types = NO_TYPES;
+        }
+        int len = vars.length;
+        String[] names = new String[len];
+        for (int i = 0; i < len; ++i) {
+            names[i] = vars[i].getName();
+        }
+        // Check here to give better error message
+        if (names.length != types.length) {
+            throw new IllegalArgumentException("Cannot create TypeBindings for class "+erasedType.getName()
+                   +" with "+types.length+" type parameter"
+                   +((types.length == 1) ? "" : "s")+": class expects "+names.length);
+        }
+        return new TypeBindings(names, types, null);
+    }
+
+    /**
+     * Method for creating an instance that has same bindings as this object,
+     * plus an indicator for additional type variable that may be unbound within
+     * this context; this is needed to resolve recursive self-references.
+     */
+    public TypeBindings withUnboundVariable(String name)
+    {
+        int len = (_unboundVariables == null) ? 0 : _unboundVariables.length;
+        String[] names =  (len == 0)
+                ? new String[1] : Arrays.copyOf(_unboundVariables, len+1);
+        names[len] = name;
+        return new TypeBindings(_names, _types, names);
+    }
+
+    /*
+    /**********************************************************************
+    /* Accessors
+    /**********************************************************************
+     */
+
+    /**
+     * Find type bound to specified name, if there is one; returns bound type if so, null if not.
+     */
+    public JavaType findBoundType(String name)
+    {
+        for (int i = 0, len = _names.length; i < len; ++i) {
+            if (name.equals(_names[i])) {
+                JavaType t = _types[i];
+                if (t instanceof ResolvedRecursiveType) {
+                    ResolvedRecursiveType rrt = (ResolvedRecursiveType) t;
+                    JavaType t2 = rrt.getSelfReferencedType();
+                    if (t2 != null) {
+                        t = t2;
+                    } else {
+                        /* 25-Feb-2016, tatu: Looks like a potential problem, but alas
+                         *   we have a test where this should NOT fail and things... seem
+                         *   to work. So be it.
+                         */
+/*
+                        throw new IllegalStateException(String.format
+("Unresolved ResolvedRecursiveType for parameter '%s' (index #%d; erased type %s)",
+name, i, t.getRawClass()));
+*/
+                    }
+                }
+                return t;
+            }
+        }
+        return null;
+    }
+
+    public boolean isEmpty() {
+        return (_types.length == 0);
+    }
+
+    /**
+     * Returns number of bindings contained
+     */
+    public int size() {
+        return _types.length;
+    }
+
+    public String getBoundName(int index)
+    {
+        if (index < 0 || index >= _names.length) {
+            return null;
+        }
+        return _names[index];
+    }
+
+    public JavaType getBoundType(int index)
+    {
+        if (index < 0 || index >= _types.length) {
+            return null;
+        }
+        return _types[index];
+    }
+
+    /**
+     * Accessor for getting bound types in declaration order
+     */
+    public List<JavaType> getTypeParameters()
+    {
+        if (_types.length == 0) {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(_types);
+    }
+
+    /**
+     * @since 2.3
+     */
+    public boolean hasUnbound(String name) {
+        if (_unboundVariables != null) {
+            for (int i = _unboundVariables.length; --i >= 0; ) {
+                if (name.equals(_unboundVariables[i])) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Factory method that will create an object that can be used as a key for
+     * caching purposes by {@link TypeFactory}
+     *
+     * @since 2.8
+     */
+    public Object asKey(Class<?> rawBase) {
+        // safe to pass _types array without copy since it is not exposed via
+        // any access, nor modified by this class
+        return new AsKey(rawBase, _types, _hashCode);
+    }
+
+    /*
+    /**********************************************************************
+    /* Standard methods
+    /**********************************************************************
+     */
+
+    @Override public String toString()
+    {
+        if (_types.length == 0) {
+            return "<>";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append('<');
+        for (int i = 0, len = _types.length; i < len; ++i) {
+            if (i > 0) {
+                sb.append(',');
+            }
+//            sb = _types[i].appendBriefDescription(sb);
+            String sig = _types[i].getGenericSignature();
+            sb.append(sig);
+        }
+        sb.append('>');
+        return sb.toString();
+    }
+
+    @Override public int hashCode() { return _hashCode; }
+
+    @Override public boolean equals(Object o)
+    {
+        if (o == this) return true;
+        if (!ClassUtil.hasClass(o, getClass())) {
+            return false;
+        }
+        TypeBindings other = (TypeBindings) o;
+        int len = _types.length;
+        if (len != other.size()) {
+            return false;
+        }
+        JavaType[] otherTypes = other._types;
+        for (int i = 0; i < len; ++i) {
+            if (!otherTypes[i].equals(_types[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /*
+    /**********************************************************************
+    /* Package accessible methods
+    /**********************************************************************
+     */
+
+    protected JavaType[] typeParameterArray() {
+        return _types;
+    }
+
+    /*
+    /**********************************************************************
+    /* Helper classes
+    /**********************************************************************
+     */
+
+    // 30-Oct-2015, tatu: Surprising, but looks like type parameters access can be bit of
+    //    a hot spot. So avoid for a small number of common generic types. Note that we do
+    //    need both common abstract types and concrete ones; latter for specialization
+
+    /**
+     * Helper class that contains simple logic for avoiding repeated lookups via
+     * {@link Class#getTypeParameters()} as that can be a performance issue for
+     * some use cases (wasteful, usually one-off or not reusing mapper).
+     * Partly isolated to avoid initialization for cases where no generic types are
+     * used.
+     */
+    static class TypeParamStash {
+        private final static TypeVariable<?>[] VARS_ABSTRACT_LIST = AbstractList.class.getTypeParameters();
+        private final static TypeVariable<?>[] VARS_COLLECTION = Collection.class.getTypeParameters();
+        private final static TypeVariable<?>[] VARS_ITERABLE = Iterable.class.getTypeParameters();
+        private final static TypeVariable<?>[] VARS_LIST = List.class.getTypeParameters();
+        private final static TypeVariable<?>[] VARS_ARRAY_LIST = ArrayList.class.getTypeParameters();
+
+        private final static TypeVariable<?>[] VARS_MAP = Map.class.getTypeParameters();
+        private final static TypeVariable<?>[] VARS_HASH_MAP = HashMap.class.getTypeParameters();
+        private final static TypeVariable<?>[] VARS_LINKED_HASH_MAP = LinkedHashMap.class.getTypeParameters();
+
+        public static TypeVariable<?>[] paramsFor1(Class<?> erasedType)
+        {
+            if (erasedType == Collection.class) {
+                return VARS_COLLECTION;
+            }
+            if (erasedType == List.class) {
+                return VARS_LIST;
+            }
+            if (erasedType == ArrayList.class) {
+                return VARS_ARRAY_LIST;
+            }
+            if (erasedType == AbstractList.class) {
+                return VARS_ABSTRACT_LIST;
+            }
+            if (erasedType == Iterable.class) {
+                return VARS_ITERABLE;
+            }
+            return erasedType.getTypeParameters();
+        }
+
+        public static TypeVariable<?>[] paramsFor2(Class<?> erasedType)
+        {
+            if (erasedType == Map.class) {
+                return VARS_MAP;
+            }
+            if (erasedType == HashMap.class) {
+                return VARS_HASH_MAP;
+            }
+            if (erasedType == LinkedHashMap.class) {
+                return VARS_LINKED_HASH_MAP;
+            }
+            return erasedType.getTypeParameters();
+        }
+    }
+
+    /**
+     * Helper type used to allow caching of generic types
+     *
+     * @since 2.8
+     */
+    final static class AsKey {
+        private final Class<?> _raw;
+        private final JavaType[] _params;
+        private final int _hash;
+
+        public AsKey(Class<?> raw, JavaType[] params, int hash) {
+            _raw = raw ;
+            _params = params;
+            _hash = hash;
+        }
+
+        @Override
+        public int hashCode() { return _hash; }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (o == null) return false;
+            if (o.getClass() != getClass()) return false;
+            AsKey other = (AsKey) o;
+
+            if ((_hash == other._hash) && (_raw == other._raw)) {
+                final JavaType[] otherParams = other._params;
+                final int len = _params.length;
+
+                if (len == otherParams.length) {
+                    for (int i = 0; i < len; ++i) {
+                        if (!_params[i].equals(otherParams[i])) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return _raw.getName()+"<>";
+        }
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/TypeFactory.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/TypeFactory.java
@@ -1,0 +1,1679 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.util.ArrayBuilders;
+import org.apache.ibatis.reflection.type.jackson.databind.util.ClassUtil;
+import org.apache.ibatis.reflection.type.jackson.databind.util.LRUMap;
+import org.apache.ibatis.reflection.type.jackson.databind.util.LookupCache;
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.lang.reflect.*;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Class used for creating concrete {@link JavaType} instances,
+ * given various inputs.
+ *<p>
+ * Instances of this class are accessible using {@link org.apache.ibatis.type.resolved.jackson.databind.ObjectMapper}
+ * as well as many objects it constructs (like
+* {@link org.apache.ibatis.type.resolved.jackson.databind.DeserializationConfig} and
+ * {@link org.apache.ibatis.type.resolved.jackson.databind.SerializationConfig})),
+ * but usually those objects also
+ * expose convenience methods (<code>constructType</code>).
+ * So, you can do for example:
+ *<pre>
+ *   JavaType stringType = mapper.constructType(String.class);
+ *</pre>
+ * However, more advanced methods are only exposed by factory so that you
+ * may need to use:
+ *<pre>
+ *   JavaType stringCollection = mapper.getTypeFactory().constructCollectionType(List.class, String.class);
+ *</pre>
+ *<p>
+ * Note on optimizations: generic type parameters are resolved for all types, with following
+ * exceptions:
+ *<ul>
+ *  <li>For optimization purposes, type resolution is skipped for following commonly seen
+ * types that do have type parameters, but ones that are rarely needed:
+ *     <ul>
+ *       <li>{@link Enum}: Self-referential type reference is simply dropped and
+ *       Class is exposed as a simple, non-parameterized {@link SimpleType}
+ *        </li>
+ *       <li>{@link Comparable}: Type parameter is simply dropped and and
+ *       interface is exposed as a simple, non-parameterized {@link SimpleType}
+ *        </li>
+ *       <li>Up until Jackson 2.13, {@link Class} type parameter was dropped; resolution
+ *         was added back in Jackson 2.14.
+ *        </li>
+ *     </ul>
+ *   </li>
+ *  <li>For {@link Collection} subtypes, resolved type is ALWAYS the parameter for
+ *     {link java.util.Collection} and not that of actually resolved subtype.
+ *     This is usually (but not always) same parameter.
+ *   </li>
+ *  <li>For {@link Map} subtypes, resolved type is ALWAYS the parameter for
+ *     {link java.util.Map} and not that of actually resolved subtype.
+ *     These are usually (but not always) same parameters.
+ *   </li>
+ *</ul>
+ */
+@SuppressWarnings({"rawtypes" })
+public class TypeFactory // note: was final in 2.9, removed from 2.10
+    implements java.io.Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    private final static JavaType[] NO_TYPES = new JavaType[0];
+
+    /**
+     * Globally shared singleton. Not accessed directly; non-core
+     * code should use per-ObjectMapper instance (via configuration objects).
+     * Core Jackson code uses {@link #defaultInstance} for accessing it.
+     */
+    protected final static TypeFactory instance = new TypeFactory();
+
+    protected final static TypeBindings EMPTY_BINDINGS = TypeBindings.emptyBindings();
+
+    /*
+    /**********************************************************
+    /* Constants for "well-known" classes
+    /**********************************************************
+     */
+
+    // // // Let's assume that a small set of core primitive/basic types
+    // // // will not be modified, and can be freely shared to streamline
+    // // // parts of processing
+
+    private final static Class<?> CLS_STRING = String.class;
+    private final static Class<?> CLS_OBJECT = Object.class;
+
+    private final static Class<?> CLS_COMPARABLE = Comparable.class;
+    private final static Class<?> CLS_ENUM = Enum.class;
+//    private final static Class<?> CLS_JSON_NODE = JsonNode.class; // since 2.10
+
+    private final static Class<?> CLS_BOOL = Boolean.TYPE;
+    private final static Class<?> CLS_INT = Integer.TYPE;
+    private final static Class<?> CLS_LONG = Long.TYPE;
+
+    /*
+    /**********************************************************
+    /* Cached pre-constructed JavaType instances
+    /**********************************************************
+     */
+
+    // note: these are primitive, hence no super types
+    protected final static SimpleType CORE_TYPE_BOOL = new SimpleType(CLS_BOOL);
+    protected final static SimpleType CORE_TYPE_INT = new SimpleType(CLS_INT);
+    protected final static SimpleType CORE_TYPE_LONG = new SimpleType(CLS_LONG);
+
+    // and as to String... well, for now, ignore its super types
+    protected final static SimpleType CORE_TYPE_STRING = new SimpleType(CLS_STRING);
+
+    // @since 2.7
+    protected final static SimpleType CORE_TYPE_OBJECT = new SimpleType(CLS_OBJECT);
+
+    /**
+     * Cache {@link Comparable} because it is both parameteric (relatively costly to
+     * resolve) and mostly useless (no special handling), better handle directly
+     *
+     * @since 2.7
+     */
+    protected final static SimpleType CORE_TYPE_COMPARABLE = new SimpleType(CLS_COMPARABLE);
+
+    /**
+     * Cache {@link Enum} because it is parametric AND self-referential (costly to
+     * resolve) and useless in itself (no special handling).
+     *
+     * @since 2.7
+     */
+    protected final static SimpleType CORE_TYPE_ENUM = new SimpleType(CLS_ENUM);
+
+    /**
+     * Cache {@link JsonNode} because it is no critical path of simple tree model
+     * reading and does not have things to override
+     *
+     * @since 2.10
+     */
+//    protected final static SimpleType CORE_TYPE_JSON_NODE = new SimpleType(CLS_JSON_NODE);
+
+    /**
+     * Since type resolution can be expensive (specifically when resolving
+     * actual generic types), we will use small cache to avoid repetitive
+     * resolution of core types
+     */
+    protected final LookupCache<Object,JavaType> _typeCache;
+
+    /*
+    /**********************************************************
+    /* Configuration
+    /**********************************************************
+     */
+
+    /**
+     * Registered {@link TypeModifier}s: objects that can change details
+     * of {@link JavaType} instances factory constructs.
+     */
+    protected final TypeModifier[] _modifiers;
+
+    protected final TypeParser _parser;
+
+    /**
+     * ClassLoader used by this factory [databind#624].
+     */
+    protected final ClassLoader _classLoader;
+
+    /*
+    /**********************************************************
+    /* Life-cycle
+    /**********************************************************
+     */
+
+    private TypeFactory() {
+        this((LookupCache<Object,JavaType>) null);
+    }
+
+    /**
+     * @since 2.8
+     * @deprecated Since 2.12
+     */
+    @Deprecated // since 2.12
+    protected TypeFactory(LRUMap<Object,JavaType> typeCache) {
+        this((LookupCache<Object,JavaType>) typeCache);
+    }
+
+    /**
+     * @since 2.12
+     */
+    protected TypeFactory(LookupCache<Object,JavaType> typeCache) {
+        if (typeCache == null) {
+            typeCache = new LRUMap<>(16, 200);
+        }
+        _typeCache = typeCache;
+        _parser = new TypeParser(this);
+        _modifiers = null;
+        _classLoader = null;
+    }
+
+    /**
+     * @deprecated Since 2.12
+     */
+    @Deprecated // since 2.12
+    protected TypeFactory(LRUMap<Object,JavaType> typeCache, TypeParser p,
+            TypeModifier[] mods, ClassLoader classLoader)
+    {
+        this((LookupCache<Object,JavaType>) typeCache, p, mods, classLoader);
+    }
+
+    /**
+     * @since 2.12
+     */
+    protected TypeFactory(LookupCache<Object,JavaType> typeCache, TypeParser p,
+                          TypeModifier[] mods, ClassLoader classLoader)
+    {
+        if (typeCache == null) {
+            typeCache = new LRUMap<>(16, 200);
+        }
+        _typeCache = typeCache;
+        // As per [databind#894] must ensure we have back-linkage from TypeFactory:
+        _parser = p.withFactory(this);
+        _modifiers = mods;
+        _classLoader = classLoader;
+    }
+
+    /**
+     * "Mutant factory" method which will construct a new instance with specified
+     * {@link TypeModifier} added as the first modifier to call (in case there
+     * are multiple registered).
+     */
+    public TypeFactory withModifier(TypeModifier mod)
+    {
+        LookupCache<Object,JavaType> typeCache = _typeCache;
+        TypeModifier[] mods;
+        if (mod == null) { // mostly for unit tests
+            mods = null;
+            // 30-Jun-2016, tatu: for some reason expected semantics are to clear cache
+            //    in this case; can't recall why, but keeping the same
+            typeCache = null;
+        } else if (_modifiers == null) {
+            mods = new TypeModifier[] { mod };
+            // 29-Jul-2019, tatu: Actually I think we better clear cache in this case
+            //    as well to ensure no leakage occurs (see [databind#2395])
+            typeCache = null;
+        } else {
+            // but may keep existing cache otherwise
+            mods = ArrayBuilders.insertInListNoDup(_modifiers, mod);
+        }
+        return new TypeFactory(typeCache, _parser, mods, _classLoader);
+    }
+
+    /**
+     * "Mutant factory" method which will construct a new instance with specified
+     * {@link ClassLoader} to use by {@link #findClass}.
+     */
+    public TypeFactory withClassLoader(ClassLoader classLoader) {
+        return new TypeFactory(_typeCache, _parser, _modifiers, classLoader);
+    }
+
+    /**
+     * Mutant factory method that will construct new {@link TypeFactory} with
+     * identical settings except for different cache; most likely one with
+     * bigger maximum size.
+     *
+     * @since 2.8
+     * @deprecated Since 2.12
+     */
+    @Deprecated // since 2.12
+    public TypeFactory withCache(LRUMap<Object,JavaType> cache)  {
+        return new TypeFactory(cache, _parser, _modifiers, _classLoader);
+    }
+
+    /**
+     * Mutant factory method that will construct new {@link TypeFactory} with
+     * identical settings except for different cache; most likely one with
+     * bigger maximum size.
+     *
+     * @since 2.12
+     */
+    public TypeFactory withCache(LookupCache<Object,JavaType> cache)  {
+        return new TypeFactory(cache, _parser, _modifiers, _classLoader);
+    }
+
+    /**
+     * Method used to access the globally shared instance, which has
+     * no custom configuration. Used by <code>ObjectMapper</code> to
+     * get the default factory when constructed.
+     */
+    public static TypeFactory defaultInstance() { return instance; }
+
+    /**
+     * Method that will clear up any cached type definitions that may
+     * be cached by this {@link TypeFactory} instance.
+     * This method should not be commonly used, that is, only use it
+     * if you know there is a problem with retention of type definitions;
+     * the most likely (and currently only known) problem is retention
+     * of {@link Class} instances via {@link JavaType} reference.
+     *
+     * @since 2.4.1
+     */
+    public void clearCache() {
+        _typeCache.clear();
+    }
+
+    public ClassLoader getClassLoader() {
+        return _classLoader;
+    }
+
+    /*
+    /**********************************************************
+    /* Static methods for non-instance-specific functionality
+    /**********************************************************
+     */
+
+    /**
+     * Method for constructing a marker type that indicates missing generic
+     * type information, which is handled same as simple type for
+     * <code>java.lang.Object</code>.
+     */
+    public static JavaType unknownType() {
+        return defaultInstance()._unknownType();
+    }
+
+    /**
+     * Static helper method that can be called to figure out type-erased
+     * call for given JDK type. It can be called statically since type resolution
+     * process can never change actual type-erased class; thereby static
+     * default instance is used for determination.
+     */
+    public static Class<?> rawClass(Type t) {
+        if (t instanceof Class<?>) {
+            return (Class<?>) t;
+        }
+        // Should be able to optimize bit more in future...
+        return defaultInstance().constructType(t).getRawClass();
+    }
+
+    /*
+    /**********************************************************
+    /* Low-level helper methods
+    /**********************************************************
+     */
+
+    /**
+     * Low-level lookup method moved from {@link ClassUtil},
+     * to allow for overriding of lookup functionality in environments like OSGi.
+     *
+     * @since 2.6
+     */
+    public Class<?> findClass(String className) throws ClassNotFoundException
+    {
+        if (className.indexOf('.') < 0) {
+            Class<?> prim = _findPrimitive(className);
+            if (prim != null) {
+                return prim;
+            }
+        }
+        // Two-phase lookup: first using context ClassLoader; then default
+        Throwable prob = null;
+        ClassLoader loader = this.getClassLoader();
+        if (loader == null) {
+            loader = Thread.currentThread().getContextClassLoader();
+        }
+        if (loader != null) {
+            try {
+                return classForName(className, true, loader);
+            } catch (Exception e) {
+                prob = ClassUtil.getRootCause(e);
+            }
+        }
+        try {
+            return classForName(className);
+        } catch (Exception e) {
+            if (prob == null) {
+                prob = ClassUtil.getRootCause(e);
+            }
+        }
+        ClassUtil.throwIfRTE(prob);
+        throw new ClassNotFoundException(prob.getMessage(), prob);
+    }
+
+    protected Class<?> classForName(String name, boolean initialize,
+            ClassLoader loader) throws ClassNotFoundException {
+        return Class.forName(name, true, loader);
+    }
+
+    protected Class<?> classForName(String name) throws ClassNotFoundException {
+        return Class.forName(name);
+    }
+
+    protected Class<?> _findPrimitive(String className)
+    {
+        if ("int".equals(className)) return Integer.TYPE;
+        if ("long".equals(className)) return Long.TYPE;
+        if ("float".equals(className)) return Float.TYPE;
+        if ("double".equals(className)) return Double.TYPE;
+        if ("boolean".equals(className)) return Boolean.TYPE;
+        if ("byte".equals(className)) return Byte.TYPE;
+        if ("char".equals(className)) return Character.TYPE;
+        if ("short".equals(className)) return Short.TYPE;
+        if ("void".equals(className)) return Void.TYPE;
+        return null;
+    }
+
+    /*
+    /**********************************************************
+    /* Type conversion, parameterization resolution methods
+    /**********************************************************
+     */
+
+    /**
+     * Factory method for creating a subtype of given base type, as defined
+     * by specified subclass; but retaining generic type information if any.
+     * Can be used, for example, to get equivalent of "HashMap&lt;String,Integer&gt;"
+     * from "Map&lt;String,Integer&gt;" by giving <code>HashMap.class</code>
+     * as subclass.
+     * Short-cut for:
+     *<pre>
+     * constructSpecializedType(baseType, subclass, class);
+     *</pre>
+     * that is, will use "strict" compatibility checking, usually used for
+     * deserialization purposes (but often not for serialization).
+     */
+    public JavaType constructSpecializedType(JavaType baseType, Class<?> subclass)
+        throws IllegalArgumentException
+    {
+        return constructSpecializedType(baseType, subclass, false);
+    }
+
+    /**
+     * Factory method for creating a subtype of given base type, as defined
+     * by specified subclass; but retaining generic type information if any.
+     * Can be used, for example, to get equivalent of "HashMap&lt;String,Integer&gt;"
+     * from "Map&lt;String,Integer&gt;" by giving <code>HashMap.class</code>
+     * as subclass.
+     *
+     * @param baseType Declared base type with resolved type parameters
+     * @param subclass Runtime subtype to use for resolving
+     * @param relaxedCompatibilityCheck Whether checking for type-assignment compatibility
+     *    should be "relaxed" ({@code true}) or "strict" ({@code false}): typically
+     *    serialization uses relaxed, deserialization strict checking.
+     *
+     * @return Resolved sub-type
+     *
+     * @since 2.11
+     */
+    public JavaType constructSpecializedType(JavaType baseType, Class<?> subclass,
+            boolean relaxedCompatibilityCheck)
+        throws IllegalArgumentException
+    {
+        // simple optimization to avoid costly introspection if type-erased type does NOT differ
+        final Class<?> rawBase = baseType.getRawClass();
+        if (rawBase == subclass) {
+            return baseType;
+        }
+        JavaType newType;
+
+        // also: if we start from untyped, not much to save
+        do { // bogus loop to be able to break
+            if (rawBase == Object.class) {
+                newType = _fromClass(null, subclass, EMPTY_BINDINGS);
+                break;
+            }
+            if (!rawBase.isAssignableFrom(subclass)) {
+                throw new IllegalArgumentException(String.format("Class %s not subtype of %s",
+                        ClassUtil.nameOf(subclass), ClassUtil.getTypeDescription(baseType)
+                ));
+            }
+            // A few special cases where we can simplify handling:
+
+            // (1) A small set of "well-known" List/Map subtypes where can take a short-cut
+            if (baseType.isContainerType()) {
+                if (baseType.isMapLikeType()) {
+                    if ((subclass == HashMap.class)
+                            || (subclass == LinkedHashMap.class)
+                            || (subclass == EnumMap.class)
+                            || (subclass == TreeMap.class)) {
+                        newType = _fromClass(null, subclass,
+                                TypeBindings.create(subclass, baseType.getKeyType(), baseType.getContentType()));
+                        break;
+                    }
+                } else if (baseType.isCollectionLikeType()) {
+                    if ((subclass == ArrayList.class)
+                            || (subclass == LinkedList.class)
+                            || (subclass == HashSet.class)
+                            || (subclass == TreeSet.class)) {
+                        newType = _fromClass(null, subclass,
+                                TypeBindings.create(subclass, baseType.getContentType()));
+                        break;
+                    }
+                    // 29-Oct-2015, tatu: One further shortcut: there are variants of `EnumSet`,
+                    //    but they are impl details and we basically do not care...
+                    if (rawBase == EnumSet.class) {
+                        return baseType;
+                    }
+                }
+            }
+            // (2) Original target type has no generics -- just resolve subtype
+            if (baseType.getBindings().isEmpty()) {
+                newType = _fromClass(null, subclass, EMPTY_BINDINGS);
+                break;
+            }
+
+            // (3) Sub-class does not take type parameters -- just resolve subtype
+            int typeParamCount = subclass.getTypeParameters().length;
+            if (typeParamCount == 0) {
+                newType = _fromClass(null, subclass, EMPTY_BINDINGS);
+                break;
+            }
+            // (4) If all else fails, do the full traversal using placeholders
+            TypeBindings tb = _bindingsForSubtype(baseType, typeParamCount,
+                    subclass, relaxedCompatibilityCheck);
+            newType = _fromClass(null, subclass, tb);
+
+        } while (false);
+
+        // 25-Sep-2016, tatu: As per [databind#1384] also need to ensure handlers get
+        //   copied as well
+        newType = newType.withHandlersFrom(baseType);
+        return newType;
+    }
+
+    private TypeBindings _bindingsForSubtype(JavaType baseType, int typeParamCount,
+            Class<?> subclass, boolean relaxedCompatibilityCheck)
+    {
+        PlaceholderForType[] placeholders = new PlaceholderForType[typeParamCount];
+        for (int i = 0; i < typeParamCount; ++i) {
+            placeholders[i] = new PlaceholderForType(i);
+        }
+        TypeBindings b = TypeBindings.create(subclass, placeholders);
+        // First: pseudo-resolve to get placeholders in place:
+        JavaType tmpSub = _fromClass(null, subclass, b);
+        // Then find super-type
+        JavaType baseWithPlaceholders = tmpSub.findSuperType(baseType.getRawClass());
+        if (baseWithPlaceholders == null) { // should be found but...
+            throw new IllegalArgumentException(String.format(
+                    "Internal error: unable to locate supertype (%s) from resolved subtype %s", baseType.getRawClass().getName(),
+                    subclass.getName()));
+        }
+        // and traverse type hierarchies to both verify and to resolve placeholders
+        String error = _resolveTypePlaceholders(baseType, baseWithPlaceholders);
+        if (error != null) {
+            // 28-Mar-2020, tatu: As per [databind#2632], need to ignore the issue in
+            //   some cases. For now, just fully ignore; may need to refine in future
+            if (!relaxedCompatibilityCheck) {
+                throw new IllegalArgumentException("Failed to specialize base type "+baseType.toCanonical()+" as "
+                        +subclass.getName()+", problem: "+error);
+            }
+        }
+
+        final JavaType[] typeParams = new JavaType[typeParamCount];
+        for (int i = 0; i < typeParamCount; ++i) {
+            JavaType t = placeholders[i].actualType();
+            // 18-Oct-2017, tatu: Looks like sometimes we have incomplete bindings (even if not
+            //     common, it is possible if subtype is type-erased class with added type
+            //     variable -- see test(s) with "bogus" type(s)).
+            if (t == null) {
+                t = unknownType();
+            }
+            typeParams[i] = t;
+        }
+        return TypeBindings.create(subclass, typeParams);
+    }
+
+    private String _resolveTypePlaceholders(JavaType sourceType, JavaType actualType)
+        throws IllegalArgumentException
+    {
+        List<JavaType> expectedTypes = sourceType.getBindings().getTypeParameters();
+        List<JavaType> actualTypes = actualType.getBindings().getTypeParameters();
+
+        final int actCount = actualTypes.size();
+
+        for (int i = 0, expCount = expectedTypes.size(); i < expCount; ++i) {
+            JavaType exp = expectedTypes.get(i);
+            JavaType act = (i < actCount) ? actualTypes.get(i) : unknownType();
+
+            if (!_verifyAndResolvePlaceholders(exp, act)) {
+                // 14-May-2018, tatu: As per [databind#2034] it seems we better relax assignment
+                //   rules further -- at least likely "raw" (untyped, non-generic) base should probably
+                //   allow specialization.
+                if (exp.hasRawClass(Object.class)) {
+                    continue;
+                }
+                // 19-Apr-2018, tatu: Hack for [databind#1964] -- allow type demotion
+                //    for `java.util.Map` key type if (and only if) target type is
+                //    `java.lang.Object`
+                // 19-Aug-2019, tatu: Further, allow for all Map-like types, with assumption
+                //    first argument would be key; initially just because Scala Maps have
+                //    some issues (see [databind#2422])
+                if (i == 0) {
+                    if (sourceType.isMapLikeType()
+                            && act.hasRawClass(Object.class)) {
+                        continue;
+                    }
+                }
+                // 19-Nov-2018, tatu: To solve [databind#2155], let's allow type-compatible
+                //   assignment for interfaces at least...
+                if (exp.isInterface()) {
+                    if (exp.isTypeOrSuperTypeOf(act.getRawClass())) {
+                        continue;
+                    }
+                }
+                return String.format("Type parameter #%d/%d differs; can not specialize %s with %s",
+                        (i+1), expCount, exp.toCanonical(), act.toCanonical());
+            }
+        }
+        return null;
+    }
+
+    private boolean _verifyAndResolvePlaceholders(JavaType exp, JavaType act)
+    {
+        // See if we have an actual type placeholder to resolve; if yes, replace
+        if (act instanceof PlaceholderForType) {
+            ((PlaceholderForType) act).actualType(exp);
+            return true;
+        }
+        // if not, try to verify compatibility. But note that we can not
+        // use simple equality as we need to resolve recursively
+        if (exp.getRawClass() != act.getRawClass()) {
+            return false;
+        }
+        // But we can check type parameters "blindly"
+        List<JavaType> expectedTypes = exp.getBindings().getTypeParameters();
+        List<JavaType> actualTypes = act.getBindings().getTypeParameters();
+        for (int i = 0, len = expectedTypes.size(); i < len; ++i) {
+            JavaType exp2 = expectedTypes.get(i);
+            JavaType act2 = actualTypes.get(i);
+            if (!_verifyAndResolvePlaceholders(exp2, act2)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Method similar to {@link #constructSpecializedType}, but that creates a
+     * less-specific type of given type. Usually this is as simple as simply
+     * finding super-type with type erasure of <code>superClass</code>, but
+     * there may be need for some additional work-arounds.
+     *
+     * @param superClass
+     *
+     * @since 2.7
+     */
+    public JavaType constructGeneralizedType(JavaType baseType, Class<?> superClass)
+    {
+        // simple optimization to avoid costly introspection if type-erased type does NOT differ
+        final Class<?> rawBase = baseType.getRawClass();
+        if (rawBase == superClass) {
+            return baseType;
+        }
+        JavaType superType = baseType.findSuperType(superClass);
+        if (superType == null) {
+            // Most likely, caller did not verify sub/super-type relationship
+            if (!superClass.isAssignableFrom(rawBase)) {
+                throw new IllegalArgumentException(String.format(
+                        "Class %s not a super-type of %s", superClass.getName(), baseType));
+            }
+            // 01-Nov-2015, tatu: Should never happen, but ch
+            throw new IllegalArgumentException(String.format(
+                    "Internal error: class %s not included as super-type for %s",
+                    superClass.getName(), baseType));
+        }
+        return superType;
+    }
+
+    /**
+     * Factory method for constructing a {@link JavaType} out of its canonical
+     * representation (see {@link JavaType#toCanonical()}).
+     *
+     * @param canonical Canonical string representation of a type
+     *
+     * @throws IllegalArgumentException If canonical representation is malformed,
+     *   or class that type represents (including its generic parameters) is
+     *   not found
+     */
+    public JavaType constructFromCanonical(String canonical) throws IllegalArgumentException
+    {
+        return _parser.parse(canonical);
+    }
+
+    /**
+     * Method that is to figure out actual type parameters that given
+     * class binds to generic types defined by given (generic)
+     * interface or class.
+     * This could mean, for example, trying to figure out
+     * key and value types for Map implementations.
+     *
+     * @param type Sub-type (leaf type) that implements <code>expType</code>
+     */
+    public JavaType[] findTypeParameters(JavaType type, Class<?> expType)
+    {
+        JavaType match = type.findSuperType(expType);
+        if (match == null) {
+            return NO_TYPES;
+        }
+        return match.getBindings().typeParameterArray();
+    }
+
+    /**
+     * @deprecated Since 2.7 resolve raw type first, then find type parameters
+     */
+    @Deprecated // since 2.7
+    public JavaType[] findTypeParameters(Class<?> clz, Class<?> expType, TypeBindings bindings) {
+        return findTypeParameters(constructType(clz, bindings), expType);
+    }
+
+    /**
+     * @deprecated Since 2.7 resolve raw type first, then find type parameters
+     */
+    @Deprecated // since 2.7
+    public JavaType[] findTypeParameters(Class<?> clz, Class<?> expType) {
+        return findTypeParameters(constructType(clz), expType);
+    }
+
+    /**
+     * Method that can be called to figure out more specific of two
+     * types (if they are related; that is, one implements or extends the
+     * other); or if not related, return the primary type.
+     *
+     * @param type1 Primary type to consider
+     * @param type2 Secondary type to consider
+     *
+     * @since 2.2
+     */
+    public JavaType moreSpecificType(JavaType type1, JavaType type2)
+    {
+        if (type1 == null) {
+            return type2;
+        }
+        if (type2 == null) {
+            return type1;
+        }
+        Class<?> raw1 = type1.getRawClass();
+        Class<?> raw2 = type2.getRawClass();
+        if (raw1 == raw2) {
+            return type1;
+        }
+        // TODO: maybe try sub-classing, to retain generic types?
+        if (raw1.isAssignableFrom(raw2)) {
+            return type2;
+        }
+        return type1;
+    }
+
+    /*
+    /**********************************************************
+    /* Public general-purpose factory methods
+    /**********************************************************
+     */
+
+    public JavaType constructType(Type type) {
+        return _fromAny(null, type, EMPTY_BINDINGS);
+    }
+
+    /*public JavaType constructType(TypeReference<?> typeRef)
+    {
+        // 19-Oct-2015, tatu: Simpler variant like so should work
+        return _fromAny(null, typeRef.getType(), EMPTY_BINDINGS);
+
+        // but if not, due to funky sub-classing, type variables, what follows
+        // is a more complete processing a la Java ClassMate.
+
+        final Class<?> refdRawType = typeRef.getClass();
+        JavaType type = _fromClass(null, refdRawType, EMPTY_BINDINGS);
+        JavaType genType = type.findSuperType(TypeReference.class);
+        if (genType == null) { // sanity check; shouldn't occur
+            throw new IllegalArgumentException("Unparameterized GenericType instance ("+refdRawType.getName()+")");
+        }
+        TypeBindings b = genType.getBindings();
+        JavaType[] params = b.typeParameterArray();
+        if (params.length == 0) {
+            throw new IllegalArgumentException("Unparameterized GenericType instance ("+refdRawType.getName()+")");
+        }
+        return params[0];
+    }*/
+
+    /**
+     * Method to call when resolving types of {@link Member}s
+     * like Fields, Methods and Constructor parameters and there is a
+     * {@link TypeBindings} (that describes binding of type parameters within
+     * context) to pass.
+     * This is typically used only by code in databind itself.
+     *
+     * @param type Type of a {@link Member} to resolve
+     * @param contextBindings Type bindings from the context, often class in which
+     *     member declared but may be subtype of that type (to bind actual bound
+     *     type parametrers). Not used if {@code type} is of type {@code Class<?>}.
+     *
+     * @return Fully resolve type
+     *
+     * @since 2.12 as replacement for deprecated {@link #constructType(Type, TypeBindings)}
+     */
+    public JavaType resolveMemberType(Type type, TypeBindings contextBindings) {
+        return _fromAny(null, type, contextBindings);
+    }
+
+    /*
+    /**********************************************************
+    /* Deprecated public factory methods
+    /**********************************************************
+     */
+
+    /**
+     * Method that you very likely should NOT be using -- you need to know a lot
+     * about internal details of {@link TypeBindings} and even then it will probably
+     * not do what you want.
+     * Usually you would instead want to call one of {@code constructXxxType()}
+     * methods (where {@code Xxx} would be "Array", "Collection[Like]", "Map[Like]"
+     * or "Parametric").
+     *
+     * @deprecated Since 2.12
+     */
+    @Deprecated // since 2.12
+    public JavaType constructType(Type type, TypeBindings bindings) {
+        // 15-Jun-2020, tatu: To resolve (parts of) [databind#2796], need to
+        //    call _fromClass() directly if we get `Class` argument
+        if (type instanceof Class<?>) {
+            JavaType resultType = _fromClass(null, (Class<?>) type, bindings);
+            return _applyModifiers(type, resultType);
+        }
+        return _fromAny(null, type, bindings);
+    }
+
+    /**
+     * @deprecated Since 2.7 (accidentally removed in 2.7.0; added back in 2.7.1)
+     */
+    @Deprecated
+    public JavaType constructType(Type type, Class<?> contextClass) {
+        JavaType contextType = (contextClass == null) ? null : constructType(contextClass);
+        return constructType(type, contextType);
+    }
+
+    /**
+     * @deprecated Since 2.7 (accidentally removed in 2.7.0; added back in 2.7.1)
+     */
+    @Deprecated
+    public JavaType constructType(Type type, JavaType contextType) {
+        TypeBindings bindings;
+        if (contextType == null) {
+            bindings = EMPTY_BINDINGS;
+        } else {
+            bindings = contextType.getBindings();
+            // 16-Nov-2016, tatu: Unfortunately as per [databind#1456] this can't
+            //   be made to work for some cases used to work (even if accidentally);
+            //   however, we can try a simple heuristic to increase chances of
+            //   compatibility from 2.6 code
+            if (type.getClass() != Class.class) {
+                // Ok: so, ideally we would test super-interfaces if necessary;
+                // but let's assume most if not all cases are for classes.
+                while (bindings.isEmpty()) {
+                    contextType = contextType.getSuperClass();
+                    if (contextType == null) {
+                        break;
+                    }
+                    bindings = contextType.getBindings();
+                }
+            }
+        }
+        return _fromAny(null, type, bindings);
+    }
+
+    /*
+    /**********************************************************
+    /* Direct factory methods
+    /**********************************************************
+     */
+
+    /**
+     * Method for constructing an {@link ArrayType}.
+     *<p>
+     * NOTE: type modifiers are NOT called on array type itself; but are called
+     * for element type (and other contained types)
+     */
+    public ArrayType constructArrayType(Class<?> elementType) {
+        return ArrayType.construct(_fromAny(null, elementType, null), null);
+    }
+
+    /**
+     * Method for constructing an {@link ArrayType}.
+     *<p>
+     * NOTE: type modifiers are NOT called on array type itself; but are called
+     * for contained types.
+     */
+    public ArrayType constructArrayType(JavaType elementType) {
+        return ArrayType.construct(elementType, null);
+    }
+
+    /**
+     * Method for constructing a {@link CollectionType}.
+     *<p>
+     * NOTE: type modifiers are NOT called on Collection type itself; but are called
+     * for contained types.
+     */
+    public CollectionType constructCollectionType(Class<? extends Collection> collectionClass,
+            Class<?> elementClass) {
+        return constructCollectionType(collectionClass,
+                _fromClass(null, elementClass, EMPTY_BINDINGS));
+    }
+
+    /**
+     * Method for constructing a {@link CollectionType}.
+     *<p>
+     * NOTE: type modifiers are NOT called on Collection type itself; but are called
+     * for contained types.
+     */
+    public CollectionType constructCollectionType(Class<? extends Collection> collectionClass,
+            JavaType elementType)
+    {
+        TypeBindings bindings = TypeBindings.createIfNeeded(collectionClass, elementType);
+        CollectionType result = (CollectionType) _fromClass(null, collectionClass, bindings);
+        // 17-May-2017, tatu: As per [databind#1415], we better verify bound values if (but only if)
+        //    type being resolved was non-generic (i.e.element type was ignored)
+        if (bindings.isEmpty() && (elementType != null)) {
+            JavaType t = result.findSuperType(Collection.class);
+            JavaType realET = t.getContentType();
+            if (!realET.equals(elementType)) {
+                throw new IllegalArgumentException(String.format(
+                        "Non-generic Collection class %s did not resolve to something with element type %s but %s ",
+                        ClassUtil.nameOf(collectionClass), elementType, realET));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Method for constructing a {@link CollectionLikeType}.
+     *<p>
+     * NOTE: type modifiers are NOT called on constructed type itself; but are called
+     * for contained types.
+     */
+    public CollectionLikeType constructCollectionLikeType(Class<?> collectionClass, Class<?> elementClass) {
+        return constructCollectionLikeType(collectionClass,
+                _fromClass(null, elementClass, EMPTY_BINDINGS));
+    }
+
+    /**
+     * Method for constructing a {@link CollectionLikeType}.
+     *<p>
+     * NOTE: type modifiers are NOT called on constructed type itself; but are called
+     * for contained types.
+     */
+    public CollectionLikeType constructCollectionLikeType(Class<?> collectionClass, JavaType elementType) {
+        JavaType type = _fromClass(null, collectionClass,
+                TypeBindings.createIfNeeded(collectionClass, elementType));
+        if (type instanceof CollectionLikeType) {
+            return (CollectionLikeType) type;
+        }
+        return CollectionLikeType.upgradeFrom(type, elementType);
+    }
+
+    /**
+     * Method for constructing a {@link MapType} instance
+     *<p>
+     * NOTE: type modifiers are NOT called on constructed type itself; but are called
+     * for contained types.
+     */
+    public MapType constructMapType(Class<? extends Map> mapClass,
+            Class<?> keyClass, Class<?> valueClass) {
+        JavaType kt, vt;
+        if (mapClass == Properties.class) {
+            kt = vt = CORE_TYPE_STRING;
+        } else {
+            kt = _fromClass(null, keyClass, EMPTY_BINDINGS);
+            vt = _fromClass(null, valueClass, EMPTY_BINDINGS);
+        }
+        return constructMapType(mapClass, kt, vt);
+    }
+
+    /**
+     * Method for constructing a {@link MapType} instance
+     *<p>
+     * NOTE: type modifiers are NOT called on constructed type itself.
+     */
+    public MapType constructMapType(Class<? extends Map> mapClass, JavaType keyType, JavaType valueType) {
+        TypeBindings bindings = TypeBindings.createIfNeeded(mapClass, new JavaType[] { keyType, valueType });
+        MapType result = (MapType) _fromClass(null, mapClass, bindings);
+        // 17-May-2017, tatu: As per [databind#1415], we better verify bound values if (but only if)
+        //    type being resolved was non-generic (i.e.element type was ignored)
+        if (bindings.isEmpty()) {
+            JavaType t = result.findSuperType(Map.class);
+            JavaType realKT = t.getKeyType();
+            if (!realKT.equals(keyType)) {
+                throw new IllegalArgumentException(String.format(
+                        "Non-generic Map class %s did not resolve to something with key type %s but %s ",
+                        ClassUtil.nameOf(mapClass), keyType, realKT));
+            }
+            JavaType realVT = t.getContentType();
+            if (!realVT.equals(valueType)) {
+                throw new IllegalArgumentException(String.format(
+                        "Non-generic Map class %s did not resolve to something with value type %s but %s ",
+                        ClassUtil.nameOf(mapClass), valueType, realVT));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Method for constructing a {@link MapLikeType} instance
+     *<p>
+     * NOTE: type modifiers are NOT called on constructed type itself; but are called
+     * for contained types.
+     */
+    public MapLikeType constructMapLikeType(Class<?> mapClass, Class<?> keyClass, Class<?> valueClass) {
+        return constructMapLikeType(mapClass,
+                _fromClass(null, keyClass, EMPTY_BINDINGS),
+                _fromClass(null, valueClass, EMPTY_BINDINGS));
+    }
+
+    /**
+     * Method for constructing a {@link MapLikeType} instance
+     *<p>
+     * NOTE: type modifiers are NOT called on constructed type itself.
+     */
+    public MapLikeType constructMapLikeType(Class<?> mapClass, JavaType keyType, JavaType valueType) {
+        // 19-Oct-2015, tatu: Allow case of no-type-variables, since it seems likely to be
+        //    a valid use case here
+        JavaType type = _fromClass(null, mapClass,
+                TypeBindings.createIfNeeded(mapClass, new JavaType[] { keyType, valueType }));
+        if (type instanceof MapLikeType) {
+            return (MapLikeType) type;
+        }
+        return MapLikeType.upgradeFrom(type, keyType, valueType);
+    }
+
+    /**
+     * Method for constructing a type instance with specified parameterization.
+     *<p>
+     * NOTE: type modifiers are NOT called on constructed type itself.
+     */
+    public JavaType constructSimpleType(Class<?> rawType, JavaType[] parameterTypes) {
+        return _fromClass(null, rawType, TypeBindings.create(rawType, parameterTypes));
+    }
+
+    /**
+     * Method for constructing a type instance with specified parameterization.
+     *
+     * @since 2.6
+     *
+     * @deprecated Since 2.7
+     */
+    @Deprecated
+    public JavaType constructSimpleType(Class<?> rawType, Class<?> parameterTarget,
+            JavaType[] parameterTypes)
+    {
+        return constructSimpleType(rawType, parameterTypes);
+    }
+
+    /**
+     * Method for constructing a {@link ReferenceType} instance with given type parameter
+     * (type MUST take one and only one type parameter)
+     *<p>
+     * NOTE: type modifiers are NOT called on constructed type itself.
+     *
+     * @since 2.6
+     */
+    public JavaType constructReferenceType(Class<?> rawType, JavaType referredType)
+    {
+        return ReferenceType.construct(rawType,
+                TypeBindings.create(rawType, referredType), // [databind#2091]
+                null, null, // or super-class, interfaces?
+                referredType);
+    }
+
+    /**
+     * Method that use by core Databind functionality, and that should NOT be called
+     * by application code outside databind package.
+     *<p>
+     * Unchecked here not only means that no checks are made as to whether given class
+     * might be non-simple type (like {@link CollectionType}) but also that most of supertype
+     * information is not gathered. This means that unless called on primitive types or
+     * {@link String}, results are probably not what you want to use.
+     *
+     * @deprecated Since 2.8, to indicate users should never call this method.
+     */
+    @Deprecated // since 2.8
+    public JavaType uncheckedSimpleType(Class<?> cls) {
+        // 18-Oct-2015, tatu: Not sure how much problem missing super-type info is here
+        return _constructSimple(cls, EMPTY_BINDINGS, null, null);
+    }
+
+    /**
+     * Factory method for constructing {@link JavaType} that
+     * represents a parameterized type. For example, to represent
+     * type {@code List<Set<Integer>>}, you could
+     * call
+     *<pre>
+     *  JavaType inner = TypeFactory.constructParametricType(Set.class, Integer.class);
+     *  return TypeFactory.constructParametricType(List.class, inner);
+     *</pre>
+     *<p>
+     * NOTE: since 2.11.2 {@link TypeModifier}s ARE called on result (fix for [databind#2796])
+     *
+     * @param parametrized Type-erased type to parameterize
+     * @param parameterClasses Type parameters to apply
+     *
+     * @since 2.5 NOTE: was briefly deprecated for 2.6
+     */
+    public JavaType constructParametricType(Class<?> parametrized, Class<?>... parameterClasses) {
+        int len = parameterClasses.length;
+        JavaType[] pt = new JavaType[len];
+        for (int i = 0; i < len; ++i) {
+            pt[i] = _fromClass(null, parameterClasses[i], EMPTY_BINDINGS);
+        }
+        return constructParametricType(parametrized, pt);
+    }
+
+    /**
+     * Factory method for constructing {@link JavaType} that
+     * represents a parameterized type. For example, to represent
+     * type {@code List<Set<Integer>>}, you could
+     *<pre>
+     *  JavaType inner = TypeFactory.constructParametricType(Set.class, Integer.class);
+     *  return TypeFactory.constructParametricType(List.class, inner);
+     *</pre>
+     *<p>
+     * NOTE: since 2.11.2 {@link TypeModifier}s ARE called on result (fix for [databind#2796])
+     *
+     * @param rawType Actual type-erased type
+     * @param parameterTypes Type parameters to apply
+     *
+     * @return Fully resolved type for given base type and type parameters
+     */
+    public JavaType constructParametricType(Class<?> rawType, JavaType... parameterTypes)
+    {
+        return constructParametricType(rawType, TypeBindings.create(rawType, parameterTypes));
+    }
+
+    /**
+     * Factory method for constructing {@link JavaType} that
+     * represents a parameterized type. The type's parameters are
+     * specified as an instance of {@link TypeBindings}. This
+     * is useful if you already have the type's parameters such
+     * as those found on {@link JavaType}. For example, you could call
+     * <pre>
+     *   return TypeFactory.constructParametricType(ArrayList.class, javaType.getBindings());
+     * </pre>
+     * This effectively applies the parameterized types from one
+     * {@link JavaType} to another class.
+     *
+     * @param rawType Actual type-erased type
+     * @param parameterTypes Type bindings for the raw type
+     *
+     * @since 2.12
+     */
+    public JavaType constructParametricType(Class<?> rawType, TypeBindings parameterTypes)
+    {
+        // 16-Jul-2020, tatu: Since we do not call `_fromAny()`, need to make
+        //   sure `TypeModifier`s are applied:
+        JavaType resultType =  _fromClass(null, rawType, parameterTypes);
+        return _applyModifiers(rawType, resultType);
+    }
+
+    /**
+     * @since 2.5
+     * @deprecated since 2.9 Use {@link #constructParametricType(Class,JavaType...)} instead
+     */
+    @Deprecated
+    public JavaType constructParametrizedType(Class<?> parametrized, Class<?> parametersFor,
+            JavaType... parameterTypes)
+    {
+        return constructParametricType(parametrized, parameterTypes);
+    }
+
+    /**
+     * @since 2.5
+     * @deprecated since 2.9 Use {@link #constructParametricType(Class,Class...)} instead
+     */
+    @Deprecated
+    public JavaType constructParametrizedType(Class<?> parametrized, Class<?> parametersFor,
+            Class<?>... parameterClasses)
+    {
+        return constructParametricType(parametrized, parameterClasses);
+    }
+
+    /*
+    /**********************************************************
+    /* Direct factory methods for "raw" variants, used when
+    /* parameterization is unknown
+    /**********************************************************
+     */
+
+    /**
+     * Method that can be used to construct "raw" Collection type; meaning that its
+     * parameterization is unknown.
+     * This is similar to using <code>Object.class</code> parameterization,
+     * and is equivalent to calling:
+     *<pre>
+     *  typeFactory.constructCollectionType(collectionClass, typeFactory.unknownType());
+     *</pre>
+     *<p>
+     * This method should only be used if parameterization is completely unavailable.
+     */
+    public CollectionType constructRawCollectionType(Class<? extends Collection> collectionClass) {
+        return constructCollectionType(collectionClass, unknownType());
+    }
+
+    /**
+     * Method that can be used to construct "raw" Collection-like type; meaning that its
+     * parameterization is unknown.
+     * This is similar to using <code>Object.class</code> parameterization,
+     * and is equivalent to calling:
+     *<pre>
+     *  typeFactory.constructCollectionLikeType(collectionClass, typeFactory.unknownType());
+     *</pre>
+     *<p>
+     * This method should only be used if parameterization is completely unavailable.
+     */
+    public CollectionLikeType constructRawCollectionLikeType(Class<?> collectionClass) {
+        return constructCollectionLikeType(collectionClass, unknownType());
+    }
+
+    /**
+     * Method that can be used to construct "raw" Map type; meaning that its
+     * parameterization is unknown.
+     * This is similar to using <code>Object.class</code> parameterization,
+     * and is equivalent to calling:
+     *<pre>
+     *  typeFactory.constructMapType(collectionClass, typeFactory.unknownType(), typeFactory.unknownType());
+     *</pre>
+     *<p>
+     * This method should only be used if parameterization is completely unavailable.
+     */
+    public MapType constructRawMapType(Class<? extends Map> mapClass) {
+        return constructMapType(mapClass, unknownType(), unknownType());
+    }
+
+    /**
+     * Method that can be used to construct "raw" Map-like type; meaning that its
+     * parameterization is unknown.
+     * This is similar to using <code>Object.class</code> parameterization,
+     * and is equivalent to calling:
+     *<pre>
+     *  typeFactory.constructMapLikeType(collectionClass, typeFactory.unknownType(), typeFactory.unknownType());
+     *</pre>
+     *<p>
+     * This method should only be used if parameterization is completely unavailable.
+     */
+    public MapLikeType constructRawMapLikeType(Class<?> mapClass) {
+        return constructMapLikeType(mapClass, unknownType(), unknownType());
+    }
+
+    /*
+    /**********************************************************
+    /* Low-level factory methods
+    /**********************************************************
+     */
+
+    private JavaType _mapType(Class<?> rawClass, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces)
+    {
+        JavaType kt, vt;
+
+        // 28-May-2015, tatu: Properties are special, as per [databind#810]; fake "correct" parameter sig
+        if (rawClass == Properties.class) {
+            kt = vt = CORE_TYPE_STRING;
+        } else {
+            List<JavaType> typeParams = bindings.getTypeParameters();
+            // ok to have no types ("raw")
+            final int pc = typeParams.size();
+            switch (pc) {
+            case 0: // acceptable?
+                kt = vt = _unknownType();
+                break;
+            case 2:
+                kt = typeParams.get(0);
+                vt = typeParams.get(1);
+                break;
+            default:
+                throw new IllegalArgumentException(String.format(
+"Strange Map type %s with %d type parameter%s (%s), can not resolve",
+ClassUtil.nameOf(rawClass), pc, (pc == 1) ? "" : "s", bindings));
+            }
+        }
+        return MapType.construct(rawClass, bindings, superClass, superInterfaces, kt, vt);
+    }
+
+    private JavaType _collectionType(Class<?> rawClass, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces)
+    {
+        List<JavaType> typeParams = bindings.getTypeParameters();
+        // ok to have no types ("raw")
+        JavaType ct;
+        if (typeParams.isEmpty()) {
+            ct = _unknownType();
+        } else if (typeParams.size() == 1) {
+            ct = typeParams.get(0);
+        } else {
+            throw new IllegalArgumentException("Strange Collection type "+rawClass.getName()+": cannot determine type parameters");
+        }
+        return CollectionType.construct(rawClass, bindings, superClass, superInterfaces, ct);
+    }
+
+    private JavaType _referenceType(Class<?> rawClass, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces)
+    {
+        List<JavaType> typeParams = bindings.getTypeParameters();
+        // ok to have no types ("raw")
+        JavaType ct;
+        if (typeParams.isEmpty()) {
+            ct = _unknownType();
+        } else if (typeParams.size() == 1) {
+            ct = typeParams.get(0);
+        } else {
+            throw new IllegalArgumentException("Strange Reference type "+rawClass.getName()+": cannot determine type parameters");
+        }
+        return ReferenceType.construct(rawClass, bindings, superClass, superInterfaces, ct);
+    }
+
+    /**
+     * Factory method to call when no special {@link JavaType} is needed,
+     * no generic parameters are passed. Default implementation may check
+     * pre-constructed values for "well-known" types, but if none found
+     * will simply call {@link #_newSimpleType}
+     *
+     * @since 2.7
+     */
+    protected JavaType _constructSimple(Class<?> raw, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces)
+    {
+        if (bindings.isEmpty()) {
+            JavaType result = _findWellKnownSimple(raw);
+            if (result != null) {
+                return result;
+            }
+        }
+        return _newSimpleType(raw, bindings, superClass, superInterfaces);
+    }
+
+    /**
+     * Factory method that is to create a new {@link SimpleType} with no
+     * checks whatsoever. Default implementation calls the single argument
+     * constructor of {@link SimpleType}.
+     *
+     * @since 2.7
+     */
+    protected JavaType _newSimpleType(Class<?> raw, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces)
+    {
+        return new SimpleType(raw, bindings, superClass, superInterfaces);
+    }
+
+    protected JavaType _unknownType() {
+        /* 15-Sep-2015, tatu: Prior to 2.7, we constructed new instance for each call.
+         *    This may have been due to potential mutability of the instance; but that
+         *    should not be issue any more, and creation is somewhat wasteful. So let's
+         *    try reusing singleton/flyweight instance.
+         */
+        return CORE_TYPE_OBJECT;
+    }
+
+    /**
+     * Helper method called to see if requested, non-generic-parameterized
+     * type is one of common, "well-known" types, instances of which are
+     * pre-constructed and do not need dynamic caching.
+     *
+     * @since 2.7
+     */
+    protected JavaType _findWellKnownSimple(Class<?> clz) {
+        if (clz.isPrimitive()) {
+            if (clz == CLS_BOOL) return CORE_TYPE_BOOL;
+            if (clz == CLS_INT) return CORE_TYPE_INT;
+            if (clz == CLS_LONG) return CORE_TYPE_LONG;
+        } else {
+            if (clz == CLS_STRING) return CORE_TYPE_STRING;
+            if (clz == CLS_OBJECT) return CORE_TYPE_OBJECT; // since 2.7
+//            if (clz == CLS_JSON_NODE) return CORE_TYPE_JSON_NODE; // since 2.10
+        }
+        return null;
+    }
+
+    /*
+    /**********************************************************
+    /* Actual type resolution, traversal
+    /**********************************************************
+     */
+
+    /**
+     * Factory method that can be used if type information is passed
+     * as Java typing returned from <code>getGenericXxx</code> methods
+     * (usually for a return or argument type).
+     */
+    protected JavaType _fromAny(ClassStack context, Type srcType, TypeBindings bindings)
+    {
+        JavaType resultType;
+
+        // simple class?
+        if (srcType instanceof Class<?>) {
+            // Important: remove possible bindings since this is type-erased thingy
+            resultType = _fromClass(context, (Class<?>) srcType, EMPTY_BINDINGS);
+        }
+        // But if not, need to start resolving.
+        else if (srcType instanceof ParameterizedType) {
+            resultType = _fromParamType(context, (ParameterizedType) srcType, bindings);
+        }
+        else if (srcType instanceof JavaType) { // [databind#116]
+            // no need to modify further if we already had JavaType
+            return (JavaType) srcType;
+        }
+        else if (srcType instanceof GenericArrayType) {
+            resultType = _fromArrayType(context, (GenericArrayType) srcType, bindings);
+        }
+        else if (srcType instanceof TypeVariable<?>) {
+            resultType = _fromVariable(context, (TypeVariable<?>) srcType, bindings);
+        }
+        else if (srcType instanceof WildcardType) {
+            resultType = _fromWildcard(context, (WildcardType) srcType, bindings);
+        } else {
+            // sanity check
+            throw new IllegalArgumentException("Unrecognized Type: "+((srcType == null) ? "[null]" : srcType.toString()));
+        }
+        // 21-Feb-2016, nateB/tatu: as per [databind#1129] (applied for 2.7.2),
+        //   we do need to let all kinds of types to be refined, esp. for Scala module.
+        return _applyModifiers(srcType, resultType);
+    }
+
+    protected JavaType _applyModifiers(Type srcType, JavaType resolvedType)
+    {
+        if (_modifiers == null) {
+            return resolvedType;
+        }
+        JavaType resultType = resolvedType;
+        TypeBindings b = resultType.getBindings();
+        if (b == null) {
+            b = EMPTY_BINDINGS;
+        }
+        for (TypeModifier mod : _modifiers) {
+            JavaType t = mod.modifyType(resultType, srcType, b, this);
+            if (t == null) {
+                throw new IllegalStateException(String.format(
+                        "TypeModifier %s (of type %s) return null for type %s",
+                        mod, mod.getClass().getName(), resultType));
+            }
+            resultType = t;
+        }
+        return resultType;
+    }
+
+    /**
+     * @param bindings Mapping of formal parameter declarations (for generic
+     *   types) into actual types
+     */
+    protected JavaType _fromClass(ClassStack context, Class<?> rawType, TypeBindings bindings)
+    {
+        // Very first thing: small set of core types we know well:
+        JavaType result = _findWellKnownSimple(rawType);
+        if (result != null) {
+            return result;
+        }
+        // Barring that, we may have recently constructed an instance
+        final Object key;
+        if ((bindings == null) || bindings.isEmpty()) {
+            key = rawType;
+        } else {
+            key = bindings.asKey(rawType);
+        }
+        result = _typeCache.get(key); // ok, cache object is synced
+        if (result != null) {
+            return result;
+        }
+
+        // 15-Oct-2015, tatu: recursive reference?
+        if (context == null) {
+            context = new ClassStack(rawType);
+        } else {
+            ClassStack prev = context.find(rawType);
+            if (prev != null) {
+                // Self-reference: needs special handling, then...
+                ResolvedRecursiveType selfRef = new ResolvedRecursiveType(rawType, EMPTY_BINDINGS);
+                prev.addSelfReference(selfRef);
+                return selfRef;
+            }
+            // no, but need to update context to allow for proper cycle resolution
+            context = context.child(rawType);
+        }
+
+        // First: do we have an array type?
+        if (rawType.isArray()) {
+            result = ArrayType.construct(_fromAny(context, rawType.getComponentType(), bindings),
+                    bindings);
+        } else {
+            // If not, need to proceed by first resolving parent type hierarchy
+
+            JavaType superClass;
+            JavaType[] superInterfaces;
+
+            if (rawType.isInterface()) {
+                superClass = null;
+                superInterfaces = _resolveSuperInterfaces(context, rawType, bindings);
+            } else {
+                // Note: even Enums can implement interfaces, so cannot drop those
+                superClass = _resolveSuperClass(context, rawType, bindings);
+                superInterfaces = _resolveSuperInterfaces(context, rawType, bindings);
+            }
+
+            // 19-Oct-2015, tatu: Bit messy, but we need to 'fix' java.util.Properties here...
+            if (rawType == Properties.class) {
+                result = MapType.construct(rawType, bindings, superClass, superInterfaces,
+                        CORE_TYPE_STRING, CORE_TYPE_STRING);
+            }
+            // And then check what flavor of type we got. Start by asking resolved
+            // super-type if refinement is all that is needed?
+            else if (superClass != null) {
+                result = superClass.refine(rawType, bindings, superClass, superInterfaces);
+            }
+            // if not, perhaps we are now resolving a well-known class or interface?
+            if (result == null) {
+                result = _fromWellKnownClass(context, rawType, bindings, superClass, superInterfaces);
+                if (result == null) {
+                    result = _fromWellKnownInterface(context, rawType, bindings, superClass, superInterfaces);
+                    if (result == null) {
+                        // but if nothing else, "simple" class for now:
+                        result = _newSimpleType(rawType, bindings, superClass, superInterfaces);
+                    }
+                }
+            }
+        }
+        context.resolveSelfReferences(result);
+        // 16-Jul-2016, tatu: [databind#1302] is solved different way, but ideally we shouldn't
+        //     cache anything with partially resolved `ResolvedRecursiveType`... so maybe improve
+        if (!result.hasHandlers()) {
+            _typeCache.putIfAbsent(key, result); // cache object syncs
+        }
+        return result;
+    }
+
+    protected JavaType _resolveSuperClass(ClassStack context, Class<?> rawType, TypeBindings parentBindings)
+    {
+        Type parent = ClassUtil.getGenericSuperclass(rawType);
+        if (parent == null) {
+            return null;
+        }
+        return _fromAny(context, parent, parentBindings);
+    }
+
+    protected JavaType[] _resolveSuperInterfaces(ClassStack context, Class<?> rawType, TypeBindings parentBindings)
+    {
+        Type[] types = ClassUtil.getGenericInterfaces(rawType);
+        if (types == null || types.length == 0) {
+            return NO_TYPES;
+        }
+        int len = types.length;
+        JavaType[] resolved = new JavaType[len];
+        for (int i = 0; i < len; ++i) {
+            Type type = types[i];
+            resolved[i] = _fromAny(context, type, parentBindings);
+        }
+        return resolved;
+    }
+
+    /**
+     * Helper class used to check whether exact class for which type is being constructed
+     * is one of well-known base interfaces or classes that indicates alternate
+     * {@link JavaType} implementation.
+     */
+    protected JavaType _fromWellKnownClass(ClassStack context, Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces)
+    {
+        if (bindings == null) {
+            bindings = EMPTY_BINDINGS;
+        }
+        // Quite simple when we resolving exact class/interface; start with that
+        if (rawType == Map.class) {
+            return _mapType(rawType, bindings, superClass, superInterfaces);
+        }
+        if (rawType == Collection.class) {
+            return _collectionType(rawType, bindings, superClass, superInterfaces);
+        }
+        // and since 2.6 one referential type
+        if (rawType == AtomicReference.class) {
+            return _referenceType(rawType, bindings, superClass, superInterfaces);
+        }
+        // 01-Nov-2015, tatu: As of 2.7, couple of potential `CollectionLikeType`s (like
+        //    `Iterable`, `Iterator`), and `MapLikeType`s (`Map.Entry`) are not automatically
+        //    detected, related to difficulties in propagating type upwards (Iterable, for
+        //    example, is a weak, tag-on type). They may be detectable in future.
+        return null;
+    }
+
+    protected JavaType _fromWellKnownInterface(ClassStack context, Class<?> rawType, TypeBindings bindings,
+            JavaType superClass, JavaType[] superInterfaces)
+    {
+        // But that's not all: may be possible current type actually implements an
+        // interface type. So...
+        final int intCount = superInterfaces.length;
+
+        for (int i = 0; i < intCount; ++i) {
+            JavaType result = superInterfaces[i].refine(rawType, bindings, superClass, superInterfaces);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * This method deals with parameterized types, that is,
+     * first class generic classes.
+     */
+    protected JavaType _fromParamType(ClassStack context, ParameterizedType ptype,
+            TypeBindings parentBindings)
+    {
+        // Assumption here is we'll always get Class, not one of other Types
+        Class<?> rawType = (Class<?>) ptype.getRawType();
+
+        // 29-Oct-2015, tatu: For performance reasons, let's streamline handling of
+        //   couple of not-so-useful parametric types
+        if (rawType == CLS_ENUM) {
+            return CORE_TYPE_ENUM;
+        }
+        if (rawType == CLS_COMPARABLE) {
+            return CORE_TYPE_COMPARABLE;
+        }
+
+        // First: what is the actual base type? One odd thing is that 'getRawType'
+        // returns Type, not Class<?> as one might expect. But let's assume it is
+        // always of type Class: if not, need to add more code to resolve it to Class.
+        Type[] args = ptype.getActualTypeArguments();
+        int paramCount = (args == null) ? 0 : args.length;
+        TypeBindings newBindings;
+
+        if (paramCount == 0) {
+            newBindings = EMPTY_BINDINGS;
+        } else {
+            JavaType[] pt = new JavaType[paramCount];
+            for (int i = 0; i < paramCount; ++i) {
+                pt[i] = _fromAny(context, args[i], parentBindings);
+            }
+            newBindings = TypeBindings.create(rawType, pt);
+        }
+        return _fromClass(context, rawType, newBindings);
+    }
+
+    protected JavaType _fromArrayType(ClassStack context, GenericArrayType type, TypeBindings bindings)
+    {
+        JavaType elementType = _fromAny(context, type.getGenericComponentType(), bindings);
+        return ArrayType.construct(elementType, bindings);
+    }
+
+    protected JavaType _fromVariable(ClassStack context, TypeVariable<?> var, TypeBindings bindings)
+    {
+        // ideally should find it via bindings:
+        final String name = var.getName();
+        if (bindings == null) {
+            throw new IllegalArgumentException("Null `bindings` passed (type variable \""+name+"\")");
+        }
+        JavaType type = bindings.findBoundType(name);
+        if (type != null) {
+            return type;
+        }
+        // but if not, use bounds... note that approach here is simplistic; not taking
+        // into account possible multiple bounds, nor consider upper bounds.
+        if (bindings.hasUnbound(name)) {
+            return CORE_TYPE_OBJECT;
+        }
+        bindings = bindings.withUnboundVariable(name);
+
+        final Type[] bounds;
+
+        // 15-Jan-2019, tatu: As weird as this looks, apparently on some platforms (Arm CPU, mobile
+        //    devices), unsynchronized internal access can lead to issues, see:
+        //
+        //  https://vmlens.com/articles/java-lang-reflect-typevariable-getbounds-is-not-thread-safe/
+        //
+        //    No good way to reproduce but since this should not be on critical path, let's add
+        //    syncing as it seems potentially necessary.
+        synchronized (var) {
+            bounds = var.getBounds();
+        }
+        return _fromAny(context, bounds[0], bindings);
+    }
+
+    protected JavaType _fromWildcard(ClassStack context, WildcardType type, TypeBindings bindings)
+    {
+        /* Similar to challenges with TypeVariable, we may have multiple upper bounds.
+         * But it is also possible that if upper bound defaults to Object, we might
+         * want to consider lower bounds instead.
+         * For now, we won't try anything more advanced; above is just for future reference.
+         */
+        return _fromAny(context, type.getUpperBounds()[0], bindings);
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/TypeModifier.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/TypeModifier.java
@@ -1,0 +1,36 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.lang.reflect.Type;
+
+/**
+ * Class that defines API that can be used to modify details of
+ * {@link JavaType} instances constructed using {@link TypeFactory}.
+ * Registered modifiers are called in order, to let them modify (or
+ * replace) basic type instance factory constructs.
+ * This is typically needed to support creation of
+ * {@link MapLikeType} and {@link CollectionLikeType} instances,
+ * as those cannot be constructed in generic fashion.
+ */
+public abstract class TypeModifier
+{
+    /**
+     * Method called to let modifier change constructed type definition.
+     * Note that this is only guaranteed to be called for
+     * non-container types ("simple" types not recognized as arrays,
+     * <code>java.util.Collection</code> or <code>java.util.Map</code>).
+     *
+     * @param type Instance to modify
+     * @param jdkType JDK type that was used to construct instance to modify
+     * @param context Type resolution context used for the type
+     * @param typeFactory Type factory that can be used to construct parameter type; note,
+     *   however, that care must be taken to avoid infinite loops -- specifically, do not
+     *   construct instance of primary type itself
+     *
+     * @return Actual type instance to use; usually either <code>type</code> (as is or with
+     *    modifications), or a newly constructed type instance based on it. Cannot be null.
+     */
+    public abstract JavaType modifyType(JavaType type, Type jdkType, TypeBindings context,
+            TypeFactory typeFactory);
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/TypeParser.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/TypeParser.java
@@ -1,0 +1,138 @@
+package org.apache.ibatis.reflection.type.jackson.databind.type;
+
+import org.apache.ibatis.reflection.type.jackson.databind.util.ClassUtil;
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+/**
+ * Simple recursive-descent parser for parsing canonical {@link JavaType}
+ * representations and constructing type instances.
+ */
+public class TypeParser
+    implements java.io.Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    protected final TypeFactory _factory;
+
+    public TypeParser(TypeFactory f) {
+        _factory = f;
+    }
+
+    /**
+     * @since 2.6.2
+     */
+    public TypeParser withFactory(TypeFactory f) {
+        return (f == _factory) ? this : new TypeParser(f);
+    }
+
+    public JavaType parse(String canonical) throws IllegalArgumentException
+    {
+        MyTokenizer tokens = new MyTokenizer(canonical.trim());
+        JavaType type = parseType(tokens);
+        // must be end, now
+        if (tokens.hasMoreTokens()) {
+            throw _problem(tokens, "Unexpected tokens after complete type");
+        }
+        return type;
+    }
+
+    protected JavaType parseType(MyTokenizer tokens)
+        throws IllegalArgumentException
+    {
+        if (!tokens.hasMoreTokens()) {
+            throw _problem(tokens, "Unexpected end-of-string");
+        }
+        Class<?> base = findClass(tokens.nextToken(), tokens);
+
+        // either end (ok, non generic type), or generics
+        if (tokens.hasMoreTokens()) {
+            String token = tokens.nextToken();
+            if ("<".equals(token)) {
+                List<JavaType> parameterTypes = parseTypes(tokens);
+                TypeBindings b = TypeBindings.create(base, parameterTypes);
+                return _factory._fromClass(null, base, b);
+            }
+            // can be comma that separates types, or closing '>'
+            tokens.pushBack(token);
+        }
+        return _factory._fromClass(null, base, TypeBindings.emptyBindings());
+    }
+
+    protected List<JavaType> parseTypes(MyTokenizer tokens)
+        throws IllegalArgumentException
+    {
+        ArrayList<JavaType> types = new ArrayList<JavaType>();
+        while (tokens.hasMoreTokens()) {
+            types.add(parseType(tokens));
+            if (!tokens.hasMoreTokens()) break;
+            String token = tokens.nextToken();
+            if (">".equals(token)) return types;
+            if (!",".equals(token)) {
+                throw _problem(tokens, "Unexpected token '"+token+"', expected ',' or '>')");
+            }
+        }
+        throw _problem(tokens, "Unexpected end-of-string");
+    }
+
+    protected Class<?> findClass(String className, MyTokenizer tokens)
+    {
+        try {
+            return _factory.findClass(className);
+        } catch (Exception e) {
+            ClassUtil.throwIfRTE(e);
+            throw _problem(tokens, "Cannot locate class '"+className+"', problem: "+e.getMessage());
+        }
+    }
+
+    protected IllegalArgumentException _problem(MyTokenizer tokens, String msg)
+    {
+        return new IllegalArgumentException(String.format("Failed to parse type '%s' (remaining: '%s'): %s",
+                tokens.getAllInput(), tokens.getRemainingInput(), msg));
+    }
+
+    final static class MyTokenizer extends StringTokenizer
+    {
+        protected final String _input;
+
+        protected int _index;
+
+        protected String _pushbackToken;
+
+        public MyTokenizer(String str) {
+            super(str, "<,>", true);
+            _input = str;
+        }
+
+        @Override
+        public boolean hasMoreTokens() {
+            return (_pushbackToken != null) || super.hasMoreTokens();
+        }
+
+        @Override
+        public String nextToken() {
+            String token;
+            if (_pushbackToken != null) {
+                token = _pushbackToken;
+                _pushbackToken = null;
+            } else {
+                token = super.nextToken();
+                _index += token.length();
+                token = token.trim();
+            }
+            return token;
+        }
+
+        public void pushBack(String token) {
+            _pushbackToken = token;
+            // let's NOT change index for now, since token may have been trim()ed
+        }
+
+        public String getAllInput() { return _input; }
+//        public String getUsedInput() { return _input.substring(0, _index); }
+        public String getRemainingInput() { return _input.substring(_index); }
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/package-info.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/type/package-info.java
@@ -1,0 +1,10 @@
+/**
+ * Package that contains concrete implementations of
+ * {@link org.apache.ibatis.reflection.type.jackson.databind.JavaType}, as
+ * well as the factory ({@link org.apache.ibatis.reflection.type.jackson.databind.type.TypeFactory}) for
+ * constructing instances from various input data types
+ * (like {@link java.lang.Class}, {@link java.lang.reflect.Type})
+ * and programmatically (for structured types, arrays,
+ * {@link java.util.List}s and {@link java.util.Map}s).
+ */
+package org.apache.ibatis.reflection.type.jackson.databind.type;

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/ArrayBuilders.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/ArrayBuilders.java
@@ -1,0 +1,239 @@
+package org.apache.ibatis.reflection.type.jackson.databind.util;
+
+import java.lang.reflect.Array;
+import java.util.HashSet;
+
+/**
+ * Helper class that contains set of distinct builders for different
+ * arrays of primitive values. It also provides trivially simple
+ * reuse scheme, which assumes that caller knows not to use instances
+ * concurrently (which works ok with primitive arrays since they can
+ * not contain other non-primitive types).
+ * Also note that instances are not thread safe; the intent is that
+ * a builder is constructed on per-call (deserialization) basis.
+ */
+public final class ArrayBuilders
+{
+    private BooleanBuilder _booleanBuilder = null;
+
+    // note: no need for char[] builder, assume they are Strings
+
+    private ByteBuilder _byteBuilder = null;
+    private ShortBuilder _shortBuilder = null;
+    private IntBuilder _intBuilder = null;
+    private LongBuilder _longBuilder = null;
+
+    private FloatBuilder _floatBuilder = null;
+    private DoubleBuilder _doubleBuilder = null;
+
+    public ArrayBuilders() { }
+
+    public BooleanBuilder getBooleanBuilder()
+    {
+        if (_booleanBuilder == null) {
+            _booleanBuilder = new BooleanBuilder();
+        }
+        return _booleanBuilder;
+    }
+
+    public ByteBuilder getByteBuilder()
+    {
+        if (_byteBuilder == null) {
+            _byteBuilder = new ByteBuilder();
+        }
+        return _byteBuilder;
+    }
+    public ShortBuilder getShortBuilder()
+    {
+        if (_shortBuilder == null) {
+            _shortBuilder = new ShortBuilder();
+        }
+        return _shortBuilder;
+    }
+    public IntBuilder getIntBuilder()
+    {
+        if (_intBuilder == null) {
+            _intBuilder = new IntBuilder();
+        }
+        return _intBuilder;
+    }
+    public LongBuilder getLongBuilder()
+    {
+        if (_longBuilder == null) {
+            _longBuilder = new LongBuilder();
+        }
+        return _longBuilder;
+    }
+
+    public FloatBuilder getFloatBuilder()
+    {
+        if (_floatBuilder == null) {
+            _floatBuilder = new FloatBuilder();
+        }
+        return _floatBuilder;
+    }
+    public DoubleBuilder getDoubleBuilder()
+    {
+        if (_doubleBuilder == null) {
+            _doubleBuilder = new DoubleBuilder();
+        }
+        return _doubleBuilder;
+    }
+
+    /*
+    /**********************************************************
+    /* Impl classes
+    /**********************************************************
+     */
+
+    public final static class BooleanBuilder
+        extends PrimitiveArrayBuilder<boolean[]>
+    {
+        public BooleanBuilder() { }
+        @Override
+        public final boolean[] _constructArray(int len) { return new boolean[len]; }
+    }
+
+    public final static class ByteBuilder
+        extends PrimitiveArrayBuilder<byte[]>
+    {
+        public ByteBuilder() { }
+        @Override
+        public final byte[] _constructArray(int len) { return new byte[len]; }
+    }
+    public final static class ShortBuilder
+        extends PrimitiveArrayBuilder<short[]>
+    {
+        public ShortBuilder() { }
+        @Override
+        public final short[] _constructArray(int len) { return new short[len]; }
+    }
+    public final static class IntBuilder
+        extends PrimitiveArrayBuilder<int[]>
+    {
+        public IntBuilder() { }
+        @Override
+        public final int[] _constructArray(int len) { return new int[len]; }
+    }
+    public final static class LongBuilder
+        extends PrimitiveArrayBuilder<long[]>
+    {
+        public LongBuilder() { }
+        @Override
+        public final long[] _constructArray(int len) { return new long[len]; }
+    }
+
+    public final static class FloatBuilder
+        extends PrimitiveArrayBuilder<float[]>
+    {
+        public FloatBuilder() { }
+        @Override
+        public final float[] _constructArray(int len) { return new float[len]; }
+    }
+    public final static class DoubleBuilder
+        extends PrimitiveArrayBuilder<double[]>
+    {
+        public DoubleBuilder() { }
+        @Override
+        public final double[] _constructArray(int len) { return new double[len]; }
+    }
+
+    /*
+    /**********************************************************
+    /* Static helper methods
+    /**********************************************************
+     */
+
+    /**
+     * Helper method used for constructing simple value comparator used for
+     * comparing arrays for content equality.
+     *<p>
+     * Note: current implementation is not optimized for speed; if performance
+     * ever becomes an issue, it is possible to construct much more efficient
+     * typed instances (one for Object[] and sub-types; one per primitive type).
+     *
+     * @since 2.2 Moved from earlier <code>Comparators</code> class
+     */
+    public static Object getArrayComparator(final Object defaultValue)
+    {
+        final int length = Array.getLength(defaultValue);
+        final Class<?> defaultValueType = defaultValue.getClass();
+        return new Object() {
+            @Override
+            public boolean equals(Object other) {
+                if (other == this) return true;
+                if (!ClassUtil.hasClass(other, defaultValueType)) {
+                    return false;
+                }
+                if (Array.getLength(other) != length) return false;
+                // so far so good: compare actual equality; but only shallow one
+                for (int i = 0; i < length; ++i) {
+                    Object value1 = Array.get(defaultValue, i);
+                    Object value2 = Array.get(other, i);
+                    if (value1 == value2) continue;
+                    if (value1 != null) {
+                        if (!value1.equals(value2)) {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }
+        };
+    }
+
+    public static <T> HashSet<T> arrayToSet(T[] elements)
+    {
+        if (elements != null) {
+            int len = elements.length;
+            HashSet<T> result = new HashSet<T>(len);
+            for (int i = 0; i < len; ++i) {
+                result.add(elements[i]);
+            }
+            return result;
+        }
+        return new HashSet<T>();
+    }
+
+    /**
+     * Helper method for constructing a new array that contains specified
+     * element followed by contents of the given array but never contains
+     * duplicates.
+     * If element already existed, one of two things happens: if the element
+     * was already the first one in array, array is returned as is; but
+     * if not, a new copy is created in which element has moved as the head.
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T[] insertInListNoDup(T[] array, T element)
+    {
+        final int len = array.length;
+
+        // First: see if the element already exists
+        for (int ix = 0; ix < len; ++ix) {
+            if (array[ix] == element) {
+                // if at head already, return as is
+                if (ix == 0) {
+                    return array;
+                }
+                // otherwise move things around
+                T[] result = (T[]) Array.newInstance(array.getClass().getComponentType(), len);
+                System.arraycopy(array, 0, result, 1, ix);
+                result[0] = element;
+                ++ix;
+                int left = len - ix;
+                if (left > 0) {
+                	System.arraycopy(array, ix, result, ix, left);
+                }
+                return result;
+            }
+        }
+
+        // but if not, allocate new array, move
+        T[] result = (T[]) Array.newInstance(array.getClass().getComponentType(), len+1);
+        if (len > 0) {
+            System.arraycopy(array, 0, result, 1, len);
+        }
+        result[0] = element;
+        return result;
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/ClassUtil.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/ClassUtil.java
@@ -1,0 +1,1522 @@
+package org.apache.ibatis.reflection.type.jackson.databind.util;
+
+import org.apache.ibatis.reflection.type.jackson.databind.JavaType;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.*;
+import java.util.*;
+
+public final class ClassUtil
+{
+    private final static Class<?> CLS_OBJECT = Object.class;
+
+    private final static Annotation[] NO_ANNOTATIONS = new Annotation[0];
+    private final static Ctor[] NO_CTORS = new Ctor[0];
+
+    private final static Iterator<?> EMPTY_ITERATOR = Collections.emptyIterator();
+
+    /*
+    /**********************************************************
+    /* Simple factory methods
+    /**********************************************************
+     */
+
+    /**
+     * @since 2.7
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> Iterator<T> emptyIterator() {
+        return (Iterator<T>) EMPTY_ITERATOR;
+    }
+
+    /*
+    /**********************************************************
+    /* Methods that deal with inheritance
+    /**********************************************************
+     */
+
+    /**
+     * Method that will find all sub-classes and implemented interfaces
+     * of a given class or interface. Classes are listed in order of
+     * precedence, starting with the immediate super-class, followed by
+     * interfaces class directly declares to implemented, and then recursively
+     * followed by parent of super-class and so forth.
+     * Note that <code>Object.class</code> is not included in the list
+     * regardless of whether <code>endBefore</code> argument is defined or not.
+     *
+     * @param endBefore Super-type to NOT include in results, if any; when
+     *    encountered, will be ignored (and no super types are checked).
+     *
+     * @since 2.7
+     */
+    public static List<JavaType> findSuperTypes(JavaType type, Class<?> endBefore,
+            boolean addClassItself) {
+        if ((type == null) || type.hasRawClass(endBefore) || type.hasRawClass(Object.class)) {
+            return Collections.emptyList();
+        }
+        List<JavaType> result = new ArrayList<JavaType>(8);
+        _addSuperTypes(type, endBefore, result, addClassItself);
+        return result;
+    }
+
+    /**
+     * @since 2.7
+     */
+    public static List<Class<?>> findRawSuperTypes(Class<?> cls, Class<?> endBefore, boolean addClassItself) {
+        if ((cls == null) || (cls == endBefore) || (cls == Object.class)) {
+            return Collections.emptyList();
+        }
+        List<Class<?>> result = new ArrayList<Class<?>>(8);
+        _addRawSuperTypes(cls, endBefore, result, addClassItself);
+        return result;
+    }
+
+    /**
+     * Method for finding all super classes (but not super interfaces) of given class,
+     * starting with the immediate super class and ending in the most distant one.
+     * Class itself is included if <code>addClassItself</code> is true.
+     *<p>
+     * NOTE: mostly/only called to resolve mix-ins as that's where we do not care
+     * about fully-resolved types, just associated annotations.
+     *
+     * @since 2.7
+     */
+    public static List<Class<?>> findSuperClasses(Class<?> cls, Class<?> endBefore,
+            boolean addClassItself) {
+        List<Class<?>> result = new ArrayList<Class<?>>(8);
+        if ((cls != null) && (cls != endBefore))  {
+            if (addClassItself) {
+                result.add(cls);
+            }
+            while ((cls = cls.getSuperclass()) != null) {
+                if (cls == endBefore) {
+                    break;
+                }
+                result.add(cls);
+            }
+        }
+        return result;
+    }
+
+    @Deprecated // since 2.7
+    public static List<Class<?>> findSuperTypes(Class<?> cls, Class<?> endBefore) {
+        return findSuperTypes(cls, endBefore, new ArrayList<Class<?>>(8));
+    }
+
+    @Deprecated // since 2.7
+    public static List<Class<?>> findSuperTypes(Class<?> cls, Class<?> endBefore, List<Class<?>> result) {
+        _addRawSuperTypes(cls, endBefore, result, false);
+        return result;
+    }
+
+    private static void _addSuperTypes(JavaType type, Class<?> endBefore, Collection<JavaType> result,
+            boolean addClassItself)
+    {
+        if (type == null) {
+            return;
+        }
+        final Class<?> cls = type.getRawClass();
+        if (cls == endBefore || cls == Object.class) { return; }
+        if (addClassItself) {
+            if (result.contains(type)) { // already added, no need to check supers
+                return;
+            }
+            result.add(type);
+        }
+        for (JavaType intCls : type.getInterfaces()) {
+            _addSuperTypes(intCls, endBefore, result, true);
+        }
+        _addSuperTypes(type.getSuperClass(), endBefore, result, true);
+    }
+
+    private static void _addRawSuperTypes(Class<?> cls, Class<?> endBefore, Collection<Class<?>> result, boolean addClassItself) {
+        if (cls == endBefore || cls == null || cls == Object.class) { return; }
+        if (addClassItself) {
+            if (result.contains(cls)) { // already added, no need to check supers
+                return;
+            }
+            result.add(cls);
+        }
+        for (Class<?> intCls : _interfaces(cls)) {
+            _addRawSuperTypes(intCls, endBefore, result, true);
+        }
+        _addRawSuperTypes(cls.getSuperclass(), endBefore, result, true);
+    }
+
+    /*
+    /**********************************************************
+    /* Class type detection methods
+    /**********************************************************
+     */
+
+    /**
+     * @return Null if class might be a bean; type String (that identifies
+     *   why it's not a bean) if not
+     */
+    public static String canBeABeanType(Class<?> type)
+    {
+        // First: language constructs that ain't beans:
+        if (type.isAnnotation()) {
+            return "annotation";
+        }
+        if (type.isArray()) {
+            return "array";
+        }
+        if (Enum.class.isAssignableFrom(type)) {
+            return "enum";
+        }
+        if (type.isPrimitive()) {
+            return "primitive";
+        }
+
+        // Anything else? Seems valid, then
+        return null;
+    }
+
+    public static String isLocalType(Class<?> type, boolean allowNonStatic)
+    {
+        /* As per [JACKSON-187], GAE seems to throw SecurityExceptions
+         * here and there... and GAE itself has a bug, too
+         * Bah. So we need to catch some wayward exceptions on GAE
+         */
+        try {
+            final boolean isStatic = Modifier.isStatic(type.getModifiers());
+
+            // one more: method locals, anonymous, are not good:
+            // 23-Jun-2020, tatu: [databind#2758] With JDK14+ should allow
+            //    local Record types, however
+            if (!isStatic && hasEnclosingMethod(type)) {
+                return "local/anonymous";
+            }
+            /* But how about non-static inner classes? Can't construct
+             * easily (theoretically, we could try to check if parent
+             * happens to be enclosing... but that gets convoluted)
+             */
+            if (!allowNonStatic) {
+                if (!isStatic && getEnclosingClass(type) != null) {
+                    return "non-static member class";
+                }
+            }
+        }
+        catch (SecurityException e) { }
+        catch (NullPointerException e) { }
+        return null;
+    }
+
+    /**
+     * Method for finding enclosing class for non-static inner classes
+     */
+    public static Class<?> getOuterClass(Class<?> type)
+    {
+        // as above, GAE has some issues...
+        if (!Modifier.isStatic(type.getModifiers())) {
+            try {
+                // one more: method locals, anonymous, are not good:
+                if (hasEnclosingMethod(type)) {
+                    return null;
+                }
+                return getEnclosingClass(type);
+            } catch (SecurityException e) { }
+        }
+        return null;
+    }
+
+    /**
+     * Helper method used to weed out dynamic Proxy types; types that do
+     * not expose concrete method API that we could use to figure out
+     * automatic Bean (property) based serialization.
+     */
+    public static boolean isProxyType(Class<?> type)
+    {
+        // As per [databind#57], should NOT disqualify JDK proxy:
+        /*
+        // Then: well-known proxy (etc) classes
+        if (Proxy.isProxyClass(type)) {
+            return true;
+        }
+        */
+        String name = type.getName();
+        // Hibernate uses proxies heavily as well:
+        if (name.startsWith("net.sf.cglib.proxy.")
+            || name.startsWith("org.hibernate.proxy.")) {
+            return true;
+        }
+        // Not one of known proxies, nope:
+        return false;
+    }
+
+    /**
+     * Helper method that checks if given class is a concrete one;
+     * that is, not an interface or abstract class.
+     */
+    public static boolean isConcrete(Class<?> type)
+    {
+        int mod = type.getModifiers();
+        return (mod & (Modifier.INTERFACE | Modifier.ABSTRACT)) == 0;
+    }
+
+    public static boolean isConcrete(Member member)
+    {
+        int mod = member.getModifiers();
+        return (mod & (Modifier.INTERFACE | Modifier.ABSTRACT)) == 0;
+    }
+
+    public static boolean isCollectionMapOrArray(Class<?> type)
+    {
+        if (type.isArray()) return true;
+        if (Collection.class.isAssignableFrom(type)) return true;
+        if (Map.class.isAssignableFrom(type)) return true;
+        return false;
+    }
+
+    /*public static boolean isBogusClass(Class<?> cls) {
+        return (cls == Void.class || cls == Void.TYPE
+                || cls == org.apache.ibatis.type.resolved.jackson.databind.annotation.NoClass.class);
+    }*/
+
+    /**
+     * Helper method for detecting Java14-added new {@code Record} types
+     *
+     * @since 2.12
+     */
+    public static boolean isRecordType(Class<?> cls) {
+        Class<?> parent = cls.getSuperclass();
+        return (parent != null) && "java.lang.Record".equals(parent.getName());
+    }
+
+    /**
+     * @since 2.7
+     */
+    public static boolean isObjectOrPrimitive(Class<?> cls) {
+        return (cls == CLS_OBJECT) || cls.isPrimitive();
+    }
+
+    /**
+     * @since 2.9
+     */
+    public static boolean hasClass(Object inst, Class<?> raw) {
+        // 10-Nov-2016, tatu: Could use `Class.isInstance()` if we didn't care
+        //    about being exactly that type
+        return (inst != null) && (inst.getClass() == raw);
+    }
+
+    /**
+     * @since 2.9
+     */
+    public static void verifyMustOverride(Class<?> expType, Object instance,
+            String method)
+    {
+        if (instance.getClass() != expType) {
+            throw new IllegalStateException(String.format(
+                    "Sub-class %s (of class %s) must override method '%s'",
+                instance.getClass().getName(), expType.getName(), method));
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Method type detection methods
+    /**********************************************************
+     */
+
+    /**
+     * @deprecated Since 2.6 not used; may be removed before 3.x
+     */
+    @Deprecated // since 2.6
+    public static boolean hasGetterSignature(Method m)
+    {
+        // First: static methods can't be getters
+        if (Modifier.isStatic(m.getModifiers())) {
+            return false;
+        }
+        // Must take no args
+        Class<?>[] pts = m.getParameterTypes();
+        if (pts != null && pts.length != 0) {
+            return false;
+        }
+        // Can't be a void method
+        if (Void.TYPE == m.getReturnType()) {
+            return false;
+        }
+        // Otherwise looks ok:
+        return true;
+    }
+
+    /*
+    /**********************************************************
+    /* Exception handling; simple re-throw
+    /**********************************************************
+     */
+
+    /**
+     * Helper method that will check if argument is an {@link Error},
+     * and if so, (re)throw it; otherwise just return
+     *
+     * @since 2.9
+     */
+    public static Throwable throwIfError(Throwable t) {
+        if (t instanceof Error) {
+            throw (Error) t;
+        }
+        return t;
+    }
+
+    /**
+     * Helper method that will check if argument is an {@link RuntimeException},
+     * and if so, (re)throw it; otherwise just return
+     *
+     * @since 2.9
+     */
+    public static Throwable throwIfRTE(Throwable t) {
+        if (t instanceof RuntimeException) {
+            throw (RuntimeException) t;
+        }
+        return t;
+    }
+
+    /**
+     * Helper method that will check if argument is an {@link IOException},
+     * and if so, (re)throw it; otherwise just return
+     *
+     * @since 2.9
+     */
+    public static Throwable throwIfIOE(Throwable t) throws IOException {
+        if (t instanceof IOException) {
+            throw (IOException) t;
+        }
+        return t;
+    }
+
+    /*
+    /**********************************************************
+    /* Exception handling; other
+    /**********************************************************
+     */
+
+    /**
+     * Method that can be used to find the "root cause", innermost
+     * of chained (wrapped) exceptions.
+     */
+    public static Throwable getRootCause(Throwable t)
+    {
+        while (t.getCause() != null) {
+            t = t.getCause();
+        }
+        return t;
+    }
+
+    /**
+     * Method that works like by calling {@link #getRootCause} and then
+     * either throwing it (if instanceof {@link IOException}), or
+     * return.
+     *
+     * @since 2.8
+     */
+    public static Throwable throwRootCauseIfIOE(Throwable t) throws IOException {
+        return throwIfIOE(getRootCause(t));
+    }
+
+    /**
+     * Method that will wrap 't' as an {@link IllegalArgumentException} if it
+     * is a checked exception; otherwise (runtime exception or error) throw as is
+     */
+    public static void throwAsIAE(Throwable t) {
+        throwAsIAE(t, t.getMessage());
+    }
+
+    /**
+     * Method that will wrap 't' as an {@link IllegalArgumentException} (and with
+     * specified message) if it
+     * is a checked exception; otherwise (runtime exception or error) throw as is
+     */
+    public static void throwAsIAE(Throwable t, String msg)
+    {
+        throwIfRTE(t);
+        throwIfError(t);
+        throw new IllegalArgumentException(msg, t);
+    }
+
+    /**
+     * @since 2.9
+     */
+    /*public static <T> T throwAsMappingException(DeserializationContext ctxt,
+            IOException e0) throws JsonMappingException {
+        if (e0 instanceof JsonMappingException) {
+            throw (JsonMappingException) e0;
+        }
+        throw JsonMappingException.from(ctxt, e0.getMessage())
+            .withCause(e0);
+    }*/
+
+    /**
+     * Method that will locate the innermost exception for given Throwable;
+     * and then wrap it as an {@link IllegalArgumentException} if it
+     * is a checked exception; otherwise (runtime exception or error) throw as is
+     */
+    public static void unwrapAndThrowAsIAE(Throwable t)
+    {
+        throwAsIAE(getRootCause(t));
+    }
+
+    /**
+     * Method that will locate the innermost exception for given Throwable;
+     * and then wrap it as an {@link IllegalArgumentException} if it
+     * is a checked exception; otherwise (runtime exception or error) throw as is
+     */
+    public static void unwrapAndThrowAsIAE(Throwable t, String msg)
+    {
+        throwAsIAE(getRootCause(t), msg);
+    }
+
+    /**
+     * Helper method that encapsulate logic in trying to close output generator
+     * in case of failure; useful mostly in forcing flush()ing as otherwise
+     * error conditions tend to be hard to diagnose. However, it is often the
+     * case that output state may be corrupt so we need to be prepared for
+     * secondary exception without masking original one.
+     *
+     * @since 2.8
+     */
+    /*public static void closeOnFailAndThrowAsIOE(JsonGenerator g, Exception fail)
+        throws IOException
+    {
+        // 04-Mar-2014, tatu: Let's try to prevent auto-closing of
+        //    structures, which typically causes more damage.
+        g.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
+        try {
+            g.close();
+        } catch (Exception e) {
+            fail.addSuppressed(e);
+        }
+        throwIfIOE(fail);
+        throwIfRTE(fail);
+        throw new RuntimeException(fail);
+    }*/
+
+    /**
+     * Helper method that encapsulate logic in trying to close given {@link Closeable}
+     * in case of failure; useful mostly in forcing flush()ing as otherwise
+     * error conditions tend to be hard to diagnose. However, it is often the
+     * case that output state may be corrupt so we need to be prepared for
+     * secondary exception without masking original one.
+     *
+     * @since 2.8
+     */
+    /*public static void closeOnFailAndThrowAsIOE(JsonGenerator g,
+            Closeable toClose, Exception fail)
+        throws IOException
+    {
+        if (g != null) {
+            g.disable(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT);
+            try {
+                g.close();
+            } catch (Exception e) {
+                fail.addSuppressed(e);
+            }
+        }
+        if (toClose != null) {
+            try {
+                toClose.close();
+            } catch (Exception e) {
+                fail.addSuppressed(e);
+            }
+        }
+        throwIfIOE(fail);
+        throwIfRTE(fail);
+        throw new RuntimeException(fail);
+    }*/
+
+    /*
+    /**********************************************************
+    /* Instantiation
+    /**********************************************************
+     */
+
+    /**
+     * Method that can be called to try to create an instantiate of
+     * specified type. Instantiation is done using default no-argument
+     * constructor.
+     *
+     * @param canFixAccess Whether it is possible to try to change access
+     *   rights of the default constructor (in case it is not publicly
+     *   accessible) or not.
+     *
+     * @throws IllegalArgumentException If instantiation fails for any reason;
+     *    except for cases where constructor throws an unchecked exception
+     *    (which will be passed as is)
+     */
+    public static <T> T createInstance(Class<T> cls, boolean canFixAccess)
+        throws IllegalArgumentException
+    {
+        Constructor<T> ctor = findConstructor(cls, canFixAccess);
+        if (ctor == null) {
+            throw new IllegalArgumentException("Class "+cls.getName()+" has no default (no arg) constructor");
+        }
+        try {
+            return ctor.newInstance();
+        } catch (Exception e) {
+            ClassUtil.unwrapAndThrowAsIAE(e, "Failed to instantiate class "+cls.getName()+", problem: "+e.getMessage());
+            return null;
+        }
+    }
+
+    public static <T> Constructor<T> findConstructor(Class<T> cls, boolean forceAccess)
+        throws IllegalArgumentException
+    {
+        try {
+            Constructor<T> ctor = cls.getDeclaredConstructor();
+            if (forceAccess) {
+                checkAndFixAccess(ctor, forceAccess);
+            } else {
+                // Has to be public...
+                if (!Modifier.isPublic(ctor.getModifiers())) {
+                    throw new IllegalArgumentException("Default constructor for "+cls.getName()+" is not accessible (non-public?): not allowed to try modify access via Reflection: cannot instantiate type");
+                }
+            }
+            return ctor;
+        } catch (NoSuchMethodException e) {
+            ;
+        } catch (Exception e) {
+            ClassUtil.unwrapAndThrowAsIAE(e, "Failed to find default constructor of class "+cls.getName()+", problem: "+e.getMessage());
+        }
+        return null;
+    }
+
+    /*
+    /**********************************************************
+    /* Class name, description access
+    /**********************************************************
+     */
+
+    /**
+     * @since 2.9
+     */
+    public static Class<?> classOf(Object inst) {
+        if (inst == null) {
+            return null;
+        }
+        return inst.getClass();
+    }
+
+    /**
+     * @since 2.9
+     */
+    public static Class<?> rawClass(JavaType t) {
+        if (t == null) {
+            return null;
+        }
+        return t.getRawClass();
+    }
+
+    /**
+     * @since 2.9
+     */
+    public static <T> T nonNull(T valueOrNull, T defaultValue) {
+        return (valueOrNull == null) ? defaultValue : valueOrNull;
+    }
+
+    /**
+     * @since 2.9
+     */
+    public static String nullOrToString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        return value.toString();
+    }
+
+    /**
+     * @since 2.9
+     */
+    public static String nonNullString(String str) {
+        if (str == null) {
+            return "";
+        }
+        return str;
+    }
+
+    /**
+     * Returns either quoted value (with double-quotes) -- if argument non-null
+     * String -- or String NULL (no quotes) (if null).
+     *
+     * @since 2.9
+     */
+    public static String quotedOr(Object str, String forNull) {
+        if (str == null) {
+            return forNull;
+        }
+        return String.format("\"%s\"", str);
+    }
+
+    /*
+    /**********************************************************
+    /* Type name, name, desc handling methods
+    /**********************************************************
+     */
+
+    /**
+     * Helper method used to construct appropriate description
+     * when passed either type (Class) or an instance; in latter
+     * case, class of instance is to be used.
+     */
+    public static String getClassDescription(Object classOrInstance)
+    {
+        if (classOrInstance == null) {
+            return "unknown";
+        }
+        Class<?> cls = (classOrInstance instanceof Class<?>) ?
+            (Class<?>) classOrInstance : classOrInstance.getClass();
+        return nameOf(cls);
+    }
+
+    /**
+     * Helper method to create and return "backticked" description of given
+     * resolved type (or, {@code "null"} if {@code null} passed), similar
+     * to return vaue of {@link #getClassDescription(Object)}.
+     *
+     * @param fullType Fully resolved type or null
+     * @return String description of type including generic type parameters, surrounded
+     *   by backticks, if type passed; or string "null" if {code null} passed
+     *
+     * @since 2.10
+     */
+    public static String getTypeDescription(JavaType fullType)
+    {
+        if (fullType == null) {
+            return "[null]";
+        }
+        StringBuilder sb = new StringBuilder(80).append('`');
+        sb.append(fullType.toCanonical());
+        return sb.append('`').toString();
+    }
+
+    /**
+     * Helper method used to construct appropriate description
+     * when passed either type (Class) or an instance; in latter
+     * case, class of instance is to be used.
+     *
+     * @since 2.9
+     */
+    public static String classNameOf(Object inst) {
+        if (inst == null) {
+            return "[null]";
+        }
+        Class<?> raw = (inst instanceof Class<?>) ? (Class<?>) inst : inst.getClass();
+        return nameOf(raw);
+    }
+
+    /**
+     * Returns either `cls.getName()` (if `cls` not null),
+     * or "[null]" if `cls` is null.
+     *
+     * @since 2.9
+     */
+    public static String nameOf(Class<?> cls) {
+        if (cls == null) {
+            return "[null]";
+        }
+        int index = 0;
+        while (cls.isArray()) {
+            ++index;
+            cls = cls.getComponentType();
+        }
+        String base = cls.isPrimitive() ? cls.getSimpleName() : cls.getName();
+        if (index > 0) {
+            StringBuilder sb = new StringBuilder(base);
+            do {
+                sb.append("[]");
+            } while (--index > 0);
+            base = sb.toString();
+        }
+        return backticked(base);
+    }
+
+    /**
+     * Returns either single-quoted (apostrophe) {@code 'named.getName()'} (if {@code named} not null),
+     * or "[null]" if {@code named} is null.
+     *<p>
+     * NOTE: before 2.12 returned "backticked" version instead of single-quoted name; changed
+     * to be compatible with most existing quoting usage within databind
+     *
+     * @since 2.9
+     */
+    /*public static String nameOf(Named named) {
+        if (named == null) {
+            return "[null]";
+        }
+        return apostrophed(named.getName());
+    }*/
+
+    /**
+     * Returns either single-quoted (apostrophe) {@code 'name'} (if {@code name} not null),
+     * or "[null]" if {@code name} is null.
+     *
+     * @since 2.12
+     */
+    public static String name(String name) {
+        if (name == null) {
+            return "[null]";
+        }
+        return apostrophed(name);
+    }
+
+    /**
+     * Returns either single-quoted (apostrophe) {@code 'name'} (if {@code name} not null),
+     * or "[null]" if {@code name} is null.
+     *
+     * @since 2.12
+     */
+    /*public static String name(PropertyName name) {
+        if (name == null) {
+            return "[null]";
+        }
+        // 26-Aug-2020, tatu: Should we consider namespace somehow?
+        return apostrophed(name.getSimpleName());
+    }*/
+
+    /*
+    /**********************************************************
+    /* Other escaping, description access
+    /**********************************************************
+     */
+
+    /**
+     * Returns either {@code `text`} (backtick-quoted) or {@code [null]}.
+     *
+     * @since 2.9
+     */
+    public static String backticked(String text) {
+        if (text == null) {
+            return "[null]";
+        }
+        return new StringBuilder(text.length()+2).append('`').append(text).append('`').toString();
+    }
+
+    /**
+     * Returns either {@code 'text'} (single-quoted) or {@code [null]}.
+     *
+     * @since 2.9
+     */
+    public static String apostrophed(String text) {
+        if (text == null) {
+            return "[null]";
+        }
+        return new StringBuilder(text.length()+2).append('\'').append(text).append('\'').toString();
+    }
+
+    /**
+     * Helper method that returns {@link Throwable#getMessage()} for all other exceptions
+     * except for (a) {@link JacksonException}, for which {@code getOriginalMessage()} is
+     * returned, and (b) {@link InvocationTargetException}, for which the cause's message
+     * is returned, if available.
+     * Method is used to avoid accidentally including trailing location information twice
+     * in message when wrapping exceptions.
+     *
+     * @since 2.9.7
+     */
+    /*public static String exceptionMessage(Throwable t) {
+        if (t instanceof JacksonException) {
+            return ((JacksonException) t).getOriginalMessage();
+        }
+        if (t instanceof InvocationTargetException && t.getCause() != null) {
+            return t.getCause().getMessage();
+        }
+        return t.getMessage();
+    }*/
+
+    /*
+    /**********************************************************
+    /* Primitive type support
+    /**********************************************************
+     */
+
+    /**
+     * Helper method used to get default value for wrappers used for primitive types
+     * (0 for Integer etc)
+     */
+    public static Object defaultValue(Class<?> cls)
+    {
+        if (cls == Integer.TYPE) {
+            return Integer.valueOf(0);
+        }
+        if (cls == Long.TYPE) {
+            return Long.valueOf(0L);
+        }
+        if (cls == Boolean.TYPE) {
+            return Boolean.FALSE;
+        }
+        if (cls == Double.TYPE) {
+            return Double.valueOf(0.0);
+        }
+        if (cls == Float.TYPE) {
+            return Float.valueOf(0.0f);
+        }
+        if (cls == Byte.TYPE) {
+            return Byte.valueOf((byte) 0);
+        }
+        if (cls == Short.TYPE) {
+            return Short.valueOf((short) 0);
+        }
+        if (cls == Character.TYPE) {
+            return '\0';
+        }
+        throw new IllegalArgumentException("Class "+cls.getName()+" is not a primitive type");
+    }
+
+    /**
+     * Helper method for finding wrapper type for given primitive type (why isn't
+     * there one in JDK?).
+     * NOTE: throws {@link IllegalArgumentException} if given type is NOT primitive
+     * type (caller has to check).
+     */
+    public static Class<?> wrapperType(Class<?> primitiveType)
+    {
+        if (primitiveType == Integer.TYPE) {
+            return Integer.class;
+        }
+        if (primitiveType == Long.TYPE) {
+            return Long.class;
+        }
+        if (primitiveType == Boolean.TYPE) {
+            return Boolean.class;
+        }
+        if (primitiveType == Double.TYPE) {
+            return Double.class;
+        }
+        if (primitiveType == Float.TYPE) {
+            return Float.class;
+        }
+        if (primitiveType == Byte.TYPE) {
+            return Byte.class;
+        }
+        if (primitiveType == Short.TYPE) {
+            return Short.class;
+        }
+        if (primitiveType == Character.TYPE) {
+            return Character.class;
+        }
+        throw new IllegalArgumentException("Class "+primitiveType.getName()+" is not a primitive type");
+    }
+
+    /**
+     * Method that can be used to find primitive type for given class if (but only if)
+     * it is either wrapper type or primitive type; returns {@code null} if type is neither.
+     *
+     * @since 2.7
+     */
+    public static Class<?> primitiveType(Class<?> type)
+    {
+        if (type.isPrimitive()) {
+            return type;
+        }
+
+        if (type == Integer.class) {
+            return Integer.TYPE;
+        }
+        if (type == Long.class) {
+            return Long.TYPE;
+        }
+        if (type == Boolean.class) {
+            return Boolean.TYPE;
+        }
+        if (type == Double.class) {
+            return Double.TYPE;
+        }
+        if (type == Float.class) {
+            return Float.TYPE;
+        }
+        if (type == Byte.class) {
+            return Byte.TYPE;
+        }
+        if (type == Short.class) {
+            return Short.TYPE;
+        }
+        if (type == Character.class) {
+            return Character.TYPE;
+        }
+        return null;
+    }
+
+    /*
+    /**********************************************************
+    /* Access checking/handling methods
+    /**********************************************************
+     */
+
+    /**
+     * Equivalent to call:
+     *<pre>
+     *   checkAndFixAccess(member, false);
+     *</pre>
+     *
+     * @deprecated Since 2.7 call variant that takes boolean flag.
+     */
+    @Deprecated
+    public static void checkAndFixAccess(Member member) {
+        checkAndFixAccess(member, false);
+    }
+
+    /**
+     * Method that is called if a {@link Member} may need forced access,
+     * to force a field, method or constructor to be accessible: this
+     * is done by calling {@link AccessibleObject#setAccessible(boolean)}.
+     *
+     * @param member Accessor to call <code>setAccessible()</code> on.
+     * @param evenIfAlreadyPublic Whether to always try to make accessor
+     *   accessible, even if {@code public} (true),
+     *   or only if needed to force by-pass of non-{@code public} access (false)
+     *
+     * @since 2.7
+     */
+    public static void checkAndFixAccess(Member member, boolean evenIfAlreadyPublic)
+    {
+        // We know all members are also accessible objects...
+        AccessibleObject ao = (AccessibleObject) member;
+
+        // 14-Jan-2009, tatu: It seems safe and potentially beneficial to
+        //   always to make it accessible (latter because it will force
+        //   skipping checks we have no use for...), so let's always call it.
+        try {
+            // 15-Apr-2021, tatu: With JDK 14+ we will be hitting access limitations
+            //    esp. wrt JDK types so let's change a bit
+            final Class<?> declaringClass = member.getDeclaringClass();
+            boolean isPublic = Modifier.isPublic(member.getModifiers())
+                    && Modifier.isPublic(declaringClass.getModifiers());
+            if (!isPublic || (evenIfAlreadyPublic && !isJDKClass(declaringClass))) {
+                ao.setAccessible(true);
+            }
+        } catch (SecurityException se) {
+            // 17-Apr-2009, tatu: This can fail on platforms like
+            // Google App Engine); so let's only fail if we really needed it...
+            if (!ao.isAccessible()) {
+                Class<?> declClass = member.getDeclaringClass();
+                throw new IllegalArgumentException("Cannot access "+member+" (from class "+declClass.getName()+"; failed to set access: "+se.getMessage());
+            }
+            // 14-Apr-2021, tatu: [databind#3118] Java 9/JPMS causes new fails...
+            //    But while our baseline is Java 8, must check name
+        } catch (RuntimeException se) {
+            if ("InaccessibleObjectException".equals(se.getClass().getSimpleName())) {
+                throw new IllegalArgumentException(String.format(
+"Failed to call `setAccess()` on %s '%s' (of class %s) due to `%s`, problem: %s",
+member.getClass().getSimpleName(), member.getName(),
+nameOf(member.getDeclaringClass()),
+se.getClass().getName(), se.getMessage()),
+                        se);
+            }
+            throw se;
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Enum type detection
+    /**********************************************************
+     */
+
+    /**
+     * Helper method that encapsulates reliable check on whether
+     * given raw type "is an Enum", that is, is or extends {@link Enum}.
+     *
+     * @since 2.10.1
+     */
+    public static boolean isEnumType(Class<?> rawType) {
+        return Enum.class.isAssignableFrom(rawType);
+    }
+
+    /**
+     * Helper method that can be used to dynamically figure out
+     * enumeration type of given {@link EnumSet}, without having
+     * access to its declaration.
+     * Code is needed to work around design flaw in JDK.
+     */
+    public static Class<? extends Enum<?>> findEnumType(EnumSet<?> s)
+    {
+        // First things first: if not empty, easy to determine
+        if (!s.isEmpty()) {
+            return findEnumType(s.iterator().next());
+        }
+        // Otherwise need to locate using an internal field
+        return EnumTypeLocator.instance.enumTypeFor(s);
+    }
+
+    /**
+     * Helper method that can be used to dynamically figure out
+     * enumeration type of given {@link EnumSet}, without having
+     * access to its declaration.
+     * Code is needed to work around design flaw in JDK.
+     */
+    public static Class<? extends Enum<?>> findEnumType(EnumMap<?,?> m)
+    {
+        if (!m.isEmpty()) {
+            return findEnumType(m.keySet().iterator().next());
+        }
+        // Otherwise need to locate using an internal field
+        return EnumTypeLocator.instance.enumTypeFor(m);
+    }
+
+    /**
+     * Helper method that can be used to dynamically figure out formal
+     * enumeration type (class) for given enumeration. This is either
+     * class of enum instance (for "simple" enumerations), or its
+     * superclass (for enums with instance fields or methods)
+     */
+    public static Class<? extends Enum<?>> findEnumType(Enum<?> en)
+    {
+        // enums with "body" are sub-classes of the formal type
+        return en.getDeclaringClass();
+    }
+
+    /**
+     * Helper method that can be used to dynamically figure out formal
+     * enumeration type (class) for given class of an enumeration value.
+     * This is either class of enum instance (for "simple" enumerations),
+     * or its superclass (for enums with instance fields or methods)
+     */
+    @SuppressWarnings("unchecked")
+    public static Class<? extends Enum<?>> findEnumType(Class<?> cls)
+    {
+        // enums with "body" are sub-classes of the formal type
+        if (cls.getSuperclass() != Enum.class) {
+            cls = cls.getSuperclass();
+        }
+        return (Class<? extends Enum<?>>) cls;
+    }
+
+    /**
+     * A method that will look for the first Enum value annotated with the given Annotation.
+     * <p>
+     * If there's more than one value annotated, the first one found will be returned. Which one exactly is used is undetermined.
+     *
+     * @param enumClass The Enum class to scan for a value with the given annotation
+     * @param annotationClass The annotation to look for.
+     * @return the Enum value annotated with the given Annotation or {@code null} if none is found.
+     * @throws IllegalArgumentException if there's a reflection issue accessing the Enum
+     * @since 2.8
+     */
+    public static <T extends Annotation> Enum<?> findFirstAnnotatedEnumValue(Class<Enum<?>> enumClass, Class<T> annotationClass)
+    {
+        Field[] fields = enumClass.getDeclaredFields();
+        for (Field field : fields) {
+            if (field.isEnumConstant()) {
+                Annotation defaultValueAnnotation = field.getAnnotation(annotationClass);
+                if (defaultValueAnnotation != null) {
+                    final String name = field.getName();
+                    for (Enum<?> enumValue : enumClass.getEnumConstants()) {
+                        if (name.equals(enumValue.name())) {
+                            return enumValue;
+                        }
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /*
+    /**********************************************************************
+    /* Methods for detecting special class categories
+    /**********************************************************************
+     */
+
+    /**
+     * Method that can be called to determine if given Object is the default
+     * implementation Jackson uses; as opposed to a custom serializer installed by
+     * a module or calling application. Determination is done using
+     * {@link JacksonStdImpl} annotation on handler (serializer, deserializer etc)
+     * class.
+     *<p>
+     * NOTE: passing `null` is legal, and will result in <code>true</code>
+     * being returned.
+     */
+    /*public static boolean isJacksonStdImpl(Object impl) {
+        return (impl == null) || isJacksonStdImpl(impl.getClass());
+    }
+
+    public static boolean isJacksonStdImpl(Class<?> implClass) {
+        return (implClass.getAnnotation(JacksonStdImpl.class) != null);
+    }*/
+
+    /**
+     * Accessor for checking whether given {@code Class} is under Java package
+     * of {@code java.*} or {@code javax.*} (including all sub-packages).
+     *<p>
+     * Added since some aspects of handling need to be changed for JDK types (and
+     * possibly some extensions under {@code javax.}?): for example, forcing of access
+     * will not work well for future JDKs (12 and later).
+     *<p>
+     * Note: in Jackson 2.11 only returned true for {@code java.*} (and not {@code javax.*});
+     * was changed in 2.12.
+     *
+     * @since 2.11
+     */
+    public static boolean isJDKClass(Class<?> rawType) {
+        final String clsName = rawType.getName();
+        return clsName.startsWith("java.") || clsName.startsWith("javax.");
+    }
+
+    /**
+     * Convenience method for:
+     *<pre>
+     *   return getJDKMajorVersion() >= 17
+     *</pre>
+     * that also catches any possible exceptions so it is safe to call
+     * from static contexts.
+     *
+     * @return {@code True} if we can determine that the code is running on
+     *    JDK 17 or above; {@code false} otherwise.
+     *
+     * @since 2.15
+     */
+    public static boolean isJDK17OrAbove() {
+        try {
+            return getJDKMajorVersion() >= 17;
+        } catch (Throwable t) {
+            System.err.println("Failed to determine JDK major version, assuming pre-JDK-17; problem: "+t);
+            return false;
+        }
+    }
+
+    /**
+     * @return Major version of JDK we are running on
+     *
+     * @throws IllegalStateException If JDK version information cannot be determined
+     *
+     * @since 2.15
+     */
+    public static int getJDKMajorVersion() {
+        String version;
+
+        try {
+            version = System.getProperty("java.version");
+        } catch (SecurityException e) {
+            throw new IllegalStateException("Could not access 'java.version': cannot determine JDK major version");
+        }
+        if (version.startsWith("1.")) {
+            // 25-Nov-2022, tatu: We'll consider JDK 8 to be the baseline since
+            //    Jackson 2.15+ only runs on 8 and above
+            return 8;
+        }
+        int dotIndex = version.indexOf(".");
+        String cleaned = (dotIndex < 0) ? version : version.substring(0, dotIndex);
+        try {
+            return Integer.parseInt(cleaned);
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("Invalid JDK version String '"+version+"' cannot determine JDK major version");
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Access to various Class definition aspects; possibly
+    /* cacheable; and attempts was made in 2.7.0 - 2.7.7; however
+    /* unintented retention (~= memory leak) wrt [databind#1363]
+    /* resulted in removal of caching
+    /**********************************************************
+     */
+
+    public static boolean isNonStaticInnerClass(Class<?> cls) {
+        return !Modifier.isStatic(cls.getModifiers())
+                && (getEnclosingClass(cls) != null);
+    }
+
+    /**
+     * @since 2.7
+     *
+     * @deprecated Since 2.12 (just call methods directly or check class name)
+     */
+    @Deprecated // since 2.12
+    public static String getPackageName(Class<?> cls) {
+        Package pkg = cls.getPackage();
+        return (pkg == null) ? null : pkg.getName();
+    }
+
+    /**
+     * @since 2.7
+     */
+    public static boolean hasEnclosingMethod(Class<?> cls) {
+        return !isObjectOrPrimitive(cls) && (cls.getEnclosingMethod() != null);
+    }
+
+    /**
+     * @deprecated since 2.11 (just call Class method directly)
+     */
+    @Deprecated
+    public static Field[] getDeclaredFields(Class<?> cls) {
+        return cls.getDeclaredFields();
+    }
+
+    /**
+     * @deprecated since 2.11 (just call Class method directly)
+     */
+    @Deprecated
+    public static Method[] getDeclaredMethods(Class<?> cls) {
+        return cls.getDeclaredMethods();
+    }
+
+    /**
+     * @since 2.7
+     */
+    public static Annotation[] findClassAnnotations(Class<?> cls) {
+        if (isObjectOrPrimitive(cls)) {
+            return NO_ANNOTATIONS;
+        }
+        return cls.getDeclaredAnnotations();
+    }
+
+    /**
+     * Helper method that gets methods declared in given class; usually a simple thing,
+     * but sometimes (as per [databind#785]) more complicated, depending on classloader
+     * setup.
+     *
+     * @since 2.9
+     */
+    public static Method[] getClassMethods(Class<?> cls)
+    {
+        try {
+            return cls.getDeclaredMethods();
+        } catch (final NoClassDefFoundError ex) {
+            // One of the methods had a class that was not found in the cls.getClassLoader.
+            // Maybe the developer was nice and has a different class loader for this context.
+            final ClassLoader loader = Thread.currentThread().getContextClassLoader();
+            if (loader == null){
+                // Nope... this is going to end poorly
+                return _failGetClassMethods(cls, ex);
+            }
+            final Class<?> contextClass;
+            try {
+                contextClass = loader.loadClass(cls.getName());
+            } catch (ClassNotFoundException e) {
+                ex.addSuppressed(e);
+                return _failGetClassMethods(cls, ex);
+            }
+            try {
+                return contextClass.getDeclaredMethods(); // Cross fingers
+            } catch (Throwable t) {
+                return _failGetClassMethods(cls, t);
+            }
+        } catch (Throwable t) {
+            return _failGetClassMethods(cls, t);
+        }
+    }
+
+    // @since 2.11.4 (see [databind#2807])
+    private static Method[] _failGetClassMethods(Class<?> cls, Throwable rootCause)
+            throws IllegalArgumentException
+    {
+        throw new IllegalArgumentException(String.format(
+"Failed on call to `getDeclaredMethods()` on class `%s`, problem: (%s) %s",
+cls.getName(), rootCause.getClass().getName(), rootCause.getMessage()),
+                rootCause);
+    }
+
+    /**
+     * @since 2.7
+     */
+    public static Ctor[] getConstructors(Class<?> cls) {
+        // Note: can NOT skip abstract classes as they may be used with mix-ins
+        // and for regular use shouldn't really matter.
+        if (cls.isInterface() || isObjectOrPrimitive(cls)) {
+            return NO_CTORS;
+        }
+        Constructor<?>[] rawCtors = cls.getDeclaredConstructors();
+        final int len = rawCtors.length;
+        Ctor[] result = new Ctor[len];
+        for (int i = 0; i < len; ++i) {
+            result[i] = new Ctor(rawCtors[i]);
+        }
+        return result;
+    }
+
+    // // // Then methods that do NOT cache access but were considered
+    // // // (and could be added to do caching if it was proven effective)
+
+    /**
+     * @since 2.7
+     */
+    public static Class<?> getDeclaringClass(Class<?> cls) {
+        return isObjectOrPrimitive(cls) ? null : cls.getDeclaringClass();
+    }
+
+    /**
+     * @since 2.7
+     */
+    public static Type getGenericSuperclass(Class<?> cls) {
+        return cls.getGenericSuperclass();
+    }
+
+    /**
+     * @since 2.7
+     */
+    public static Type[] getGenericInterfaces(Class<?> cls) {
+        return cls.getGenericInterfaces();
+    }
+
+    /**
+     * @since 2.7
+     */
+    public static Class<?> getEnclosingClass(Class<?> cls) {
+        // Caching does not seem worthwhile, as per profiling
+        return isObjectOrPrimitive(cls) ? null : cls.getEnclosingClass();
+    }
+
+    private static Class<?>[] _interfaces(Class<?> cls) {
+        return cls.getInterfaces();
+    }
+
+    /*
+    /**********************************************************
+    /* Helper classes
+    /**********************************************************
+     */
+
+    /**
+     * Inner class used to contain gory details of how we can determine
+     * details of instances of common JDK types like {@link EnumMap}s.
+     */
+    private static class EnumTypeLocator
+    {
+        final static EnumTypeLocator instance = new EnumTypeLocator();
+
+        private final Field enumSetTypeField;
+        private final Field enumMapTypeField;
+
+        private final String failForEnumSet;
+        private final String failForEnumMap;
+
+        private EnumTypeLocator() {
+            //JDK uses following fields to store information about actual Enumeration
+            // type for EnumSets, EnumMaps...
+
+            Field f = null;
+            String msg = null;
+
+            try {
+                f = locateField(EnumSet.class, "elementType", Class.class);
+            } catch (Exception e) {
+                msg = e.toString();
+            }
+            enumSetTypeField = f;
+            failForEnumSet = msg;
+
+            f = null;
+            msg = null;
+            try {
+                f = locateField(EnumMap.class, "keyType", Class.class);
+            } catch (Exception e) {
+                msg  = e.toString();
+            }
+            enumMapTypeField = f;
+            failForEnumMap = msg;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<? extends Enum<?>> enumTypeFor(EnumSet<?> set)
+        {
+            if (enumSetTypeField != null) {
+                return (Class<? extends Enum<?>>) get(set, enumSetTypeField);
+            }
+            throw new IllegalStateException(
+"Cannot figure out type parameter for `EnumSet` (odd JDK platform?), problem: "+failForEnumSet);
+        }
+
+        @SuppressWarnings("unchecked")
+        public Class<? extends Enum<?>> enumTypeFor(EnumMap<?,?> set)
+        {
+            if (enumMapTypeField != null) {
+                return (Class<? extends Enum<?>>) get(set, enumMapTypeField);
+            }
+            throw new IllegalStateException(
+"Cannot figure out type parameter for `EnumMap` (odd JDK platform?), problem: "+failForEnumMap);
+        }
+
+        private Object get(Object bean, Field field)
+        {
+            try {
+                return field.get(bean);
+            } catch (Exception e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+
+        private static Field locateField(Class<?> fromClass, String expectedName, Class<?> type)
+            throws Exception
+        {
+    	        // First: let's see if we can find exact match:
+            Field[] fields = fromClass.getDeclaredFields();
+            for (Field f : fields) {
+                if (!expectedName.equals(f.getName()) || f.getType() != type) {
+                    continue;
+                }
+                f.setAccessible(true);
+                return f;
+            }
+            // If not found, indicate with exception
+            throw new IllegalStateException(String.format(
+"No field named '%s' in class '%s'", expectedName, fromClass.getName()));
+        }
+    }
+
+    /*
+    /**********************************************************
+    /* Helper classed used for caching
+    /**********************************************************
+     */
+
+    /**
+     * Value class used for caching Constructor declarations; used because
+     * caching done by JDK appears to be somewhat inefficient for some use cases.
+     *
+     * @since 2.7
+     */
+    public final static class Ctor
+    {
+        public final Constructor<?> _ctor;
+
+        private transient Annotation[] _annotations;
+
+        private transient Annotation[][] _paramAnnotations;
+
+        private int _paramCount = -1;
+
+        public Ctor(Constructor<?> ctor) {
+            _ctor = ctor;
+        }
+
+        public Constructor<?> getConstructor() {
+            return _ctor;
+        }
+
+        public int getParamCount() {
+            int c = _paramCount;
+            if (c < 0) {
+                c = _ctor.getParameterCount();
+                _paramCount = c;
+            }
+            return c;
+        }
+
+        public Class<?> getDeclaringClass() {
+            return _ctor.getDeclaringClass();
+        }
+
+        public Annotation[] getDeclaredAnnotations() {
+            Annotation[] result = _annotations;
+            if (result == null) {
+                result = _ctor.getDeclaredAnnotations();
+                _annotations = result;
+            }
+            return result;
+        }
+
+        public  Annotation[][] getParameterAnnotations() {
+            Annotation[][] result = _paramAnnotations;
+            if (result == null) {
+                result = _ctor.getParameterAnnotations();
+                _paramAnnotations = result;
+            }
+            return result;
+        }
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/LRUMap.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/LRUMap.java
@@ -1,0 +1,87 @@
+package org.apache.ibatis.reflection.type.jackson.databind.util;
+
+import org.apache.ibatis.reflection.type.jackson.databind.util.internal.PrivateMaxEntriesMap;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+/**
+ * Helper for simple bounded maps used for reusing lookup values.
+ *<p>
+ * Note that serialization behavior is such that contents are NOT serialized,
+ * on assumption that all use cases are for caching where persistence
+ * does not make sense. The only thing serialized is the cache size of Map.
+ *<p>
+ * NOTE: since Jackson 2.14, the implementation evicts the least recently used
+ * entry when max size is reached.
+ *<p>
+ * Since Jackson 2.12, there has been pluggable {@link LookupCache} interface which
+ * allows users, frameworks, provide their own cache implementations.
+ */
+public class LRUMap<K,V>
+    implements LookupCache<K,V>, // since 2.12
+        java.io.Serializable
+{
+    private static final long serialVersionUID = 2L;
+
+    protected final int _initialEntries;
+    protected final int _maxEntries;
+    protected final transient PrivateMaxEntriesMap<K,V> _map;
+
+    public LRUMap(int initialEntries, int maxEntries)
+    {
+        _initialEntries = initialEntries;
+        _maxEntries = maxEntries;
+        // We'll use concurrency level of 4, seems reasonable
+        _map = new PrivateMaxEntriesMap.Builder<K, V>()
+                .initialCapacity(initialEntries)
+                .maximumCapacity(maxEntries)
+                .concurrencyLevel(4)
+                .build();
+    }
+
+    @Override
+    public V put(K key, V value) {
+        return _map.put(key, value);
+    }
+
+    /**
+     * @since 2.5
+     */
+    @Override
+    public V putIfAbsent(K key, V value) {
+        return _map.putIfAbsent(key, value);
+    }
+
+    // NOTE: key is of type Object only to retain binary backwards-compatibility
+    @Override
+    public V get(Object key) { return _map.get(key); }
+
+    @Override
+    public void clear() { _map.clear(); }
+
+    @Override
+    public int size() { return _map.size(); }
+
+    /*
+    /**********************************************************************
+    /* Extended API (2.14)
+    /**********************************************************************
+     */
+
+    public void contents(BiConsumer<K,V> consumer) {
+        for (Map.Entry<K,V> entry : _map.entrySet()) {
+            consumer.accept(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /*
+    /**********************************************************************
+    /* Serializable overrides
+    /**********************************************************************
+     */
+
+    protected Object readResolve() {
+        return new LRUMap<K,V>(_initialEntries, _maxEntries);
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/LookupCache.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/LookupCache.java
@@ -1,0 +1,36 @@
+package org.apache.ibatis.reflection.type.jackson.databind.util;
+
+/**
+ * An interface describing the required API for the Jackson-databind Type cache.
+ *<p>
+ * Note that while interface itself does not specify synchronization requirements for
+ * implementations, specific use cases do. Typically implementations are
+ * expected to be thread-safe, that is, to handle synchronization.
+ *
+ * @since 2.12 (for forwards-compatiblity with 3.0)
+ */
+public interface LookupCache <K,V>
+{
+    /**
+     * @return Number of entries currently in cache: may be approximate, only
+     *    to be used for diagnostics, metrics reporting
+     */
+    int size();
+
+    /**
+     * NOTE: key is of type Object only to retain binary backwards-compatibility
+     *
+     * @param key
+     * @return value associated with key (can return null)
+     */
+    V get(Object key);
+
+    V put(K key, V value);
+
+    V putIfAbsent(K key, V value);
+
+    /**
+     * Method for removing all contents this cache has.
+     */
+    void clear();
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/PrimitiveArrayBuilder.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/PrimitiveArrayBuilder.java
@@ -1,0 +1,182 @@
+package org.apache.ibatis.reflection.type.jackson.databind.util;
+
+/**
+ * Base class for specialized primitive array builders.
+ */
+public abstract class PrimitiveArrayBuilder<T>
+{
+    /**
+     * Let's start with small chunks; typical usage is for small arrays anyway.
+     */
+    final static int INITIAL_CHUNK_SIZE = 12;
+
+    /**
+     * Also: let's expand by doubling up until 64k chunks (which is 16k entries for
+     * 32-bit machines)
+     */
+    final static int SMALL_CHUNK_SIZE = (1 << 14);
+
+    /**
+     * Let's limit maximum size of chunks we use; helps avoid excessive allocation
+     * overhead for huge data sets.
+     * For now, let's limit to quarter million entries, 1 meg chunks for 32-bit
+     * machines.
+     */
+    final static int MAX_CHUNK_SIZE = (1 << 18);
+
+    // // // Data storage
+
+    protected T _freeBuffer;
+
+    protected Node<T> _bufferHead;
+
+    protected Node<T> _bufferTail;
+
+    /**
+     * Number of total buffered entries in this buffer, counting all instances
+     * within linked list formed by following {@link #_bufferHead}.
+     */
+    protected int _bufferedEntryCount;
+
+    // // // Recycled instances of sub-classes
+
+    // // // Life-cycle
+
+    protected PrimitiveArrayBuilder() { }
+
+    /*
+    /**********************************************************
+    /* Public API
+    /**********************************************************
+     */
+
+    public int bufferedSize() { return _bufferedEntryCount; }
+
+    public T resetAndStart()
+    {
+        _reset();
+        return (_freeBuffer == null) ?
+            _constructArray(INITIAL_CHUNK_SIZE) : _freeBuffer;
+    }
+
+    /**
+     * @return Length of the next chunk to allocate
+     */
+    public final T appendCompletedChunk(T fullChunk, int fullChunkLength)
+    {
+        Node<T> next = new Node<T>(fullChunk, fullChunkLength);
+        if (_bufferHead == null) { // first chunk
+            _bufferHead = _bufferTail = next;
+        } else { // have something already
+            _bufferTail.linkNext(next);
+            _bufferTail = next;
+        }
+        _bufferedEntryCount += fullChunkLength;
+        int nextLen = fullChunkLength; // start with last chunk size
+        // double the size for small chunks
+        if (nextLen < SMALL_CHUNK_SIZE) {
+            nextLen += nextLen;
+        } else { // but by +25% for larger (to limit overhead)
+            nextLen += (nextLen >> 2);
+        }
+        return _constructArray(nextLen);
+    }
+
+    public T completeAndClearBuffer(T lastChunk, int lastChunkEntries)
+    {
+        int totalSize = lastChunkEntries + _bufferedEntryCount;
+        T resultArray = _constructArray(totalSize);
+
+        int ptr = 0;
+
+        for (Node<T> n = _bufferHead; n != null; n = n.next()) {
+            ptr = n.copyData(resultArray, ptr);
+        }
+        System.arraycopy(lastChunk, 0, resultArray, ptr, lastChunkEntries);
+        ptr += lastChunkEntries;
+
+        // sanity check (could have failed earlier due to out-of-bounds, too)
+        if (ptr != totalSize) {
+            throw new IllegalStateException("Should have gotten "+totalSize+" entries, got "+ptr);
+        }
+        return resultArray;
+    }
+
+    /*
+    /**********************************************************
+    /* Abstract methods for sub-classes to implement
+    /**********************************************************
+     */
+
+    protected abstract T _constructArray(int len);
+
+    /*
+    /**********************************************************
+    /* Internal methods
+    /**********************************************************
+     */
+
+    protected void _reset()
+    {
+        // can we reuse the last (and thereby biggest) array for next time?
+        if (_bufferTail != null) {
+            _freeBuffer = _bufferTail.getData();
+        }
+        // either way, must discard current contents
+        _bufferHead = _bufferTail = null;
+        _bufferedEntryCount = 0;
+    }
+
+    /*
+    /**********************************************************
+    /* Helper classes
+    /**********************************************************
+     */
+
+    /**
+     * For actual buffering beyond the current buffer, we can actually
+     * use shared class which only deals with opaque "untyped" chunks.
+     * This works because {@link System#arraycopy} does not
+     * take type; hence we can implement some aspects of primitive data
+     * handling in generic fashion.
+     */
+    final static class Node<T>
+    {
+        /**
+         * Data stored in this node.
+         */
+        final T _data;
+
+        /**
+         * Number entries in the (untyped) array. Offset is assumed to be 0.
+         */
+        final int _dataLength;
+
+        Node<T> _next;
+
+        public Node(T data, int dataLen)
+        {
+            _data = data;
+            _dataLength = dataLen;
+        }
+
+        public T getData() { return _data; }
+
+        public int copyData(T dst, int ptr)
+        {
+            System.arraycopy(_data, 0, dst, ptr, _dataLength);
+            ptr += _dataLength;
+            return ptr;
+        }
+
+        public Node<T> next() { return _next; }
+
+        public void linkNext(Node<T> next)
+        {
+            if (_next != null) { // sanity check
+                throw new IllegalStateException();
+            }
+            _next = next;
+        }
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/internal/LinkedDeque.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/internal/LinkedDeque.java
@@ -1,0 +1,456 @@
+/*
+ * Copyright 2011 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.reflection.type.jackson.databind.util.internal;
+
+import java.util.*;
+
+/**
+ * Linked list implementation of the {@link Deque} interface where the link
+ * pointers are tightly integrated with the element. Linked deques have no
+ * capacity restrictions; they grow as necessary to support usage. They are not
+ * thread-safe; in the absence of external synchronization, they do not support
+ * concurrent access by multiple threads. Null elements are prohibited.
+ * <p>
+ * Most <tt>LinkedDeque</tt> operations run in constant time by assuming that
+ * the {@code Linked} parameter is associated with the deque instance. Any usage
+ * that violates this assumption will result in non-deterministic behavior.
+ * <p>
+ * The iterators returned by this class are <em>not</em> <i>fail-fast</i>: If
+ * the deque is modified at any time after the iterator is created, the iterator
+ * will be in an unknown state. Thus, in the face of concurrent modification,
+ * the iterator risks arbitrary, non-deterministic behavior at an undetermined
+ * time in the future.
+ *
+ * @author ben.manes@gmail.com (Ben Manes)
+ * @param <E> the type of elements held in this collection
+ * @see <a href="http://code.google.com/p/concurrentlinkedhashmap/">
+ *      http://code.google.com/p/concurrentlinkedhashmap/</a>
+ */
+final class LinkedDeque<E extends Linked<E>> extends AbstractCollection<E> implements Deque<E> {
+
+    // This class provides a doubly-linked list that is optimized for the virtual
+    // machine. The first and last elements are manipulated instead of a slightly
+    // more convenient sentinel element to avoid the insertion of null checks with
+    // NullPointerException throws in the byte code. The links to a removed
+    // element are cleared to help a generational garbage collector if the
+    // discarded elements inhabit more than one generation.
+
+    /**
+     * Pointer to first node.
+     * Invariant: (first == null && last == null) ||
+     *            (first.prev == null)
+     */
+    E first;
+
+    /**
+     * Pointer to last node.
+     * Invariant: (first == null && last == null) ||
+     *            (last.next == null)
+     */
+    E last;
+
+    /**
+     * Links the element to the front of the deque so that it becomes the first
+     * element.
+     *
+     * @param e the unlinked element
+     */
+    void linkFirst(final E e) {
+        final E f = first;
+        first = e;
+
+        if (f == null) {
+            last = e;
+        } else {
+            f.setPrevious(e);
+            e.setNext(f);
+        }
+    }
+
+    /**
+     * Links the element to the back of the deque so that it becomes the last
+     * element.
+     *
+     * @param e the unlinked element
+     */
+    void linkLast(final E e) {
+        final E l = last;
+        last = e;
+
+        if (l == null) {
+            first = e;
+        } else {
+            l.setNext(e);
+            e.setPrevious(l);
+        }
+    }
+
+    /** Unlinks the non-null first element. */
+    E unlinkFirst() {
+        final E f = first;
+        final E next = f.getNext();
+        f.setNext(null);
+
+        first = next;
+        if (next == null) {
+            last = null;
+        } else {
+            next.setPrevious(null);
+        }
+        return f;
+    }
+
+    /** Unlinks the non-null last element. */
+    E unlinkLast() {
+        final E l = last;
+        final E prev = l.getPrevious();
+        l.setPrevious(null);
+        last = prev;
+        if (prev == null) {
+            first = null;
+        } else {
+            prev.setNext(null);
+        }
+        return l;
+    }
+
+    /** Unlinks the non-null element. */
+    void unlink(E e) {
+        final E prev = e.getPrevious();
+        final E next = e.getNext();
+
+        if (prev == null) {
+            first = next;
+        } else {
+            prev.setNext(next);
+            e.setPrevious(null);
+        }
+
+        if (next == null) {
+            last = prev;
+        } else {
+            next.setPrevious(prev);
+            e.setNext(null);
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return (first == null);
+    }
+
+    void checkNotEmpty() {
+        if (isEmpty()) {
+            throw new NoSuchElementException();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Beware that, unlike in most collections, this method is <em>NOT</em> a
+     * constant-time operation.
+     */
+    @Override
+    public int size() {
+        int size = 0;
+        for (E e = first; e != null; e = e.getNext()) {
+            size++;
+        }
+        return size;
+    }
+
+    @Override
+    public void clear() {
+        for (E e = first; e != null;) {
+            E next = e.getNext();
+            e.setPrevious(null);
+            e.setNext(null);
+            e = next;
+        }
+        first = last = null;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return (o instanceof Linked<?>) && contains((Linked<?>) o);
+    }
+
+    // A fast-path containment check
+    boolean contains(Linked<?> e) {
+        return (e.getPrevious() != null)
+                || (e.getNext() != null)
+                || (e == first);
+    }
+
+    /**
+     * Moves the element to the front of the deque so that it becomes the first
+     * element.
+     *
+     * @param e the linked element
+     */
+    public void moveToFront(E e) {
+        if (e != first) {
+            unlink(e);
+            linkFirst(e);
+        }
+    }
+
+    /**
+     * Moves the element to the back of the deque so that it becomes the last
+     * element.
+     *
+     * @param e the linked element
+     */
+    public void moveToBack(E e) {
+        if (e != last) {
+            unlink(e);
+            linkLast(e);
+        }
+    }
+
+    @Override
+    public E peek() {
+        return peekFirst();
+    }
+
+    @Override
+    public E peekFirst() {
+        return first;
+    }
+
+    @Override
+    public E peekLast() {
+        return last;
+    }
+
+    @Override
+    public E getFirst() {
+        checkNotEmpty();
+        return peekFirst();
+    }
+
+    @Override
+    public E getLast() {
+        checkNotEmpty();
+        return peekLast();
+    }
+
+    @Override
+    public E element() {
+        return getFirst();
+    }
+
+    @Override
+    public boolean offer(E e) {
+        return offerLast(e);
+    }
+
+    @Override
+    public boolean offerFirst(E e) {
+        if (contains(e)) {
+            return false;
+        }
+        linkFirst(e);
+        return true;
+    }
+
+    @Override
+    public boolean offerLast(E e) {
+        if (contains(e)) {
+            return false;
+        }
+        linkLast(e);
+        return true;
+    }
+
+    @Override
+    public boolean add(E e) {
+        return offerLast(e);
+    }
+
+
+    @Override
+    public void addFirst(E e) {
+        if (!offerFirst(e)) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public void addLast(E e) {
+        if (!offerLast(e)) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public E poll() {
+        return pollFirst();
+    }
+
+    @Override
+    public E pollFirst() {
+        return isEmpty() ? null : unlinkFirst();
+    }
+
+    @Override
+    public E pollLast() {
+        return isEmpty() ? null : unlinkLast();
+    }
+
+    @Override
+    public E remove() {
+        return removeFirst();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public boolean remove(Object o) {
+        return (o instanceof Linked<?>) && remove((E) o);
+    }
+
+    // A fast-path removal
+    boolean remove(E e) {
+        if (contains(e)) {
+            unlink(e);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public E removeFirst() {
+        checkNotEmpty();
+        return pollFirst();
+    }
+
+    @Override
+    public boolean removeFirstOccurrence(Object o) {
+        return remove(o);
+    }
+
+    @Override
+    public E removeLast() {
+        checkNotEmpty();
+        return pollLast();
+    }
+
+    @Override
+    public boolean removeLastOccurrence(Object o) {
+        return remove(o);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        boolean modified = false;
+        for (Object o : c) {
+            modified |= remove(o);
+        }
+        return modified;
+    }
+
+    @Override
+    public void push(E e) {
+        addFirst(e);
+    }
+
+    @Override
+    public E pop() {
+        return removeFirst();
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return new AbstractLinkedIterator(first) {
+            @Override E computeNext() {
+                return cursor.getNext();
+            }
+        };
+    }
+
+    @Override
+    public Iterator<E> descendingIterator() {
+        return new AbstractLinkedIterator(last) {
+            @Override E computeNext() {
+                return cursor.getPrevious();
+            }
+        };
+    }
+
+    abstract class AbstractLinkedIterator implements Iterator<E> {
+        E cursor;
+
+        /**
+         * Creates an iterator that can can traverse the deque.
+         *
+         * @param start the initial element to begin traversal from
+         */
+        AbstractLinkedIterator(E start) {
+            cursor = start;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return (cursor != null);
+        }
+
+        @Override
+        public E next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            E e = cursor;
+            cursor = computeNext();
+            return e;
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * Retrieves the next element to traverse to or <tt>null</tt> if there are
+         * no more elements.
+         */
+        abstract E computeNext();
+    }
+}
+
+/**
+ * An element that is linked on the {@link Deque}.
+ */
+interface Linked<T extends Linked<T>> {
+
+    /**
+     * Retrieves the previous element or <tt>null</tt> if either the element is
+     * unlinked or the first element on the deque.
+     */
+    T getPrevious();
+
+    /** Sets the previous element or <tt>null</tt> if there is no link. */
+    void setPrevious(T prev);
+
+    /**
+     * Retrieves the next element or <tt>null</tt> if either the element is
+     * unlinked or the last element on the deque.
+     */
+    T getNext();
+
+    /** Sets the next element or <tt>null</tt> if there is no link. */
+    void setNext(T next);
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/internal/PrivateMaxEntriesMap.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/internal/PrivateMaxEntriesMap.java
@@ -1,0 +1,1213 @@
+/*
+ * Copyright 2010 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ibatis.reflection.type.jackson.databind.util.internal;
+
+import java.io.InvalidObjectException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A hash table supporting full concurrency of retrievals, adjustable expected
+ * concurrency for updates, and a maximum capacity to bound the map by. This
+ * implementation differs from {@link ConcurrentHashMap} in that it maintains a
+ * page replacement algorithm that is used to evict an entry when the map has
+ * exceeded its capacity. Unlike the <tt>Java Collections Framework</tt>, this
+ * map does not have a publicly visible constructor and instances are created
+ * through a {@link Builder}.
+ * <p>
+ * An entry is evicted from the map when the entry size exceeds
+ * its <tt>maximum capacity</tt> threshold.
+ * <p>
+ * An {@code EvictionListener} may be supplied for notification when an entry
+ * is evicted from the map. This listener is invoked on a caller's thread and
+ * will not block other threads from operating on the map. An implementation
+ * should be aware that the caller's thread will not expect long execution
+ * times or failures as a side effect of the listener being notified. Execution
+ * safety and a fast turn around time can be achieved by performing the
+ * operation asynchronously, such as by submitting a task to an
+ * {@link java.util.concurrent.ExecutorService}.
+ * <p>
+ * The <tt>concurrency level</tt> determines the number of threads that can
+ * concurrently modify the table. Using a significantly higher or lower value
+ * than needed can waste space or lead to thread contention, but an estimate
+ * within an order of magnitude of the ideal value does not usually have a
+ * noticeable impact. Because placement in hash tables is essentially random,
+ * the actual concurrency will vary.
+ * <p>
+ * This class and its views and iterators implement all of the
+ * <em>optional</em> methods of the {@link Map} and {@link Iterator}
+ * interfaces.
+ * <p>
+ * Like {@link java.util.Hashtable} but unlike {@link HashMap}, this class
+ * does <em>not</em> allow <tt>null</tt> to be used as a key or value. Unlike
+ * {@link java.util.LinkedHashMap}, this class does <em>not</em> provide
+ * predictable iteration order. A snapshot of the keys and entries may be
+ * obtained in ascending and descending order of retention.
+ *
+ * @author ben.manes@gmail.com (Ben Manes)
+ * @param <K> the type of keys maintained by this map
+ * @param <V> the type of mapped values
+ * @see <a href="http://code.google.com/p/concurrentlinkedhashmap/">
+ *      http://code.google.com/p/concurrentlinkedhashmap/</a>
+ */
+//@ThreadSafe
+public final class PrivateMaxEntriesMap<K, V> extends AbstractMap<K, V>
+        implements ConcurrentMap<K, V>, Serializable {
+
+    /*
+     * This class performs a best-effort bounding of a ConcurrentHashMap using a
+     * page-replacement algorithm to determine which entries to evict when the
+     * capacity is exceeded.
+     *
+     * The page replacement algorithm's data structures are kept eventually
+     * consistent with the map. An update to the map and recording of reads may
+     * not be immediately reflected on the algorithm's data structures. These
+     * structures are guarded by a lock and operations are applied in batches to
+     * avoid lock contention. The penalty of applying the batches is spread across
+     * threads so that the amortized cost is slightly higher than performing just
+     * the ConcurrentHashMap operation.
+     *
+     * A memento of the reads and writes that were performed on the map are
+     * recorded in buffers. These buffers are drained at the first opportunity
+     * after a write or when the read buffer exceeds a threshold size. The reads
+     * are recorded in a lossy buffer, allowing the reordering operations to be
+     * discarded if the draining process cannot keep up. Due to the concurrent
+     * nature of the read and write operations a strict policy ordering is not
+     * possible, but is observably strict when single threaded.
+     *
+     * Due to a lack of a strict ordering guarantee, a task can be executed
+     * out-of-order, such as a removal followed by its addition. The state of the
+     * entry is encoded within the value's weight.
+     *
+     * Alive: The entry is in both the hash-table and the page replacement policy.
+     * This is represented by a positive weight.
+     *
+     * Retired: The entry is not in the hash-table and is pending removal from the
+     * page replacement policy. This is represented by a negative weight.
+     *
+     * Dead: The entry is not in the hash-table and is not in the page replacement
+     * policy. This is represented by a weight of zero.
+     *
+     * The Least Recently Used page replacement algorithm was chosen due to its
+     * simplicity, high hit rate, and ability to be implemented with O(1) time
+     * complexity.
+     */
+
+    /** The number of CPUs */
+    static final int NCPU = Runtime.getRuntime().availableProcessors();
+
+    /** The maximum capacity of the map. */
+    static final long MAXIMUM_CAPACITY = Long.MAX_VALUE - Integer.MAX_VALUE;
+
+    /**
+     * The number of read buffers to use.
+     * The max of 4 was introduced due to https://github.com/FasterXML/jackson-databind/issues/3665.
+     */
+    static final int NUMBER_OF_READ_BUFFERS = Math.min(4, ceilingNextPowerOfTwo(NCPU));
+
+    /** Mask value for indexing into the read buffers. */
+    static final int READ_BUFFERS_MASK = NUMBER_OF_READ_BUFFERS - 1;
+
+    /**
+     * The number of pending read operations before attempting to drain.
+     * The threshold of 4 was introduced due to https://github.com/FasterXML/jackson-databind/issues/3665.
+     */
+    static final int READ_BUFFER_THRESHOLD = 4;
+
+    /** The maximum number of read operations to perform per amortized drain. */
+    static final int READ_BUFFER_DRAIN_THRESHOLD = 2 * READ_BUFFER_THRESHOLD;
+
+    /** The maximum number of pending reads per buffer. */
+    static final int READ_BUFFER_SIZE = 2 * READ_BUFFER_DRAIN_THRESHOLD;
+
+    /** Mask value for indexing into the read buffer. */
+    static final int READ_BUFFER_INDEX_MASK = READ_BUFFER_SIZE - 1;
+
+    /** The maximum number of write operations to perform per amortized drain. */
+    static final int WRITE_BUFFER_DRAIN_THRESHOLD = 16;
+
+    static int ceilingNextPowerOfTwo(int x) {
+        // From Hacker's Delight, Chapter 3, Harry S. Warren Jr.
+        return 1 << (Integer.SIZE - Integer.numberOfLeadingZeros(x - 1));
+    }
+
+    // The backing data store holding the key-value associations
+    final ConcurrentMap<K, Node<K, V>> data;
+    final int concurrencyLevel;
+
+    // These fields provide support to bound the map by a maximum capacity
+    //@GuardedBy("evictionLock")
+    final long[] readBufferReadCount;
+    //@GuardedBy("evictionLock")
+    final LinkedDeque<Node<K, V>> evictionDeque;
+
+    //@GuardedBy("evictionLock") // must write under lock
+    final AtomicLong weightedSize;
+    //@GuardedBy("evictionLock") // must write under lock
+    final AtomicLong capacity;
+
+    final Lock evictionLock;
+    final Queue<Runnable> writeBuffer;
+    final AtomicLongArray readBufferWriteCount;
+    final AtomicLongArray readBufferDrainAtWriteCount;
+    final AtomicReferenceArray<Node<K, V>> readBuffers;
+
+    final AtomicReference<DrainStatus> drainStatus;
+
+    transient Set<K> keySet;
+    transient Collection<V> values;
+    transient Set<Entry<K, V>> entrySet;
+
+    private static int readBufferIndex(int bufferIndex, int entryIndex) {
+        return READ_BUFFER_SIZE * bufferIndex + entryIndex;
+    }
+
+    /**
+     * Creates an instance based on the builder's configuration.
+     */
+    @SuppressWarnings({"unchecked", "cast"})
+    PrivateMaxEntriesMap(Builder<K, V> builder) {
+        // The data store and its maximum capacity
+        concurrencyLevel = builder.concurrencyLevel;
+        capacity = new AtomicLong(Math.min(builder.capacity, MAXIMUM_CAPACITY));
+        data = new ConcurrentHashMap<K, Node<K, V>>(builder.initialCapacity, 0.75f, concurrencyLevel);
+
+        // The eviction support
+        evictionLock = new ReentrantLock();
+        weightedSize = new AtomicLong();
+        evictionDeque = new LinkedDeque<Node<K, V>>();
+        writeBuffer = new ConcurrentLinkedQueue<Runnable>();
+        drainStatus = new AtomicReference<DrainStatus>(DrainStatus.IDLE);
+
+        readBufferReadCount = new long[NUMBER_OF_READ_BUFFERS];
+        readBufferWriteCount = new AtomicLongArray(NUMBER_OF_READ_BUFFERS);
+        readBufferDrainAtWriteCount = new AtomicLongArray(NUMBER_OF_READ_BUFFERS);
+        readBuffers = new AtomicReferenceArray<>(NUMBER_OF_READ_BUFFERS * READ_BUFFER_SIZE);
+    }
+
+    /** Ensures that the object is not null. */
+    static void checkNotNull(Object o) {
+        if (o == null) {
+            throw new NullPointerException();
+        }
+    }
+
+    /** Ensures that the argument expression is true. */
+    static void checkArgument(boolean expression) {
+        if (!expression) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    /** Ensures that the state expression is true. */
+    static void checkState(boolean expression) {
+        if (!expression) {
+            throw new IllegalStateException();
+        }
+    }
+
+    /* ---------------- Eviction Support -------------- */
+
+    /**
+     * Retrieves the maximum capacity of the map.
+     *
+     * @return the maximum capacity
+     */
+    public long capacity() {
+        return capacity.get();
+    }
+
+    /**
+     * Sets the maximum capacity of the map and eagerly evicts entries
+     * until it shrinks to the appropriate size.
+     *
+     * @param capacity the maximum capacity of the map
+     * @throws IllegalArgumentException if the capacity is negative
+     */
+    public void setCapacity(long capacity) {
+        checkArgument(capacity >= 0);
+        evictionLock.lock();
+        try {
+            this.capacity.lazySet(Math.min(capacity, MAXIMUM_CAPACITY));
+            drainBuffers();
+            evict();
+        } finally {
+            evictionLock.unlock();
+        }
+    }
+
+    /** Determines whether the map has exceeded its capacity. */
+    //@GuardedBy("evictionLock")
+    boolean hasOverflowed() {
+        return weightedSize.get() > capacity.get();
+    }
+
+    /**
+     * Evicts entries from the map while it exceeds the capacity and appends
+     * evicted entries to the notification queue for processing.
+     */
+    //@GuardedBy("evictionLock")
+    void evict() {
+        // Attempts to evict entries from the map if it exceeds the maximum
+        // capacity. If the eviction fails due to a concurrent removal of the
+        // victim, that removal may cancel out the addition that triggered this
+        // eviction. The victim is eagerly unlinked before the removal task so
+        // that if an eviction is still required then a new victim will be chosen
+        // for removal.
+        while (hasOverflowed()) {
+            final Node<K, V> node = evictionDeque.poll();
+
+            // If weighted values are used, then the pending operations will adjust
+            // the size to reflect the correct weight
+            if (node == null) {
+                return;
+            }
+
+            data.remove(node.key, node);
+
+            makeDead(node);
+        }
+    }
+
+    /**
+     * Performs the post-processing work required after a read.
+     *
+     * @param node the entry in the page replacement policy
+     */
+    void afterRead(Node<K, V> node) {
+        final int bufferIndex = readBufferIndex();
+        final long writeCount = recordRead(bufferIndex, node);
+        drainOnReadIfNeeded(bufferIndex, writeCount);
+    }
+
+    /** Returns the index to the read buffer to record into. */
+    static int readBufferIndex() {
+        // A buffer is chosen by the thread's id so that tasks are distributed in a
+        // pseudo evenly manner. This helps avoid hot entries causing contention
+        // due to other threads trying to append to the same buffer.
+        return ((int) Thread.currentThread().getId()) & READ_BUFFERS_MASK;
+    }
+
+    /**
+     * Records a read in the buffer and return its write count.
+     *
+     * @param bufferIndex the index to the chosen read buffer
+     * @param node the entry in the page replacement policy
+     * @return the number of writes on the chosen read buffer
+     */
+    long recordRead(int bufferIndex, Node<K, V> node) {
+        // The location in the buffer is chosen in a racy fashion as the increment
+        // is not atomic with the insertion. This means that concurrent reads can
+        // overlap and overwrite one another, resulting in a lossy buffer.
+        final long writeCount = readBufferWriteCount.get(bufferIndex);
+        readBufferWriteCount.lazySet(bufferIndex, writeCount + 1);
+
+        final int index = (int) (writeCount & READ_BUFFER_INDEX_MASK);
+        readBuffers.lazySet(readBufferIndex(bufferIndex, index), node);
+
+        return writeCount;
+    }
+
+    /**
+     * Attempts to drain the buffers if it is determined to be needed when
+     * post-processing a read.
+     *
+     * @param bufferIndex the index to the chosen read buffer
+     * @param writeCount the number of writes on the chosen read buffer
+     */
+    void drainOnReadIfNeeded(int bufferIndex, long writeCount) {
+        final long pending = (writeCount - readBufferDrainAtWriteCount.get(bufferIndex));
+        final boolean delayable = (pending < READ_BUFFER_THRESHOLD);
+        final DrainStatus status = drainStatus.get();
+        if (status.shouldDrainBuffers(delayable)) {
+            tryToDrainBuffers();
+        }
+    }
+
+    /**
+     * Performs the post-processing work required after a write.
+     *
+     * @param task the pending operation to be applied
+     */
+    void afterWrite(Runnable task) {
+        writeBuffer.add(task);
+        drainStatus.lazySet(DrainStatus.REQUIRED);
+        tryToDrainBuffers();
+    }
+
+    /**
+     * Attempts to acquire the eviction lock and apply the pending operations, up
+     * to the amortized threshold, to the page replacement policy.
+     */
+    void tryToDrainBuffers() {
+        if (evictionLock.tryLock()) {
+            try {
+                drainStatus.lazySet(DrainStatus.PROCESSING);
+                drainBuffers();
+            } finally {
+                drainStatus.compareAndSet(DrainStatus.PROCESSING, DrainStatus.IDLE);
+                evictionLock.unlock();
+            }
+        }
+    }
+
+    /** Drains the read and write buffers up to an amortized threshold. */
+    //@GuardedBy("evictionLock")
+    void drainBuffers() {
+        drainReadBuffers();
+        drainWriteBuffer();
+    }
+
+    /** Drains the read buffers, each up to an amortized threshold. */
+    //@GuardedBy("evictionLock")
+    void drainReadBuffers() {
+        final int start = (int) Thread.currentThread().getId();
+        final int end = start + NUMBER_OF_READ_BUFFERS;
+        for (int i = start; i < end; i++) {
+            drainReadBuffer(i & READ_BUFFERS_MASK);
+        }
+    }
+
+    /** Drains the read buffer up to an amortized threshold. */
+    //@GuardedBy("evictionLock")
+    void drainReadBuffer(int bufferIndex) {
+        final long writeCount = readBufferWriteCount.get(bufferIndex);
+        for (int i = 0; i < READ_BUFFER_DRAIN_THRESHOLD; i++) {
+            final int index = (int) (readBufferReadCount[bufferIndex] & READ_BUFFER_INDEX_MASK);
+            final int arrayIndex = readBufferIndex(bufferIndex, index);
+            final Node<K, V> node = readBuffers.get(arrayIndex);
+            if (node == null) {
+                break;
+            }
+
+            readBuffers.lazySet(arrayIndex, null);
+            applyRead(node);
+            readBufferReadCount[bufferIndex]++;
+        }
+        readBufferDrainAtWriteCount.lazySet(bufferIndex, writeCount);
+    }
+
+    /** Updates the node's location in the page replacement policy. */
+    //@GuardedBy("evictionLock")
+    void applyRead(Node<K, V> node) {
+        // An entry may be scheduled for reordering despite having been removed.
+        // This can occur when the entry was concurrently read while a writer was
+        // removing it. If the entry is no longer linked then it does not need to
+        // be processed.
+        if (evictionDeque.contains(node)) {
+            evictionDeque.moveToBack(node);
+        }
+    }
+
+    /** Drains the read buffer up to an amortized threshold. */
+    //@GuardedBy("evictionLock")
+    void drainWriteBuffer() {
+        for (int i = 0; i < WRITE_BUFFER_DRAIN_THRESHOLD; i++) {
+            final Runnable task = writeBuffer.poll();
+            if (task == null) {
+                break;
+            }
+            task.run();
+        }
+    }
+
+    /**
+     * Attempts to transition the node from the <tt>alive</tt> state to the
+     * <tt>retired</tt> state.
+     *
+     * @param node the entry in the page replacement policy
+     * @param expect the expected weighted value
+     * @return if successful
+     */
+    boolean tryToRetire(Node<K, V> node, WeightedValue<V> expect) {
+        if (expect.isAlive()) {
+            final WeightedValue<V> retired = new WeightedValue<V>(expect.value, -expect.weight);
+            return node.compareAndSet(expect, retired);
+        }
+        return false;
+    }
+
+    /**
+     * Atomically transitions the node from the <tt>alive</tt> state to the
+     * <tt>retired</tt> state, if a valid transition.
+     *
+     * @param node the entry in the page replacement policy
+     */
+    void makeRetired(Node<K, V> node) {
+        for (;;) {
+            final WeightedValue<V> current = node.get();
+            if (!current.isAlive()) {
+                return;
+            }
+            final WeightedValue<V> retired = new WeightedValue<V>(current.value, -current.weight);
+            if (node.compareAndSet(current, retired)) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Atomically transitions the node to the <tt>dead</tt> state and decrements
+     * the <tt>weightedSize</tt>.
+     *
+     * @param node the entry in the page replacement policy
+     */
+    //@GuardedBy("evictionLock")
+    void makeDead(Node<K, V> node) {
+        for (;;) {
+            WeightedValue<V> current = node.get();
+            WeightedValue<V> dead = new WeightedValue<V>(current.value, 0);
+            if (node.compareAndSet(current, dead)) {
+                weightedSize.lazySet(weightedSize.get() - Math.abs(current.weight));
+                return;
+            }
+        }
+    }
+
+    /** Adds the node to the page replacement policy. */
+    final class AddTask implements Runnable {
+        final Node<K, V> node;
+        final int weight;
+
+        AddTask(Node<K, V> node, int weight) {
+            this.weight = weight;
+            this.node = node;
+        }
+
+        @Override
+        //@GuardedBy("evictionLock")
+        public void run() {
+            weightedSize.lazySet(weightedSize.get() + weight);
+
+            // ignore out-of-order write operations
+            if (node.get().isAlive()) {
+                evictionDeque.add(node);
+                evict();
+            }
+        }
+    }
+
+    /** Removes a node from the page replacement policy. */
+    final class RemovalTask implements Runnable {
+        final Node<K, V> node;
+
+        RemovalTask(Node<K, V> node) {
+            this.node = node;
+        }
+
+        @Override
+        //@GuardedBy("evictionLock")
+        public void run() {
+            // add may not have been processed yet
+            evictionDeque.remove(node);
+            makeDead(node);
+        }
+    }
+
+    /** Updates the weighted size and evicts an entry on overflow. */
+    final class UpdateTask implements Runnable {
+        final int weightDifference;
+        final Node<K, V> node;
+
+        UpdateTask(Node<K, V> node, int weightDifference) {
+            this.weightDifference = weightDifference;
+            this.node = node;
+        }
+
+        @Override
+        //@GuardedBy("evictionLock")
+        public void run() {
+            weightedSize.lazySet(weightedSize.get() + weightDifference);
+            applyRead(node);
+            evict();
+        }
+    }
+
+    /* ---------------- Concurrent Map Support -------------- */
+
+    @Override
+    public boolean isEmpty() {
+        return data.isEmpty();
+    }
+
+    @Override
+    public int size() {
+        return data.size();
+    }
+
+    @Override
+    public void clear() {
+        evictionLock.lock();
+        try {
+            // Discard all entries
+            Node<K, V> node;
+            while ((node = evictionDeque.poll()) != null) {
+                data.remove(node.key, node);
+                makeDead(node);
+            }
+
+            // Discard all pending reads
+            for (int i = 0; i < readBuffers.length(); i++) {
+                readBuffers.lazySet(i, null);
+            }
+
+            // Apply all pending writes
+            Runnable task;
+            while ((task = writeBuffer.poll()) != null) {
+                task.run();
+            }
+        } finally {
+            evictionLock.unlock();
+        }
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return data.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        checkNotNull(value);
+
+        for (Node<K, V> node : data.values()) {
+            if (node.getValue().equals(value)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public V get(Object key) {
+        final Node<K, V> node = data.get(key);
+        if (node == null) {
+            return null;
+        }
+        afterRead(node);
+        return node.getValue();
+    }
+
+    @Override
+    public V put(K key, V value) {
+        return put(key, value, false);
+    }
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+        return put(key, value, true);
+    }
+
+    /**
+     * Adds a node to the list and the data store. If an existing node is found,
+     * then its value is updated if allowed.
+     *
+     * @param key key with which the specified value is to be associated
+     * @param value value to be associated with the specified key
+     * @param onlyIfAbsent a write is performed only if the key is not already
+     *     associated with a value
+     * @return the prior value in the data store or null if no mapping was found
+     */
+    V put(K key, V value, boolean onlyIfAbsent) {
+        checkNotNull(key);
+        checkNotNull(value);
+
+        final int weight = 1;
+        final WeightedValue<V> weightedValue = new WeightedValue<V>(value, weight);
+        final Node<K, V> node = new Node<K, V>(key, weightedValue);
+
+        for (;;) {
+            final Node<K, V> prior = data.putIfAbsent(node.key, node);
+            if (prior == null) {
+                afterWrite(new AddTask(node, weight));
+                return null;
+            } else if (onlyIfAbsent) {
+                afterRead(prior);
+                return prior.getValue();
+            }
+            for (;;) {
+                final WeightedValue<V> oldWeightedValue = prior.get();
+                if (!oldWeightedValue.isAlive()) {
+                    break;
+                }
+
+                if (prior.compareAndSet(oldWeightedValue, weightedValue)) {
+                    final int weightedDifference = weight - oldWeightedValue.weight;
+                    if (weightedDifference == 0) {
+                        afterRead(prior);
+                    } else {
+                        afterWrite(new UpdateTask(prior, weightedDifference));
+                    }
+                    return oldWeightedValue.value;
+                }
+            }
+        }
+    }
+
+    @Override
+    public V remove(Object key) {
+        final Node<K, V> node = data.remove(key);
+        if (node == null) {
+            return null;
+        }
+
+        makeRetired(node);
+        afterWrite(new RemovalTask(node));
+        return node.getValue();
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        final Node<K, V> node = data.get(key);
+        if ((node == null) || (value == null)) {
+            return false;
+        }
+
+        WeightedValue<V> weightedValue = node.get();
+        for (;;) {
+            if (weightedValue.contains(value)) {
+                if (tryToRetire(node, weightedValue)) {
+                    if (data.remove(key, node)) {
+                        afterWrite(new RemovalTask(node));
+                        return true;
+                    }
+                } else {
+                    weightedValue = node.get();
+                    if (weightedValue.isAlive()) {
+                        // retry as an intermediate update may have replaced the value with
+                        // an equal instance that has a different reference identity
+                        continue;
+                    }
+                }
+            }
+            return false;
+        }
+    }
+
+    @Override
+    public V replace(K key, V value) {
+        checkNotNull(key);
+        checkNotNull(value);
+
+        final int weight = 1;
+        final WeightedValue<V> weightedValue = new WeightedValue<V>(value, weight);
+
+        final Node<K, V> node = data.get(key);
+        if (node == null) {
+            return null;
+        }
+        for (;;) {
+            final WeightedValue<V> oldWeightedValue = node.get();
+            if (!oldWeightedValue.isAlive()) {
+                return null;
+            }
+            if (node.compareAndSet(oldWeightedValue, weightedValue)) {
+                final int weightedDifference = weight - oldWeightedValue.weight;
+                if (weightedDifference == 0) {
+                    afterRead(node);
+                } else {
+                    afterWrite(new UpdateTask(node, weightedDifference));
+                }
+                return oldWeightedValue.value;
+            }
+        }
+    }
+
+    @Override
+    public boolean replace(K key, V oldValue, V newValue) {
+        checkNotNull(key);
+        checkNotNull(oldValue);
+        checkNotNull(newValue);
+
+        final int weight = 1;
+        final WeightedValue<V> newWeightedValue = new WeightedValue<V>(newValue, weight);
+
+        final Node<K, V> node = data.get(key);
+        if (node == null) {
+            return false;
+        }
+        for (;;) {
+            final WeightedValue<V> weightedValue = node.get();
+            if (!weightedValue.isAlive() || !weightedValue.contains(oldValue)) {
+                return false;
+            }
+            if (node.compareAndSet(weightedValue, newWeightedValue)) {
+                final int weightedDifference = weight - weightedValue.weight;
+                if (weightedDifference == 0) {
+                    afterRead(node);
+                } else {
+                    afterWrite(new UpdateTask(node, weightedDifference));
+                }
+                return true;
+            }
+        }
+    }
+
+    @Override
+    public Set<K> keySet() {
+        final Set<K> ks = keySet;
+        return (ks == null) ? (keySet = new KeySet()) : ks;
+    }
+
+    @Override
+    public Collection<V> values() {
+        final Collection<V> vs = values;
+        return (vs == null) ? (values = new Values()) : vs;
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        final Set<Entry<K, V>> es = entrySet;
+        return (es == null) ? (entrySet = new EntrySet()) : es;
+    }
+
+    /** The draining status of the buffers. */
+    enum DrainStatus {
+
+        /** A drain is not taking place. */
+        IDLE {
+            @Override boolean shouldDrainBuffers(boolean delayable) {
+                return !delayable;
+            }
+        },
+
+        /** A drain is required due to a pending write modification. */
+        REQUIRED {
+            @Override boolean shouldDrainBuffers(boolean delayable) {
+                return true;
+            }
+        },
+
+        /** A drain is in progress. */
+        PROCESSING {
+            @Override boolean shouldDrainBuffers(boolean delayable) {
+                return false;
+            }
+        };
+
+        /**
+         * Determines whether the buffers should be drained.
+         *
+         * @param delayable if a drain should be delayed until required
+         * @return if a drain should be attempted
+         */
+        abstract boolean shouldDrainBuffers(boolean delayable);
+    }
+
+    /** A value, its weight, and the entry's status. */
+    //@Immutable
+    static final class WeightedValue<V> {
+        final int weight;
+        final V value;
+
+        WeightedValue(V value, int weight) {
+            this.weight = weight;
+            this.value = value;
+        }
+
+        boolean contains(Object o) {
+            return (o == value) || value.equals(o);
+        }
+
+        /**
+         * If the entry is available in the hash-table and page replacement policy.
+         */
+        boolean isAlive() {
+            return weight > 0;
+        }
+    }
+
+    /**
+     * A node contains the key, the weighted value, and the linkage pointers on
+     * the page-replacement algorithm's data structures.
+     */
+    @SuppressWarnings("serial")
+    static final class Node<K, V> extends AtomicReference<WeightedValue<V>>
+            implements Linked<Node<K, V>> {
+        final K key;
+        //@GuardedBy("evictionLock")
+        Node<K, V> prev;
+        //@GuardedBy("evictionLock")
+        Node<K, V> next;
+
+        /** Creates a new, unlinked node. */
+        Node(K key, WeightedValue<V> weightedValue) {
+            super(weightedValue);
+            this.key = key;
+        }
+
+        @Override
+        //@GuardedBy("evictionLock")
+        public Node<K, V> getPrevious() {
+            return prev;
+        }
+
+        @Override
+        //@GuardedBy("evictionLock")
+        public void setPrevious(Node<K, V> prev) {
+            this.prev = prev;
+        }
+
+        @Override
+        //@GuardedBy("evictionLock")
+        public Node<K, V> getNext() {
+            return next;
+        }
+
+        @Override
+        //@GuardedBy("evictionLock")
+        public void setNext(Node<K, V> next) {
+            this.next = next;
+        }
+
+        /** Retrieves the value held by the current <tt>WeightedValue</tt>. */
+        V getValue() {
+            return get().value;
+        }
+    }
+
+    /** An adapter to safely externalize the keys. */
+    final class KeySet extends AbstractSet<K> {
+        final PrivateMaxEntriesMap<K, V> map = PrivateMaxEntriesMap.this;
+
+        @Override
+        public int size() {
+            return map.size();
+        }
+
+        @Override
+        public void clear() {
+            map.clear();
+        }
+
+        @Override
+        public Iterator<K> iterator() {
+            return new KeyIterator();
+        }
+
+        @Override
+        public boolean contains(Object obj) {
+            return containsKey(obj);
+        }
+
+        @Override
+        public boolean remove(Object obj) {
+            return (map.remove(obj) != null);
+        }
+
+        @Override
+        public Object[] toArray() {
+            return map.data.keySet().toArray();
+        }
+
+        @Override
+        public <T> T[] toArray(T[] array) {
+            return map.data.keySet().toArray(array);
+        }
+    }
+
+    /** An adapter to safely externalize the key iterator. */
+    final class KeyIterator implements Iterator<K> {
+        final Iterator<K> iterator = data.keySet().iterator();
+        K current;
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public K next() {
+            current = iterator.next();
+            return current;
+        }
+
+        @Override
+        public void remove() {
+            checkState(current != null);
+            PrivateMaxEntriesMap.this.remove(current);
+            current = null;
+        }
+    }
+
+    /** An adapter to safely externalize the values. */
+    final class Values extends AbstractCollection<V> {
+
+        @Override
+        public int size() {
+            return PrivateMaxEntriesMap.this.size();
+        }
+
+        @Override
+        public void clear() {
+            PrivateMaxEntriesMap.this.clear();
+        }
+
+        @Override
+        public Iterator<V> iterator() {
+            return new ValueIterator();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+            return containsValue(o);
+        }
+    }
+
+    /** An adapter to safely externalize the value iterator. */
+    final class ValueIterator implements Iterator<V> {
+        final Iterator<Node<K, V>> iterator = data.values().iterator();
+        Node<K, V> current;
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public V next() {
+            current = iterator.next();
+            return current.getValue();
+        }
+
+        @Override
+        public void remove() {
+            checkState(current != null);
+            PrivateMaxEntriesMap.this.remove(current.key);
+            current = null;
+        }
+    }
+
+    /** An adapter to safely externalize the entries. */
+    final class EntrySet extends AbstractSet<Entry<K, V>> {
+        final PrivateMaxEntriesMap<K, V> map = PrivateMaxEntriesMap.this;
+
+        @Override
+        public int size() {
+            return map.size();
+        }
+
+        @Override
+        public void clear() {
+            map.clear();
+        }
+
+        @Override
+        public Iterator<Entry<K, V>> iterator() {
+            return new EntryIterator();
+        }
+
+        @Override
+        public boolean contains(Object obj) {
+            if (!(obj instanceof Entry<?, ?>)) {
+                return false;
+            }
+            Entry<?, ?> entry = (Entry<?, ?>) obj;
+            Node<K, V> node = map.data.get(entry.getKey());
+            return (node != null) && (node.getValue().equals(entry.getValue()));
+        }
+
+        @Override
+        public boolean add(Entry<K, V> entry) {
+            throw new UnsupportedOperationException("ConcurrentLinkedHashMap does not allow add to be called on entrySet()");
+        }
+
+        @Override
+        public boolean remove(Object obj) {
+            if (!(obj instanceof Entry<?, ?>)) {
+                return false;
+            }
+            Entry<?, ?> entry = (Entry<?, ?>) obj;
+            return map.remove(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /** An adapter to safely externalize the entry iterator. */
+    final class EntryIterator implements Iterator<Entry<K, V>> {
+        final Iterator<Node<K, V>> iterator = data.values().iterator();
+        Node<K, V> current;
+
+        @Override
+        public boolean hasNext() {
+            return iterator.hasNext();
+        }
+
+        @Override
+        public Entry<K, V> next() {
+            current = iterator.next();
+            return new WriteThroughEntry(current);
+        }
+
+        @Override
+        public void remove() {
+            checkState(current != null);
+            PrivateMaxEntriesMap.this.remove(current.key);
+            current = null;
+        }
+    }
+
+    /** An entry that allows updates to write through to the map. */
+    final class WriteThroughEntry extends SimpleEntry<K, V> {
+        static final long serialVersionUID = 1;
+
+        WriteThroughEntry(Node<K, V> node) {
+            super(node.key, node.getValue());
+        }
+
+        @Override
+        public V setValue(V value) {
+            put(getKey(), value);
+            return super.setValue(value);
+        }
+
+        Object writeReplace() {
+            return new SimpleEntry<K, V>(this);
+        }
+    }
+
+    /* ---------------- Serialization Support -------------- */
+
+    static final long serialVersionUID = 1;
+
+    Object writeReplace() {
+        return new SerializationProxy<K, V>(this);
+    }
+
+    private void readObject(ObjectInputStream stream) throws InvalidObjectException {
+        throw new InvalidObjectException("Proxy required");
+    }
+
+    /**
+     * A proxy that is serialized instead of the map. The page-replacement
+     * algorithm's data structures are not serialized so the deserialized
+     * instance contains only the entries. This is acceptable as caches hold
+     * transient data that is recomputable and serialization would tend to be
+     * used as a fast warm-up process.
+     */
+    static final class SerializationProxy<K, V> implements Serializable {
+        final int concurrencyLevel;
+        final Map<K, V> data;
+        final long capacity;
+
+        SerializationProxy(PrivateMaxEntriesMap<K, V> map) {
+            concurrencyLevel = map.concurrencyLevel;
+            data = new HashMap<K, V>(map);
+            capacity = map.capacity.get();
+        }
+
+        Object readResolve() {
+            PrivateMaxEntriesMap<K, V> map = new Builder<K, V>()
+                    .maximumCapacity(capacity)
+                    .build();
+            map.putAll(data);
+            return map;
+        }
+
+        static final long serialVersionUID = 1;
+    }
+
+    /* ---------------- Builder -------------- */
+
+    /**
+     * A builder that creates {@link PrivateMaxEntriesMap} instances. It
+     * provides a flexible approach for constructing customized instances with
+     * a named parameter syntax. It can be used in the following manner:
+     * <pre>{@code
+     * ConcurrentMap<Vertex, Set<Edge>> graph = new Builder<Vertex, Set<Edge>>()
+     *     .maximumCapacity(5000)
+     *     .build();
+     * }</pre>
+     */
+    public static final class Builder<K, V> {
+        static final int DEFAULT_CONCURRENCY_LEVEL = 16;
+        static final int DEFAULT_INITIAL_CAPACITY = 16;
+
+        int concurrencyLevel;
+        int initialCapacity;
+        long capacity;
+
+        public Builder() {
+            capacity = -1;
+            initialCapacity = DEFAULT_INITIAL_CAPACITY;
+            concurrencyLevel = DEFAULT_CONCURRENCY_LEVEL;
+        }
+
+        /**
+         * Specifies the initial capacity of the hash table (default <tt>16</tt>).
+         * This is the number of key-value pairs that the hash table can hold
+         * before a resize operation is required.
+         *
+         * @param initialCapacity the initial capacity used to size the hash table
+         *     to accommodate this many entries.
+         * @throws IllegalArgumentException if the initialCapacity is negative
+         */
+        public Builder<K, V> initialCapacity(int initialCapacity) {
+            checkArgument(initialCapacity >= 0);
+            this.initialCapacity = initialCapacity;
+            return this;
+        }
+
+        /**
+         * Specifies the maximum capacity to coerce the map to and may
+         * exceed it temporarily.
+         *
+         * @param capacity the threshold to bound the map by
+         * @throws IllegalArgumentException if the maximumCapacity is negative
+         */
+        public Builder<K, V> maximumCapacity(long capacity) {
+            checkArgument(capacity >= 0);
+            this.capacity = capacity;
+            return this;
+        }
+
+        /**
+         * Specifies the estimated number of concurrently updating threads. The
+         * implementation performs internal sizing to try to accommodate this many
+         * threads (default <tt>16</tt>).
+         *
+         * @param concurrencyLevel the estimated number of concurrently updating
+         *     threads
+         * @throws IllegalArgumentException if the concurrencyLevel is less than or
+         *     equal to zero
+         */
+        public Builder<K, V> concurrencyLevel(int concurrencyLevel) {
+            checkArgument(concurrencyLevel > 0);
+            this.concurrencyLevel = concurrencyLevel;
+            return this;
+        }
+
+        /**
+         * Creates a new {@link PrivateMaxEntriesMap} instance.
+         *
+         * @throws IllegalStateException if the maximum capacity was
+         *     not set
+         */
+        public PrivateMaxEntriesMap<K, V> build() {
+            checkState(capacity >= 0);
+            return new PrivateMaxEntriesMap<K, V>(this);
+        }
+    }
+}

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/internal/package-info.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/internal/package-info.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2011 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains an implementation of a bounded
+ * {@link java.util.concurrent.ConcurrentMap} data structure.
+ * <p>
+ * This package is intended only for use internally by Jackson libraries and has
+ * missing features compared to the full <a href="http://code.google.com/p/concurrentlinkedhashmap/">
+ * http://code.google.com/p/concurrentlinkedhashmap/</a> implementation.
+ * <p>
+ * The {@link org.apache.ibatis.reflection.type.jackson.databind.util.internal.PrivateMaxEntriesMap}
+ * class supplies an efficient, scalable, thread-safe, bounded map. As with the
+ * <tt>Java Collections Framework</tt> the "Concurrent" prefix is used to
+ * indicate that the map is not governed by a single exclusion lock.
+ *
+ * @see <a href="http://code.google.com/p/concurrentlinkedhashmap/">
+ *      http://code.google.com/p/concurrentlinkedhashmap/</a>
+ */
+package org.apache.ibatis.reflection.type.jackson.databind.util.internal;

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/package-info.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/databind/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Utility classes for Mapper package.
+ */
+package org.apache.ibatis.reflection.type.jackson.databind.util;

--- a/src/main/java/org/apache/ibatis/reflection/type/jackson/package-info.java
+++ b/src/main/java/org/apache/ibatis/reflection/type/jackson/package-info.java
@@ -1,0 +1,19 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+/**
+ * Copy from jackson.
+ */
+package org.apache.ibatis.reflection.type.jackson;

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/BaseWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/BaseWrapper.java
@@ -21,6 +21,8 @@ import java.util.Map;
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.ReflectionException;
 import org.apache.ibatis.reflection.property.PropertyTokenizer;
+import org.apache.ibatis.reflection.type.ResolvedType;
+import org.apache.ibatis.reflection.type.ResolvedTypeFactory;
 
 /**
  * @author Clinton Begin
@@ -28,10 +30,12 @@ import org.apache.ibatis.reflection.property.PropertyTokenizer;
 public abstract class BaseWrapper implements ObjectWrapper {
 
   protected static final Object[] NO_ARGUMENTS = new Object[0];
+  protected final ResolvedTypeFactory resolvedTypeFactory;
   protected final MetaObject metaObject;
 
   protected BaseWrapper(MetaObject metaObject) {
     this.metaObject = metaObject;
+    this.resolvedTypeFactory = metaObject.getReflectorFactory().getResolvedTypeFactory();
   }
 
   protected Object resolveCollection(PropertyTokenizer prop, Object object) {
@@ -102,6 +106,20 @@ public abstract class BaseWrapper implements ObjectWrapper {
         throw new ReflectionException("The '" + prop.getName() + "' property of " + collection + " is not a List or Array.");
       }
     }
+  }
+
+  protected ResolvedType constructType(Class<?> clazz) {
+    return resolvedTypeFactory.constructType(clazz);
+  }
+
+  @Override
+  public Class<?> getSetterType(String name) {
+    return getSetterResolvedType(name).getRawClass();
+  }
+
+  @Override
+  public Class<?> getGetterType(String name) {
+    return getGetterResolvedType(name).getRawClass();
   }
 
 }

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/BeanWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/BeanWrapper.java
@@ -17,6 +17,7 @@ package org.apache.ibatis.reflection.wrapper;
 
 import java.util.List;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.reflection.ExceptionUtil;
 import org.apache.ibatis.reflection.MetaClass;
 import org.apache.ibatis.reflection.MetaObject;
@@ -76,32 +77,32 @@ public class BeanWrapper extends BaseWrapper {
   }
 
   @Override
-  public Class<?> getSetterType(String name) {
+  public ResolvedType getSetterResolvedType(String name) {
     PropertyTokenizer prop = new PropertyTokenizer(name);
     if (prop.hasNext()) {
       MetaObject metaValue = metaObject.metaObjectForProperty(prop.getIndexedName());
       if (metaValue == SystemMetaObject.NULL_META_OBJECT) {
-        return metaClass.getSetterType(name);
+        return metaClass.getSetterResolvedType(name);
       } else {
-        return metaValue.getSetterType(prop.getChildren());
+        return metaValue.getSetterResolvedType(prop.getChildren());
       }
     } else {
-      return metaClass.getSetterType(name);
+      return metaClass.getSetterResolvedType(name);
     }
   }
 
   @Override
-  public Class<?> getGetterType(String name) {
+  public ResolvedType getGetterResolvedType(String name) {
     PropertyTokenizer prop = new PropertyTokenizer(name);
     if (prop.hasNext()) {
       MetaObject metaValue = metaObject.metaObjectForProperty(prop.getIndexedName());
       if (metaValue == SystemMetaObject.NULL_META_OBJECT) {
-        return metaClass.getGetterType(name);
+        return metaClass.getGetterResolvedType(name);
       } else {
-        return metaValue.getGetterType(prop.getChildren());
+        return metaValue.getGetterResolvedType(prop.getChildren());
       }
     } else {
-      return metaClass.getGetterType(name);
+      return metaClass.getGetterResolvedType(name);
     }
   }
 

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/CollectionWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/CollectionWrapper.java
@@ -18,6 +18,7 @@ package org.apache.ibatis.reflection.wrapper;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.factory.ObjectFactory;
 import org.apache.ibatis.reflection.property.PropertyTokenizer;
@@ -59,12 +60,22 @@ public class CollectionWrapper implements ObjectWrapper {
   }
 
   @Override
+  public ResolvedType getSetterResolvedType(String name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public Class<?> getSetterType(String name) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   public Class<?> getGetterType(String name) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ResolvedType getGetterResolvedType(String name) {
     throw new UnsupportedOperationException();
   }
 

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.SystemMetaObject;
 import org.apache.ibatis.reflection.factory.ObjectFactory;
@@ -72,39 +73,39 @@ public class MapWrapper extends BaseWrapper {
   }
 
   @Override
-  public Class<?> getSetterType(String name) {
+  public ResolvedType getSetterResolvedType(String name) {
     PropertyTokenizer prop = new PropertyTokenizer(name);
     if (prop.hasNext()) {
       MetaObject metaValue = metaObject.metaObjectForProperty(prop.getIndexedName());
       if (metaValue == SystemMetaObject.NULL_META_OBJECT) {
-        return Object.class;
+        return resolvedTypeFactory.getObjectType();
       } else {
-        return metaValue.getSetterType(prop.getChildren());
+        return metaValue.getSetterResolvedType(prop.getChildren());
       }
     } else {
       if (map.get(name) != null) {
-        return map.get(name).getClass();
+        return constructType(map.get(name).getClass());
       } else {
-        return Object.class;
+        return resolvedTypeFactory.getObjectType();
       }
     }
   }
 
   @Override
-  public Class<?> getGetterType(String name) {
+  public ResolvedType getGetterResolvedType(String name) {
     PropertyTokenizer prop = new PropertyTokenizer(name);
     if (prop.hasNext()) {
       MetaObject metaValue = metaObject.metaObjectForProperty(prop.getIndexedName());
       if (metaValue == SystemMetaObject.NULL_META_OBJECT) {
-        return Object.class;
+        return resolvedTypeFactory.getObjectType();
       } else {
-        return metaValue.getGetterType(prop.getChildren());
+        return metaValue.getGetterResolvedType(prop.getChildren());
       }
     } else {
       if (map.get(name) != null) {
-        return map.get(name).getClass();
+        return resolvedTypeFactory.constructType(map.get(name).getClass());
       } else {
-        return Object.class;
+        return resolvedTypeFactory.getObjectType();
       }
     }
   }

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/ObjectWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/ObjectWrapper.java
@@ -20,6 +20,7 @@ import java.util.List;
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.factory.ObjectFactory;
 import org.apache.ibatis.reflection.property.PropertyTokenizer;
+import org.apache.ibatis.reflection.type.ResolvedType;
 
 /**
  * @author Clinton Begin
@@ -38,7 +39,11 @@ public interface ObjectWrapper {
 
   Class<?> getSetterType(String name);
 
+  ResolvedType getSetterResolvedType(String name);
+
   Class<?> getGetterType(String name);
+
+  ResolvedType getGetterResolvedType(String name);
 
   boolean hasSetter(String name);
 

--- a/src/main/java/org/apache/ibatis/scripting/LanguageDriver.java
+++ b/src/main/java/org/apache/ibatis/scripting/LanguageDriver.java
@@ -15,6 +15,7 @@
  */
 package org.apache.ibatis.scripting;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.executor.parameter.ParameterHandler;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.MappedStatement;
@@ -22,6 +23,7 @@ import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.parsing.XNode;
 import org.apache.ibatis.scripting.defaults.DefaultParameterHandler;
 import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.reflection.type.ResolvedTypeUtil;
 
 public interface LanguageDriver {
 
@@ -46,7 +48,23 @@ public interface LanguageDriver {
    * @param parameterType input parameter type got from a mapper method or specified in the parameterType xml attribute. Can be null.
    * @return the sql source
    */
-  SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType);
+  @Deprecated
+  default SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType) {
+    return createSqlSource(configuration, script, configuration.constructType(parameterType));
+  }
+
+  /**
+   * Creates an {@link SqlSource} that will hold the statement read from a mapper xml file.
+   * It is called during startup, when the mapped statement is read from a class or an xml file.
+   *
+   * @param configuration The MyBatis configuration
+   * @param script XNode parsed from a XML file
+   * @param parameterType input parameter type got from a mapper method or specified in the parameterType xml attribute. Can be null.
+   * @return the sql source
+   */
+  default SqlSource createSqlSource(Configuration configuration, XNode script, ResolvedType parameterType) {
+    return createSqlSource(configuration, script, ResolvedTypeUtil.getRawClass(parameterType));
+  }
 
   /**
    * Creates an {@link SqlSource} that will hold the statement read from an annotation.
@@ -57,6 +75,22 @@ public interface LanguageDriver {
    * @param parameterType input parameter type got from a mapper method or specified in the parameterType xml attribute. Can be null.
    * @return the sql source
    */
-  SqlSource createSqlSource(Configuration configuration, String script, Class<?> parameterType);
+  @Deprecated
+  default SqlSource createSqlSource(Configuration configuration, String script, Class<?> parameterType) {
+    return createSqlSource(configuration, script, configuration.constructType(parameterType));
+  }
+
+  /**
+   * Creates an {@link SqlSource} that will hold the statement read from an annotation.
+   * It is called during startup, when the mapped statement is read from a class or an xml file.
+   *
+   * @param configuration The MyBatis configuration
+   * @param script The content of the annotation
+   * @param parameterType input parameter type got from a mapper method or specified in the parameterType xml attribute. Can be null.
+   * @return the sql source
+   */
+  default SqlSource createSqlSource(Configuration configuration, String script, ResolvedType parameterType) {
+    return createSqlSource(configuration, script, ResolvedTypeUtil.getRawClass(parameterType));
+  }
 
 }

--- a/src/main/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandler.java
+++ b/src/main/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandler.java
@@ -42,12 +42,12 @@ import org.apache.ibatis.type.TypeHandlerRegistry;
  */
 public class DefaultParameterHandler implements ParameterHandler {
 
-  private final TypeHandlerRegistry typeHandlerRegistry;
+  protected final TypeHandlerRegistry typeHandlerRegistry;
 
-  private final MappedStatement mappedStatement;
-  private final Object parameterObject;
-  private final BoundSql boundSql;
-  private final Configuration configuration;
+  protected final MappedStatement mappedStatement;
+  protected final Object parameterObject;
+  protected final BoundSql boundSql;
+  protected final Configuration configuration;
 
   public DefaultParameterHandler(MappedStatement mappedStatement, Object parameterObject, BoundSql boundSql) {
     this.mappedStatement = mappedStatement;

--- a/src/main/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandler.java
+++ b/src/main/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandler.java
@@ -106,9 +106,15 @@ public class DefaultParameterHandler implements ParameterHandler {
     ResolvedType type = mappedStatement.getParameterMap().getResolvedType();
     if (ResolvedTypeUtil.isInstance(type, parameterObject)) {
       ResolvedType realType = configuration.constructType(clazz);
+      if (realType.hasContentType() && PropertyTokenizer.isIndexAccess(propertyName)) {
+        return false;
+      }
       return typeHandlerRegistry.hasTypeHandler(type) || typeHandlerRegistry.hasTypeHandler(realType);
     }
     type = configuration.constructType(clazz);
+    if (type.hasContentType() && PropertyTokenizer.isIndexAccess(propertyName)) {
+      return false;
+    }
     return typeHandlerRegistry.hasTypeHandler(type);
   }
 }

--- a/src/main/java/org/apache/ibatis/scripting/defaults/RawLanguageDriver.java
+++ b/src/main/java/org/apache/ibatis/scripting/defaults/RawLanguageDriver.java
@@ -20,6 +20,7 @@ import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.parsing.XNode;
 import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
 import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.reflection.type.ResolvedType;
 
 /**
  * As of 3.2.4 the default XML language is able to identify static statements
@@ -32,14 +33,14 @@ import org.apache.ibatis.session.Configuration;
 public class RawLanguageDriver extends XMLLanguageDriver {
 
   @Override
-  public SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType) {
+  public SqlSource createSqlSource(Configuration configuration, XNode script, ResolvedType parameterType) {
     SqlSource source = super.createSqlSource(configuration, script, parameterType);
     checkIsNotDynamic(source);
     return source;
   }
 
   @Override
-  public SqlSource createSqlSource(Configuration configuration, String script, Class<?> parameterType) {
+  public SqlSource createSqlSource(Configuration configuration, String script, ResolvedType parameterType) {
     SqlSource source = super.createSqlSource(configuration, script, parameterType);
     checkIsNotDynamic(source);
     return source;

--- a/src/main/java/org/apache/ibatis/scripting/defaults/RawSqlSource.java
+++ b/src/main/java/org/apache/ibatis/scripting/defaults/RawSqlSource.java
@@ -17,6 +17,7 @@ package org.apache.ibatis.scripting.defaults;
 
 import java.util.HashMap;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.builder.SqlSourceBuilder;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.SqlSource;
@@ -37,6 +38,10 @@ public class RawSqlSource implements SqlSource {
   private final SqlSource sqlSource;
 
   public RawSqlSource(Configuration configuration, SqlNode rootSqlNode, Class<?> parameterType) {
+    this(configuration, rootSqlNode, configuration.constructType(parameterType));
+  }
+
+  public RawSqlSource(Configuration configuration, SqlNode rootSqlNode, ResolvedType parameterType) {
     this(configuration, getSql(configuration, rootSqlNode), parameterType);
   }
 
@@ -44,6 +49,12 @@ public class RawSqlSource implements SqlSource {
     SqlSourceBuilder sqlSourceParser = new SqlSourceBuilder(configuration);
     Class<?> clazz = parameterType == null ? Object.class : parameterType;
     sqlSource = sqlSourceParser.parse(sql, clazz, new HashMap<>());
+  }
+
+  public RawSqlSource(Configuration configuration, String sql, ResolvedType parameterType) {
+    SqlSourceBuilder sqlSourceParser = new SqlSourceBuilder(configuration);
+    ResolvedType type = parameterType == null ? configuration.getResolvedTypeFactory().getObjectType() : parameterType;
+    sqlSource = sqlSourceParser.parse(sql, type, new HashMap<>());
   }
 
   private static String getSql(Configuration configuration, SqlNode rootSqlNode) {

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLLanguageDriver.java
@@ -15,6 +15,7 @@
  */
 package org.apache.ibatis.scripting.xmltags;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.builder.xml.XMLMapperEntityResolver;
 import org.apache.ibatis.executor.parameter.ParameterHandler;
 import org.apache.ibatis.mapping.BoundSql;
@@ -39,13 +40,13 @@ public class XMLLanguageDriver implements LanguageDriver {
   }
 
   @Override
-  public SqlSource createSqlSource(Configuration configuration, XNode script, Class<?> parameterType) {
+  public SqlSource createSqlSource(Configuration configuration, XNode script, ResolvedType parameterType) {
     XMLScriptBuilder builder = new XMLScriptBuilder(configuration, script, parameterType);
     return builder.parseScriptNode();
   }
 
   @Override
-  public SqlSource createSqlSource(Configuration configuration, String script, Class<?> parameterType) {
+  public SqlSource createSqlSource(Configuration configuration, String script, ResolvedType parameterType) {
     // issue #3
     if (script.startsWith("<script>")) {
       XPathParser parser = new XPathParser(script, false, configuration.getVariables(), new XMLMapperEntityResolver());
@@ -55,7 +56,7 @@ public class XMLLanguageDriver implements LanguageDriver {
       script = PropertyParser.parse(script, configuration.getVariables());
       TextSqlNode textSqlNode = new TextSqlNode(script);
       if (textSqlNode.isDynamic()) {
-        return new DynamicSqlSource(configuration, textSqlNode);
+        return new DynamicSqlSource(configuration, textSqlNode, parameterType);
       } else {
         return new RawSqlSource(configuration, script, parameterType);
       }

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.builder.BaseBuilder;
 import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.mapping.SqlSource;
@@ -36,14 +37,21 @@ public class XMLScriptBuilder extends BaseBuilder {
 
   private final XNode context;
   private boolean isDynamic;
-  private final Class<?> parameterType;
+  private final ResolvedType parameterType;
   private final Map<String, NodeHandler> nodeHandlerMap = new HashMap<>();
 
   public XMLScriptBuilder(Configuration configuration, XNode context) {
-    this(configuration, context, null);
+    this(configuration, context, (ResolvedType) null);
   }
 
   public XMLScriptBuilder(Configuration configuration, XNode context, Class<?> parameterType) {
+    super(configuration);
+    this.context = context;
+    this.parameterType = constructType(parameterType);
+    initNodeHandlerMap();
+  }
+
+  public XMLScriptBuilder(Configuration configuration, XNode context, ResolvedType parameterType) {
     super(configuration);
     this.context = context;
     this.parameterType = parameterType;
@@ -67,7 +75,7 @@ public class XMLScriptBuilder extends BaseBuilder {
     MixedSqlNode rootSqlNode = parseDynamicTags(context);
     SqlSource sqlSource;
     if (isDynamic) {
-      sqlSource = new DynamicSqlSource(configuration, rootSqlNode);
+      sqlSource = new DynamicSqlSource(configuration, rootSqlNode, parameterType);
     } else {
       sqlSource = new RawSqlSource(configuration, rootSqlNode, parameterType);
     }

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -95,6 +95,9 @@ import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeAliasRegistry;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.TypeHandlerRegistry;
+import org.apache.ibatis.reflection.type.ResolvedType;
+import org.apache.ibatis.reflection.type.ResolvedTypeFactory;
+import org.apache.ibatis.reflection.type.ResolvedTypeUtil;
 
 /**
  * @author Clinton Begin
@@ -133,7 +136,7 @@ public class Configuration {
   protected AutoMappingUnknownColumnBehavior autoMappingUnknownColumnBehavior = AutoMappingUnknownColumnBehavior.NONE;
 
   protected Properties variables = new Properties();
-  protected ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
+  protected ReflectorFactory reflectorFactory;
   protected ObjectFactory objectFactory = new DefaultObjectFactory();
   protected ObjectWrapperFactory objectWrapperFactory = new DefaultObjectWrapperFactory();
 
@@ -149,9 +152,10 @@ public class Configuration {
    */
   protected Class<?> configurationFactory;
 
+  protected final ResolvedTypeFactory resolvedTypeFactory;
   protected final MapperRegistry mapperRegistry = new MapperRegistry(this);
   protected final InterceptorChain interceptorChain = new InterceptorChain();
-  protected final TypeHandlerRegistry typeHandlerRegistry = new TypeHandlerRegistry(this);
+  protected final TypeHandlerRegistry typeHandlerRegistry;
   protected final TypeAliasRegistry typeAliasRegistry = new TypeAliasRegistry();
   protected final LanguageDriverRegistry languageRegistry = new LanguageDriverRegistry();
 
@@ -184,6 +188,14 @@ public class Configuration {
   }
 
   public Configuration() {
+    this(ResolvedTypeUtil.getResolvedTypeFactory());
+  }
+
+  public Configuration(ResolvedTypeFactory resolvedTypeFactory) {
+    this.resolvedTypeFactory = resolvedTypeFactory;
+    reflectorFactory = new DefaultReflectorFactory(resolvedTypeFactory);
+    typeHandlerRegistry = new TypeHandlerRegistry(this);
+
     typeAliasRegistry.registerAlias("JDBC", JdbcTransactionFactory.class);
     typeAliasRegistry.registerAlias("MANAGED", ManagedTransactionFactory.class);
 
@@ -592,6 +604,14 @@ public class Configuration {
    */
   public MapperRegistry getMapperRegistry() {
     return mapperRegistry;
+  }
+
+  public ResolvedTypeFactory getResolvedTypeFactory() {
+    return resolvedTypeFactory;
+  }
+
+  public ResolvedType constructType(Class<?> clazz) {
+    return resolvedTypeFactory.constructType(clazz);
   }
 
   public ReflectorFactory getReflectorFactory() {

--- a/src/main/java/org/apache/ibatis/type/ArrayTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ArrayTypeHandler.java
@@ -38,7 +38,9 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class ArrayTypeHandler extends BaseTypeHandler<Object> {
 
-  private static final ConcurrentHashMap<Class<?>, String> STANDARD_MAPPING;
+  protected static final ConcurrentHashMap<Class<?>, String> STANDARD_MAPPING;
+
+  protected static final String DEFAULT_TYPE_NAME = JdbcType.JAVA_OBJECT.name();
 
   static {
     STANDARD_MAPPING = new ConcurrentHashMap<>();
@@ -97,7 +99,7 @@ public class ArrayTypeHandler extends BaseTypeHandler<Object> {
   }
 
   protected String resolveTypeName(Class<?> type) {
-    return STANDARD_MAPPING.getOrDefault(type, JdbcType.JAVA_OBJECT.name());
+    return STANDARD_MAPPING.getOrDefault(type, DEFAULT_TYPE_NAME);
   }
 
   @Override
@@ -124,4 +126,15 @@ public class ArrayTypeHandler extends BaseTypeHandler<Object> {
     return result;
   }
 
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  protected static void register(TypeHandlerRegistry registry) {
+    TypeHandler<?> typeHandler = new ArrayTypeHandler();
+    ArrayTypeHandler.STANDARD_MAPPING.forEach((componentType, arrayTypeName) -> {
+      Class arrayClass = java.lang.reflect.Array.newInstance(componentType, 0).getClass();
+      if (!registry.hasTypeHandler(arrayClass)) {
+        // skip byte[] for BlobTypeHandler
+        registry.register(arrayClass, typeHandler);
+      }
+    });
+  }
 }

--- a/src/main/java/org/apache/ibatis/type/BaseCollectionTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BaseCollectionTypeHandler.java
@@ -1,0 +1,83 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.Array;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collection;
+
+import org.apache.ibatis.reflection.type.ResolvedType;
+
+import static org.apache.ibatis.type.ArrayTypeHandler.DEFAULT_TYPE_NAME;
+import static org.apache.ibatis.type.ArrayTypeHandler.STANDARD_MAPPING;
+
+/**
+ * @author FlyInWind
+ */
+public abstract class BaseCollectionTypeHandler<T extends Collection<Object>> extends BaseTypeHandler<T> {
+
+  protected final String arrayTypeName;
+
+  protected BaseCollectionTypeHandler(String arrayTypeName) {
+    this.arrayTypeName = arrayTypeName;
+  }
+
+  protected BaseCollectionTypeHandler(ResolvedType resolvedType) {
+    this(getArrayTypeName(resolvedType));
+  }
+
+  @Override
+  public void setNonNullParameter(PreparedStatement ps, int i, T parameter, JdbcType jdbcType) throws SQLException {
+    Object[] javaArray = parameter.toArray();
+    Array array = ps.getConnection().createArrayOf(arrayTypeName, javaArray);
+    ps.setArray(i, array);
+    array.free();
+  }
+
+  protected static String getArrayTypeName(ResolvedType type) {
+    Class<?> compType = type.findTypeParameters(Collection.class)[0].getRawClass();
+    return STANDARD_MAPPING.getOrDefault(compType, DEFAULT_TYPE_NAME);
+  }
+
+  @Override
+  public T getNullableResult(ResultSet rs, String columnName) throws SQLException {
+    return extractArray(rs.getArray(columnName));
+  }
+
+  @Override
+  public T getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+    return extractArray(rs.getArray(columnIndex));
+  }
+
+  @Override
+  public T getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+    return extractArray(cs.getArray(columnIndex));
+  }
+
+  protected T extractArray(Array array) throws SQLException {
+    if (array == null) {
+      return null;
+    }
+    Object[] javaArray = (Object[]) array.getArray();
+    array.free();
+    return toCollection(javaArray);
+  }
+
+  protected abstract T toCollection(Object[] array);
+}

--- a/src/main/java/org/apache/ibatis/type/ListTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ListTypeHandler.java
@@ -1,0 +1,60 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.ibatis.reflection.type.ResolvedType;
+import org.apache.ibatis.reflection.type.ResolvedTypeFactory;
+
+/**
+ * @author FlyInWind
+ */
+@MappedJdbcTypes(value = JdbcType.ARRAY, includeNullJdbcType = true)
+public class ListTypeHandler extends BaseCollectionTypeHandler<List<Object>> {
+
+  public ListTypeHandler(ResolvedType resolvedType) {
+    super(resolvedType);
+  }
+
+  public ListTypeHandler(String arrayTypeName) {
+    super(arrayTypeName);
+  }
+
+  @Override
+  protected List<Object> toCollection(Object[] array) {
+    return new ArrayList<>(Arrays.asList(array));
+  }
+
+  protected static void register(TypeHandlerRegistry registry) {
+    ResolvedTypeFactory resolvedTypeFactory = registry.getResolvedTypeFactory();
+    ArrayTypeHandler.STANDARD_MAPPING.forEach((componentType, arrayTypeName) -> {
+      if (componentType.isPrimitive()) {
+        return;
+      }
+      TypeHandler<?> typeHandler = new ListTypeHandler(arrayTypeName);
+      registry.register(resolvedTypeFactory.constructParametricType(Collection.class, componentType), typeHandler);
+      registry.register(resolvedTypeFactory.constructParametricType(List.class, componentType), typeHandler);
+    });
+    ListTypeHandler objectListTypeHandler = new ListTypeHandler(ArrayTypeHandler.DEFAULT_TYPE_NAME);
+    registry.register(resolvedTypeFactory.constructType(Collection.class), objectListTypeHandler);
+    registry.register(resolvedTypeFactory.constructType(List.class), objectListTypeHandler);
+    registry.addCreator(ListTypeHandler.class, ListTypeHandler::new);
+  }
+}

--- a/src/main/java/org/apache/ibatis/type/SetTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/SetTypeHandler.java
@@ -1,0 +1,57 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.apache.ibatis.reflection.type.ResolvedType;
+import org.apache.ibatis.reflection.type.ResolvedTypeFactory;
+
+/**
+ * @author FlyInWind
+ */
+@MappedJdbcTypes(value = JdbcType.ARRAY, includeNullJdbcType = true)
+public class SetTypeHandler extends BaseCollectionTypeHandler<Set<Object>> {
+
+  public SetTypeHandler(String arrayTypeName) {
+    super(arrayTypeName);
+  }
+
+  public SetTypeHandler(ResolvedType resolvedType) {
+    super(resolvedType);
+  }
+
+  @Override
+  protected Set<Object> toCollection(Object[] array) {
+    return new LinkedHashSet<>(Arrays.asList(array));
+  }
+
+  protected static void register(TypeHandlerRegistry registry) {
+    ResolvedTypeFactory resolvedTypeFactory = registry.getResolvedTypeFactory();
+    ArrayTypeHandler.STANDARD_MAPPING.forEach((componentType, arrayTypeName) -> {
+      if (componentType.isPrimitive()) {
+        return;
+      }
+      TypeHandler<?> typeHandler = new SetTypeHandler(arrayTypeName);
+      registry.register(resolvedTypeFactory.constructParametricType(Set.class, componentType), typeHandler);
+    });
+    SetTypeHandler objectSetTypeHandler = new SetTypeHandler(ArrayTypeHandler.DEFAULT_TYPE_NAME);
+    registry.register(resolvedTypeFactory.constructType(Set.class), objectSetTypeHandler);
+    registry.addCreator(SetTypeHandler.class, ListTypeHandler::new);
+  }
+}

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -192,6 +192,10 @@ public final class TypeHandlerRegistry {
     // issue #273
     register(Character.class, new CharacterTypeHandler());
     register(char.class, new CharacterTypeHandler());
+
+    ListTypeHandler.register(this);
+    SetTypeHandler.register(this);
+    ArrayTypeHandler.register(this);
   }
 
   public ResolvedTypeFactory getResolvedTypeFactory() {
@@ -532,7 +536,7 @@ public final class TypeHandlerRegistry {
    * This will flag this {@link TypeHandler} need a type for constructor, and will get null when construct without type info
    * @see #getMappingTypeHandler
    */
-  public void putCreator(Class<?> typeHandlerClazz, Function<ResolvedType, ? extends TypeHandler<?>> creator) {
+  public void addCreator(Class<?> typeHandlerClazz, Function<ResolvedType, ? extends TypeHandler<?>> creator) {
     typeHandlerCreatorMap.put(typeHandlerClazz, creator);
   }
 

--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -193,6 +193,8 @@ public final class TypeHandlerRegistry {
     register(Character.class, new CharacterTypeHandler());
     register(char.class, new CharacterTypeHandler());
 
+    addCreator(EnumTypeHandler.class, t -> new EnumTypeHandler(t.getRawClass()));
+
     ListTypeHandler.register(this);
     SetTypeHandler.register(this);
     ArrayTypeHandler.register(this);
@@ -237,6 +239,9 @@ public final class TypeHandlerRegistry {
   }
 
   public TypeHandler<?> getMappingTypeHandler(Class<? extends TypeHandler<?>> handlerType) {
+    if (typeHandlerCreatorMap.containsKey(handlerType)) {
+      return null;
+    }
     return allTypeHandlersMap.get(handlerType);
   }
 

--- a/src/main/java/org/apache/ibatis/type/TypeReference.java
+++ b/src/main/java/org/apache/ibatis/type/TypeReference.java
@@ -27,12 +27,6 @@ import java.lang.reflect.Type;
  */
 public abstract class TypeReference<T> {
 
-  private final Type rawType;
-
-  protected TypeReference() {
-    rawType = getSuperclassTypeParameter(getClass());
-  }
-
   Type getSuperclassTypeParameter(Class<?> clazz) {
     Type genericSuperclass = clazz.getGenericSuperclass();
     if (genericSuperclass instanceof Class) {
@@ -55,12 +49,12 @@ public abstract class TypeReference<T> {
   }
 
   public final Type getRawType() {
-    return rawType;
+    return getSuperclassTypeParameter(getClass());
   }
 
   @Override
   public String toString() {
-    return rawType.toString();
+    return getRawType().toString();
   }
 
 }

--- a/src/test/java/org/apache/ibatis/builder/SqlSourceBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/SqlSourceBuilderTest.java
@@ -15,6 +15,7 @@
  */
 package org.apache.ibatis.builder;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.session.Configuration;
@@ -37,7 +38,7 @@ public class SqlSourceBuilderTest {
 
   @Test
   void testShrinkWhitespacesInSqlIsFalse() {
-    SqlSource sqlSource = sqlSourceBuilder.parse(sqlFromXml, null, null);
+    SqlSource sqlSource = sqlSourceBuilder.parse(sqlFromXml, (ResolvedType) null, null);
     BoundSql boundSql = sqlSource.getBoundSql(null);
     String actual = boundSql.getSql();
     Assertions.assertEquals(sqlFromXml, actual);
@@ -46,7 +47,7 @@ public class SqlSourceBuilderTest {
   @Test
   void testShrinkWhitespacesInSqlIsTrue() {
     configuration.setShrinkWhitespacesInSql(true);
-    SqlSource sqlSource = sqlSourceBuilder.parse(sqlFromXml, null, null);
+    SqlSource sqlSource = sqlSourceBuilder.parse(sqlFromXml, (ResolvedType) null, null);
     BoundSql boundSql = sqlSource.getBoundSql(null);
     String actual = boundSql.getSql();
 

--- a/src/test/java/org/apache/ibatis/domain/misc/RichType.java
+++ b/src/test/java/org/apache/ibatis/domain/misc/RichType.java
@@ -52,11 +52,11 @@ public class RichType {
     this.richProperty = richProperty;
   }
 
-  public List getRichList() {
+  public List<String> getRichList() {
     return richList;
   }
 
-  public void setRichList(List richList) {
+  public void setRichList(List<String> richList) {
     this.richList = richList;
   }
 

--- a/src/test/java/org/apache/ibatis/reflection/BuildInJacksonResolvedTypeTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/BuildInJacksonResolvedTypeTest.java
@@ -1,0 +1,446 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection;
+
+import org.apache.ibatis.reflection.type.ResolvedMethod;
+import org.apache.ibatis.reflection.type.ResolvedType;
+import org.apache.ibatis.reflection.type.ResolvedTypeFactory;
+import org.apache.ibatis.reflection.type.ResolvedTypeUtil;
+import org.apache.ibatis.reflection.typeparam.Calculator;
+import org.apache.ibatis.reflection.typeparam.Calculator.SubCalculator;
+import org.apache.ibatis.reflection.typeparam.Level0Mapper;
+import org.apache.ibatis.reflection.typeparam.Level0Mapper.Level0InnerMapper;
+import org.apache.ibatis.reflection.typeparam.Level1Mapper;
+import org.apache.ibatis.reflection.typeparam.Level2Mapper;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class BuildInJacksonResolvedTypeTest {
+  ResolvedTypeFactory resolvedTypeFactory = ResolvedTypeUtil.getBuildInJacksonTypeFactory();
+
+  @Test
+  void testReturn_Lv0SimpleClass() throws Exception {
+    Class<?> clazz = Level0Mapper.class;
+    Method method = clazz.getMethod("simpleSelect");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Double.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleVoid() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectVoid", Integer.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(void.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_SimplePrimitive() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectPrimitive", int.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(double.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleClass() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelect");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Double.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleList() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectList");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(List.class, paramType.getRawClass());
+    assertEquals(1, paramType.findTypeParameters(List.class).length);
+    assertEquals(Double.class, paramType.findTypeParameters(List.class)[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleMap() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectMap");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Map.class, paramType.getRawClass());
+    ResolvedType[] typeParameters = paramType.findTypeParameters(Map.class);
+    assertEquals(2, typeParameters.length);
+    assertEquals(Integer.class, typeParameters[0].getRawClass());
+    assertEquals(Double.class, typeParameters[1].getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleArray() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectArray");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertTrue(paramType.isArrayType());
+    assertEquals(String.class, paramType.getContentType().getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleArrayOfArray() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectArrayOfArray");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertTrue(paramType.isArrayType());
+    assertTrue(paramType.getContentType().isArrayType());
+    assertEquals(String.class, paramType.getContentType().getContentType().getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleTypeVar() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectTypeVar");
+    ResolvedType returnType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Calculator.class, returnType.getRawClass());
+    assertEquals(1, returnType.getTypeParameters().length);
+    assertEquals(Object.class, returnType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv1Class() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("select", Object.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(String.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv2CustomClass() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectCalculator", Calculator.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Calculator.class, paramType.getRawClass());
+    assertEquals(1, paramType.getTypeParameters().length);
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv2CustomClassList() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectCalculatorList");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(List.class, paramType.getRawClass());
+    assertEquals(1, paramType.getTypeParameters().length);
+    ResolvedType paramTypeInner = paramType.getContentType();
+    assertEquals(Calculator.class, paramTypeInner.getRawClass());
+    assertEquals(Date.class, paramTypeInner.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv0InnerClass() throws Exception {
+    Class<?> clazz = Level0InnerMapper.class;
+    Method method = clazz.getMethod("select", Object.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Float.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv2Class() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("select", Object.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(String.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv1List() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("selectList", Object.class, Object.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(List.class, paramType.getRawClass());
+    assertEquals(1, paramType.getTypeParameters().length);
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv1Array() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("selectArray", List[].class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertTrue(paramType.isArrayType());
+    assertEquals(String.class, paramType.getContentType().getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv2ArrayOfArray() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectArrayOfArray");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertTrue(paramType.isArrayType());
+    assertTrue(paramType.getContentType().isArrayType());
+    assertEquals(String.class, paramType.getContentType().getContentType().getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv2ArrayOfList() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectArrayOfList");
+    ResolvedType result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertTrue(result.isArrayType());
+    ResolvedType paramType = result.getContentType();
+    assertEquals(List.class, paramType.getRawClass());
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv2WildcardList() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectWildcardList");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(List.class, paramType.getRawClass());
+    assertEquals(1, paramType.getTypeParameters().length);
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_LV2Map() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectMap");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Map.class, paramType.getRawClass());
+    assertEquals(2, paramType.getTypeParameters().length);
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+    assertEquals(Integer.class, paramType.getTypeParameters()[1].getRawClass());
+  }
+
+  @Test
+  void testReturn_Subclass() throws Exception {
+    Class<?> clazz = SubCalculator.class;
+    Method method = clazz.getMethod("getId");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(String.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testParam_Primitive() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("simpleSelectPrimitive", int.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(1, result.length);
+    assertEquals(int.class, result[0].getRawClass());
+  }
+
+  @Test
+  void testParam_Simple() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectVoid", Integer.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(1, result.length);
+    assertEquals(Integer.class, result[0].getRawClass());
+  }
+
+  @Test
+  void testParam_Lv1Single() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("select", Object.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(1, result.length);
+    assertEquals(String.class, result[0].getRawClass());
+  }
+
+  @Test
+  void testParam_Lv2Single() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("select", Object.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(1, result.length);
+    assertEquals(String.class, result[0].getRawClass());
+  }
+
+  @Test
+  void testParam_Lv2Multiple() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectList", Object.class, Object.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(2, result.length);
+    assertEquals(Integer.class, result[0].getRawClass());
+    assertEquals(String.class, result[1].getRawClass());
+  }
+
+  @Test
+  void testParam_Lv2CustomClass() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectCalculator", Calculator.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(1, result.length);
+    ResolvedType paramType = result[0];
+    assertEquals(Calculator.class, paramType.getRawClass());
+    assertEquals(1, paramType.getTypeParameters().length);
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testParam_Lv1Array() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("selectArray", List[].class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    ResolvedType paramType = result[0].getContentType();
+    assertEquals(List.class, paramType.getRawClass());
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testParam_Subclass() throws Exception {
+    Class<?> clazz = SubCalculator.class;
+    Method method = clazz.getMethod("setId", Object.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(String.class, result[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_Anonymous() throws Exception {
+    Calculator<?> instance = new Calculator<Integer>();
+    Class<?> clazz = instance.getClass();
+    Method method = clazz.getMethod("getId");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Object.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testField_GenericField() throws Exception {
+    Class<?> clazz = SubCalculator.class;
+    Class<?> declaredClass = Calculator.class;
+    Field field = declaredClass.getDeclaredField("fld");
+    ResolvedType result = resolvedTypeFactory.constructType(clazz).resolveFieldType(field);
+    assertEquals(String.class, result.getRawClass());
+  }
+
+  @Test
+  void testReturnParam_WildcardWithUpperBounds() throws Exception {
+    class Key {
+    }
+    @SuppressWarnings("unused")
+    class KeyBean<S extends Key & Cloneable, T extends Key> {
+      private S key1;
+      private T key2;
+
+      public S getKey1() {
+        return key1;
+      }
+
+      public void setKey1(S key1) {
+        this.key1 = key1;
+      }
+
+      public T getKey2() {
+        return key2;
+      }
+
+      public void setKey2(T key2) {
+        this.key2 = key2;
+      }
+    }
+    Class<?> clazz = KeyBean.class;
+    ResolvedType resolvedType = resolvedTypeFactory.constructType(clazz);
+    ResolvedMethod getter1 = resolvedType.resolveMethod("getKey1");
+    assertEquals(Key.class, getter1.getReturnType().getRawClass());
+    ResolvedMethod setter1 = resolvedType.resolveMethod("setKey1", Key.class);
+    assertEquals(Key.class, setter1.getParameterTypes()[0].getRawClass());
+    ResolvedMethod getter2 = resolvedType.resolveMethod("getKey2");
+    assertEquals(Key.class, getter2.getReturnType().getRawClass());
+    ResolvedMethod setter2 = resolvedType.resolveMethod("setKey2", Key.class);
+    assertEquals(Key.class, setter2.getParameterTypes()[0].getRawClass());
+
+    getter1 = resolvedType.findMapperMethod("getKey1");
+    assertEquals(Key.class, getter1.getReturnType().getRawClass());
+    setter1 = resolvedType.findMapperMethod("setKey1");
+    assertEquals(Key.class, setter1.getParameterTypes()[0].getRawClass());
+    getter2 = resolvedType.findMapperMethod("getKey2");
+    assertEquals(Key.class, getter2.getReturnType().getRawClass());
+    setter2 = resolvedType.findMapperMethod("setKey2");
+    assertEquals(Key.class, setter2.getParameterTypes()[0].getRawClass());
+  }
+
+  @Test
+  void testDeepHierarchy() throws Exception {
+    @SuppressWarnings("unused")
+    abstract class A<S> {
+      protected S id;
+
+      public S getId() {
+        return this.id;
+      }
+
+      public void setId(S id) {
+        this.id = id;
+      }
+    }
+    abstract class B<T> extends A<T> {
+    }
+    abstract class C<U> extends B<U> {
+    }
+    class D extends C<Integer> {
+    }
+    Class<?> clazz = D.class;
+    ResolvedType resolvedType = resolvedTypeFactory.constructType(clazz);
+    ResolvedMethod method = resolvedType.resolveMethod("getId");
+    assertEquals(Integer.class, method.getReturnType().getRawClass());
+    Field field = A.class.getDeclaredField("id");
+    assertEquals(Integer.class, resolvedType.resolveFieldType(field).getRawClass());
+  }
+
+  @Test
+  void shouldTypeVariablesBeComparedWithEquals() throws Exception {
+    // #1794
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    Future<Type> futureA = executor.submit(() -> {
+      ResolvedType retType = resolvedTypeFactory.constructType(IfaceA.class).resolveMethod(IfaceA.class.getMethods()[0]).getReturnType();
+      return retType.getTypeParameters()[0].getRawClass();
+    });
+    Future<Type> futureB = executor.submit(() -> {
+      ResolvedType retType = resolvedTypeFactory.constructType(IfaceB.class).resolveMethod(IfaceB.class.getMethods()[0]).getReturnType();
+      return retType.getTypeParameters()[0].getRawClass();
+    });
+    assertEquals(AA.class, futureA.get());
+    assertEquals(BB.class, futureB.get());
+    executor.shutdown();
+  }
+
+  // @formatter:off
+  class AA {
+  }
+
+  class BB {
+  }
+
+  interface IfaceA extends ParentIface<AA> {
+  }
+
+  interface IfaceB extends ParentIface<BB> {
+  }
+
+  interface ParentIface<T> {
+    List<T> m();
+  }
+  // @formatter:on
+}

--- a/src/test/java/org/apache/ibatis/reflection/JacksonResolvedTypeTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/JacksonResolvedTypeTest.java
@@ -1,0 +1,446 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection;
+
+import org.apache.ibatis.reflection.typeparam.Calculator;
+import org.apache.ibatis.reflection.typeparam.Calculator.SubCalculator;
+import org.apache.ibatis.reflection.typeparam.Level0Mapper;
+import org.apache.ibatis.reflection.typeparam.Level0Mapper.Level0InnerMapper;
+import org.apache.ibatis.reflection.typeparam.Level1Mapper;
+import org.apache.ibatis.reflection.typeparam.Level2Mapper;
+import org.apache.ibatis.reflection.type.ResolvedMethod;
+import org.apache.ibatis.reflection.type.ResolvedType;
+import org.apache.ibatis.reflection.type.ResolvedTypeFactory;
+import org.apache.ibatis.reflection.type.ResolvedTypeUtil;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JacksonResolvedTypeTest {
+  ResolvedTypeFactory resolvedTypeFactory = ResolvedTypeUtil.getJacksonTypeFactory();
+
+  @Test
+  void testReturn_Lv0SimpleClass() throws Exception {
+    Class<?> clazz = Level0Mapper.class;
+    Method method = clazz.getMethod("simpleSelect");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Double.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleVoid() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectVoid", Integer.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(void.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_SimplePrimitive() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectPrimitive", int.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(double.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleClass() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelect");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Double.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleList() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectList");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(List.class, paramType.getRawClass());
+    assertEquals(1, paramType.findTypeParameters(List.class).length);
+    assertEquals(Double.class, paramType.findTypeParameters(List.class)[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleMap() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectMap");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Map.class, paramType.getRawClass());
+    ResolvedType[] typeParameters = paramType.findTypeParameters(Map.class);
+    assertEquals(2, typeParameters.length);
+    assertEquals(Integer.class, typeParameters[0].getRawClass());
+    assertEquals(Double.class, typeParameters[1].getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleArray() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectArray");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertTrue(paramType.isArrayType());
+    assertEquals(String.class, paramType.getContentType().getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleArrayOfArray() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectArrayOfArray");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertTrue(paramType.isArrayType());
+    assertTrue(paramType.getContentType().isArrayType());
+    assertEquals(String.class, paramType.getContentType().getContentType().getRawClass());
+  }
+
+  @Test
+  void testReturn_SimpleTypeVar() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectTypeVar");
+    ResolvedType returnType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Calculator.class, returnType.getRawClass());
+    assertEquals(1, returnType.getTypeParameters().length);
+    assertEquals(Object.class, returnType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv1Class() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("select", Object.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(String.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv2CustomClass() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectCalculator", Calculator.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Calculator.class, paramType.getRawClass());
+    assertEquals(1, paramType.getTypeParameters().length);
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv2CustomClassList() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectCalculatorList");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(List.class, paramType.getRawClass());
+    assertEquals(1, paramType.getTypeParameters().length);
+    ResolvedType paramTypeInner = paramType.getContentType();
+    assertEquals(Calculator.class, paramTypeInner.getRawClass());
+    assertEquals(Date.class, paramTypeInner.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv0InnerClass() throws Exception {
+    Class<?> clazz = Level0InnerMapper.class;
+    Method method = clazz.getMethod("select", Object.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Float.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv2Class() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("select", Object.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(String.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv1List() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("selectList", Object.class, Object.class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(List.class, paramType.getRawClass());
+    assertEquals(1, paramType.getTypeParameters().length);
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv1Array() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("selectArray", List[].class);
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertTrue(paramType.isArrayType());
+    assertEquals(String.class, paramType.getContentType().getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv2ArrayOfArray() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectArrayOfArray");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertTrue(paramType.isArrayType());
+    assertTrue(paramType.getContentType().isArrayType());
+    assertEquals(String.class, paramType.getContentType().getContentType().getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv2ArrayOfList() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectArrayOfList");
+    ResolvedType result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertTrue(result.isArrayType());
+    ResolvedType paramType = result.getContentType();
+    assertEquals(List.class, paramType.getRawClass());
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_Lv2WildcardList() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectWildcardList");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(List.class, paramType.getRawClass());
+    assertEquals(1, paramType.getTypeParameters().length);
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_LV2Map() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectMap");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Map.class, paramType.getRawClass());
+    assertEquals(2, paramType.getTypeParameters().length);
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+    assertEquals(Integer.class, paramType.getTypeParameters()[1].getRawClass());
+  }
+
+  @Test
+  void testReturn_Subclass() throws Exception {
+    Class<?> clazz = SubCalculator.class;
+    Method method = clazz.getMethod("getId");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(String.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testParam_Primitive() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("simpleSelectPrimitive", int.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(1, result.length);
+    assertEquals(int.class, result[0].getRawClass());
+  }
+
+  @Test
+  void testParam_Simple() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("simpleSelectVoid", Integer.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(1, result.length);
+    assertEquals(Integer.class, result[0].getRawClass());
+  }
+
+  @Test
+  void testParam_Lv1Single() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("select", Object.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(1, result.length);
+    assertEquals(String.class, result[0].getRawClass());
+  }
+
+  @Test
+  void testParam_Lv2Single() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("select", Object.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(1, result.length);
+    assertEquals(String.class, result[0].getRawClass());
+  }
+
+  @Test
+  void testParam_Lv2Multiple() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectList", Object.class, Object.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(2, result.length);
+    assertEquals(Integer.class, result[0].getRawClass());
+    assertEquals(String.class, result[1].getRawClass());
+  }
+
+  @Test
+  void testParam_Lv2CustomClass() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectCalculator", Calculator.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(1, result.length);
+    ResolvedType paramType = result[0];
+    assertEquals(Calculator.class, paramType.getRawClass());
+    assertEquals(1, paramType.getTypeParameters().length);
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testParam_Lv1Array() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("selectArray", List[].class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    ResolvedType paramType = result[0].getContentType();
+    assertEquals(List.class, paramType.getRawClass());
+    assertEquals(String.class, paramType.getTypeParameters()[0].getRawClass());
+  }
+
+  @Test
+  void testParam_Subclass() throws Exception {
+    Class<?> clazz = SubCalculator.class;
+    Method method = clazz.getMethod("setId", Object.class);
+    ResolvedType[] result = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getParameterTypes();
+    assertEquals(String.class, result[0].getRawClass());
+  }
+
+  @Test
+  void testReturn_Anonymous() throws Exception {
+    Calculator<?> instance = new Calculator<Integer>();
+    Class<?> clazz = instance.getClass();
+    Method method = clazz.getMethod("getId");
+    ResolvedType paramType = resolvedTypeFactory.constructType(clazz).resolveMethod(method).getReturnType();
+    assertEquals(Object.class, paramType.getRawClass());
+  }
+
+  @Test
+  void testField_GenericField() throws Exception {
+    Class<?> clazz = SubCalculator.class;
+    Class<?> declaredClass = Calculator.class;
+    Field field = declaredClass.getDeclaredField("fld");
+    ResolvedType result = resolvedTypeFactory.constructType(clazz).resolveFieldType(field);
+    assertEquals(String.class, result.getRawClass());
+  }
+
+  @Test
+  void testReturnParam_WildcardWithUpperBounds() throws Exception {
+    class Key {
+    }
+    @SuppressWarnings("unused")
+    class KeyBean<S extends Key & Cloneable, T extends Key> {
+      private S key1;
+      private T key2;
+
+      public S getKey1() {
+        return key1;
+      }
+
+      public void setKey1(S key1) {
+        this.key1 = key1;
+      }
+
+      public T getKey2() {
+        return key2;
+      }
+
+      public void setKey2(T key2) {
+        this.key2 = key2;
+      }
+    }
+    Class<?> clazz = KeyBean.class;
+    ResolvedType resolvedType = resolvedTypeFactory.constructType(clazz);
+    ResolvedMethod getter1 = resolvedType.resolveMethod("getKey1");
+    assertEquals(Key.class, getter1.getReturnType().getRawClass());
+    ResolvedMethod setter1 = resolvedType.resolveMethod("setKey1", Key.class);
+    assertEquals(Key.class, setter1.getParameterTypes()[0].getRawClass());
+    ResolvedMethod getter2 = resolvedType.resolveMethod("getKey2");
+    assertEquals(Key.class, getter2.getReturnType().getRawClass());
+    ResolvedMethod setter2 = resolvedType.resolveMethod("setKey2", Key.class);
+    assertEquals(Key.class, setter2.getParameterTypes()[0].getRawClass());
+
+    getter1 = resolvedType.findMapperMethod("getKey1");
+    assertEquals(Key.class, getter1.getReturnType().getRawClass());
+    setter1 = resolvedType.findMapperMethod("setKey1");
+    assertEquals(Key.class, setter1.getParameterTypes()[0].getRawClass());
+    getter2 = resolvedType.findMapperMethod("getKey2");
+    assertEquals(Key.class, getter2.getReturnType().getRawClass());
+    setter2 = resolvedType.findMapperMethod("setKey2");
+    assertEquals(Key.class, setter2.getParameterTypes()[0].getRawClass());
+  }
+
+  @Test
+  void testDeepHierarchy() throws Exception {
+    @SuppressWarnings("unused")
+    abstract class A<S> {
+      protected S id;
+
+      public S getId() {
+        return this.id;
+      }
+
+      public void setId(S id) {
+        this.id = id;
+      }
+    }
+    abstract class B<T> extends A<T> {
+    }
+    abstract class C<U> extends B<U> {
+    }
+    class D extends C<Integer> {
+    }
+    Class<?> clazz = D.class;
+    ResolvedType resolvedType = resolvedTypeFactory.constructType(clazz);
+    ResolvedMethod method = resolvedType.resolveMethod("getId");
+    assertEquals(Integer.class, method.getReturnType().getRawClass());
+    Field field = A.class.getDeclaredField("id");
+    assertEquals(Integer.class, resolvedType.resolveFieldType(field).getRawClass());
+  }
+
+  @Test
+  void shouldTypeVariablesBeComparedWithEquals() throws Exception {
+    // #1794
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+    Future<Type> futureA = executor.submit(() -> {
+      ResolvedType retType = resolvedTypeFactory.constructType(IfaceA.class).resolveMethod(IfaceA.class.getMethods()[0]).getReturnType();
+      return retType.getTypeParameters()[0].getRawClass();
+    });
+    Future<Type> futureB = executor.submit(() -> {
+      ResolvedType retType = resolvedTypeFactory.constructType(IfaceB.class).resolveMethod(IfaceB.class.getMethods()[0]).getReturnType();
+      return retType.getTypeParameters()[0].getRawClass();
+    });
+    assertEquals(AA.class, futureA.get());
+    assertEquals(BB.class, futureB.get());
+    executor.shutdown();
+  }
+
+  // @formatter:off
+  class AA {
+  }
+
+  class BB {
+  }
+
+  interface IfaceA extends ParentIface<AA> {
+  }
+
+  interface IfaceB extends ParentIface<BB> {
+  }
+
+  interface ParentIface<T> {
+    List<T> m();
+  }
+  // @formatter:on
+}

--- a/src/test/java/org/apache/ibatis/submitted/array_result_type/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/array_result_type/User.java
@@ -15,10 +15,14 @@
  */
 package org.apache.ibatis.submitted.array_result_type;
 
+import java.util.List;
+
 public class User {
 
   private Integer id;
   private String name;
+
+  private List<String> nicknameList;
 
   public Integer getId() {
     return id;
@@ -34,5 +38,13 @@ public class User {
 
   public void setName(String name) {
     this.name = name;
+  }
+
+  public List<String> getNicknameList() {
+    return nicknameList;
+  }
+
+  public void setNicknameList(List<String> nicknameList) {
+    this.nicknameList = nicknameList;
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/array_type_handler/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/array_type_handler/Mapper.java
@@ -15,9 +15,12 @@
  */
 package org.apache.ibatis.submitted.array_type_handler;
 
+
 public interface Mapper {
 
   void insert(User user);
+
+  void insertWithoutAssignTypeHandler(User user2);
 
   int getUserCount();
 
@@ -25,4 +28,6 @@ public interface Mapper {
    * HSQL returns NULL when asked for the cardinality of an array column with NULL value :-(
    */
   Integer getNicknameCount();
+
+  void updateNickname(Integer id, String[] nicknames);
 }

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectWrapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomObjectWrapper.java
@@ -17,6 +17,7 @@ package org.apache.ibatis.submitted.custom_collection_handling;
 
 import java.util.List;
 
+import org.apache.ibatis.reflection.type.ResolvedType;
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.factory.ObjectFactory;
 import org.apache.ibatis.reflection.property.PropertyTokenizer;
@@ -65,7 +66,19 @@ public class CustomObjectWrapper implements org.apache.ibatis.reflection.wrapper
   }
 
   @Override
+  public ResolvedType getSetterResolvedType(String name) {
+    // Not Implemented
+    return null;
+  }
+
+  @Override
   public Class<?> getGetterType(String name) {
+    // Not Implemented
+    return null;
+  }
+
+  @Override
+  public ResolvedType getGetterResolvedType(String name) {
     // Not Implemented
     return null;
   }

--- a/src/test/java/org/apache/ibatis/submitted/generictypes/GenericTypesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/generictypes/GenericTypesTest.java
@@ -16,6 +16,7 @@
 package org.apache.ibatis.submitted.generictypes;
 
 import java.io.Reader;
+import java.util.Collections;
 
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
@@ -46,6 +47,7 @@ class GenericTypesTest {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       Group group = mapper.getGroup();
       Assertions.assertNotNull(group.getOwner());
+      Assertions.assertEquals(Collections.singletonList("User1,User2,User3"), group.getMembers());
     }
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/list_type_handler/ListTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/list_type_handler/ListTypeHandlerTest.java
@@ -13,12 +13,14 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.submitted.array_type_handler;
+package org.apache.ibatis.submitted.list_type_handler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.Reader;
+import java.util.Arrays;
+import java.util.List;
 
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
@@ -28,19 +30,19 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ArrayTypeHandlerTest {
+class ListTypeHandlerTest {
 
   private SqlSessionFactory sqlSessionFactory;
 
   @BeforeEach
   void setUp() throws Exception {
     try (Reader reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/array_type_handler/mybatis-config.xml")) {
+      .getResourceAsReader("org/apache/ibatis/submitted/list_type_handler/mybatis-config.xml")) {
       sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
     }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
-        "org/apache/ibatis/submitted/array_type_handler/CreateDB.sql");
+            "org/apache/ibatis/submitted/list_type_handler/CreateDB.sql");
   }
 
   @Test
@@ -49,7 +51,7 @@ class ArrayTypeHandlerTest {
       User user = new User();
       user.setId(1);
       user.setName("User 1");
-      user.setNicknames(new String[] { "User", "one" });
+      user.setNicknames(Arrays.asList("User", "one"));
 
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       mapper.insert(user);
@@ -57,7 +59,7 @@ class ArrayTypeHandlerTest {
       User user2 = new User();
       user2.setId(2);
       user2.setName("User 2");
-      user2.setNicknames(new String[] { "User", "two" });
+      user2.setNicknames(Arrays.asList("User", "two"));
       mapper.insertWithoutAssignTypeHandler(user2);
 
       sqlSession.commit();
@@ -101,11 +103,12 @@ class ArrayTypeHandlerTest {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       mapper.insert(user);
 
-      String[] nickNames = new String[]{"User", "User"};
+      List<String> nickNames = Arrays.asList("User", "User");
       mapper.updateNickname(1, nickNames);
 
-      Integer nicknameCount = mapper.getNicknameCount();
-      assertEquals(2, nicknameCount);
+      List<User> users = mapper.selectByNicknames(nickNames);
+      user = users.get(0);
+      assertEquals(nickNames, user.getNicknames());
     }
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/list_type_handler/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/list_type_handler/Mapper.java
@@ -13,13 +13,24 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.submitted.generictypes;
+package org.apache.ibatis.submitted.list_type_handler;
 
-import org.apache.ibatis.annotations.Select;
+import java.util.List;
 
 public interface Mapper {
 
-  @Select("select id, owner, array[members] members from groups where id=1")
-  Group getGroup();
+  void insert(User user);
 
+  void insertWithoutAssignTypeHandler(User user);
+
+  int getUserCount();
+
+  /**
+   * HSQL returns NULL when asked for the cardinality of an array column with NULL value :-(
+   */
+  Integer getNicknameCount();
+
+  List<User> selectByNicknames(List<String> nicknames);
+
+  void updateNickname(Integer id, List<String> nicknames);
 }

--- a/src/test/java/org/apache/ibatis/submitted/list_type_handler/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/list_type_handler/User.java
@@ -13,13 +13,38 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.submitted.generictypes;
+package org.apache.ibatis.submitted.list_type_handler;
 
-import org.apache.ibatis.annotations.Select;
+import java.util.List;
 
-public interface Mapper {
+public class User {
 
-  @Select("select id, owner, array[members] members from groups where id=1")
-  Group getGroup();
+  private Integer id;
+  private String name;
+  private List<String> nicknames;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<String> getNicknames() {
+    return nicknames;
+  }
+
+  public void setNicknames(List<String> nicknames) {
+    this.nicknames = nicknames;
+  }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/no_result_type_map/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/no_result_type_map/Mapper.java
@@ -1,0 +1,28 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.no_result_type_map;
+
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+public interface Mapper {
+
+  User getUser(@Param("id") Integer id);
+
+  List<User> getAllUsers();
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/no_result_type_map/ResulthandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/no_result_type_map/ResulthandlerTest.java
@@ -1,0 +1,65 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.no_result_type_map;
+
+import java.io.Reader;
+import java.util.List;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ResulthandlerTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    // create a SqlSessionFactory
+    try (Reader reader = Resources
+      .getResourceAsReader("org/apache/ibatis/submitted/no_result_type_map/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().addMapper(Mapper.class);
+    }
+
+    // populate in-memory database
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/submitted/no_result_type_map/CreateDB.sql");
+  }
+
+  @Test
+  void shouldGetAUser() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.getUser(1);
+      Assertions.assertEquals("User1", user.getName());
+    }
+  }
+
+  @Test
+  void shouldGetAllUsers() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<User> users = mapper.getAllUsers();
+      Assertions.assertEquals(3, users.size());
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/no_result_type_map/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/no_result_type_map/User.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.no_result_type_map;
+
+public class User {
+
+  private Integer id;
+  private String name;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/set_type_handler/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/set_type_handler/Mapper.java
@@ -13,13 +13,25 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.submitted.generictypes;
+package org.apache.ibatis.submitted.set_type_handler;
 
-import org.apache.ibatis.annotations.Select;
+import java.util.List;
+import java.util.Set;
 
 public interface Mapper {
 
-  @Select("select id, owner, array[members] members from groups where id=1")
-  Group getGroup();
+  void insert(User user);
 
+  void insertWithoutAssignTypeHandler(User user);
+
+  int getUserCount();
+
+  /**
+   * HSQL returns NULL when asked for the cardinality of an array column with NULL value :-(
+   */
+  Integer getNicknameCount();
+
+  List<User> selectByNicknames(Set<String> nicknames);
+
+  void updateNickname(Integer id, Set<String> nicknames);
 }

--- a/src/test/java/org/apache/ibatis/submitted/set_type_handler/SetTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/set_type_handler/SetTypeHandlerTest.java
@@ -13,12 +13,16 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.submitted.array_type_handler;
+package org.apache.ibatis.submitted.set_type_handler;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.Reader;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
@@ -28,19 +32,19 @@ import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ArrayTypeHandlerTest {
+class SetTypeHandlerTest {
 
   private SqlSessionFactory sqlSessionFactory;
 
   @BeforeEach
   void setUp() throws Exception {
     try (Reader reader = Resources
-        .getResourceAsReader("org/apache/ibatis/submitted/array_type_handler/mybatis-config.xml")) {
+      .getResourceAsReader("org/apache/ibatis/submitted/set_type_handler/mybatis-config.xml")) {
       sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
     }
 
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
-        "org/apache/ibatis/submitted/array_type_handler/CreateDB.sql");
+            "org/apache/ibatis/submitted/set_type_handler/CreateDB.sql");
   }
 
   @Test
@@ -49,7 +53,7 @@ class ArrayTypeHandlerTest {
       User user = new User();
       user.setId(1);
       user.setName("User 1");
-      user.setNicknames(new String[] { "User", "one" });
+      user.setNicknames(new HashSet<>(Arrays.asList("User", "one")));
 
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       mapper.insert(user);
@@ -57,7 +61,7 @@ class ArrayTypeHandlerTest {
       User user2 = new User();
       user2.setId(2);
       user2.setName("User 2");
-      user2.setNicknames(new String[] { "User", "two" });
+      user2.setNicknames(new HashSet<>(Arrays.asList("User", "two")));
       mapper.insertWithoutAssignTypeHandler(user2);
 
       sqlSession.commit();
@@ -101,11 +105,12 @@ class ArrayTypeHandlerTest {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       mapper.insert(user);
 
-      String[] nickNames = new String[]{"User", "User"};
+      Set<String> nickNames = new HashSet<>(Arrays.asList("User", "User"));
       mapper.updateNickname(1, nickNames);
 
-      Integer nicknameCount = mapper.getNicknameCount();
-      assertEquals(2, nicknameCount);
+      List<User> users = mapper.selectByNicknames(nickNames);
+      user = users.get(0);
+      assertEquals(nickNames, user.getNicknames());
     }
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/set_type_handler/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/set_type_handler/User.java
@@ -13,13 +13,38 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-package org.apache.ibatis.submitted.generictypes;
+package org.apache.ibatis.submitted.set_type_handler;
 
-import org.apache.ibatis.annotations.Select;
+import java.util.Set;
 
-public interface Mapper {
+public class User {
 
-  @Select("select id, owner, array[members] members from groups where id=1")
-  Group getGroup();
+  private Integer id;
+  private String name;
+  private Set<String> nicknames;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Set<String> getNicknames() {
+    return nicknames;
+  }
+
+  public void setNicknames(Set<String> nicknames) {
+    this.nicknames = nicknames;
+  }
 
 }

--- a/src/test/java/org/apache/ibatis/type/ListTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ListTypeHandlerTest.java
@@ -1,0 +1,111 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.Types;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class ListTypeHandlerTest extends BaseTypeHandlerTest {
+
+  static final ListTypeHandler TYPE_HANDLER = new ListTypeHandler(JdbcType.VARCHAR.name());
+
+  @Mock
+  Array mockArray;
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    Connection connection = mock(Connection.class);
+    when(ps.getConnection()).thenReturn(connection);
+
+    Array array = mock(Array.class);
+    when(connection.createArrayOf(anyString(), any(Object[].class))).thenReturn(array);
+
+    TYPE_HANDLER.setParameter(ps, 1, Collections.singletonList("Hello World"), JdbcType.ARRAY);
+    verify(ps).setArray(1, array);
+    verify(array).free();
+  }
+
+  @Test
+  public void shouldSetNullParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, null, JdbcType.ARRAY);
+    verify(ps).setNull(1, Types.ARRAY);
+  }
+
+  @Override
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getArray("column")).thenReturn(mockArray);
+    String[] stringArray = new String[]{"a", "b"};
+    when(mockArray.getArray()).thenReturn(stringArray);
+    List<String> list = new ArrayList<>(Arrays.asList(stringArray));
+    assertEquals(list, TYPE_HANDLER.getResult(rs, "column"));
+    verify(mockArray).free();
+  }
+
+  @Override
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getArray("column")).thenReturn(null);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getArray(1)).thenReturn(mockArray);
+    String[] stringArray = new String[]{"a", "b"};
+    when(mockArray.getArray()).thenReturn(stringArray);
+    List<String> list = new ArrayList<>(Arrays.asList(stringArray));
+    assertEquals(list, TYPE_HANDLER.getResult(rs, 1));
+    verify(mockArray).free();
+  }
+
+  @Override
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getArray(1)).thenReturn(null);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getArray(1)).thenReturn(mockArray);
+    String[] stringArray = new String[]{"a", "b"};
+    when(mockArray.getArray()).thenReturn(stringArray);
+    List<String> list = new ArrayList<>(Arrays.asList(stringArray));
+    assertEquals(list, TYPE_HANDLER.getResult(cs, 1));
+    verify(mockArray).free();
+  }
+
+  @Override
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getArray(1)).thenReturn(null);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/SetTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/SetTypeHandlerTest.java
@@ -1,0 +1,111 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.Types;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class SetTypeHandlerTest extends BaseTypeHandlerTest {
+
+  static final SetTypeHandler TYPE_HANDLER = new SetTypeHandler(JdbcType.VARCHAR.name());
+
+  @Mock
+  Array mockArray;
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    Connection connection = mock(Connection.class);
+    when(ps.getConnection()).thenReturn(connection);
+
+    Array array = mock(Array.class);
+    when(connection.createArrayOf(anyString(), any(Object[].class))).thenReturn(array);
+
+    TYPE_HANDLER.setParameter(ps, 1, Collections.singleton("Hello World"), JdbcType.ARRAY);
+    verify(ps).setArray(1, array);
+    verify(array).free();
+  }
+
+  @Test
+  public void shouldSetNullParameter() throws Exception {
+    TYPE_HANDLER.setParameter(ps, 1, null, JdbcType.ARRAY);
+    verify(ps).setNull(1, Types.ARRAY);
+  }
+
+  @Override
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    when(rs.getArray("column")).thenReturn(mockArray);
+    String[] stringArray = new String[]{"a", "b"};
+    when(mockArray.getArray()).thenReturn(stringArray);
+    Set<String> set = new HashSet<>(Arrays.asList(stringArray));
+    assertEquals(set, TYPE_HANDLER.getResult(rs, "column"));
+    verify(mockArray).free();
+  }
+
+  @Override
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getArray("column")).thenReturn(null);
+    assertNull(TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    when(rs.getArray(1)).thenReturn(mockArray);
+    String[] stringArray = new String[]{"a", "b"};
+    when(mockArray.getArray()).thenReturn(stringArray);
+    Set<String> set = new HashSet<>(Arrays.asList(stringArray));
+    assertEquals(set, TYPE_HANDLER.getResult(rs, 1));
+    verify(mockArray).free();
+  }
+
+  @Override
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    when(rs.getArray(1)).thenReturn(null);
+    assertNull(TYPE_HANDLER.getResult(rs, 1));
+  }
+
+  @Override
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    when(cs.getArray(1)).thenReturn(mockArray);
+    String[] stringArray = new String[]{"a", "b"};
+    when(mockArray.getArray()).thenReturn(stringArray);
+    Set<String> set = new HashSet<>(Arrays.asList(stringArray));
+    assertEquals(set, TYPE_HANDLER.getResult(cs, 1));
+    verify(mockArray).free();
+  }
+
+  @Override
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getArray(1)).thenReturn(null);
+    assertNull(TYPE_HANDLER.getResult(cs, 1));
+  }
+}

--- a/src/test/resources/org/apache/ibatis/submitted/list_type_handler/CreateDB.sql
+++ b/src/test/resources/org/apache/ibatis/submitted/list_type_handler/CreateDB.sql
@@ -1,0 +1,23 @@
+--
+--    Copyright 2009-2022 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       https://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(20),
+  nicknames varchar(20) array
+);

--- a/src/test/resources/org/apache/ibatis/submitted/list_type_handler/Mapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/list_type_handler/Mapper.xml
@@ -17,17 +17,17 @@
 
 -->
 <!DOCTYPE mapper
-    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="org.apache.ibatis.submitted.array_type_handler.Mapper">
+<mapper namespace="org.apache.ibatis.submitted.list_type_handler.Mapper">
 
   <insert id="insert"
-    parameterType="org.apache.ibatis.submitted.array_type_handler.User">
+          parameterType="org.apache.ibatis.submitted.list_type_handler.User">
     insert into users
-      (id, name, nicknames)
+    (id, name, nicknames)
     values
-      (#{id}, #{name}, #{nicknames,typeHandler=org.apache.ibatis.type.ArrayTypeHandler})
+    (#{id}, #{name}, #{nicknames,typeHandler=org.apache.ibatis.type.ListTypeHandler})
   </insert>
 
   <insert id="insertWithoutAssignTypeHandler">
@@ -41,8 +41,17 @@
     select count(*) from users
   </select>
 
-  <select id="getNicknameCount" resultType="int">
+  <select id="getNicknameCount" resultType="java.lang.Integer">
     select sum(cardinality(nicknames)) "nicknames_count" from users
+  </select>
+
+  <resultMap id="selectAllMap" type="org.apache.ibatis.submitted.list_type_handler.User">
+    <id property="id" column="id"/>
+    <result property="nicknames" column="nicknames"/>
+  </resultMap>
+
+  <select id="selectByNicknames" resultType="org.apache.ibatis.submitted.list_type_handler.User">
+    select * from users where nicknames = #{nicknames}
   </select>
 
   <update id="updateNickname">

--- a/src/test/resources/org/apache/ibatis/submitted/list_type_handler/mybatis-config.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/list_type_handler/mybatis-config.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2022 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+	<environments default="development">
+		<environment id="development">
+			<transactionManager type="JDBC"></transactionManager>
+			<dataSource type="UNPOOLED">
+				<property name="driver" value="org.hsqldb.jdbcDriver" />
+				<property name="url" value="jdbc:hsqldb:mem:arrayrtypehandler" />
+				<property name="username" value="sa" />
+			</dataSource>
+		</environment>
+	</environments>
+
+	<mappers>
+		<mapper class="org.apache.ibatis.submitted.list_type_handler.Mapper" />
+	</mappers>
+
+</configuration>

--- a/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/CreateDB.sql
+++ b/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/CreateDB.sql
@@ -1,0 +1,26 @@
+--
+--    Copyright 2009-2022 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       https://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(20)
+);
+
+insert into users (id, name) values(1, 'User1');
+insert into users (id, name) values(2, 'User2');
+insert into users (id, name) values(3, 'User3');

--- a/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/Mapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/Mapper.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2022 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.no_result_type_map.Mapper">
+
+  <select id="getUser">
+    select * from users where id = #{id}
+  </select>
+
+  <select id="getAllUsers">
+    select * from users
+  </select>
+</mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/mybatis-config.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/mybatis-config.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2022 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value="" />
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="org.hsqldb.jdbcDriver" />
+                <property name="url" value="jdbc:hsqldb:mem:basetest" />
+                <property name="username" value="sa" />
+            </dataSource>
+        </environment>
+    </environments>
+
+</configuration>

--- a/src/test/resources/org/apache/ibatis/submitted/set_type_handler/CreateDB.sql
+++ b/src/test/resources/org/apache/ibatis/submitted/set_type_handler/CreateDB.sql
@@ -1,0 +1,23 @@
+--
+--    Copyright 2009-2022 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       https://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(20),
+  nicknames varchar(20) array
+);

--- a/src/test/resources/org/apache/ibatis/submitted/set_type_handler/Mapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/set_type_handler/Mapper.xml
@@ -17,17 +17,17 @@
 
 -->
 <!DOCTYPE mapper
-    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
-<mapper namespace="org.apache.ibatis.submitted.array_type_handler.Mapper">
+<mapper namespace="org.apache.ibatis.submitted.set_type_handler.Mapper">
 
   <insert id="insert"
-    parameterType="org.apache.ibatis.submitted.array_type_handler.User">
+          parameterType="org.apache.ibatis.submitted.set_type_handler.User">
     insert into users
-      (id, name, nicknames)
+    (id, name, nicknames)
     values
-      (#{id}, #{name}, #{nicknames,typeHandler=org.apache.ibatis.type.ArrayTypeHandler})
+    (#{id}, #{name}, #{nicknames,typeHandler=org.apache.ibatis.type.ListTypeHandler})
   </insert>
 
   <insert id="insertWithoutAssignTypeHandler">
@@ -41,8 +41,17 @@
     select count(*) from users
   </select>
 
-  <select id="getNicknameCount" resultType="int">
+  <select id="getNicknameCount" resultType="java.lang.Integer">
     select sum(cardinality(nicknames)) "nicknames_count" from users
+  </select>
+
+  <resultMap id="selectAllMap" type="org.apache.ibatis.submitted.set_type_handler.User">
+    <id property="id" column="id"/>
+    <result property="nicknames" column="nicknames"/>
+  </resultMap>
+
+  <select id="selectByNicknames" resultType="org.apache.ibatis.submitted.set_type_handler.User">
+    select * from users where nicknames = #{nicknames}
   </select>
 
   <update id="updateNickname">

--- a/src/test/resources/org/apache/ibatis/submitted/set_type_handler/mybatis-config.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/set_type_handler/mybatis-config.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2022 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+	<environments default="development">
+		<environment id="development">
+			<transactionManager type="JDBC"></transactionManager>
+			<dataSource type="UNPOOLED">
+				<property name="driver" value="org.hsqldb.jdbcDriver" />
+				<property name="url" value="jdbc:hsqldb:mem:arrayrtypehandler" />
+				<property name="username" value="sa" />
+			</dataSource>
+		</environment>
+	</environments>
+
+	<mappers>
+		<mapper class="org.apache.ibatis.submitted.set_type_handler.Mapper" />
+	</mappers>
+
+</configuration>


### PR DESCRIPTION
**I know this is really a big change, and may bring up some backward compatible problem, so suggest is welcome**

### Add future

1. Add ResolvedType, only wrap Jackson JavaType. For not depend on jackson, copy classes relate to JavaType into
   org.apache.ibatis.reflection.type.jackson package. Now use JavaType from external Jackson first. #2187
2. Add ResolvedMethod, to get returnType and parameterType easier
3. Implement ListTypeHandler SetTypeHandler. #1445
4. Register ListTypeHandler, SetTypeHandler and ArrayTypeHandler into TypeHandlerRegistry, then we don't
   need to write typeHandler="ArrayTypeHandler" in xml
5. resultType and resultMap in xml is not obligatory, get Mapper Class by namespace and get Method by id, then we can
   get returnType

### Other changes

1. Add ParamNameResolver#getNamedParamsType, this may return a MapDescriptorResolvedType when
   ParamNameResolver#getNamedParams return a ParamMap, MapDescriptorResolvedType contains each value ResolvedType
2. List or array index access check, see PropertyTokenizer#isIndexAccess, without this change ArrayTypeHandler will use
   for #{array[0]}
3. LanguageDriver interface add two createSqlSource methods that use ResolvedType instead of Class, all createSqlSource
   methods are default for backward compatible
4. TypeReference do not resolve TypeParameter at construct time, getRawType is useless for now
5. Make some method and field protected. I tried to make my futures compatible with mybatisPlus, but fond they copy
   lost of code to their project. make method protected, so that mybatisPlus do not need copy

### May be not backward compatible

1. TypeHandlerRegistry#typeHandlerMap use ResolvedType as map key, this may have problem for user custom typeHandler.
   For example user write a typeHandler for ArrayList\<Object> but hope autoMapping for ArrayList\<String>, this may no
   problem before, but now autoMapping will can't find typeHandler, because of typeParameter not match
2. TypeHandlerRegistry#getMappingTypeHandler will check whether the TypeHandler need a Class for construct. I hope user
   can just write typeHandler without write javaType, because javaType attribute can't resolve ParameterizedType. #995
3. Try to resolve TypeHandler at SqlSourceBuilder, not use UnknownTypeHandler, because in UnknownTypeHandler can only
   get parameter Class, not ParameterizedType
4. DynamicSqlSource add ParamType, for pass ParameterizedType, I add a parameterType parameter to constructor, this may
   occur exception if user pass instance that not instanceof parameterType
5. User can pass Map<String,String> into function with Map<Map,Integer> parameter by cast, just like (Map)
   stringValueMap. Mybatis use UnknownTypeHandler for Map parameter at before, there is no problem if user pass wrong
   type. but now we can know we just need use IntegerTypeHandler to handle Map values, use IntegerTypeHandler to handle
   String will occur exception
