### PR TITLE
Update test code to clarify the consequence

### DIFF
--- a/src/test/java/org/apache/ibatis/executor/BaseExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/BaseExecutorTest.java
@@ -253,8 +253,10 @@ class BaseExecutorTest extends BaseDataTest {
       for (Map<String, String> m : products) {
         if ("IMAGES".equals(m.get("SECTION"))) {
           assertNull(m.get("subject"));
+          assertNotNull(m.get("id"));
         } else {
           assertNotNull(m.get("subject"));
+          assertNull(m.get("id"));
         }
       }
     } finally {
@@ -274,8 +276,10 @@ class BaseExecutorTest extends BaseDataTest {
       for (Map<String, String> m : products) {
         if ("IMAGES".equals(m.get("SECTION"))) {
           assertNull(m.get("subject"));
+          assertNotNull(m.get("id"));
         } else {
           assertNotNull(m.get("subject"));
+          assertNull(m.get("id"));
         }
       }
     } finally {

--- a/src/test/java/org/apache/ibatis/executor/ExecutorTestHelper.java
+++ b/src/test/java/org/apache/ibatis/executor/ExecutorTestHelper.java
@@ -305,7 +305,7 @@ class ExecutorTestHelper {
                     put("NEWS", discriminatorResultMap.getId());
                     put("VIDEOS", discriminatorResultMap.getId());
                     put("PODCASTS", discriminatorResultMap.getId());
-                    // NEWS left out on purpose.
+                    // IMAGES left out on purpose.
                   }
                 }).build()).build());
 


### PR DESCRIPTION
### 1. Fix wrong comment

### 2. Update discriminator test code in BaseExecutorTest.

IMAGES section does not match with discriminator,
thus the query result is forwarded to "defaultResultMap" instead of "postResultMap".

The "defaultResultMap" maps "id" column to "id" key in HashMap.
The "postResultMap" maps "id" column to "ID" key in HashMap, this is because by default MyBatis converts the column name to uppercase when using a HashMap as the result type in a result map.

To clarify this consequence, I updated test code.