### PR TITLE
Use method signature to resolve `resultType` of `<select>`

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
+++ b/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
@@ -15,29 +15,19 @@
  */
 package org.apache.ibatis.builder;
 
-import java.lang.reflect.Array;
-import java.lang.reflect.GenericArrayType;
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import org.apache.ibatis.annotations.MapKey;
-import org.apache.ibatis.annotations.ResultType;
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.cache.decorators.LruCache;
 import org.apache.ibatis.cache.impl.PerpetualCache;
-import org.apache.ibatis.cursor.Cursor;
 import org.apache.ibatis.executor.ErrorContext;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
 import org.apache.ibatis.mapping.CacheBuilder;
@@ -54,7 +44,6 @@ import org.apache.ibatis.mapping.SqlCommandType;
 import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.mapping.StatementType;
 import org.apache.ibatis.reflection.MetaClass;
-import org.apache.ibatis.reflection.TypeParameterResolver;
 import org.apache.ibatis.scripting.LanguageDriver;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.type.JdbcType;
@@ -579,63 +568,6 @@ public class MapperBuilderAssistant extends BaseBuilder {
       javaType = Object.class;
     }
     return javaType;
-  }
-
-  public Class<?> getReturnType(Method method, Class<?> type) {
-    Class<?> returnType = method.getReturnType();
-    Type resolvedReturnType = TypeParameterResolver.resolveReturnType(method, type);
-    if (resolvedReturnType instanceof Class) {
-      returnType = (Class<?>) resolvedReturnType;
-      if (returnType.isArray()) {
-        returnType = returnType.getComponentType();
-      }
-      // gcode issue #508
-      if (void.class.equals(returnType)) {
-        ResultType rt = method.getAnnotation(ResultType.class);
-        if (rt != null) {
-          returnType = rt.value();
-        }
-      }
-    } else if (resolvedReturnType instanceof ParameterizedType) {
-      ParameterizedType parameterizedType = (ParameterizedType) resolvedReturnType;
-      Class<?> rawType = (Class<?>) parameterizedType.getRawType();
-      if (Collection.class.isAssignableFrom(rawType) || Cursor.class.isAssignableFrom(rawType)) {
-        Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
-        if (actualTypeArguments != null && actualTypeArguments.length == 1) {
-          Type returnTypeParameter = actualTypeArguments[0];
-          if (returnTypeParameter instanceof Class<?>) {
-            returnType = (Class<?>) returnTypeParameter;
-          } else if (returnTypeParameter instanceof ParameterizedType) {
-            // (gcode issue #443) actual type can be a also a parameterized type
-            returnType = (Class<?>) ((ParameterizedType) returnTypeParameter).getRawType();
-          } else if (returnTypeParameter instanceof GenericArrayType) {
-            Class<?> componentType = (Class<?>) ((GenericArrayType) returnTypeParameter).getGenericComponentType();
-            // (gcode issue #525) support List<byte[]>
-            returnType = Array.newInstance(componentType, 0).getClass();
-          }
-        }
-      } else if (method.isAnnotationPresent(MapKey.class) && Map.class.isAssignableFrom(rawType)) {
-        // (gcode issue 504) Do not look into Maps if there is not MapKey annotation
-        Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
-        if (actualTypeArguments != null && actualTypeArguments.length == 2) {
-          Type returnTypeParameter = actualTypeArguments[1];
-          if (returnTypeParameter instanceof Class<?>) {
-            returnType = (Class<?>) returnTypeParameter;
-          } else if (returnTypeParameter instanceof ParameterizedType) {
-            // (gcode issue 443) actual type can be a also a parameterized type
-            returnType = (Class<?>) ((ParameterizedType) returnTypeParameter).getRawType();
-          }
-        }
-      } else if (Optional.class.equals(rawType)) {
-        Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
-        Type returnTypeParameter = actualTypeArguments[0];
-        if (returnTypeParameter instanceof Class<?>) {
-          returnType = (Class<?>) returnTypeParameter;
-        }
-      }
-    }
-
-    return returnType;
   }
 
 }

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,12 +15,12 @@
  */
 package org.apache.ibatis.builder.xml;
 
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Locale;
 
 import org.apache.ibatis.builder.BaseBuilder;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.apache.ibatis.builder.annotation.MapperAnnotationBuilder;
 import org.apache.ibatis.executor.keygen.Jdbc3KeyGenerator;
 import org.apache.ibatis.executor.keygen.KeyGenerator;
 import org.apache.ibatis.executor.keygen.NoKeyGenerator;
@@ -103,8 +103,7 @@ public class XMLStatementBuilder extends BaseBuilder {
     Class<?> resultTypeClass = resolveClass(resultType);
     String resultMap = context.getStringAttribute("resultMap");
     if (resultTypeClass == null && resultMap == null) {
-      // Resolve resultType by namespace and id, if not provide resultType and resultMap
-      resultTypeClass = resolveResultType(id);
+      resultTypeClass = MapperAnnotationBuilder.getMethodReturnType(builderAssistant.getCurrentNamespace(), id);
     }
     String resultSetType = context.getStringAttribute("resultSetType");
     ResultSetType resultSetTypeEnum = resolveResultSetType(resultSetType);
@@ -204,34 +203,4 @@ public class XMLStatementBuilder extends BaseBuilder {
     return configuration.getLanguageDriver(langClass);
   }
 
-  private Class<?> resolveResultType(String id) {
-    String namespace = builderAssistant.getCurrentNamespace();
-    Class<?> type;
-    try {
-      type = resolveClass(namespace);
-      if (type == null) {
-        return null;
-      }
-    } catch (Exception e) {
-      // ignore
-      return null;
-    }
-    Method mapperMethod = findMapperMethod(type, id);
-    if (mapperMethod != null) {
-      return builderAssistant.getReturnType(mapperMethod, type);
-    }
-    return null;
-  }
-
-  private Method findMapperMethod(Class<?> type, String methodName) {
-    Method[] methods = type.getMethods();
-    Method foundMethod = null;
-    for (Method method : methods) {
-      if (method.getName().equals(methodName) && !method.isBridge() && !method.isDefault()) {
-        foundMethod = method;
-        break;
-      }
-    }
-    return foundMethod;
-  }
 }

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -294,7 +294,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   private void validateResultMapsCount(ResultSetWrapper rsw, int resultMapCount) {
     if (rsw != null && resultMapCount < 1) {
       throw new ExecutorException("A query was run and no Result Maps were found for the Mapped Statement '" + mappedStatement.getId()
-          + "'.  It's likely that neither a Result Type nor a Result Map was specified.");
+          + "'. 'resultType' or 'resultMap' must be specified when there is no corresponding method.");
     }
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/no_result_type_map/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/no_result_type_map/Mapper.java
@@ -1,0 +1,28 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.no_result_type_map;
+
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+public interface Mapper {
+
+  User getUser(@Param("id") Integer id);
+
+  List<User> getAllUsers();
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/no_result_type_map/NoResultTypeMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/no_result_type_map/NoResultTypeMapTest.java
@@ -1,0 +1,66 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.no_result_type_map;
+
+import java.io.Reader;
+import java.util.List;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class NoResultTypeMapTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    // create a SqlSessionFactory
+    try (Reader reader = Resources
+      .getResourceAsReader("org/apache/ibatis/submitted/no_result_type_map/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().addMapper(Mapper.class);
+    }
+
+    // populate in-memory database
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/submitted/no_result_type_map/CreateDB.sql");
+  }
+
+  @Test
+  void shouldGetAUser() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      User user = mapper.getUser(1);
+      Assertions.assertEquals("User1", user.getName());
+    }
+  }
+
+  @Test
+  void shouldGetAllUsers() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<User> users = mapper.getAllUsers();
+      Assertions.assertEquals(3, users.size());
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/no_result_type_map/ParentMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/no_result_type_map/ParentMapper.java
@@ -15,14 +15,10 @@
  */
 package org.apache.ibatis.submitted.no_result_type_map;
 
-import org.apache.ibatis.annotations.Param;
-
 import java.util.List;
 
-public interface Mapper extends ParentMapper<User>{
+public interface ParentMapper<T> {
 
-  User getUser(@Param("id") Integer id);
-
-  List<User> getAllUsers();
+  List<T> getAllUsersInParent();
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/no_result_type_map/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/no_result_type_map/User.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/no_result_type_map/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/no_result_type_map/User.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.no_result_type_map;
+
+public class User {
+
+  private Integer id;
+  private String name;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/CreateDB.sql
+++ b/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/CreateDB.sql
@@ -1,0 +1,26 @@
+--
+--    Copyright 2009-2022 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       https://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(20)
+);
+
+insert into users (id, name) values(1, 'User1');
+insert into users (id, name) values(2, 'User2');
+insert into users (id, name) values(3, 'User3');

--- a/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/CreateDB.sql
+++ b/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/CreateDB.sql
@@ -1,5 +1,5 @@
 --
---    Copyright 2009-2022 the original author or authors.
+--    Copyright 2009-2023 the original author or authors.
 --
 --    Licensed under the Apache License, Version 2.0 (the "License");
 --    you may not use this file except in compliance with the License.

--- a/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/Mapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2022 the original author or authors.
+       Copyright 2009-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -27,6 +27,14 @@
   </select>
 
   <select id="getAllUsers">
+    select * from users
+  </select>
+
+  <select id="getAllUsersInParent">
+    select * from users
+  </select>
+
+  <select id="noMatchingMethod">
     select * from users
   </select>
 

--- a/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/Mapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/Mapper.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2022 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.no_result_type_map.Mapper">
+
+  <select id="getUser">
+    select * from users where id = #{id}
+  </select>
+
+  <select id="getAllUsers">
+    select * from users
+  </select>
+
+</mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/mybatis-config.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/mybatis-config.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2022 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value="" />
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="org.hsqldb.jdbcDriver" />
+                <property name="url" value="jdbc:hsqldb:mem:basetest" />
+                <property name="username" value="sa" />
+            </dataSource>
+        </environment>
+    </environments>
+
+</configuration>

--- a/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/mybatis-config.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/no_result_type_map/mybatis-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
 
-       Copyright 2009-2022 the original author or authors.
+       Copyright 2009-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.


### PR DESCRIPTION
In our work time it's is possible to write a error resultType in mapper.xml. I think we can resolve resultType by namespce and id in mapper.xml, then we can avoid this error