### PR TITLE
[ci] formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ Essentials
 * [See the docs](https://mybatis.org/mybatis-3)
 * [Download Latest](https://github.com/mybatis/mybatis-3/releases)
 * [Download Snapshot](https://oss.sonatype.org/content/repositories/snapshots/org/mybatis/mybatis/)
+
+Contributions
+-------------
+
+Mybatis-core is now being auto formatted.  Given nature of some code logic with mybatis, it is more appropriate to force a formatting structure manually for snippets such as sql statements.  To do so, add following blocks around code.
+
+```// @formatter:off``` - to start the block of unformatted code
+```// @formatter:off``` - to end the block of unformatted code
+
+If comment sections need same behaviour such as javadocs, note that the entire block must be around entire comment as direct usage does not properly indicate that formatter treats it all as one comment block regardless.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Contributions
 
 Mybatis-core is now being auto formatted.  Given nature of some code logic with mybatis, it is more appropriate to force a formatting structure manually for snippets such as sql statements.  To do so, add following blocks around code.
 
-```// @formatter:off``` - to start the block of unformatted code
-```// @formatter:off``` - to end the block of unformatted code
+    ```// @formatter:off``` to start the block of unformatted code
+    ```// @formatter:off``` to end the block of unformatted code
 
 If comment sections need same behaviour such as javadocs, note that the entire block must be around entire comment as direct usage does not properly indicate that formatter treats it all as one comment block regardless.

--- a/format.xml
+++ b/format.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2023 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE Format>
+<Format>
+ <!-- Dummy format file -->
+</Format>

--- a/pom.xml
+++ b/pom.xml
@@ -447,6 +447,13 @@
                 </testExcludes>
               </configuration>
             </plugin>
+            <plugin>
+              <groupId>net.revelc.code</groupId>
+              <artifactId>impsort-maven-plugin</artifactId>
+              <configuration>
+                <skip>true</skip>
+              </configuration>
+            </plugin>
           </plugins>
         </pluginManagement>
       </build>

--- a/src/main/java/org/apache/ibatis/annotations/SelectProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/SelectProvider.java
@@ -65,7 +65,6 @@ public @interface SelectProvider {
    * Specify a type that implements an SQL provider method.
    * <p>
    * This attribute is alias of {@link #value()}.
-   * </p>
    *
    * @return a type that implements an SQL provider method
    *
@@ -77,18 +76,24 @@ public @interface SelectProvider {
    * Specify a method for providing an SQL.
    * <p>
    * Since 3.5.1, this attribute can omit.
+   * <p>
    * If this attribute omit, the MyBatis will call a method that decide by following rules.
+   *
+   * <pre>
    * <ul>
    *   <li>
    *     If class that specified the {@link #type()} attribute implements the
    *     {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver},
-   *     the MyBatis use a method that returned by it
+   *     the MyBatis use a method that returned by it.
    *   </li>
    *   <li>
-   *     If cannot resolve a method by {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver}(= not implement it or it was returned {@code null}),
-   *     the MyBatis will search and use a fallback method that named {@code provideSql} from specified type
+   *     If cannot resolve a method by {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver}
+   *     (= not implement it or it was returned <code>null</code>,
+   *     the MyBatis will search and use a fallback method that named <code>provideSql</code> from
+   *     specified type.
    *   </li>
    * </ul>
+   * </pre>
    *
    * @return a method name of method for providing an SQL
    */

--- a/src/main/java/org/apache/ibatis/annotations/TypeDiscriminator.java
+++ b/src/main/java/org/apache/ibatis/annotations/TypeDiscriminator.java
@@ -25,6 +25,7 @@ import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
 import org.apache.ibatis.type.UnknownTypeHandler;
 
+// @formatter:off
 /**
  * The annotation that be grouping conditional mapping definitions.
  * <p>
@@ -48,6 +49,7 @@ import org.apache.ibatis.type.UnknownTypeHandler;
  *
  * @author Clinton Begin
  */
+// @formatter:on
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/src/main/java/org/apache/ibatis/annotations/UpdateProvider.java
+++ b/src/main/java/org/apache/ibatis/annotations/UpdateProvider.java
@@ -78,6 +78,8 @@ public @interface UpdateProvider {
    * <p>
    * Since 3.5.1, this attribute can omit. If this attribute omit, the MyBatis will call a method that decide by
    * following rules.
+   *
+   * <pre>
    * <ul>
    *   <li>
    *     If class that specified the {@link #type()} attribute implements the
@@ -85,10 +87,12 @@ public @interface UpdateProvider {
    *     the MyBatis use a method that returned by it
    *   </li>
    *   <li>
-   *     If cannot resolve a method by {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver}(= not implement it or it was returned {@code null}),
-   *     the MyBatis will search and use a fallback method that named {@code provideSql} from specified type
+   *     If cannot resolve a method by {@link org.apache.ibatis.builder.annotation.ProviderMethodResolver}
+   *     (= not implement it or it was returned <code>null</code>,
+   *     the MyBatis will search and use a fallback method that named <code>provideSql</code> from specified type
    *   </li>
    * </ul>
+   * </pre>
    *
    * @return a method name of method for providing an SQL
    */

--- a/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
+++ b/src/main/java/org/apache/ibatis/builder/MapperBuilderAssistant.java
@@ -121,22 +121,11 @@ public class MapperBuilderAssistant extends BaseBuilder {
     }
   }
 
-  public Cache useNewCache(Class<? extends Cache> typeClass,
-      Class<? extends Cache> evictionClass,
-      Long flushInterval,
-      Integer size,
-      boolean readWrite,
-      boolean blocking,
-      Properties props) {
-    Cache cache = new CacheBuilder(currentNamespace)
-        .implementation(valueOrDefault(typeClass, PerpetualCache.class))
-        .addDecorator(valueOrDefault(evictionClass, LruCache.class))
-        .clearInterval(flushInterval)
-        .size(size)
-        .readWrite(readWrite)
-        .blocking(blocking)
-        .properties(props)
-        .build();
+  public Cache useNewCache(Class<? extends Cache> typeClass, Class<? extends Cache> evictionClass, Long flushInterval,
+      Integer size, boolean readWrite, boolean blocking, Properties props) {
+    Cache cache = new CacheBuilder(currentNamespace).implementation(valueOrDefault(typeClass, PerpetualCache.class))
+        .addDecorator(valueOrDefault(evictionClass, LruCache.class)).clearInterval(flushInterval).size(size)
+        .readWrite(readWrite).blocking(blocking).properties(props).build();
     configuration.addCache(cache);
     currentCache = cache;
     return cache;
@@ -149,14 +138,8 @@ public class MapperBuilderAssistant extends BaseBuilder {
     return parameterMap;
   }
 
-  public ParameterMapping buildParameterMapping(
-      Class<?> parameterType,
-      String property,
-      Class<?> javaType,
-      JdbcType jdbcType,
-      String resultMap,
-      ParameterMode parameterMode,
-      Class<? extends TypeHandler<?>> typeHandler,
+  public ParameterMapping buildParameterMapping(Class<?> parameterType, String property, Class<?> javaType,
+      JdbcType jdbcType, String resultMap, ParameterMode parameterMode, Class<? extends TypeHandler<?>> typeHandler,
       Integer numericScale) {
     resultMap = applyCurrentNamespace(resultMap, true);
 
@@ -164,22 +147,12 @@ public class MapperBuilderAssistant extends BaseBuilder {
     Class<?> javaTypeClass = resolveParameterJavaType(parameterType, property, javaType, jdbcType);
     TypeHandler<?> typeHandlerInstance = resolveTypeHandler(javaTypeClass, typeHandler);
 
-    return new ParameterMapping.Builder(configuration, property, javaTypeClass)
-        .jdbcType(jdbcType)
-        .resultMapId(resultMap)
-        .mode(parameterMode)
-        .numericScale(numericScale)
-        .typeHandler(typeHandlerInstance)
-        .build();
+    return new ParameterMapping.Builder(configuration, property, javaTypeClass).jdbcType(jdbcType)
+        .resultMapId(resultMap).mode(parameterMode).numericScale(numericScale).typeHandler(typeHandlerInstance).build();
   }
 
-  public ResultMap addResultMap(
-      String id,
-      Class<?> type,
-      String extend,
-      Discriminator discriminator,
-      List<ResultMapping> resultMappings,
-      Boolean autoMapping) {
+  public ResultMap addResultMap(String id, Class<?> type, String extend, Discriminator discriminator,
+      List<ResultMapping> resultMappings, Boolean autoMapping) {
     id = applyCurrentNamespace(id, false);
     extend = applyCurrentNamespace(extend, true);
 
@@ -209,28 +182,10 @@ public class MapperBuilderAssistant extends BaseBuilder {
     return resultMap;
   }
 
-  public Discriminator buildDiscriminator(
-      Class<?> resultType,
-      String column,
-      Class<?> javaType,
-      JdbcType jdbcType,
-      Class<? extends TypeHandler<?>> typeHandler,
-      Map<String, String> discriminatorMap) {
-    ResultMapping resultMapping = buildResultMapping(
-        resultType,
-        null,
-        column,
-        javaType,
-        jdbcType,
-        null,
-        null,
-        null,
-        null,
-        typeHandler,
-        new ArrayList<>(),
-        null,
-        null,
-        false);
+  public Discriminator buildDiscriminator(Class<?> resultType, String column, Class<?> javaType, JdbcType jdbcType,
+      Class<? extends TypeHandler<?>> typeHandler, Map<String, String> discriminatorMap) {
+    ResultMapping resultMapping = buildResultMapping(resultType, null, column, javaType, jdbcType, null, null, null,
+        null, typeHandler, new ArrayList<>(), null, null, false);
     Map<String, String> namespaceDiscriminatorMap = new HashMap<>();
     for (Map.Entry<String, String> e : discriminatorMap.entrySet()) {
       String resultMap = e.getValue();
@@ -240,28 +195,11 @@ public class MapperBuilderAssistant extends BaseBuilder {
     return new Discriminator.Builder(configuration, resultMapping, namespaceDiscriminatorMap).build();
   }
 
-  public MappedStatement addMappedStatement(
-      String id,
-      SqlSource sqlSource,
-      StatementType statementType,
-      SqlCommandType sqlCommandType,
-      Integer fetchSize,
-      Integer timeout,
-      String parameterMap,
-      Class<?> parameterType,
-      String resultMap,
-      Class<?> resultType,
-      ResultSetType resultSetType,
-      boolean flushCache,
-      boolean useCache,
-      boolean resultOrdered,
-      KeyGenerator keyGenerator,
-      String keyProperty,
-      String keyColumn,
-      String databaseId,
-      LanguageDriver lang,
-      String resultSets,
-      boolean dirtySelect) {
+  public MappedStatement addMappedStatement(String id, SqlSource sqlSource, StatementType statementType,
+      SqlCommandType sqlCommandType, Integer fetchSize, Integer timeout, String parameterMap, Class<?> parameterType,
+      String resultMap, Class<?> resultType, ResultSetType resultSetType, boolean flushCache, boolean useCache,
+      boolean resultOrdered, KeyGenerator keyGenerator, String keyProperty, String keyColumn, String databaseId,
+      LanguageDriver lang, String resultSets, boolean dirtySelect) {
 
     if (unresolvedCacheRef) {
       throw new IncompleteElementException("Cache-ref not yet resolved");
@@ -270,23 +208,11 @@ public class MapperBuilderAssistant extends BaseBuilder {
     id = applyCurrentNamespace(id, false);
 
     MappedStatement.Builder statementBuilder = new MappedStatement.Builder(configuration, id, sqlSource, sqlCommandType)
-        .resource(resource)
-        .fetchSize(fetchSize)
-        .timeout(timeout)
-        .statementType(statementType)
-        .keyGenerator(keyGenerator)
-        .keyProperty(keyProperty)
-        .keyColumn(keyColumn)
-        .databaseId(databaseId)
-        .lang(lang)
-        .resultOrdered(resultOrdered)
-        .resultSets(resultSets)
-        .resultMaps(getStatementResultMaps(resultMap, resultType, id))
-        .resultSetType(resultSetType)
-        .flushCacheRequired(flushCache)
-        .useCache(useCache)
-        .cache(currentCache)
-        .dirtySelect(dirtySelect);
+        .resource(resource).fetchSize(fetchSize).timeout(timeout).statementType(statementType)
+        .keyGenerator(keyGenerator).keyProperty(keyProperty).keyColumn(keyColumn).databaseId(databaseId).lang(lang)
+        .resultOrdered(resultOrdered).resultSets(resultSets)
+        .resultMaps(getStatementResultMaps(resultMap, resultType, id)).resultSetType(resultSetType)
+        .flushCacheRequired(flushCache).useCache(useCache).cache(currentCache).dirtySelect(dirtySelect);
 
     ParameterMap statementParameterMap = getStatementParameterMap(parameterMap, parameterType, id);
     if (statementParameterMap != null) {
@@ -418,19 +344,12 @@ public class MapperBuilderAssistant extends BaseBuilder {
     } else {
       composites = parseCompositeColumnName(column);
     }
-    return new ResultMapping.Builder(configuration, property, column, javaTypeClass)
-        .jdbcType(jdbcType)
+    return new ResultMapping.Builder(configuration, property, column, javaTypeClass).jdbcType(jdbcType)
         .nestedQueryId(applyCurrentNamespace(nestedSelect, true))
-        .nestedResultMapId(applyCurrentNamespace(nestedResultMap, true))
-        .resultSet(resultSet)
-        .typeHandler(typeHandlerInstance)
-        .flags(flags == null ? new ArrayList<>() : flags)
-        .composites(composites)
-        .notNullColumns(parseMultipleColumnNames(notNullColumn))
-        .columnPrefix(columnPrefix)
-        .foreignColumn(foreignColumn)
-        .lazy(lazy)
-        .build();
+        .nestedResultMapId(applyCurrentNamespace(nestedResultMap, true)).resultSet(resultSet)
+        .typeHandler(typeHandlerInstance).flags(flags == null ? new ArrayList<>() : flags).composites(composites)
+        .notNullColumns(parseMultipleColumnNames(notNullColumn)).columnPrefix(columnPrefix).foreignColumn(foreignColumn)
+        .lazy(lazy).build();
   }
 
   /**

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -362,31 +362,13 @@ public class MapperAnnotationBuilder {
         }
       }
 
-      assistant.addMappedStatement(
-          mappedStatementId,
-          sqlSource,
-          statementType,
-          sqlCommandType,
-          fetchSize,
-          timeout,
+      assistant.addMappedStatement(mappedStatementId, sqlSource, statementType, sqlCommandType, fetchSize, timeout,
           // ParameterMapID
-          null,
-          parameterTypeClass,
-          resultMapId,
-          getReturnType(method, type),
-          resultSetType,
-          flushCache,
-          useCache,
+          null, parameterTypeClass, resultMapId, getReturnType(method, type), resultSetType, flushCache, useCache,
           // TODO gcode issue #577
-          false,
-          keyGenerator,
-          keyProperty,
-          keyColumn,
-          statementAnnotation.getDatabaseId(),
-          languageDriver,
+          false, keyGenerator, keyProperty, keyColumn, statementAnnotation.getDatabaseId(), languageDriver,
           // ResultSets
-          options != null ? nullOrEmpty(options.resultSets()) : null,
-          statementAnnotation.isDirtySelect());
+          options != null ? nullOrEmpty(options.resultSets()) : null, statementAnnotation.isDirtySelect());
     });
   }
 
@@ -480,24 +462,15 @@ public class MapperAnnotationBuilder {
         flags.add(ResultFlag.ID);
       }
       @SuppressWarnings("unchecked")
-      Class<? extends TypeHandler<?>> typeHandler = (Class<? extends TypeHandler<?>>)
-              ((result.typeHandler() == UnknownTypeHandler.class) ? null : result.typeHandler());
+      Class<? extends TypeHandler<?>> typeHandler = (Class<? extends TypeHandler<?>>) ((result
+          .typeHandler() == UnknownTypeHandler.class) ? null : result.typeHandler());
       boolean hasNestedResultMap = hasNestedResultMap(result);
-      ResultMapping resultMapping = assistant.buildResultMapping(
-          resultType,
-          nullOrEmpty(result.property()),
-          nullOrEmpty(result.column()),
-          result.javaType() == void.class ? null : result.javaType(),
+      ResultMapping resultMapping = assistant.buildResultMapping(resultType, nullOrEmpty(result.property()),
+          nullOrEmpty(result.column()), result.javaType() == void.class ? null : result.javaType(),
           result.jdbcType() == JdbcType.UNDEFINED ? null : result.jdbcType(),
           hasNestedSelect(result) ? nestedSelectId(result) : null,
-          hasNestedResultMap ? nestedResultMapId(result) : null,
-          null,
-          hasNestedResultMap ? findColumnPrefix(result) : null,
-          typeHandler,
-          flags,
-          null,
-          null,
-          isLazy(result));
+          hasNestedResultMap ? nestedResultMapId(result) : null, null,
+          hasNestedResultMap ? findColumnPrefix(result) : null, typeHandler, flags, null, null, isLazy(result));
       resultMappings.add(resultMapping);
     }
   }
@@ -564,23 +537,12 @@ public class MapperAnnotationBuilder {
         flags.add(ResultFlag.ID);
       }
       @SuppressWarnings("unchecked")
-      Class<? extends TypeHandler<?>> typeHandler = (Class<? extends TypeHandler<?>>)
-              (arg.typeHandler() == UnknownTypeHandler.class ? null : arg.typeHandler());
-      ResultMapping resultMapping = assistant.buildResultMapping(
-          resultType,
-          nullOrEmpty(arg.name()),
-          nullOrEmpty(arg.column()),
-          arg.javaType() == void.class ? null : arg.javaType(),
-          arg.jdbcType() == JdbcType.UNDEFINED ? null : arg.jdbcType(),
-          nullOrEmpty(arg.select()),
-          nullOrEmpty(arg.resultMap()),
-          null,
-          nullOrEmpty(arg.columnPrefix()),
-          typeHandler,
-          flags,
-          null,
-          null,
-          false);
+      Class<? extends TypeHandler<?>> typeHandler = (Class<? extends TypeHandler<?>>) (arg
+          .typeHandler() == UnknownTypeHandler.class ? null : arg.typeHandler());
+      ResultMapping resultMapping = assistant.buildResultMapping(resultType, nullOrEmpty(arg.name()),
+          nullOrEmpty(arg.column()), arg.javaType() == void.class ? null : arg.javaType(),
+          arg.jdbcType() == JdbcType.UNDEFINED ? null : arg.jdbcType(), nullOrEmpty(arg.select()),
+          nullOrEmpty(arg.resultMap()), null, nullOrEmpty(arg.columnPrefix()), typeHandler, flags, null, null, false);
       resultMappings.add(resultMapping);
     }
   }

--- a/src/main/java/org/apache/ibatis/plugin/Intercepts.java
+++ b/src/main/java/org/apache/ibatis/plugin/Intercepts.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+// @formatter:off
 /**
  * The annotation that specify target methods to intercept.
  * <p>
@@ -44,6 +45,7 @@ import java.lang.annotation.Target;
  *
  * @author Clinton Begin
  */
+// @formatter:on
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/src/main/java/org/apache/ibatis/session/TransactionIsolationLevel.java
+++ b/src/main/java/org/apache/ibatis/session/TransactionIsolationLevel.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,13 +22,18 @@ import java.sql.Connection;
  */
 public enum TransactionIsolationLevel {
   NONE(Connection.TRANSACTION_NONE),
+
   READ_COMMITTED(Connection.TRANSACTION_READ_COMMITTED),
+
   READ_UNCOMMITTED(Connection.TRANSACTION_READ_UNCOMMITTED),
+
   REPEATABLE_READ(Connection.TRANSACTION_REPEATABLE_READ),
+
   SERIALIZABLE(Connection.TRANSACTION_SERIALIZABLE),
+
   /**
-   * A non-standard isolation level for Microsoft SQL Server.
-   * Defined in the SQL Server JDBC driver {@link com.microsoft.sqlserver.jdbc.ISQLServerConnection}
+   * A non-standard isolation level for Microsoft SQL Server. Defined in the SQL Server JDBC driver
+   * {@link com.microsoft.sqlserver.jdbc.ISQLServerConnection}
    *
    * @since 3.5.6
    */

--- a/src/test/java/org/apache/ibatis/binding/BoundAuthorMapper.java
+++ b/src/test/java/org/apache/ibatis/binding/BoundAuthorMapper.java
@@ -45,8 +45,9 @@ public interface BoundAuthorMapper {
 
   int insertAuthorDynamic(Author author);
 
-  //======================================================
+  // ======================================================
 
+  // @formatter:off
   @ConstructorArgs({
       @Arg(column = "AUTHOR_ID", javaType = int.class)
   })
@@ -64,6 +65,7 @@ public interface BoundAuthorMapper {
       "  EMAIL as AUTHOR_EMAIL,",
       "  BIO as AUTHOR_BIO",
       "FROM AUTHOR WHERE ID = #{id}"})
+  // @formatter:on
   Author selectAuthor(int id);
 
   // ======================================================
@@ -73,6 +75,7 @@ public interface BoundAuthorMapper {
   @Result(property = "password", column = "AUTHOR_PASSWORD")
   @Result(property = "email", column = "AUTHOR_EMAIL")
   @Result(property = "bio", column = "AUTHOR_BIO")
+  // @formatter:off
   @Select({
     "SELECT ",
     "  ID as AUTHOR_ID,",
@@ -81,10 +84,12 @@ public interface BoundAuthorMapper {
     "  EMAIL as AUTHOR_EMAIL,",
     "  BIO as AUTHOR_BIO",
     "FROM AUTHOR WHERE ID = #{id}"})
+  // @formatter:on
   Author selectAuthorMapToPropertiesUsingRepeatable(int id);
 
   // ======================================================
 
+  // @formatter:off
   @ConstructorArgs({
       @Arg(column = "AUTHOR_ID", javaType = Integer.class),
       @Arg(column = "AUTHOR_USERNAME", javaType = String.class),
@@ -102,6 +107,7 @@ public interface BoundAuthorMapper {
       "  BIO as AUTHOR_BIO," +
           "  FAVOURITE_SECTION as AUTHOR_SECTION",
       "FROM AUTHOR WHERE ID = #{id}"})
+  // @formatter:on
   Author selectAuthorConstructor(int id);
 
   // ======================================================
@@ -112,6 +118,7 @@ public interface BoundAuthorMapper {
   @Arg(column = "AUTHOR_EMAIL", javaType = String.class)
   @Arg(column = "AUTHOR_BIO", javaType = String.class)
   @Arg(column = "AUTHOR_SECTION", javaType = Section.class)
+  // @formatter:off
   @Select({
     "SELECT ",
     "  ID as AUTHOR_ID,",
@@ -121,12 +128,14 @@ public interface BoundAuthorMapper {
     "  BIO as AUTHOR_BIO," +
       "  FAVOURITE_SECTION as AUTHOR_SECTION",
     "FROM AUTHOR WHERE ID = #{id}"})
+  // @formatter:on
   Author selectAuthorMapToConstructorUsingRepeatable(int id);
 
   // ======================================================
 
   @Arg(column = "AUTHOR_ID", javaType = int.class)
   @Result(property = "username", column = "AUTHOR_USERNAME")
+  // @formatter:off
   @Select({
     "SELECT ",
     "  ID as AUTHOR_ID,",
@@ -135,10 +144,12 @@ public interface BoundAuthorMapper {
     "  EMAIL as AUTHOR_EMAIL,",
     "  BIO as AUTHOR_BIO",
     "FROM AUTHOR WHERE ID = #{id}"})
+  // @formatter:on
   Author selectAuthorUsingSingleRepeatable(int id);
 
   // ======================================================
 
+  // @formatter:off
   @ConstructorArgs({
     @Arg(column = "AUTHOR_ID", javaType = Integer.class),
     @Arg(column = "AUTHOR_USERNAME", javaType = String.class),
@@ -156,10 +167,12 @@ public interface BoundAuthorMapper {
     "  BIO as AUTHOR_BIO," +
       "  FAVOURITE_SECTION as AUTHOR_SECTION",
     "FROM AUTHOR WHERE ID = #{id}"})
+  // @formatter:on
   Author selectAuthorUsingBothArgAndConstructorArgs(int id);
 
   // ======================================================
 
+  // @formatter:off
   @Results(
     @Result(property = "id", column = "AUTHOR_ID")
   )
@@ -169,14 +182,12 @@ public interface BoundAuthorMapper {
     "  ID as AUTHOR_ID,",
     "  USERNAME as AUTHOR_USERNAME",
     "FROM AUTHOR WHERE ID = #{id}"})
+  // @formatter:on
   Author selectAuthorUsingBothResultAndResults(int id);
 
   // ======================================================
 
-  List<Post> findThreeSpecificPosts(@Param("one") int one,
-                                    RowBounds rowBounds,
-                                    @Param("two") int two,
-                                    int three);
+  List<Post> findThreeSpecificPosts(@Param("one") int one, RowBounds rowBounds, @Param("two") int two, int three);
 
   @Flush
   List<BatchResult> flush();

--- a/src/test/java/org/apache/ibatis/binding/BoundBlogMapper.java
+++ b/src/test/java/org/apache/ibatis/binding/BoundBlogMapper.java
@@ -51,26 +51,31 @@ public interface BoundBlogMapper {
 
   // ======================================================
 
+  // @formatter:off
   @Select({
       "SELECT *",
       "FROM blog"
   })
+  // @formatter:on
   List<Blog> selectBlogs();
 
+  // @formatter:off
   @Select({
           "SELECT *",
           "FROM blog",
           "ORDER BY id"
   })
+  // @formatter:on
   @ResultType(Blog.class)
   void collectRangeBlogs(ResultHandler<Object> blog, RowBounds rowBounds);
 
-
+  // @formatter:off
   @Select({
           "SELECT *",
           "FROM blog",
           "ORDER BY id"
   })
+  // @formatter:on
   Cursor<Blog> openRangeBlogs(RowBounds rowBounds);
 
   // ======================================================
@@ -79,11 +84,13 @@ public interface BoundBlogMapper {
 
   // ======================================================
 
+  // @formatter:off
   @Select({
       "SELECT *",
       "FROM blog"
   })
-  List<Map<String,Object>> selectBlogsAsMaps();
+  // @formatter:on
+  List<Map<String, Object>> selectBlogsAsMaps();
 
   // ======================================================
 
@@ -93,16 +100,19 @@ public interface BoundBlogMapper {
   // ======================================================
 
   @Select("SELECT * FROM post ORDER BY id")
+  // @formatter:off
   @TypeDiscriminator(
       column = "draft",
       javaType = String.class,
       cases = {@Case(value = "1", type = DraftPost.class)}
   )
+  // @formatter:on
   List<Post> selectPosts();
 
   // ======================================================
 
   @Select("SELECT * FROM post ORDER BY id")
+  // @formatter:off
   @Results({
       @Result(id = true, property = "id", column = "id")
   })
@@ -112,16 +122,20 @@ public interface BoundBlogMapper {
       cases = {@Case(value = "1", type = DraftPost.class,
           results = {@Result(id = true, property = "id", column = "id")})}
   )
+  // @formatter:on
   List<Post> selectPostsWithResultMap();
 
   // ======================================================
 
+  // @formatter:off
   @Select("SELECT * FROM " +
       "blog WHERE id = #{id}")
+  // @formatter:on
   Blog selectBlog(int id);
 
   // ======================================================
 
+  // @formatter:off
   @Select("SELECT * FROM " +
       "blog WHERE id = #{id}")
   @ConstructorArgs({
@@ -130,6 +144,7 @@ public interface BoundBlogMapper {
       @Arg(column = "author_id", javaType = Author.class, select = "org.apache.ibatis.binding.BoundAuthorMapper.selectAuthor"),
       @Arg(column = "id", javaType = List.class, select = "selectPostsForBlog")
   })
+  // @formatter:on
   Blog selectBlogUsingConstructor(int id);
 
   Blog selectBlogUsingConstructorWithResultMap(int i);
@@ -142,38 +157,49 @@ public interface BoundBlogMapper {
 
   // ======================================================
 
+  // @formatter:off
   @Select("SELECT * FROM " +
       "blog WHERE id = #{id}")
-  Map<String,Object> selectBlogAsMap(Map<String,Object> params);
+  // @formatter:on
+  Map<String, Object> selectBlogAsMap(Map<String, Object> params);
 
   // ======================================================
 
+  // @formatter:off
   @Select("SELECT * FROM " +
     "post WHERE subject like #{query}")
+  // @formatter:on
   List<Post> selectPostsLike(RowBounds bounds, String query);
-
-  //======================================================
-
-  @Select("SELECT * FROM " +
-    "post WHERE subject like #{subjectQuery} and body like #{bodyQuery}")
-  List<Post> selectPostsLikeSubjectAndBody(RowBounds bounds,
-                             @Param("subjectQuery") String subjectQuery,
-                             @Param("bodyQuery") String bodyQuery);
 
   // ======================================================
 
+  // @formatter:off
+  @Select("SELECT * FROM " +
+    "post WHERE subject like #{subjectQuery} and body like #{bodyQuery}")
+  // @formatter:on
+  List<Post> selectPostsLikeSubjectAndBody(RowBounds bounds, @Param("subjectQuery") String subjectQuery,
+      @Param("bodyQuery") String bodyQuery);
+
+  // ======================================================
+
+  // @formatter:off
   @Select("SELECT * FROM " +
     "post WHERE id = #{id}")
+  // @formatter:on
   List<Post> selectPostsById(int id);
 
   // ======================================================
 
+  // @formatter:off
   @Select("SELECT * FROM blog " +
           "WHERE id = #{id} AND title = #{nonExistentParam,jdbcType=VARCHAR}")
+  // @formatter:on
   Blog selectBlogByNonExistentParam(@Param("id") int id);
 
+  // @formatter:off
   @Select("SELECT * FROM blog " +
           "WHERE id = #{id} AND title = #{params.nonExistentParam,jdbcType=VARCHAR}")
+  // @formatter:on
   Blog selectBlogByNonExistentNestedParam(@Param("id") int id, @Param("params") Map<String, Object> params);
 
   @Select("SELECT * FROM blog WHERE id = #{id}")
@@ -181,22 +207,30 @@ public interface BoundBlogMapper {
 
   // ======================================================
 
+  // @formatter:off
   @Select("SELECT * FROM blog " +
       "WHERE id = #{0} AND title = #{1}")
+  // @formatter:on
   Blog selectBlogByDefault30ParamNames(int id, String title);
 
+  // @formatter:off
   @Select("SELECT * FROM blog " +
       "WHERE id = #{param1} AND title = #{param2}")
+  // @formatter:on
   Blog selectBlogByDefault31ParamNames(int id, String title);
 
   // ======================================================
 
+  // @formatter:off
   @Select("SELECT * FROM blog " +
       "WHERE ${column} = #{id} AND title = #{value}")
-  Blog selectBlogWithAParamNamedValue(@Param("column") String column, @Param("id") int id, @Param("value") String title);
+  // @formatter:on
+  Blog selectBlogWithAParamNamedValue(@Param("column") String column, @Param("id") int id,
+      @Param("value") String title);
 
   // ======================================================
 
+  // @formatter:off
   @Select({
       "SELECT *",
       "FROM blog"
@@ -205,8 +239,10 @@ public interface BoundBlogMapper {
       @Result(property = "author", column = "author_id", one = @One(select = "org.apache.ibatis.binding.BoundAuthorMapper.selectAuthor")),
       @Result(property = "posts", column = "id", many = @Many(select = "selectPostsById"))
   })
+  // @formatter:on
   List<Blog> selectBlogsWithAutorAndPosts();
 
+  // @formatter:off
   @Select({
       "SELECT *",
       "FROM blog"
@@ -215,6 +251,7 @@ public interface BoundBlogMapper {
       @Result(property = "author", column = "author_id", one = @One(select = "org.apache.ibatis.binding.BoundAuthorMapper.selectAuthor", fetchType=FetchType.EAGER)),
       @Result(property = "posts", column = "id", many = @Many(select = "selectPostsById", fetchType=FetchType.EAGER))
   })
+  // @formatter:on
   List<Blog> selectBlogsWithAutorAndPostsEagerly();
 
 }

--- a/src/test/java/org/apache/ibatis/binding/MapperWithOneAndMany.java
+++ b/src/test/java/org/apache/ibatis/binding/MapperWithOneAndMany.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.apache.ibatis.domain.blog.Blog;
 
 public interface MapperWithOneAndMany {
 
+  // @formatter:off
   @Select({
     "SELECT *",
     "FROM blog"
@@ -36,6 +37,7 @@ public interface MapperWithOneAndMany {
        one = @One(select = "org.apache.ibatis.binding.BoundAuthorMapper.selectAuthor"),
        many = @Many(select = "org.apache.ibatis.binding.BoundBlogMapper.selectPostsById"))
   })
+  // @formatter:on
   List<Blog> selectWithBothOneAndMany();
 
 }

--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -151,6 +151,7 @@ class XmlConfigBuilderTest {
 
   @Test
   void registerJavaTypeInitializingTypeHandler() {
+    // @formatter:off
     final String MAPPER_CONFIG = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
         + "<!DOCTYPE configuration PUBLIC \"-//mybatis.org//DTD Config 3.0//EN\" \"https://mybatis.org/dtd/mybatis-3-config.dtd\">\n"
         + "<configuration>\n"
@@ -159,6 +160,7 @@ class XmlConfigBuilderTest {
         + "      handler=\"org.apache.ibatis.builder.XmlConfigBuilderTest$EnumOrderTypeHandler\"/>\n"
         + "  </typeHandlers>\n"
         + "</configuration>\n";
+    // @formatter:on
 
     XMLConfigBuilder builder = new XMLConfigBuilder(new StringReader(MAPPER_CONFIG));
     builder.parse();
@@ -278,6 +280,7 @@ class XmlConfigBuilderTest {
 
   @Test
   void unknownSettings() {
+    // @formatter:off
     final String MAPPER_CONFIG = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
             + "<!DOCTYPE configuration PUBLIC \"-//mybatis.org//DTD Config 3.0//EN\" \"https://mybatis.org/dtd/mybatis-3-config.dtd\">\n"
             + "<configuration>\n"
@@ -285,6 +288,7 @@ class XmlConfigBuilderTest {
             + "    <setting name=\"foo\" value=\"bar\"/>\n"
             + "  </settings>\n"
             + "</configuration>\n";
+    // @formatter:on
 
     XMLConfigBuilder builder = new XMLConfigBuilder(new StringReader(MAPPER_CONFIG));
     when(builder::parse);
@@ -294,6 +298,7 @@ class XmlConfigBuilderTest {
 
   @Test
   void unknownJavaTypeOnTypeHandler() {
+    // @formatter:off
     final String MAPPER_CONFIG = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
             + "<!DOCTYPE configuration PUBLIC \"-//mybatis.org//DTD Config 3.0//EN\" \"https://mybatis.org/dtd/mybatis-3-config.dtd\">\n"
             + "<configuration>\n"
@@ -301,6 +306,7 @@ class XmlConfigBuilderTest {
             + "    <typeAlias type=\"a.b.c.Foo\"/>\n"
             + "  </typeAliases>\n"
             + "</configuration>\n";
+    // @formatter:on
 
     XMLConfigBuilder builder = new XMLConfigBuilder(new StringReader(MAPPER_CONFIG));
     when(builder::parse);
@@ -310,11 +316,13 @@ class XmlConfigBuilderTest {
 
   @Test
   void propertiesSpecifyResourceAndUrlAtSameTime() {
+    // @formatter:off
     final String MAPPER_CONFIG = "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
         + "<!DOCTYPE configuration PUBLIC \"-//mybatis.org//DTD Config 3.0//EN\" \"https://mybatis.org/dtd/mybatis-3-config.dtd\">\n"
         + "<configuration>\n"
         + "  <properties resource=\"a/b/c/foo.properties\" url=\"file:./a/b/c/jdbc.properties\"/>\n"
         + "</configuration>\n";
+    // @formatter:on
 
     XMLConfigBuilder builder = new XMLConfigBuilder(new StringReader(MAPPER_CONFIG));
     when(builder::parse);

--- a/src/test/java/org/apache/ibatis/builder/xml/dynamic/DynamicSqlSourceTest.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/dynamic/DynamicSqlSourceTest.java
@@ -58,8 +58,7 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldDemonstrateMultipartExpectedTextWithNoLoopsOrConditionals() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE ID = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
         new TextSqlNode("WHERE ID = ?"));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
@@ -68,10 +67,8 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldConditionallyIncludeWhere() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE ID = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new IfSqlNode(mixedContents(new TextSqlNode("WHERE ID = ?")), "true"
-        ));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new IfSqlNode(mixedContents(new TextSqlNode("WHERE ID = ?")), "true"));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -79,10 +76,8 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldConditionallyExcludeWhere() throws Exception {
     final String expected = "SELECT * FROM BLOG";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new IfSqlNode(mixedContents(new TextSqlNode("WHERE ID = ?")), "false"
-        ));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new IfSqlNode(mixedContents(new TextSqlNode("WHERE ID = ?")), "false"));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -90,14 +85,13 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldConditionallyDefault() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE CATEGORY = 'DEFAULT'";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new ChooseSqlNode(new ArrayList<SqlNode>() {{
-          add(new IfSqlNode(mixedContents(new TextSqlNode("WHERE CATEGORY = ?")), "false"
-          ));
-          add(new IfSqlNode(mixedContents(new TextSqlNode("WHERE CATEGORY = 'NONE'")), "false"
-          ));
-        }}, mixedContents(new TextSqlNode("WHERE CATEGORY = 'DEFAULT'"))));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new ChooseSqlNode(new ArrayList<SqlNode>() {
+          {
+            add(new IfSqlNode(mixedContents(new TextSqlNode("WHERE CATEGORY = ?")), "false"));
+            add(new IfSqlNode(mixedContents(new TextSqlNode("WHERE CATEGORY = 'NONE'")), "false"));
+          }
+        }, mixedContents(new TextSqlNode("WHERE CATEGORY = 'DEFAULT'"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -105,14 +99,13 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldConditionallyChooseFirst() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE CATEGORY = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new ChooseSqlNode(new ArrayList<SqlNode>() {{
-          add(new IfSqlNode(mixedContents(new TextSqlNode("WHERE CATEGORY = ?")), "true"
-          ));
-          add(new IfSqlNode(mixedContents(new TextSqlNode("WHERE CATEGORY = 'NONE'")), "false"
-          ));
-        }}, mixedContents(new TextSqlNode("WHERE CATEGORY = 'DEFAULT'"))));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new ChooseSqlNode(new ArrayList<SqlNode>() {
+          {
+            add(new IfSqlNode(mixedContents(new TextSqlNode("WHERE CATEGORY = ?")), "true"));
+            add(new IfSqlNode(mixedContents(new TextSqlNode("WHERE CATEGORY = 'NONE'")), "false"));
+          }
+        }, mixedContents(new TextSqlNode("WHERE CATEGORY = 'DEFAULT'"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -120,14 +113,13 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldConditionallyChooseSecond() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE CATEGORY = 'NONE'";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new ChooseSqlNode(new ArrayList<SqlNode>() {{
-          add(new IfSqlNode(mixedContents(new TextSqlNode("WHERE CATEGORY = ?")), "false"
-          ));
-          add(new IfSqlNode(mixedContents(new TextSqlNode("WHERE CATEGORY = 'NONE'")), "true"
-          ));
-        }}, mixedContents(new TextSqlNode("WHERE CATEGORY = 'DEFAULT'"))));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new ChooseSqlNode(new ArrayList<SqlNode>() {
+          {
+            add(new IfSqlNode(mixedContents(new TextSqlNode("WHERE CATEGORY = ?")), "false"));
+            add(new IfSqlNode(mixedContents(new TextSqlNode("WHERE CATEGORY = 'NONE'")), "true"));
+          }
+        }, mixedContents(new TextSqlNode("WHERE CATEGORY = 'DEFAULT'"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -135,14 +127,10 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimWHEREInsteadOfANDForFirstCondition() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE  ID = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new WhereSqlNode(new Configuration(),mixedContents(
-            new IfSqlNode(mixedContents(new TextSqlNode("   and ID = ?  ")), "true"
-            ),
-            new IfSqlNode(mixedContents(new TextSqlNode("   or NAME = ?  ")), "false"
-            )
-        )));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new WhereSqlNode(new Configuration(),
+            mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("   and ID = ?  ")), "true"),
+                new IfSqlNode(mixedContents(new TextSqlNode("   or NAME = ?  ")), "false"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -150,12 +138,9 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimWHEREANDWithLFForFirstCondition() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE \n ID = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new WhereSqlNode(new Configuration(),mixedContents(
-            new IfSqlNode(mixedContents(new TextSqlNode("   and\n ID = ?  ")), "true"
-                )
-            )));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new WhereSqlNode(new Configuration(),
+            mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("   and\n ID = ?  ")), "true"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -163,12 +148,9 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimWHEREANDWithCRLFForFirstCondition() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE \r\n ID = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new WhereSqlNode(new Configuration(),mixedContents(
-            new IfSqlNode(mixedContents(new TextSqlNode("   and\r\n ID = ?  ")), "true"
-                )
-            )));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new WhereSqlNode(new Configuration(),
+            mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("   and\r\n ID = ?  ")), "true"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -176,12 +158,9 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimWHEREANDWithTABForFirstCondition() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE \t ID = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new WhereSqlNode(new Configuration(),mixedContents(
-            new IfSqlNode(mixedContents(new TextSqlNode("   and\t ID = ?  ")), "true"
-                )
-            )));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new WhereSqlNode(new Configuration(),
+            mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("   and\t ID = ?  ")), "true"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -189,12 +168,8 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimWHEREORWithLFForFirstCondition() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE \n ID = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new WhereSqlNode(new Configuration(),mixedContents(
-            new IfSqlNode(mixedContents(new TextSqlNode("   or\n ID = ?  ")), "true"
-                )
-            )));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"), new WhereSqlNode(
+        new Configuration(), mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("   or\n ID = ?  ")), "true"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -202,12 +177,9 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimWHEREORWithCRLFForFirstCondition() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE \r\n ID = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new WhereSqlNode(new Configuration(),mixedContents(
-            new IfSqlNode(mixedContents(new TextSqlNode("   or\r\n ID = ?  ")), "true"
-                )
-            )));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new WhereSqlNode(new Configuration(),
+            mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("   or\r\n ID = ?  ")), "true"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -215,12 +187,8 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimWHEREORWithTABForFirstCondition() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE \t ID = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new WhereSqlNode(new Configuration(),mixedContents(
-            new IfSqlNode(mixedContents(new TextSqlNode("   or\t ID = ?  ")), "true"
-                )
-            )));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"), new WhereSqlNode(
+        new Configuration(), mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("   or\t ID = ?  ")), "true"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -228,14 +196,10 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimWHEREInsteadOfORForSecondCondition() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE  NAME = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new WhereSqlNode(new Configuration(),mixedContents(
-            new IfSqlNode(mixedContents(new TextSqlNode("   and ID = ?  ")), "false"
-            ),
-            new IfSqlNode(mixedContents(new TextSqlNode("   or NAME = ?  ")), "true"
-            )
-        )));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new WhereSqlNode(new Configuration(),
+            mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("   and ID = ?  ")), "false"),
+                new IfSqlNode(mixedContents(new TextSqlNode("   or NAME = ?  ")), "true"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -243,14 +207,10 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimWHEREInsteadOfANDForBothConditions() throws Exception {
     final String expected = "SELECT * FROM BLOG WHERE  ID = ?   OR NAME = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new WhereSqlNode(new Configuration(),mixedContents(
-            new IfSqlNode(mixedContents(new TextSqlNode("   and ID = ?   ")), "true"
-            ),
-            new IfSqlNode(mixedContents(new TextSqlNode("OR NAME = ?  ")), "true"
-            )
-        )));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new WhereSqlNode(new Configuration(),
+            mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("   and ID = ?   ")), "true"),
+                new IfSqlNode(mixedContents(new TextSqlNode("OR NAME = ?  ")), "true"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -258,14 +218,10 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimNoWhereClause() throws Exception {
     final String expected = "SELECT * FROM BLOG";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG"),
-        new WhereSqlNode(new Configuration(),mixedContents(
-            new IfSqlNode(mixedContents(new TextSqlNode("   and ID = ?   ")), "false"
-            ),
-            new IfSqlNode(mixedContents(new TextSqlNode("OR NAME = ?  ")), "false"
-            )
-        )));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
+        new WhereSqlNode(new Configuration(),
+            mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("   and ID = ?   ")), "false"),
+                new IfSqlNode(mixedContents(new TextSqlNode("OR NAME = ?  ")), "false"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -273,14 +229,10 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimSETInsteadOfCOMMAForBothConditions() throws Exception {
     final String expected = "UPDATE BLOG SET ID = ?,  NAME = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("UPDATE BLOG"),
-        new SetSqlNode(new Configuration(),mixedContents(
-            new IfSqlNode(mixedContents(new TextSqlNode(" ID = ?, ")), "true"
-            ),
-            new IfSqlNode(mixedContents(new TextSqlNode(" NAME = ?, ")), "true"
-            )
-        )));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("UPDATE BLOG"),
+        new SetSqlNode(new Configuration(),
+            mixedContents(new IfSqlNode(mixedContents(new TextSqlNode(" ID = ?, ")), "true"),
+                new IfSqlNode(mixedContents(new TextSqlNode(" NAME = ?, ")), "true"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -288,11 +240,10 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimCommaAfterSET() throws Exception {
     final String expected = "UPDATE BLOG SET  NAME = ?";
-    DynamicSqlSource source = createDynamicSqlSource(
-      new TextSqlNode("UPDATE BLOG"),
-      new SetSqlNode(new Configuration(), mixedContents(
-        new IfSqlNode(mixedContents(new TextSqlNode("ID = ?")), "false"),
-        new IfSqlNode(mixedContents(new TextSqlNode(", NAME = ?")), "true"))));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("UPDATE BLOG"),
+        new SetSqlNode(new Configuration(),
+            mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("ID = ?")), "false"),
+                new IfSqlNode(mixedContents(new TextSqlNode(", NAME = ?")), "true"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
@@ -300,27 +251,25 @@ class DynamicSqlSourceTest extends BaseDataTest {
   @Test
   void shouldTrimNoSetClause() throws Exception {
     final String expected = "UPDATE BLOG";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("UPDATE BLOG"),
-        new SetSqlNode(new Configuration(),mixedContents(
-            new IfSqlNode(mixedContents(new TextSqlNode("   , ID = ?   ")), "false"
-            ),
-            new IfSqlNode(mixedContents(new TextSqlNode(", NAME = ?  ")), "false"
-            )
-        )));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("UPDATE BLOG"),
+        new SetSqlNode(new Configuration(),
+            mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("   , ID = ?   ")), "false"),
+                new IfSqlNode(mixedContents(new TextSqlNode(", NAME = ?  ")), "false"))));
     BoundSql boundSql = source.getBoundSql(null);
     assertEquals(expected, boundSql.getSql());
   }
 
   @Test
   void shouldIterateOnceForEachItemInCollection() throws Exception {
-    final HashMap<String, String[]> parameterObject = new HashMap<String, String[]>() {{
-      put("array", new String[]{"one", "two", "three"});
-    }};
+    final HashMap<String, String[]> parameterObject = new HashMap<String, String[]>() {
+      {
+        put("array", new String[] { "one", "two", "three" });
+      }
+    };
     final String expected = "SELECT * FROM BLOG WHERE ID in (  one = ? AND two = ? AND three = ? )";
-    DynamicSqlSource source = createDynamicSqlSource(
-        new TextSqlNode("SELECT * FROM BLOG WHERE ID in"),
-        new ForEachSqlNode(new Configuration(),mixedContents(new TextSqlNode("${item} = #{item}")), "array", "index", "item", "(", ")", "AND"));
+    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG WHERE ID in"),
+        new ForEachSqlNode(new Configuration(), mixedContents(new TextSqlNode("${item} = #{item}")), "array", "index",
+            "item", "(", ")", "AND"));
     BoundSql boundSql = source.getBoundSql(parameterObject);
     assertEquals(expected, boundSql.getSql());
     assertEquals(3, boundSql.getParameterMappings().size());
@@ -331,24 +280,29 @@ class DynamicSqlSourceTest extends BaseDataTest {
 
   @Test
   void shouldHandleOgnlExpression() throws Exception {
-    final HashMap<String, String> parameterObject = new HashMap<String, String>() {{
-      put("name", "Steve");
-    }};
+    final HashMap<String, String> parameterObject = new HashMap<String, String>() {
+      {
+        put("name", "Steve");
+      }
+    };
     final String expected = "Expression test: 3 / yes.";
-    DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("Expression test: ${name.indexOf('v')} / ${name in {'Bob', 'Steve'\\} ? 'yes' : 'no'}."));
+    DynamicSqlSource source = createDynamicSqlSource(
+        new TextSqlNode("Expression test: ${name.indexOf('v')} / ${name in {'Bob', 'Steve'\\} ? 'yes' : 'no'}."));
     BoundSql boundSql = source.getBoundSql(parameterObject);
     assertEquals(expected, boundSql.getSql());
   }
 
   @Test
   void shouldSkipForEachWhenCollectionIsEmpty() throws Exception {
-    final HashMap<String, Integer[]> parameterObject = new HashMap<String, Integer[]>() {{
+    final HashMap<String, Integer[]> parameterObject = new HashMap<String, Integer[]>() {
+      {
         put("array", new Integer[] {});
-    }};
+      }
+    };
     final String expected = "SELECT * FROM BLOG";
     DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
-        new ForEachSqlNode(new Configuration(), mixedContents(
-            new TextSqlNode("#{item}")), "array", null, "item", "WHERE id in (", ")", ","));
+        new ForEachSqlNode(new Configuration(), mixedContents(new TextSqlNode("#{item}")), "array", null, "item",
+            "WHERE id in (", ")", ","));
     BoundSql boundSql = source.getBoundSql(parameterObject);
     assertEquals(expected, boundSql.getSql());
     assertEquals(0, boundSql.getParameterMappings().size());
@@ -365,9 +319,11 @@ class DynamicSqlSourceTest extends BaseDataTest {
     param.put("uuuu", uuuu);
     DynamicSqlSource source = createDynamicSqlSource(
         new TextSqlNode("INSERT INTO BLOG (ID, NAME, NOTE, COMMENT) VALUES"),
-        new ForEachSqlNode(new Configuration(),mixedContents(
-            new TextSqlNode("#{uuu.u}, #{u.id}, #{ u,typeHandler=org.apache.ibatis.type.StringTypeHandler},"
-                + " #{u:VARCHAR,typeHandler=org.apache.ibatis.type.StringTypeHandler}")), "uuuu", "uu", "u", "(", ")", ","));
+        new ForEachSqlNode(new Configuration(),
+            mixedContents(
+                new TextSqlNode("#{uuu.u}, #{u.id}, #{ u,typeHandler=org.apache.ibatis.type.StringTypeHandler},"
+                    + " #{u:VARCHAR,typeHandler=org.apache.ibatis.type.StringTypeHandler}")),
+            "uuuu", "uu", "u", "(", ")", ","));
     BoundSql boundSql = source.getBoundSql(param);
     assertEquals(4, boundSql.getParameterMappings().size());
     assertEquals("uuu.u", boundSql.getParameterMappings().get(0).getProperty());

--- a/src/test/java/org/apache/ibatis/jdbc/SQLTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/SQLTest.java
@@ -29,6 +29,7 @@ class SQLTest {
     // From the tutorial
     final String sql = example1().usingAppender(sb).toString();
 
+    // @formatter:off
     assertEquals("SELECT P.ID, P.USERNAME, P.PASSWORD, P.FULL_NAME, P.LAST_NAME, P.CREATED_ON, P.UPDATED_ON\n" +
         "FROM PERSON P, ACCOUNT A\n" +
         "INNER JOIN DEPARTMENT D on D.ID = P.DEPARTMENT_ID\n" +
@@ -39,78 +40,91 @@ class SQLTest {
         "HAVING (P.LAST_NAME like ?) \n" +
         "OR (P.FIRST_NAME like ?)\n" +
         "ORDER BY P.ID, P.FULL_NAME", sql);
+    // @formatter:on
   }
 
   @Test
   void shouldDemonstrateMixedStyle() {
-    //Mixed
-    final String sql = new SQL() {{
-      SELECT("id, name");
-      FROM("PERSON A");
-      WHERE("name like ?").WHERE("id = ?");
-    }}.toString();
+    // Mixed
+    final String sql = new SQL() {
+      {
+        SELECT("id, name");
+        FROM("PERSON A");
+        WHERE("name like ?").WHERE("id = ?");
+      }
+    }.toString();
 
+    // @formatter:off
     assertEquals("" +
         "SELECT id, name\n" +
         "FROM PERSON A\n" +
         "WHERE (name like ? AND id = ?)", sql);
+    // @formatter:on
   }
 
   @Test
   void shouldDemonstrateFluentStyle() {
-    //Fluent Style
-    final String sql = new SQL()
-        .SELECT("id, name").FROM("PERSON A")
-        .WHERE("name like ?")
-        .WHERE("id = ?").toString();
+    // Fluent Style
+    final String sql = new SQL().SELECT("id, name").FROM("PERSON A").WHERE("name like ?").WHERE("id = ?").toString();
 
+    // @formatter:off
     assertEquals("" +
         "SELECT id, name\n" +
         "FROM PERSON A\n" +
         "WHERE (name like ? AND id = ?)", sql);
+    // @formatter:on
   }
 
   @Test
   void shouldProduceExpectedSimpleSelectStatement() {
+    // @formatter:off
     final String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME\n" +
             "FROM PERSON P\n" +
             "WHERE (P.ID like #id# AND P.FIRST_NAME like #firstName# AND P.LAST_NAME like #lastName#)\n" +
             "ORDER BY P.LAST_NAME";
+    // @formatter:on
     assertEquals(expected, example2("a", "b", "c"));
   }
 
   @Test
   void shouldProduceExpectedSimpleSelectStatementMissingFirstParam() {
+    // @formatter:off
     final String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME\n" +
             "FROM PERSON P\n" +
             "WHERE (P.FIRST_NAME like #firstName# AND P.LAST_NAME like #lastName#)\n" +
             "ORDER BY P.LAST_NAME";
+    // @formatter:on
     assertEquals(expected, example2(null, "b", "c"));
   }
 
   @Test
   void shouldProduceExpectedSimpleSelectStatementMissingFirstTwoParams() {
+    // @formatter:off
     final String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME\n" +
             "FROM PERSON P\n" +
             "WHERE (P.LAST_NAME like #lastName#)\n" +
             "ORDER BY P.LAST_NAME";
+    // @formatter:on
     assertEquals(expected, example2(null, null, "c"));
   }
 
   @Test
   void shouldProduceExpectedSimpleSelectStatementMissingAllParams() {
+    // @formatter:off
     final String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME\n" +
             "FROM PERSON P\n" +
             "ORDER BY P.LAST_NAME";
+    // @formatter:on
     assertEquals(expected, example2(null, null, null));
   }
 
   @Test
   void shouldProduceExpectedComplexSelectStatement() {
+    // @formatter:off
     final String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FULL_NAME, P.LAST_NAME, P.CREATED_ON, P.UPDATED_ON\n" +
             "FROM PERSON P, ACCOUNT A\n" +
@@ -122,176 +136,202 @@ class SQLTest {
             "HAVING (P.LAST_NAME like ?) \n" +
             "OR (P.FIRST_NAME like ?)\n" +
             "ORDER BY P.ID, P.FULL_NAME";
+    // @formatter:on
     assertEquals(expected, example1().toString());
   }
 
   private static SQL example1() {
-    return new SQL() {{
-      SELECT("P.ID, P.USERNAME, P.PASSWORD, P.FULL_NAME");
-      SELECT("P.LAST_NAME, P.CREATED_ON, P.UPDATED_ON");
-      FROM("PERSON P");
-      FROM("ACCOUNT A");
-      INNER_JOIN("DEPARTMENT D on D.ID = P.DEPARTMENT_ID");
-      INNER_JOIN("COMPANY C on D.COMPANY_ID = C.ID");
-      WHERE("P.ID = A.ID");
-      WHERE("P.FIRST_NAME like ?");
-      OR();
-      WHERE("P.LAST_NAME like ?");
-      GROUP_BY("P.ID");
-      HAVING("P.LAST_NAME like ?");
-      OR();
-      HAVING("P.FIRST_NAME like ?");
-      ORDER_BY("P.ID");
-      ORDER_BY("P.FULL_NAME");
-    }};
+    return new SQL() {
+      {
+        SELECT("P.ID, P.USERNAME, P.PASSWORD, P.FULL_NAME");
+        SELECT("P.LAST_NAME, P.CREATED_ON, P.UPDATED_ON");
+        FROM("PERSON P");
+        FROM("ACCOUNT A");
+        INNER_JOIN("DEPARTMENT D on D.ID = P.DEPARTMENT_ID");
+        INNER_JOIN("COMPANY C on D.COMPANY_ID = C.ID");
+        WHERE("P.ID = A.ID");
+        WHERE("P.FIRST_NAME like ?");
+        OR();
+        WHERE("P.LAST_NAME like ?");
+        GROUP_BY("P.ID");
+        HAVING("P.LAST_NAME like ?");
+        OR();
+        HAVING("P.FIRST_NAME like ?");
+        ORDER_BY("P.ID");
+        ORDER_BY("P.FULL_NAME");
+      }
+    };
   }
 
   private static String example2(final String id, final String firstName, final String lastName) {
-    return new SQL() {{
-      SELECT("P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME");
-      FROM("PERSON P");
-      if (id != null) {
-        WHERE("P.ID like #id#");
+    return new SQL() {
+      {
+        SELECT("P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME");
+        FROM("PERSON P");
+        if (id != null) {
+          WHERE("P.ID like #id#");
+        }
+        if (firstName != null) {
+          WHERE("P.FIRST_NAME like #firstName#");
+        }
+        if (lastName != null) {
+          WHERE("P.LAST_NAME like #lastName#");
+        }
+        ORDER_BY("P.LAST_NAME");
       }
-      if (firstName != null) {
-        WHERE("P.FIRST_NAME like #firstName#");
-      }
-      if (lastName != null) {
-        WHERE("P.LAST_NAME like #lastName#");
-      }
-      ORDER_BY("P.LAST_NAME");
-    }}.toString();
+    }.toString();
   }
-
 
   @Test
   void variableLengthArgumentOnSelect() {
-    final String sql = new SQL() {{
-      SELECT("P.ID", "P.USERNAME");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT("P.ID", "P.USERNAME");
+      }
+    }.toString();
 
     assertEquals("SELECT P.ID, P.USERNAME", sql);
   }
 
   @Test
   void variableLengthArgumentOnSelectDistinct() {
-    final String sql = new SQL() {{
-      SELECT_DISTINCT("P.ID", "P.USERNAME");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT_DISTINCT("P.ID", "P.USERNAME");
+      }
+    }.toString();
 
     assertEquals("SELECT DISTINCT P.ID, P.USERNAME", sql);
   }
 
   @Test
   void variableLengthArgumentOnFrom() {
-    final String sql = new SQL() {{
-      SELECT().FROM("TABLE_A a", "TABLE_B b");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT().FROM("TABLE_A a", "TABLE_B b");
+      }
+    }.toString();
 
     assertEquals("FROM TABLE_A a, TABLE_B b", sql);
   }
 
   @Test
   void variableLengthArgumentOnJoin() {
-    final String sql = new SQL() {{
-      SELECT().JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT().JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
+      }
+    }.toString();
 
-    assertEquals("JOIN TABLE_A b ON b.id = a.id\n" +
-        "JOIN TABLE_C c ON c.id = a.id", sql);
+    assertEquals("JOIN TABLE_A b ON b.id = a.id\n" + "JOIN TABLE_C c ON c.id = a.id", sql);
   }
 
   @Test
   void variableLengthArgumentOnInnerJoin() {
-    final String sql = new SQL() {{
-      SELECT().INNER_JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT().INNER_JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
+      }
+    }.toString();
 
-    assertEquals("INNER JOIN TABLE_A b ON b.id = a.id\n" +
-        "INNER JOIN TABLE_C c ON c.id = a.id", sql);
+    assertEquals("INNER JOIN TABLE_A b ON b.id = a.id\n" + "INNER JOIN TABLE_C c ON c.id = a.id", sql);
   }
 
   @Test
   void variableLengthArgumentOnOuterJoin() {
-    final String sql = new SQL() {{
-      SELECT().OUTER_JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT().OUTER_JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
+      }
+    }.toString();
 
-    assertEquals("OUTER JOIN TABLE_A b ON b.id = a.id\n" +
-        "OUTER JOIN TABLE_C c ON c.id = a.id", sql);
+    assertEquals("OUTER JOIN TABLE_A b ON b.id = a.id\n" + "OUTER JOIN TABLE_C c ON c.id = a.id", sql);
   }
 
   @Test
   void variableLengthArgumentOnLeftOuterJoin() {
-    final String sql = new SQL() {{
-      SELECT().LEFT_OUTER_JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT().LEFT_OUTER_JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
+      }
+    }.toString();
 
-    assertEquals("LEFT OUTER JOIN TABLE_A b ON b.id = a.id\n" +
-        "LEFT OUTER JOIN TABLE_C c ON c.id = a.id", sql);
+    assertEquals("LEFT OUTER JOIN TABLE_A b ON b.id = a.id\n" + "LEFT OUTER JOIN TABLE_C c ON c.id = a.id", sql);
   }
 
   @Test
   void variableLengthArgumentOnRightOuterJoin() {
-    final String sql = new SQL() {{
-      SELECT().RIGHT_OUTER_JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT().RIGHT_OUTER_JOIN("TABLE_A b ON b.id = a.id", "TABLE_C c ON c.id = a.id");
+      }
+    }.toString();
 
-    assertEquals("RIGHT OUTER JOIN TABLE_A b ON b.id = a.id\n" +
-        "RIGHT OUTER JOIN TABLE_C c ON c.id = a.id", sql);
+    assertEquals("RIGHT OUTER JOIN TABLE_A b ON b.id = a.id\n" + "RIGHT OUTER JOIN TABLE_C c ON c.id = a.id", sql);
   }
 
   @Test
   void variableLengthArgumentOnWhere() {
-    final String sql = new SQL() {{
-      SELECT().WHERE("a = #{a}", "b = #{b}");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT().WHERE("a = #{a}", "b = #{b}");
+      }
+    }.toString();
 
     assertEquals("WHERE (a = #{a} AND b = #{b})", sql);
   }
 
   @Test
   void variableLengthArgumentOnGroupBy() {
-    final String sql = new SQL() {{
-      SELECT().GROUP_BY("a", "b");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT().GROUP_BY("a", "b");
+      }
+    }.toString();
 
     assertEquals("GROUP BY a, b", sql);
   }
 
   @Test
   void variableLengthArgumentOnHaving() {
-    final String sql = new SQL() {{
-      SELECT().HAVING("a = #{a}", "b = #{b}");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT().HAVING("a = #{a}", "b = #{b}");
+      }
+    }.toString();
 
     assertEquals("HAVING (a = #{a} AND b = #{b})", sql);
   }
 
   @Test
   void variableLengthArgumentOnOrderBy() {
-    final String sql = new SQL() {{
-      SELECT().ORDER_BY("a", "b");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT().ORDER_BY("a", "b");
+      }
+    }.toString();
 
     assertEquals("ORDER BY a, b", sql);
   }
 
   @Test
   void variableLengthArgumentOnSet() {
-    final String sql = new SQL() {{
-      UPDATE("TABLE_A").SET("a = #{a}", "b = #{b}");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        UPDATE("TABLE_A").SET("a = #{a}", "b = #{b}");
+      }
+    }.toString();
 
-    assertEquals("UPDATE TABLE_A\n" +
-        "SET a = #{a}, b = #{b}", sql);
+    assertEquals("UPDATE TABLE_A\n" + "SET a = #{a}, b = #{b}", sql);
   }
 
   @Test
   void variableLengthArgumentOnIntoColumnsAndValues() {
-    final String sql = new SQL() {{
-      INSERT_INTO("TABLE_A").INTO_COLUMNS("a", "b").INTO_VALUES("#{a}", "#{b}");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        INSERT_INTO("TABLE_A").INTO_COLUMNS("a", "b").INTO_VALUES("#{a}", "#{b}");
+      }
+    }.toString();
 
     assertEquals("INSERT INTO TABLE_A\n (a, b)\nVALUES (#{a}, #{b})", sql);
   }
@@ -304,132 +344,159 @@ class SQLTest {
 
   @Test
   void selectUsingLimitVariableName() {
-    final String sql = new SQL() {{
-      SELECT("*").FROM("test").ORDER_BY("id").LIMIT("#{limit}");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT("*").FROM("test").ORDER_BY("id").LIMIT("#{limit}");
+      }
+    }.toString();
 
     assertEquals("SELECT *\nFROM test\nORDER BY id LIMIT #{limit}", sql);
   }
 
   @Test
   void selectUsingOffsetVariableName() {
-    final String sql = new SQL() {{
-      SELECT("*").FROM("test").ORDER_BY("id").OFFSET("#{offset}");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT("*").FROM("test").ORDER_BY("id").OFFSET("#{offset}");
+      }
+    }.toString();
 
     assertEquals("SELECT *\nFROM test\nORDER BY id OFFSET #{offset}", sql);
   }
 
   @Test
   void selectUsingLimitAndOffset() {
-    final String sql = new SQL() {{
-      SELECT("*").FROM("test").ORDER_BY("id").LIMIT(20).OFFSET(100);
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT("*").FROM("test").ORDER_BY("id").LIMIT(20).OFFSET(100);
+      }
+    }.toString();
 
     assertEquals("SELECT *\nFROM test\nORDER BY id LIMIT 20 OFFSET 100", sql);
   }
 
   @Test
   void updateUsingLimit() {
-    final String sql = new SQL() {{
-      UPDATE("test").SET("status = #{updStatus}").WHERE("status = #{status}").LIMIT(20);
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        UPDATE("test").SET("status = #{updStatus}").WHERE("status = #{status}").LIMIT(20);
+      }
+    }.toString();
 
     assertEquals("UPDATE test\nSET status = #{updStatus}\nWHERE (status = #{status}) LIMIT 20", sql);
   }
 
   @Test
   void deleteUsingLimit() {
-    final String sql = new SQL() {{
-      DELETE_FROM("test").WHERE("status = #{status}").LIMIT(20);
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        DELETE_FROM("test").WHERE("status = #{status}").LIMIT(20);
+      }
+    }.toString();
 
     assertEquals("DELETE FROM test\nWHERE (status = #{status}) LIMIT 20", sql);
   }
 
   @Test
   void selectUsingFetchFirstRowsOnlyVariableName() {
-    final String sql = new SQL() {{
-      SELECT("*").FROM("test").ORDER_BY("id").FETCH_FIRST_ROWS_ONLY("#{fetchFirstRows}");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT("*").FROM("test").ORDER_BY("id").FETCH_FIRST_ROWS_ONLY("#{fetchFirstRows}");
+      }
+    }.toString();
 
     assertEquals("SELECT *\nFROM test\nORDER BY id FETCH FIRST #{fetchFirstRows} ROWS ONLY", sql);
   }
 
   @Test
   void selectUsingOffsetRowsVariableName() {
-    final String sql = new SQL() {{
-      SELECT("*").FROM("test").ORDER_BY("id").OFFSET_ROWS("#{offsetRows}");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT("*").FROM("test").ORDER_BY("id").OFFSET_ROWS("#{offsetRows}");
+      }
+    }.toString();
 
     assertEquals("SELECT *\nFROM test\nORDER BY id OFFSET #{offsetRows} ROWS", sql);
   }
 
   @Test
   void selectUsingOffsetRowsAndFetchFirstRowsOnly() {
-    final String sql = new SQL() {{
-      SELECT("*").FROM("test").ORDER_BY("id").OFFSET_ROWS(100).FETCH_FIRST_ROWS_ONLY(20);
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        SELECT("*").FROM("test").ORDER_BY("id").OFFSET_ROWS(100).FETCH_FIRST_ROWS_ONLY(20);
+      }
+    }.toString();
 
     assertEquals("SELECT *\nFROM test\nORDER BY id OFFSET 100 ROWS FETCH FIRST 20 ROWS ONLY", sql);
   }
 
   @Test
-  void supportBatchInsert(){
-    final String sql =  new SQL(){{
-      INSERT_INTO("table1 a");
-      INTO_COLUMNS("col1,col2");
-      INTO_VALUES("val1","val2");
-      ADD_ROW();
-      INTO_VALUES("val1","val2");
-    }}.toString();
+  void supportBatchInsert() {
+    final String sql = new SQL() {
+      {
+        INSERT_INTO("table1 a");
+        INTO_COLUMNS("col1,col2");
+        INTO_VALUES("val1", "val2");
+        ADD_ROW();
+        INTO_VALUES("val1", "val2");
+      }
+    }.toString();
 
     assertThat(sql).isEqualToIgnoringWhitespace("INSERT INTO table1 a (col1,col2) VALUES (val1,val2), (val1,val2)");
   }
 
   @Test
   void singleInsert() {
-    final String sql = new SQL() {{
-      INSERT_INTO("table1 a");
-      INTO_COLUMNS("col1,col2");
-      INTO_VALUES("val1", "val2");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        INSERT_INTO("table1 a");
+        INTO_COLUMNS("col1,col2");
+        INTO_VALUES("val1", "val2");
+      }
+    }.toString();
 
     assertThat(sql).isEqualToIgnoringWhitespace("INSERT INTO table1 a (col1,col2) VALUES (val1,val2)");
   }
 
   @Test
   void singleInsertWithMultipleInsertValues() {
-    final String sql = new SQL() {{
-      INSERT_INTO("TABLE_A").INTO_COLUMNS("a", "b").INTO_VALUES("#{a}").INTO_VALUES("#{b}");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        INSERT_INTO("TABLE_A").INTO_COLUMNS("a", "b").INTO_VALUES("#{a}").INTO_VALUES("#{b}");
+      }
+    }.toString();
 
     assertThat(sql).isEqualToIgnoringWhitespace("INSERT INTO TABLE_A (a, b) VALUES (#{a}, #{b})");
   }
 
   @Test
   void batchInsertWithMultipleInsertValues() {
-    final String sql = new SQL() {{
-      INSERT_INTO("TABLE_A");
-      INTO_COLUMNS("a", "b");
-      INTO_VALUES("#{a1}");
-      INTO_VALUES("#{b1}");
-      ADD_ROW();
-      INTO_VALUES("#{a2}");
-      INTO_VALUES("#{b2}");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        INSERT_INTO("TABLE_A");
+        INTO_COLUMNS("a", "b");
+        INTO_VALUES("#{a1}");
+        INTO_VALUES("#{b1}");
+        ADD_ROW();
+        INTO_VALUES("#{a2}");
+        INTO_VALUES("#{b2}");
+      }
+    }.toString();
 
     assertThat(sql).isEqualToIgnoringWhitespace("INSERT INTO TABLE_A (a, b) VALUES (#{a1}, #{b1}), (#{a2}, #{b2})");
   }
 
   @Test
   void testValues() {
-    final String sql = new SQL() {{
-      INSERT_INTO("PERSON");
-      VALUES("ID, FIRST_NAME", "#{id}, #{firstName}");
-      VALUES("LAST_NAME", "#{lastName}");
-    }}.toString();
+    final String sql = new SQL() {
+      {
+        INSERT_INTO("PERSON");
+        VALUES("ID, FIRST_NAME", "#{id}, #{firstName}");
+        VALUES("LAST_NAME", "#{lastName}");
+      }
+    }.toString();
 
-    assertThat(sql).isEqualToIgnoringWhitespace("INSERT INTO PERSON (ID, FIRST_NAME, LAST_NAME) VALUES (#{id}, #{firstName}, #{lastName})");
+    assertThat(sql).isEqualToIgnoringWhitespace(
+        "INSERT INTO PERSON (ID, FIRST_NAME, LAST_NAME) VALUES (#{id}, #{firstName}, #{lastName})");
   }
 }

--- a/src/test/java/org/apache/ibatis/jdbc/SelectBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/SelectBuilderTest.java
@@ -24,45 +24,54 @@ class SelectBuilderTest {
 
   @Test
   void shouldProduceExpectedSimpleSelectStatement() {
+    // @formatter:off
     String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME\n" +
             "FROM PERSON P\n" +
             "WHERE (P.ID like #id# AND P.FIRST_NAME like #firstName# AND P.LAST_NAME like #lastName#)\n" +
             "ORDER BY P.LAST_NAME";
+    // @formatter:on
     assertEquals(expected, example2("a", "b", "c"));
   }
 
   @Test
   void shouldProduceExpectedSimpleSelectStatementMissingFirstParam() {
+    // @formatter:off
     String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME\n" +
             "FROM PERSON P\n" +
             "WHERE (P.FIRST_NAME like #firstName# AND P.LAST_NAME like #lastName#)\n" +
             "ORDER BY P.LAST_NAME";
+    // @formatter:on
     assertEquals(expected, example2(null, "b", "c"));
   }
 
   @Test
   void shouldProduceExpectedSimpleSelectStatementMissingFirstTwoParams() {
+    // @formatter:off
     String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME\n" +
             "FROM PERSON P\n" +
             "WHERE (P.LAST_NAME like #lastName#)\n" +
             "ORDER BY P.LAST_NAME";
+    // @formatter:on
     assertEquals(expected, example2(null, null, "c"));
   }
 
   @Test
   void shouldProduceExpectedSimpleSelectStatementMissingAllParams() {
+    // @formatter:off
     String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME\n" +
             "FROM PERSON P\n" +
             "ORDER BY P.LAST_NAME";
+    // @formatter:on
     assertEquals(expected, example2(null, null, null));
   }
 
   @Test
   void shouldProduceExpectedComplexSelectStatement() {
+    // @formatter:off
     String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FULL_NAME, P.LAST_NAME, P.CREATED_ON, P.UPDATED_ON\n" +
             "FROM PERSON P, ACCOUNT A\n" +
@@ -74,6 +83,7 @@ class SelectBuilderTest {
             "HAVING (P.LAST_NAME like ?) \n" +
             "OR (P.FIRST_NAME like ?)\n" +
             "ORDER BY P.ID, P.FULL_NAME";
+    // @formatter:on
     assertEquals(expected, example1());
   }
 

--- a/src/test/java/org/apache/ibatis/jdbc/SqlBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/SqlBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,45 +24,54 @@ class SqlBuilderTest {
 
   @Test
   void shouldProduceExpectedSimpleSelectStatement() {
+    // @formatter:off
     String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME\n" +
             "FROM PERSON P\n" +
             "WHERE (P.ID like #id# AND P.FIRST_NAME like #firstName# AND P.LAST_NAME like #lastName#)\n" +
             "ORDER BY P.LAST_NAME";
+    // @formatter:on
     assertEquals(expected, example2("a", "b", "c"));
   }
 
   @Test
   void shouldProduceExpectedSimpleSelectStatementMissingFirstParam() {
+    // @formatter:off
     String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME\n" +
             "FROM PERSON P\n" +
             "WHERE (P.FIRST_NAME like #firstName# AND P.LAST_NAME like #lastName#)\n" +
             "ORDER BY P.LAST_NAME";
+    // @formatter:on
     assertEquals(expected, example2(null, "b", "c"));
   }
 
   @Test
   void shouldProduceExpectedSimpleSelectStatementMissingFirstTwoParams() {
+    // @formatter:off
     String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME\n" +
             "FROM PERSON P\n" +
             "WHERE (P.LAST_NAME like #lastName#)\n" +
             "ORDER BY P.LAST_NAME";
+    // @formatter:on
     assertEquals(expected, example2(null, null, "c"));
   }
 
   @Test
   void shouldProduceExpectedSimpleSelectStatementMissingAllParams() {
+    // @formatter:off
     String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FIRST_NAME, P.LAST_NAME\n" +
             "FROM PERSON P\n" +
             "ORDER BY P.LAST_NAME";
+    // @formatter:on
     assertEquals(expected, example2(null, null, null));
   }
 
   @Test
   void shouldProduceExpectedComplexSelectStatement() {
+    // @formatter:off
     String expected =
         "SELECT P.ID, P.USERNAME, P.PASSWORD, P.FULL_NAME, P.LAST_NAME, P.CREATED_ON, P.UPDATED_ON\n" +
             "FROM PERSON P, ACCOUNT A\n" +
@@ -74,6 +83,7 @@ class SqlBuilderTest {
             "HAVING (P.LAST_NAME like ?) \n" +
             "OR (P.FIRST_NAME like ?)\n" +
             "ORDER BY P.ID, P.FULL_NAME";
+    // @formatter:on
     assertEquals(expected, example1());
   }
 

--- a/src/test/java/org/apache/ibatis/parsing/GenericTokenParserTest.java
+++ b/src/test/java/org/apache/ibatis/parsing/GenericTokenParserTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -48,43 +48,38 @@ class GenericTokenParserTest {
   @ParameterizedTest
   @MethodSource("shouldDemonstrateGenericTokenReplacementProvider")
   void shouldDemonstrateGenericTokenReplacement(String expected, String text) {
-    GenericTokenParser parser = new GenericTokenParser("${", "}", new VariableTokenHandler(new HashMap<String, String>() {
-      {
-        put("first_name", "James");
-        put("initial", "T");
-        put("last_name", "Kirk");
-        put("var{with}brace", "Hiya");
-        put("", "");
-      }
-    }));
+    GenericTokenParser parser = new GenericTokenParser("${", "}",
+        new VariableTokenHandler(new HashMap<String, String>() {
+          {
+            put("first_name", "James");
+            put("initial", "T");
+            put("last_name", "Kirk");
+            put("var{with}brace", "Hiya");
+            put("", "");
+          }
+        }));
     assertEquals(expected, parser.parse(text));
   }
 
   static Stream<Arguments> shouldDemonstrateGenericTokenReplacementProvider() {
-    return Stream.of(
-      arguments("James T Kirk reporting.", "${first_name} ${initial} ${last_name} reporting."),
-      arguments("Hello captain James T Kirk", "Hello captain ${first_name} ${initial} ${last_name}"),
-      arguments("James T Kirk", "${first_name} ${initial} ${last_name}"),
-      arguments("JamesTKirk", "${first_name}${initial}${last_name}"),
-      arguments("{}JamesTKirk", "{}${first_name}${initial}${last_name}"),
-      arguments("}JamesTKirk", "}${first_name}${initial}${last_name}"),
+    return Stream.of(arguments("James T Kirk reporting.", "${first_name} ${initial} ${last_name} reporting."),
+        arguments("Hello captain James T Kirk", "Hello captain ${first_name} ${initial} ${last_name}"),
+        arguments("James T Kirk", "${first_name} ${initial} ${last_name}"),
+        arguments("JamesTKirk", "${first_name}${initial}${last_name}"),
+        arguments("{}JamesTKirk", "{}${first_name}${initial}${last_name}"),
+        arguments("}JamesTKirk", "}${first_name}${initial}${last_name}"),
 
-      arguments("}James{{T}}Kirk", "}${first_name}{{${initial}}}${last_name}"),
-      arguments("}James}T{Kirk", "}${first_name}}${initial}{${last_name}"),
-      arguments("}James}T{Kirk", "}${first_name}}${initial}{${last_name}"),
-      arguments("}James}T{Kirk{{}}", "}${first_name}}${initial}{${last_name}{{}}"),
-      arguments("}James}T{Kirk{{}}", "}${first_name}}${initial}{${last_name}{{}}${}"),
+        arguments("}James{{T}}Kirk", "}${first_name}{{${initial}}}${last_name}"),
+        arguments("}James}T{Kirk", "}${first_name}}${initial}{${last_name}"),
+        arguments("}James}T{Kirk", "}${first_name}}${initial}{${last_name}"),
+        arguments("}James}T{Kirk{{}}", "}${first_name}}${initial}{${last_name}{{}}"),
+        arguments("}James}T{Kirk{{}}", "}${first_name}}${initial}{${last_name}{{}}${}"),
 
-      arguments("{$$something}JamesTKirk", "{$$something}${first_name}${initial}${last_name}"),
-      arguments("${", "${"),
-      arguments("${\\}", "${\\}"),
-      arguments("Hiya", "${var{with\\}brace}"),
-      arguments("", "${}"),
-      arguments("}", "}"),
-      arguments("Hello ${ this is a test.", "Hello ${ this is a test."),
-      arguments("Hello } this is a test.", "Hello } this is a test."),
-      arguments("Hello } ${ this is a test.", "Hello } ${ this is a test.")
-    );
+        arguments("{$$something}JamesTKirk", "{$$something}${first_name}${initial}${last_name}"), arguments("${", "${"),
+        arguments("${\\}", "${\\}"), arguments("Hiya", "${var{with\\}brace}"), arguments("", "${}"),
+        arguments("}", "}"), arguments("Hello ${ this is a test.", "Hello ${ this is a test."),
+        arguments("Hello } this is a test.", "Hello } this is a test."),
+        arguments("Hello } ${ this is a test.", "Hello } ${ this is a test."));
   }
 
   @ParameterizedTest
@@ -95,12 +90,10 @@ class GenericTokenParserTest {
   }
 
   static Stream<Arguments> shallNotInterpolateSkippedVariablesProvider() {
-    return Stream.of(
-      arguments("${skipped} variable", "\\${skipped} variable"),
-      arguments("This is a ${skipped} variable", "This is a \\${skipped} variable"),
-      arguments("null ${skipped} variable", "${skipped} \\${skipped} variable"),
-      arguments("The null is ${skipped} variable", "The ${skipped} is \\${skipped} variable")
-    );
+    return Stream.of(arguments("${skipped} variable", "\\${skipped} variable"),
+        arguments("This is a ${skipped} variable", "This is a \\${skipped} variable"),
+        arguments("null ${skipped} variable", "${skipped} \\${skipped} variable"),
+        arguments("The null is ${skipped} variable", "The ${skipped} is \\${skipped} variable"));
   }
 
   @Disabled("Because it randomly fails on Github CI. It could be useful during development.")
@@ -108,14 +101,15 @@ class GenericTokenParserTest {
   void shouldParseFastOnJdk7u6() {
     Assertions.assertTimeout(Duration.ofMillis(1000), () -> {
       // issue #760
-      GenericTokenParser parser = new GenericTokenParser("${", "}", new VariableTokenHandler(new HashMap<String, String>() {
-        {
-          put("first_name", "James");
-          put("initial", "T");
-          put("last_name", "Kirk");
-          put("", "");
-        }
-      }));
+      GenericTokenParser parser = new GenericTokenParser("${", "}",
+          new VariableTokenHandler(new HashMap<String, String>() {
+            {
+              put("first_name", "James");
+              put("initial", "T");
+              put("last_name", "Kirk");
+              put("", "");
+            }
+          }));
 
       StringBuilder input = new StringBuilder();
       for (int i = 0; i < 10000; i++) {

--- a/src/test/java/org/apache/ibatis/parsing/XPathParserTest.java
+++ b/src/test/java/org/apache/ibatis/parsing/XPathParserTest.java
@@ -219,6 +219,7 @@ class XPathParserTest {
     String userNodeToString = parser.evalNode("/users/user").toString();
     String carsNodeToString = parser.evalNode("/users/user/cars").toString();
 
+    // @formatter:off
     String usersNodeToStringExpect =
       "<users>\n" +
       "    <user>\n" +
@@ -232,7 +233,9 @@ class XPathParserTest {
       "        </cars>\n" +
       "    </user>\n" +
       "</users>\n";
+    // @formatter:on
 
+    // @formatter:off
     String userNodeToStringExpect =
       "<user>\n" +
       "    <id>100</id>\n" +
@@ -244,13 +247,16 @@ class XPathParserTest {
       "        <car index=\"3\">Benz</car>\n" +
       "    </cars>\n" +
       "</user>\n";
+    // @formatter:on
 
-  String carsNodeToStringExpect =
+    // @formatter:off
+    String carsNodeToStringExpect =
       "<cars>\n" +
       "    <car index=\"1\">BMW</car>\n" +
       "    <car index=\"2\">Audi</car>\n" +
       "    <car index=\"3\">Benz</car>\n" +
       "</cars>\n";
+    // @formatter:on
 
     assertEquals(usersNodeToStringExpect, usersNodeToString);
     assertEquals(userNodeToStringExpect, userNodeToString);

--- a/src/test/java/org/apache/ibatis/submitted/annotion_many_one_add_columnprefix/RoleDao.java
+++ b/src/test/java/org/apache/ibatis/submitted/annotion_many_one_add_columnprefix/RoleDao.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,9 +26,11 @@ import org.apache.ibatis.annotations.Select;
  */
 public interface RoleDao {
   @Select("select * from role")
+  // @formatter:off
   @Results(id = "roleMap1", value = {
-    @Result(id = true, column = "id", property = "id"),
-    @Result(column = "name", property = "name")
-  })
+      @Result(id = true, column = "id", property = "id"),
+      @Result(column = "name", property = "name")
+    })
+  // @formatter:on
   public List<Role> findAll();
 }

--- a/src/test/java/org/apache/ibatis/submitted/annotion_many_one_add_columnprefix/UserDao.java
+++ b/src/test/java/org/apache/ibatis/submitted/annotion_many_one_add_columnprefix/UserDao.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,65 +27,76 @@ import org.apache.ibatis.annotations.Select;
  * @author lvyang
  */
 public interface UserDao {
+  // @formatter:off
   @Select({ "select",
-    "     u.id, u.username, r.id role_id, r.name role_name",
-    "    from user u",
-    "    left join user_role ur on u.id = ur.user_id",
-    "    left join role r on ur.role_id = r.id" })
+      "  u.id, u.username, r.id role_id, r.name role_name",
+      " from user u",
+      " left join user_role ur on u.id = ur.user_id",
+      " left join role r on ur.role_id = r.id" })
   @Results({
-    @Result(id = true, column = "id", property = "id"),
-    @Result(column = "username", property = "username"),
-    @Result(property = "roles", many = @Many(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_columnprefix.RoleDao.roleMap1", columnPrefix = "role_"))
-  })
+      @Result(id = true, column = "id", property = "id"),
+      @Result(column = "username", property = "username"),
+      @Result(property = "roles", many = @Many(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_columnprefix.RoleDao.roleMap1", columnPrefix = "role_"))
+    })
+  // @formatter:on
   List<User> findAll();
 
+  // @formatter:off
   @Select({ "select",
-    "     u.id, u.username, r.id role_id, r.name role_name",
-    "    from user u",
-    "    left join user_role ur on u.id = ur.user_id",
-    "    left join role r on ur.role_id = r.id" })
+      "  u.id, u.username, r.id role_id, r.name role_name",
+      " from user u",
+      " left join user_role ur on u.id = ur.user_id",
+      " left join role r on ur.role_id = r.id" })
   @Results({
-    @Result(id = true, column = "id", property = "id"),
-    @Result(column = "username", property = "username"),
-    @Result(property = "roles", many = @Many(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_columnprefix.RoleDao.roleMap2", columnPrefix = "role_"))
-  })
+      @Result(id = true, column = "id", property = "id"),
+      @Result(column = "username", property = "username"),
+      @Result(property = "roles", many = @Many(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_columnprefix.RoleDao.roleMap2", columnPrefix = "role_"))
+    })
+  // @formatter:on
   List<User> findAll2();
 
+  // @formatter:off
   @Select({ "select",
-    "     u.id, u.username, r.id role_id, r.name role_name",
-    "    from user u",
-    "    left join user_role ur on u.id = ur.user_id",
-    "    left join role r on ur.role_id = r.id where u.id in (2, 3)" })
+      "  u.id, u.username, r.id role_id, r.name role_name",
+      " from user u",
+      " left join user_role ur on u.id = ur.user_id",
+      " left join role r on ur.role_id = r.id where u.id in (2, 3)" })
   @Results({
-    @Result(id = true, column = "id", property = "id"),
-    @Result(column = "username", property = "username"),
-    @Result(property = "role", one = @One(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_columnprefix.RoleDao.roleMap2", columnPrefix = "role_"))
-  })
+      @Result(id = true, column = "id", property = "id"),
+      @Result(column = "username", property = "username"),
+      @Result(property = "role", one = @One(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_columnprefix.RoleDao.roleMap2", columnPrefix = "role_"))
+    })
+  // @formatter:on
   List<User> findAll3();
 
+  // @formatter:off
   @Select("select id teacher_id, username teacher_name from user")
   @Results(id = "userMap", value = {
-    @Result(id = true, column = "teacher_id", property = "id"),
-    @Result(column = "teacher_name", property = "username")
-  })
+      @Result(id = true, column = "teacher_id", property = "id"),
+      @Result(column = "teacher_name", property = "username")
+    })
+  // @formatter:on
   List<User> justUseResult();
 
+  // @formatter:off
   @Select({ "select",
-    "     u.id, u.username, r.id role_id, r.name role_name,",
-    "     f.id friend_id, f.username, fr.id friend_role_id, fr.name friend_role_name",
-    "    from user u",
-    "    left join user_role ur on u.id = ur.user_id",
-    "    left join role r on ur.role_id = r.id" ,
-    "    left join user f on u.friend_id = f.id",
-    "    left join user_role fur on f.id = fur.user_id",
-    "    left join role fr on fur.role_id = fr.id" ,
-    "    where u.id = #{userId} order by r.id, fr.id"
+      "  u.id, u.username, r.id role_id, r.name role_name,",
+      "  f.id friend_id, f.username, fr.id friend_role_id, fr.name friend_role_name",
+      " from user u",
+      " left join user_role ur on u.id = ur.user_id",
+      " left join role r on ur.role_id = r.id" ,
+      " left join user f on u.friend_id = f.id",
+      " left join user_role fur on f.id = fur.user_id",
+      " left join role fr on fur.role_id = fr.id" ,
+      " where u.id = #{userId} order by r.id, fr.id"
     })
   @Results(id = "userWithFriendMap", value = {
-    @Result(id = true, column = "id", property = "id"),
-    @Result(column = "username", property = "username"),
-    @Result(property = "roles", many = @Many(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_columnprefix.RoleDao.roleMap1", columnPrefix = "role_")),
-    @Result(property = "friend", one = @One(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_columnprefix.UserDao.userWithFriendMap", columnPrefix = "friend_"))
-  })
+      @Result(id = true, column = "id", property = "id"),
+      @Result(column = "username", property = "username"),
+      @Result(property = "roles", many = @Many(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_columnprefix.RoleDao.roleMap1", columnPrefix = "role_")),
+      @Result(property = "friend", one = @One(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_columnprefix.UserDao.userWithFriendMap", columnPrefix = "friend_"))
+    })
+  // @formatter:on
   User findUserWithFriend(Integer userId);
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/annotion_many_one_add_resultmapid/RoleDao.java
+++ b/src/test/java/org/apache/ibatis/submitted/annotion_many_one_add_resultmapid/RoleDao.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,9 +26,11 @@ import org.apache.ibatis.annotations.Select;
  */
 public interface RoleDao {
   @Select("select * from role")
+  // @formatter:off
   @Results(id = "roleMap1", value = {
-    @Result(id = true, column = "role_id", property = "id"),
-    @Result(column = "role_name", property = "roleName")
-  })
+      @Result(id = true, column = "role_id", property = "id"),
+      @Result(column = "role_name", property = "roleName")
+    })
+  // @formatter:on
   public List<Role> findAll();
 }

--- a/src/test/java/org/apache/ibatis/submitted/annotion_many_one_add_resultmapid/UserDao.java
+++ b/src/test/java/org/apache/ibatis/submitted/annotion_many_one_add_resultmapid/UserDao.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,61 +23,71 @@ import org.apache.ibatis.annotations.*;
  * @author lvyang
  */
 public interface UserDao {
+  // @formatter:off
   @Select({ "select",
-    "     u.id, u.username, r.id role_id, r.role_name",
-    "    from user u",
-    "    left join user_role ur on u.id = ur.user_id",
-    "    left join role r on ur.role_id = r.id" })
+      "     u.id, u.username, r.id role_id, r.role_name",
+      "    from user u",
+      "    left join user_role ur on u.id = ur.user_id",
+      "    left join role r on ur.role_id = r.id" })
   @Results({
-    @Result(id = true, column = "id", property = "id"),
-    @Result(column = "username", property = "username"),
-    @Result(property = "roles", many = @Many(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_resultmapid.RoleDao.roleMap1"))
-  })
+      @Result(id = true, column = "id", property = "id"),
+      @Result(column = "username", property = "username"),
+      @Result(property = "roles", many = @Many(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_resultmapid.RoleDao.roleMap1"))
+    })
+  // @formatter:on
   public List<User> findAll();
 
+  // @formatter:off
   @Select({ "select",
-    "     u.id, u.username, r.id role_id, r.role_name",
-    "    from user u",
-    "    left join user_role ur on u.id = ur.user_id",
-    "    left join role r on ur.role_id = r.id" })
+      "     u.id, u.username, r.id role_id, r.role_name",
+      "    from user u",
+      "    left join user_role ur on u.id = ur.user_id",
+      "    left join role r on ur.role_id = r.id" })
   @Results({
-    @Result(id = true, column = "id", property = "id"),
-    @Result(column = "username", property = "username"),
-    @Result(property = "roles", many = @Many(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_resultmapid.RoleDao.roleMap2"))
-  })
+      @Result(id = true, column = "id", property = "id"),
+      @Result(column = "username", property = "username"),
+      @Result(property = "roles", many = @Many(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_resultmapid.RoleDao.roleMap2"))
+    })
+  // @formatter:on
   public List<User> findAll2();
 
+  // @formatter:off
   @Select({ "select",
-    "     u.id, u.username, r.id role_id, r.role_name",
-    "    from user u",
-    "    left join user_role ur on u.id = ur.user_id",
-    "    left join role r on ur.role_id = r.id where u.id in (2, 3)" })
+      "     u.id, u.username, r.id role_id, r.role_name",
+      "    from user u",
+      "    left join user_role ur on u.id = ur.user_id",
+      "    left join role r on ur.role_id = r.id where u.id in (2, 3)" })
   @Results({
-    @Result(id = true, column = "id", property = "id"),
-    @Result(column = "username", property = "username"),
-    @Result(property = "role", one = @One(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_resultmapid.RoleDao.roleMap2"))
-  })
+      @Result(id = true, column = "id", property = "id"),
+      @Result(column = "username", property = "username"),
+      @Result(property = "role", one = @One(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_resultmapid.RoleDao.roleMap2"))
+    })
+  // @formatter:on
   public List<User> findAll3();
 
+  // @formatter:off
   @Select("select id teacher_id, username teacher_name from user")
   @Results(id = "userMap", value = {
-    @Result(id = true, column = "teacher_id", property = "id"),
-    @Result(column = "teacher_name", property = "username")
-  })
+      @Result(id = true, column = "teacher_id", property = "id"),
+      @Result(column = "teacher_name", property = "username")
+    })
+  // @formatter:on
   public List<User> justUseResult();
 
+  // @formatter:off
   @Select({ "select",
-    "u.id, u.username, r.id role_id, r.role_name, ut.id teacher_id, ut.username teacher_name",
-    "from user u",
-    "left join user_role ur on u.id = ur.user_id",
-    "left join role r on ur.role_id = r.id",
-    "left join user ut on ut.id != u.id",
-    "where role_id = 3" })
+      "u.id, u.username, r.id role_id, r.role_name, ut.id teacher_id, ut.username teacher_name",
+      "from user u",
+      "left join user_role ur on u.id = ur.user_id",
+      "left join role r on ur.role_id = r.id",
+      "left join user ut on ut.id != u.id",
+      "where role_id = 3" })
   @Results({
-    @Result(id = true, column = "id", property = "id"),
-    @Result(column = "username", property = "username"),
-    @Result(property = "role", one = @One(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_resultmapid.RoleDao.roleMap2")),
-    @Result(property = "teachers", many = @Many(resultMap = "userMap"))
-  })
+      @Result(id = true, column = "id", property = "id"),
+      @Result(column = "username", property = "username"),
+      @Result(property = "role", one = @One(resultMap = "org.apache.ibatis.submitted.annotion_many_one_add_resultmapid.RoleDao.roleMap2")),
+      @Result(property = "teachers", many = @Many(resultMap = "userMap"))
+    })
+  // @formatter:on
   public User findHeadmaster();
 }

--- a/src/test/java/org/apache/ibatis/submitted/cache/CacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cache/CacheTest.java
@@ -53,7 +53,8 @@ class CacheTest {
         "org/apache/ibatis/submitted/cache/CreateDB.sql");
   }
 
-  /*
+  // @formatter:off
+  /**
    * Test Plan:
    *  1) SqlSession 1 executes "select * from A".
    *  2) SqlSession 1 closes.
@@ -63,6 +64,7 @@ class CacheTest {
    * Assert:
    *   Step 4 returns 1 row. (This case fails when caching is enabled.)
    */
+  // @formatter:on
   @Test
   void testplan1() {
     try (SqlSession sqlSession1 = sqlSessionFactory.openSession(false)) {
@@ -81,7 +83,8 @@ class CacheTest {
     }
   }
 
-  /*
+  // @formatter:off
+  /**
    * Test Plan:
    *  1) SqlSession 1 executes "select * from A".
    *  2) SqlSession 1 closes.
@@ -93,6 +96,7 @@ class CacheTest {
    * Assert:
    *   Step 6 returns 2 rows.
    */
+  // @formatter:on
   @Test
   void testplan2() {
     try (SqlSession sqlSession1 = sqlSessionFactory.openSession(false)) {
@@ -115,7 +119,8 @@ class CacheTest {
     }
   }
 
-  /*
+  // @formatter:off
+  /**
    * Test Plan with Autocommit on:
    *  1) SqlSession 1 executes "select * from A".
    *  2) SqlSession 1 closes.
@@ -127,6 +132,7 @@ class CacheTest {
    * Assert:
    *   Step 6 returns 1 row.
    */
+  // @formatter:on
   @Test
   void testplan3() {
     try (SqlSession sqlSession1 = sqlSessionFactory.openSession(true)) {
@@ -145,7 +151,8 @@ class CacheTest {
     }
   }
 
-  /*-
+  // @formatter:off
+  /**
    * Test case for #405
    *
    * Test Plan with Autocommit on:
@@ -159,6 +166,7 @@ class CacheTest {
    * Assert:
    *   Step 5 returns 3 row.
    */
+  // @formatter:on
   @Test
   void shouldInsertWithOptionsFlushesCache() {
     try (SqlSession sqlSession1 = sqlSessionFactory.openSession(true)) {
@@ -178,7 +186,8 @@ class CacheTest {
     }
   }
 
-  /*-
+  // @formatter:off
+  /**
    * Test Plan with Autocommit on:
    *  1) SqlSession 1 executes select to cache result
    *  2) SqlSession 1 closes.
@@ -193,6 +202,7 @@ class CacheTest {
    *   Step 5 returns 2 row.
    *   Step 7 returns 3 row.
    */
+  // @formatter:on
   @Test
   void shouldApplyFlushCacheOptions() {
     try (SqlSession sqlSession1 = sqlSessionFactory.openSession(true)) {
@@ -328,9 +338,11 @@ class CacheTest {
     }
   }
 
+  // @formatter:off
   @CacheNamespace(implementation = CustomCache.class, properties = {
-    @Property(name = "date", value = "2016/11/21")
-  })
+      @Property(name = "date", value = "2016/11/21")
+    })
+  // @formatter:on
   private interface CustomCacheUnsupportedPropertyMapper {
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/cache/CustomCacheMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/cache/CustomCacheMapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.ibatis.submitted.cache;
 import org.apache.ibatis.annotations.CacheNamespace;
 import org.apache.ibatis.annotations.Property;
 
+// @formatter:off
 @CacheNamespace(implementation = CustomCache.class, properties = {
     @Property(name = "stringValue", value = "bar"),
     @Property(name = "integerValue", value = "1"),
@@ -35,5 +36,6 @@ import org.apache.ibatis.annotations.Property;
     @Property(name = "booleanWrapperValue", value = "true"),
     @Property(name = "booleanValue", value = "true")
 })
+// @formatter:on
 public interface CustomCacheMapper {
 }

--- a/src/test/java/org/apache/ibatis/submitted/complex_column/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_column/PersonMapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,43 +19,52 @@ import org.apache.ibatis.annotations.*;
 
 public interface PersonMapper {
 
-    Person getWithoutComplex(Long id);
-    Person getWithComplex(Long id);
-    Person getParentWithComplex(Person person);
+  Person getWithoutComplex(Long id);
 
-    @Select({
+  Person getWithComplex(Long id);
+
+  Person getParentWithComplex(Person person);
+
+  // @formatter:off
+  @Select({
       "SELECT id, firstName, lastName, parent_id, parent_firstName, parent_lastName",
       "FROM Person",
       "WHERE id = #{id,jdbcType=INTEGER}"
     })
-    @ResultMap("personMapComplex")
-    Person getWithComplex2(Long id);
+  // @formatter:on
+  @ResultMap("personMapComplex")
+  Person getWithComplex2(Long id);
 
-    @Select({
-        "SELECT id, firstName, lastName, parent_id, parent_firstName, parent_lastName",
-        "FROM Person",
-        "WHERE id = #{id,jdbcType=INTEGER}"
-      })
-    @ResultMap("org.apache.ibatis.submitted.complex_column.PersonMapper.personMapComplex")
-    Person getWithComplex3(Long id);
-
-
-    @Select({
-            "SELECT id, firstName, lastName, parent_id, parent_firstName, parent_lastName",
-            "FROM Person",
-            "WHERE id = #{id,jdbcType=INTEGER}"
+  // @formatter:off
+  @Select({
+      "SELECT id, firstName, lastName, parent_id, parent_firstName, parent_lastName",
+      "FROM Person",
+      "WHERE id = #{id,jdbcType=INTEGER}"
     })
-    @Results({
-            @Result(id=true, column = "id", property = "id"),
-            @Result(property = "parent", column="{firstName=parent_firstName,lastName=parent_lastName}", one=@One(select="getParentWithParamAttributes"))
+  // @formatter:on
+  @ResultMap("org.apache.ibatis.submitted.complex_column.PersonMapper.personMapComplex")
+  Person getWithComplex3(Long id);
 
+  // @formatter:off
+  @Select({
+      "SELECT id, firstName, lastName, parent_id, parent_firstName, parent_lastName",
+      "FROM Person",
+      "WHERE id = #{id,jdbcType=INTEGER}"
     })
-    Person getComplexWithParamAttributes(Long id);
+  @Results({
+      @Result(id=true, column = "id", property = "id"),
+      @Result(property = "parent", column="{firstName=parent_firstName,lastName=parent_lastName}", one=@One(select="getParentWithParamAttributes"))
+    })
+  // @formatter:on
+  Person getComplexWithParamAttributes(Long id);
 
-    @Select("SELECT id, firstName, lastName, parent_id, parent_firstName, parent_lastName" +
-            " FROM Person" +
-            " WHERE firstName = #{firstName,jdbcType=VARCHAR}" +
-            " AND lastName = #{lastName,jdbcType=VARCHAR}" +
-            " LIMIT 1")
-    Person getParentWithParamAttributes(@Param("firstName") String firstName, @Param("lastName") String lastname);
+  // @formatter:off
+  @Select("SELECT id, firstName, lastName, parent_id, parent_firstName, parent_lastName" +
+      " FROM Person" +
+      " WHERE firstName = #{firstName,jdbcType=VARCHAR}" +
+      " AND lastName = #{lastName,jdbcType=VARCHAR}" +
+      " LIMIT 1")
+  // @formatter:on
+  Person getParentWithParamAttributes(@Param("firstName") String firstName, @Param("lastName") String lastname);
+
 }

--- a/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/constructor_columnprefix/Mapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,12 +25,13 @@ public interface Mapper {
 
   List<Article> getArticles();
 
+  // @formatter:off
   @ConstructorArgs({
       @Arg(id = true, resultMap = "keyRM", columnPrefix = "key_", javaType = EntityKey.class),
       @Arg(column = "name", javaType = String.class),
       @Arg(resultMap = "authorRM", columnPrefix = "author_", javaType = Author.class),
       @Arg(resultMap = "authorRM", columnPrefix = "coauthor_", javaType = Author.class),
-  })
+    })
   @Select({
       "select id key_id, name, author.id author_id, author.name author_name,",
       "  coauthor.id coauthor_id, coauthor.name coauthor_name",
@@ -38,7 +39,8 @@ public interface Mapper {
       "left join authors author on author.id = articles.author_id",
       "left join authors coauthor on coauthor.id = articles.coauthor_id",
       "order by articles.id"
-  })
+    })
+  // @formatter:on
   List<Article> getArticlesAnno();
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/Mapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,15 +24,17 @@ public interface Mapper {
 
   Cursor<User> getAllUsers();
 
+  // @formatter:off
   @Select({
-    "select null id, null name from (values (0))",
-    "union all",
-    "select 99 id, 'Kate' name from (values (0))",
-    "union all",
-    "select null id, null name from (values (0))",
-    "union all",
-    "select null id, null name from (values (0))"
-  })
+      "select null id, null name from (values (0))",
+      "union all",
+      "select 99 id, 'Kate' name from (values (0))",
+      "union all",
+      "select null id, null name from (values (0))",
+      "union all",
+      "select null id, null name from (values (0))"
+    })
+  // @formatter:on
   Cursor<User> getNullUsers(RowBounds rowBounds);
 
   @Select("select * from users")

--- a/src/test/java/org/apache/ibatis/submitted/empty_row/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/empty_row/Mapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -52,9 +52,11 @@ public interface Mapper {
   Parent getCollection(Integer id);
 
   @ResultMap("twoCollectionsRM")
+  // @formatter:off
   @Select({ "select p.id, c.name child_name, e.name pet_name from parent p",
       "left join child c on c.parent_id = p.id",
       "left join pet e on e.parent_id = p.id", "where p.id = #{id}" })
+  // @formatter:on
   Parent getTwoCollections(Integer id);
 
   @Select("select col1, col2 from parent where id = #{id}")

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_annotation/PersonMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_annotation/PersonMapper.java
@@ -26,32 +26,38 @@ import org.apache.ibatis.type.EnumOrdinalTypeHandler;
  */
 public interface PersonMapper {
 
-    @ConstructorArgs({
-            @Arg(column = "id", javaType = Integer.class, id = true)
-            , @Arg(column = "firstName", javaType = String.class)
-            , @Arg(column = "lastName", javaType = String.class)
-            // target for test (ordinal number -> Enum constant)
-            , @Arg(column = "personType", javaType = PersonType.class, typeHandler = EnumOrdinalTypeHandler.class)
+  // @formatter:off
+  @ConstructorArgs({
+        @Arg(column = "id", javaType = Integer.class, id = true)
+      , @Arg(column = "firstName", javaType = String.class)
+      , @Arg(column = "lastName", javaType = String.class)
+      // target for test (ordinal number -> Enum constant)
+      , @Arg(column = "personType", javaType = PersonType.class, typeHandler = EnumOrdinalTypeHandler.class)
     })
-    @Select("SELECT id, firstName, lastName, personType FROM person WHERE id = #{id}")
-    Person findOneUsingConstructor(int id);
+  // @formatter:on
+  @Select("SELECT id, firstName, lastName, personType FROM person WHERE id = #{id}")
+  Person findOneUsingConstructor(int id);
 
-    @Results({
-            // target for test (ordinal number -> Enum constant)
-            @Result(property = "personType", column = "personType", typeHandler = EnumOrdinalTypeHandler.class)
+  // @formatter:off
+  @Results({
+      // target for test (ordinal number -> Enum constant)
+      @Result(property = "personType", column = "personType", typeHandler = EnumOrdinalTypeHandler.class)
     })
-    @Select("SELECT id, firstName, lastName, personType FROM person WHERE id = #{id}")
-    Person findOneUsingSetter(int id);
+  // @formatter:on
+  @Select("SELECT id, firstName, lastName, personType FROM person WHERE id = #{id}")
+  Person findOneUsingSetter(int id);
 
-    @TypeDiscriminator(
-            // target for test (ordinal number -> Enum constant)
-            column = "personType", javaType = PersonType.class, typeHandler = EnumOrdinalTypeHandler.class,
-            // Switch using enum constant name(PERSON or EMPLOYEE) at cases attribute
-            cases = {
-                    @Case(value = "PERSON", type = Person.class, results = {@Result(property = "personType", column = "personType", typeHandler = EnumOrdinalTypeHandler.class)})
-                    , @Case(value = "EMPLOYEE", type = Employee.class, results = {@Result(property = "personType", column = "personType", typeHandler = EnumOrdinalTypeHandler.class)})
-            })
-    @Select("SELECT id, firstName, lastName, personType FROM person WHERE id = #{id}")
-    Person findOneUsingTypeDiscriminator(int id);
+  // @formatter:off
+  @TypeDiscriminator(
+      // target for test (ordinal number -> Enum constant)
+      column = "personType", javaType = PersonType.class, typeHandler = EnumOrdinalTypeHandler.class,
+      // Switch using enum constant name(PERSON or EMPLOYEE) at cases attribute
+      cases = {
+            @Case(value = "PERSON", type = Person.class, results = {@Result(property = "personType", column = "personType", typeHandler = EnumOrdinalTypeHandler.class)})
+          , @Case(value = "EMPLOYEE", type = Employee.class, results = {@Result(property = "personType", column = "personType", typeHandler = EnumOrdinalTypeHandler.class)})
+        })
+  // @formatter:on
+  @Select("SELECT id, firstName, lastName, personType FROM person WHERE id = #{id}")
+  Person findOneUsingTypeDiscriminator(int id);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/heavy_initial_load/HeavyInitialLoadTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/heavy_initial_load/HeavyInitialLoadTest.java
@@ -47,8 +47,8 @@ class HeavyInitialLoadTest {
   /**
    * Test to demonstrate the effect of the https://issues.apache.org/jira/browse/OGNL-121 issue in ognl on mybatis.
    * <p>
-   * Use the thing mapper for the first time in multiple threads. The mapper contains a lot of ognl references to
-   * static final class members like:
+   * Use the thing mapper for the first time in multiple threads. The mapper contains a lot of ognl references to static
+   * final class members like:
    * <p>
    * <code>@org.apache.ibatis.submitted.heavy_initial_load.Code@_1.equals(code)</code>
    * <p>

--- a/src/test/java/org/apache/ibatis/submitted/keycolumn/InsertMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/keycolumn/InsertMapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,13 +20,15 @@ import org.apache.ibatis.annotations.Options;
 
 public interface InsertMapper {
 
-    @Insert({
-        "insert into mbtest.test_identity",
-        "(first_name, last_name)",
-        "values(#{firstName,jdbcType=VARCHAR}, #{lastName,jdbcType=VARCHAR})"
+  // @formatter:off
+  @Insert({
+      "insert into mbtest.test_identity",
+      "(first_name, last_name)",
+      "values(#{firstName,jdbcType=VARCHAR}, #{lastName,jdbcType=VARCHAR})"
     })
-    @Options(keyProperty="id", useGeneratedKeys=true, keyColumn="name_id")
-    int insertNameAnnotated(Name name);
+  // @formatter:on
+  @Options(keyProperty = "id", useGeneratedKeys = true, keyColumn = "name_id")
+  int insertNameAnnotated(Name name);
 
   int insertNameMapped(Name name);
 }

--- a/src/test/java/org/apache/ibatis/submitted/manyanno/PostMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/manyanno/PostMapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,21 +21,24 @@ import org.apache.ibatis.annotations.*;
 
 public interface PostMapper {
 
+  @Select("select * from post where author_id = #{id} order by id")
+  // @formatter:off
+  @Results(value = {
+      @Result(property="id", column="id"),
+      @Result(property="subject", column="subject"),
+      @Result(property="body", column="body"),
+      @Result(property="tags", javaType=List.class, column="id", many=@Many(select="getTagsForPost"))
+    })
+  // @formatter:on
+  List<AnnoPost> getPosts(int authorId);
 
-    @Select("select * from post where author_id = #{id} order by id")
-    @Results(value = {
-                      @Result(property="id", column="id"),
-                      @Result(property="subject", column="subject"),
-                      @Result(property="body", column="body"),
-                      @Result(property="tags", javaType=List.class, column="id", many=@Many(select="getTagsForPost"))
-                      })
-    List<AnnoPost> getPosts(int authorId);
-
-    @Select("select t.id, t.name from tag t inner join post_tag pt on pt.tag_id = t.id where pt.post_id = #{postId} order by id")
-    @ConstructorArgs(value = {
-                  @Arg(column="id",javaType=int.class),
-                  @Arg(column="name",javaType=String.class)
-                  })
-    List<AnnoPostTag> getTagsForPost(int postId);
+  @Select("select t.id, t.name from tag t inner join post_tag pt on pt.tag_id = t.id where pt.post_id = #{postId} order by id")
+  // @formatter:off
+  @ConstructorArgs(value = {
+      @Arg(column="id",javaType=int.class),
+      @Arg(column="name",javaType=String.class)
+    })
+  // @formatter:on
+  List<AnnoPostTag> getTagsForPost(int postId);
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/param_name_resolve/ActualParamNameTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/param_name_resolve/ActualParamNameTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -99,64 +99,76 @@ class ActualParamNameTest {
   }
 
   interface Mapper {
+    // @formatter:off
     @Select({
-      "<script>",
-      "  select count(*) from users u where u.id in",
-      "  <foreach item='item' index='index' collection='ids' open='(' separator=',' close=')'>",
-      "    #{item}",
-      "  </foreach>",
-      "</script>"
-    })
+        "<script>",
+        "  select count(*) from users u where u.id in",
+        "  <foreach item='item' index='index' collection='ids' open='(' separator=',' close=')'>",
+        "    #{item}",
+        "  </foreach>",
+        "</script>"
+      })
+    // @formatter:on
     Long getUserCountUsingList(List<Integer> ids);
 
+    // @formatter:off
     @Select({
-      "<script>",
-      "  select count(*) from users u where u.id in",
-      "  <foreach item='item' index='index' collection='collection' open='(' separator=',' close=')'>",
-      "    #{item}",
-      "  </foreach>",
-      "</script>"
-    })
+        "<script>",
+        "  select count(*) from users u where u.id in",
+        "  <foreach item='item' index='index' collection='collection' open='(' separator=',' close=')'>",
+        "    #{item}",
+        "  </foreach>",
+        "</script>"
+      })
+    // @formatter:on
     Long getUserCountUsingListWithAliasIsCollection(List<Integer> ids);
 
+    // @formatter:off
     @Select({
-      "<script>",
-      "  select count(*) from users u where u.id in",
-      "  <foreach item='item' index='index' collection='list' open='(' separator=',' close=')'>",
-      "    #{item}",
-      "  </foreach>",
-      "</script>"
-    })
+        "<script>",
+        "  select count(*) from users u where u.id in",
+        "  <foreach item='item' index='index' collection='list' open='(' separator=',' close=')'>",
+        "    #{item}",
+        "  </foreach>",
+        "</script>"
+      })
+    // @formatter:on
     Long getUserCountUsingListWithAliasIsList(List<Integer> ids);
 
+    // @formatter:off
     @Select({
-      "<script>",
-      "  select count(*) from users u where u.id in",
-      "  <foreach item='item' index='index' collection='ids' open='(' separator=',' close=')'>",
-      "    #{item}",
-      "  </foreach>",
-      "</script>"
-    })
+        "<script>",
+        "  select count(*) from users u where u.id in",
+        "  <foreach item='item' index='index' collection='ids' open='(' separator=',' close=')'>",
+        "    #{item}",
+        "  </foreach>",
+        "</script>"
+      })
+    // @formatter:on
     Long getUserCountUsingArray(Integer... ids);
 
+    // @formatter:off
     @Select({
-      "<script>",
-      "  select count(*) from users u where u.id in",
-      "  <foreach item='item' index='index' collection='array' open='(' separator=',' close=')'>",
-      "    #{item}",
-      "  </foreach>",
-      "</script>"
-    })
+        "<script>",
+        "  select count(*) from users u where u.id in",
+        "  <foreach item='item' index='index' collection='array' open='(' separator=',' close=')'>",
+        "    #{item}",
+        "  </foreach>",
+        "</script>"
+      })
+    // @formatter:on
     Long getUserCountUsingArrayWithAliasArray(Integer... ids);
 
+    // @formatter:off
     @Select({
-      "<script>",
-      "  select count(*) from users u where u.id in",
-      "  <foreach item='item' index='index' collection='ids' open='(' separator=',' close=')'>",
-      "    #{item}",
-      "  </foreach>",
-      "</script>"
-    })
+        "<script>",
+        "  select count(*) from users u where u.id in",
+        "  <foreach item='item' index='index' collection='ids' open='(' separator=',' close=')'>",
+        "    #{item}",
+        "  </foreach>",
+        "</script>"
+      })
+    // @formatter:on
     Long getUserCountUsingList_RowBounds(RowBounds rowBounds, List<Integer> ids);
   }
 


### PR DESCRIPTION
formatting now enabled.  did the best I could to preserve items that do not format the best such as select statements in tests throughout.  Its possible some where missed.  I have drafted 3.5.12 release and note there but also will update read me to note that.  This hasn't been a specific issue on the extension projects but was more prevalent here.  

Blocking any code with '// @formatter:off' and '// @formatter:on' will lock the formatting self applied.  Some of this I did on javadocs which probably have a better javadoc friendly way to resolve so hopefully we can eventually work these out so they don't need to exist after seeing how that can be addressed in each case.  