### PR TITLE
fix Chinese translation error for `parameterType`

### DIFF
--- a/src/site/zh/xdoc/sqlmap-xml.xml
+++ b/src/site/zh/xdoc/sqlmap-xml.xml
@@ -144,7 +144,7 @@ ps.setInt(1,id);]]></source>
               <td><code>parameterType</code></td>
               <td>
                 将会传入这条语句的参数的类全限定名或别名。这个属性是可选的，因为
-                MyBatis 可以通过类型处理器（TypeHandler）推断出具体传入语句的参数，默认值为未设置（unset）。
+                MyBatis 可以根据语句中实际传入的参数计算出应该使用的类型处理器（TypeHandler），默认值为未设置（unset）。
               </td>
             </tr>
             <tr>
@@ -288,7 +288,7 @@ ps.setInt(1,id);]]></source>
               <td><code>parameterType</code></td>
               <td>
                 将会传入这条语句的参数的类全限定名或别名。这个属性是可选的，因为
-                MyBatis 可以通过类型处理器（TypeHandler）推断出具体传入语句的参数，默认值为未设置（unset）。
+                MyBatis 可以根据语句中实际传入的参数计算出应该使用的类型处理器（TypeHandler），默认值为未设置（unset）。
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
The original English doc for `parameterType` is:
> This attribute is optional because MyBatis can calculate the TypeHandler to use out of the actual parameter passed to the statement.

I think the original meaning is that the "actual parameter passed to the statement" makes "MyBatis calculates the TypeHandler to use" happen.

However, the Chinese translated version:
> MyBatis 可以通过类型处理器（TypeHandler）推断出具体传入语句的参数

**is a inversion of cause and effect**, which means that "MyBatis can infer the actual parameter passed to the statement" BY MEANS OF "its TypeHandler".

This is confusing and misleading.

The correct translation I believe should be:
> MyBatis 可以根据语句中实际传入的参数计算出应该使用的类型处理器（TypeHandler）