### PR TITLE
Updated rows is not returned

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/statement/PreparedStatementHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/statement/PreparedStatementHandler.java
@@ -44,9 +44,8 @@ public class PreparedStatementHandler extends BaseStatementHandler {
 
   @Override
   public int update(Statement statement) throws SQLException {
-    PreparedStatement ps = (PreparedStatement) statement;
-    ps.execute();
-    int rows = ps.getUpdateCount();
+    PreparedStatement ps = (PreparedStatement) statement;    
+    int rows = ps.executeUpdate();
     Object parameterObject = boundSql.getParameterObject();
     KeyGenerator keyGenerator = mappedStatement.getKeyGenerator();
     keyGenerator.processAfter(executor, mappedStatement, ps, parameterObject);


### PR DESCRIPTION
In the PreparedStatementHandler the execute function is used and afterwards the getUpdateCount is used. However in my case (Sybase) the updateCount returns zero. The two statements can be combined to 1; executeUpdate which returns the correct result.