### PR TITLE
Modify Comments: Configuration.StrictMap<V> put(String key, V value) …

### DIFF
--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -1067,7 +1067,7 @@ public class Configuration {
     @SuppressWarnings("unchecked")
     public V put(String key, V value) {
       if (containsKey(key)) {
-        throw new IllegalArgumentException(name + " already contains key for " + key
+        throw new IllegalArgumentException(name + " already contains key " + key
             + (conflictMessageProducer == null ? "" : conflictMessageProducer.apply(super.get(key), value)));
       }
       if (key.contains(".")) {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -1067,7 +1067,7 @@ public class Configuration {
     @SuppressWarnings("unchecked")
     public V put(String key, V value) {
       if (containsKey(key)) {
-        throw new IllegalArgumentException(name + " already contains value for " + key
+        throw new IllegalArgumentException(name + " already contains key for " + key
             + (conflictMessageProducer == null ? "" : conflictMessageProducer.apply(super.get(key), value)));
       }
       if (key.contains(".")) {

--- a/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
+++ b/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
@@ -127,7 +127,7 @@ class SqlSessionTest extends BaseDataTest {
       c.addCache(cache);
       fail("Exception expected.");
     } catch (Exception e) {
-      assertTrue(e.getMessage().contains("already contains value"));
+      assertTrue(e.getMessage().contains("already contains key"));
     }
   }
 
@@ -441,7 +441,7 @@ class SqlSessionTest extends BaseDataTest {
       fail("Expected exception to be thrown due to statement that already exists.");
     } catch (Exception e) {
       assertTrue(e.getMessage().contains(
-          "already contains value for org.apache.ibatis.domain.blog.mappers.BlogMapper.selectBlogWithPostsUsingSubSelect. please check org/apache/ibatis/builder/BlogMapper.xml and org/mybatis/TestMapper.xml"));
+          "already contains key for org.apache.ibatis.domain.blog.mappers.BlogMapper.selectBlogWithPostsUsingSubSelect. please check org/apache/ibatis/builder/BlogMapper.xml and org/mybatis/TestMapper.xml"));
     }
   }
 
@@ -456,7 +456,7 @@ class SqlSessionTest extends BaseDataTest {
       fail("Expected exception to be thrown due to statement that already exists.");
     } catch (Exception e) {
       assertTrue(e.getMessage().contains(
-          "already contains value for org.apache.ibatis.domain.blog.mappers.AuthorMapper.selectAuthor2. please check org/apache/ibatis/domain/blog/mappers/AuthorMapper.java (best guess) and org/mybatis/TestMapper.xml"));
+          "already contains key for org.apache.ibatis.domain.blog.mappers.AuthorMapper.selectAuthor2. please check org/apache/ibatis/domain/blog/mappers/AuthorMapper.java (best guess) and org/mybatis/TestMapper.xml"));
     }
   }
 

--- a/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
+++ b/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
@@ -441,7 +441,7 @@ class SqlSessionTest extends BaseDataTest {
       fail("Expected exception to be thrown due to statement that already exists.");
     } catch (Exception e) {
       assertTrue(e.getMessage().contains(
-          "already contains key for org.apache.ibatis.domain.blog.mappers.BlogMapper.selectBlogWithPostsUsingSubSelect. please check org/apache/ibatis/builder/BlogMapper.xml and org/mybatis/TestMapper.xml"));
+          "already contains key org.apache.ibatis.domain.blog.mappers.BlogMapper.selectBlogWithPostsUsingSubSelect. please check org/apache/ibatis/builder/BlogMapper.xml and org/mybatis/TestMapper.xml"));
     }
   }
 
@@ -456,7 +456,7 @@ class SqlSessionTest extends BaseDataTest {
       fail("Expected exception to be thrown due to statement that already exists.");
     } catch (Exception e) {
       assertTrue(e.getMessage().contains(
-          "already contains key for org.apache.ibatis.domain.blog.mappers.AuthorMapper.selectAuthor2. please check org/apache/ibatis/domain/blog/mappers/AuthorMapper.java (best guess) and org/mybatis/TestMapper.xml"));
+          "already contains key org.apache.ibatis.domain.blog.mappers.AuthorMapper.selectAuthor2. please check org/apache/ibatis/domain/blog/mappers/AuthorMapper.java (best guess) and org/mybatis/TestMapper.xml"));
     }
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/results_id/IdConflictTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/IdConflictTest.java
@@ -29,7 +29,7 @@ class IdConflictTest {
     Configuration configuration = new Configuration();
     when(() -> configuration.addMapper(IdConflictMapper.class));
     then(caughtException()).isInstanceOf(RuntimeException.class).hasMessage(
-        "Result Maps collection already contains key for org.apache.ibatis.submitted.results_id.IdConflictMapper.userResult");
+        "Result Maps collection already contains key org.apache.ibatis.submitted.results_id.IdConflictMapper.userResult");
   }
 
 }

--- a/src/test/java/org/apache/ibatis/submitted/results_id/IdConflictTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/IdConflictTest.java
@@ -29,7 +29,7 @@ class IdConflictTest {
     Configuration configuration = new Configuration();
     when(() -> configuration.addMapper(IdConflictMapper.class));
     then(caughtException()).isInstanceOf(RuntimeException.class).hasMessage(
-        "Result Maps collection already contains value for org.apache.ibatis.submitted.results_id.IdConflictMapper.userResult");
+        "Result Maps collection already contains key for org.apache.ibatis.submitted.results_id.IdConflictMapper.userResult");
   }
 
 }


### PR DESCRIPTION
When key exists , the exception message `already contains value for... `is thrown,
which is inappropriate and should be prompted for `already contains key for...`.