### PR TITLE
Use CountDownLatch to coordinate the execution order

### DIFF
--- a/src/test/java/org/apache/ibatis/datasource/pooled/PooledDataSourceTest.java
+++ b/src/test/java/org/apache/ibatis/datasource/pooled/PooledDataSourceTest.java
@@ -67,9 +67,11 @@ class PooledDataSourceTest {
   @Test
   void PoppedConnectionShouldBeNotEqualToClosedConnection() throws Exception {
     Connection connectionToClose = dataSource.getConnection();
+    CountDownLatch latch = new CountDownLatch(1);
 
     new Thread(() -> {
       try {
+        latch.await();
         assertNotEquals(connectionToClose, dataSource.getConnection());
       } catch (Exception e) {
         throw new RuntimeException(e);
@@ -77,6 +79,7 @@ class PooledDataSourceTest {
     }).start();
 
     connectionToClose.close();
+    latch.countDown();
   }
 
   @Test


### PR DESCRIPTION
I committed PooledDataSourceTest.java a few days ago (1640f1a).
In this commit, I added CountDownLatch to make sure the execution order I intended.

Execution Order I intended
1. Close the connection. (-> new connection is opened and it is saved in the list of Idle connection)
2. Get the new connection (-> get the idle connection it saved above)
3. See they are not equal. (-> closed connection != idle connection)

Thank you :)