### PR TITLE
[pom] Add mockito subclass support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2022 the original author or authors.
+       Copyright 2009-2023 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -237,6 +237,12 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>5.0.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-subclass</artifactId>
       <version>5.0.0</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
some of our tests need the legacy style support that mockito made available.  We should look at those in longer term to get on fact that inline is now the default as per mockito we will likely have other issues.

note: This will fix @harawata attempt at adding jdk 21.