### PR TITLE
Print prepared sql log without ?

### DIFF
--- a/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
@@ -133,7 +133,6 @@ public abstract class BaseJdbcLogger {
   }
 
   protected void debug(String text, boolean input) {
-    System.out.println(text);
     if (statementLog.isDebugEnabled()) {
       statementLog.debug(prefix(input) + text);
     }

--- a/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
@@ -43,10 +43,10 @@ public abstract class BaseJdbcLogger {
   protected static final Set<String> SET_METHODS;
   protected static final Set<String> EXECUTE_METHODS = new HashSet<>();
 
-  private final Map<Object, Object> columnMap = new HashMap<>();
+  protected final Map<Object, Object> columnMap = new HashMap<>();
 
-  private final List<Object> columnNames = new ArrayList<>();
-  private final List<Object> columnValues = new ArrayList<>();
+  protected final List<Object> columnNames = new ArrayList<>();
+  protected final List<Object> columnValues = new ArrayList<>();
 
   protected final Log statementLog;
   protected final int queryStack;
@@ -133,6 +133,7 @@ public abstract class BaseJdbcLogger {
   }
 
   protected void debug(String text, boolean input) {
+    System.out.println(text);
     if (statementLog.isDebugEnabled()) {
       statementLog.debug(prefix(input) + text);
     }

--- a/src/main/java/org/apache/ibatis/logging/jdbc/ConnectionLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/ConnectionLogger.java
@@ -49,11 +49,14 @@ public final class ConnectionLogger extends BaseJdbcLogger implements Invocation
         return method.invoke(this, params);
       }
       if ("prepareStatement".equals(method.getName()) || "prepareCall".equals(method.getName())) {
-        if (isDebugEnabled()) {
-          debug(" Preparing: " + removeExtraWhitespace((String) params[0]), true);
-        }
         PreparedStatement stmt = (PreparedStatement) method.invoke(connection, params);
-        stmt = PreparedStatementLogger.newInstance(stmt, statementLog, queryStack);
+        if (isDebugEnabled()) {
+          String boundSql = removeExtraWhitespace((String) params[0]);
+          debug(" Preparing: " + boundSql, true);
+          stmt = PreparedStatementLogger.newInstance(stmt, statementLog, queryStack, boundSql);
+        } else {
+          stmt = PreparedStatementLogger.newInstance(stmt, statementLog, queryStack);
+        }
         return stmt;
       } else if ("createStatement".equals(method.getName())) {
         Statement stmt = (Statement) method.invoke(connection, params);

--- a/src/test/java/org/apache/ibatis/logging/jdbc/PreparedStatementLoggerTest.java
+++ b/src/test/java/org/apache/ibatis/logging/jdbc/PreparedStatementLoggerTest.java
@@ -95,4 +95,18 @@ class PreparedStatementLoggerTest {
 
     verify(log).debug(contains("Updates: 1"));
   }
+
+  @Test
+  void shouldPrintExecutingLog() throws SQLException {
+    PreparedStatement ps = PreparedStatementLogger.newInstance(this.preparedStatement, log, 1, "update name = ? from test limit ?");
+
+    when(log.isDebugEnabled()).thenReturn(true);
+
+    ps.setNull(1, JdbcType.VARCHAR.TYPE_CODE);
+    ps.setInt(2, 10);
+
+    verify(log).debug(contains("update name = null from test limit 10"));
+    verify(log).debug(contains("Parameters: null"));
+
+  }
 }


### PR DESCRIPTION
Hello, about the printing problem of this sql log, see this
https://github.com/mybatis/mybatis-3/issues/2761

I understand that the main problem now is that the SQL content printed by the PreparedStatement statement carries a question mark, and the actual value must be associated and mapped through the Parameters log content.

I have thought about it for a while, and the specific ways to solve this problem are as follows:

1. Obtain boundSql through interceptor logic, and then setParameter to obtain specific sql, this way can solve the problem

2. You can get the PreparedStatement, and then get the complete sql to be executed for different database types, such as mysql, oracle, postgresql, but this is limited by the implementation methods of different database types, which is not advisable.

**3. The last one is what I use here. When mybatis actually creates the PreparedStatement, it has already passed in the boundSql, and then holds the boundSql in the PreparedStatementLogger object, and directly replaces the parameters when executing execute, executeUpdate, executeQuery, addBatch and other methods .**

See the following code for specific implementation logic.

Thanks for your time here