### PR TITLE
Optimize code: 1. Break the loop to improve performance. 2. Remove unnecessary forced cast.

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/loader/ResultLoaderMap.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/ResultLoaderMap.java
@@ -261,8 +261,8 @@ public class ResultLoaderMap {
             + FACTORY_METHOD + "] didn't return [" + Configuration.class + "] but ["
             + (configurationObject == null ? "null" : configurationObject.getClass()) + "].");
       }
-
-      return Configuration.class.cast(configurationObject);
+      // The type of Configuration has been checked before, cast directly by SeasonPan
+      return (Configuration) configurationObject;
     }
 
     private Log getLogger() {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -994,16 +994,14 @@ public class Configuration {
   // Slow but a one time cost. A better solution is welcome.
   protected void checkGloballyForDiscriminatedNestedResultMaps(ResultMap rm) {
     if (rm.hasNestedResultMaps()) {
-      for (Map.Entry<String, ResultMap> entry : resultMaps.entrySet()) {
-        Object value = entry.getValue();
-        if (value instanceof ResultMap) {
-          ResultMap entryResultMap = (ResultMap) value;
-          if (!entryResultMap.hasNestedResultMaps() && entryResultMap.getDiscriminator() != null) {
-            Collection<String> discriminatedResultMapNames = entryResultMap.getDiscriminator().getDiscriminatorMap()
-                .values();
-            if (discriminatedResultMapNames.contains(rm.getId())) {
-              entryResultMap.forceNestedResultMaps();
-            }
+      for (ResultMap entryResultMap : resultMaps.values()) {
+        if (entryResultMap != null && !entryResultMap.hasNestedResultMaps() && entryResultMap.getDiscriminator() != null) {
+          Collection<String> discriminatedResultMapNames = entryResultMap.getDiscriminator().getDiscriminatorMap()
+              .values();
+          if (discriminatedResultMapNames.contains(rm.getId())) {
+            entryResultMap.forceNestedResultMaps();
+            // No need to cycle to the end, break the loop in advance to improve performance. By PanLongfei
+            break;
           }
         }
       }
@@ -1013,8 +1011,7 @@ public class Configuration {
   // Slow but a one time cost. A better solution is welcome.
   protected void checkLocallyForDiscriminatedNestedResultMaps(ResultMap rm) {
     if (!rm.hasNestedResultMaps() && rm.getDiscriminator() != null) {
-      for (Map.Entry<String, String> entry : rm.getDiscriminator().getDiscriminatorMap().entrySet()) {
-        String discriminatedResultMapName = entry.getValue();
+      for (String discriminatedResultMapName : rm.getDiscriminator().getDiscriminatorMap().values()) {
         if (hasResultMap(discriminatedResultMapName)) {
           ResultMap discriminatedResultMap = resultMaps.get(discriminatedResultMapName);
           if (discriminatedResultMap.hasNestedResultMaps()) {

--- a/src/test/java/org/apache/ibatis/submitted/foreach_map/StringStringMapEntry.java
+++ b/src/test/java/org/apache/ibatis/submitted/foreach_map/StringStringMapEntry.java
@@ -66,7 +66,7 @@ public class StringStringMapEntry {
 
   @Override
   public String toString() {
-    return '{' + key.toString() + '=' + value + '}';
+    return '{' + key + '=' + value + '}';
   }
 
   private String key;


### PR DESCRIPTION
1. org.apache.ibatis.session.Configuration#checkGloballyForDiscriminatedNestedResultMaps: 
    there is no need to cycle to the end, break the loop in advance to improve performance.
2. org.apache.ibatis.executor.loader.ResultLoaderMap.LoadPair#getConfiguration:
    the type of Configuration has been checked before, cast directly.
3. org.apache.ibatis.submitted.foreach_map.StringStringMapEntry#toString: 
    the key is string type, no need to invoke toString().
    