### PR TITLE
mysql batch insert generatedKeys test

### DIFF
--- a/src/test/java/org/apache/ibatis/submitted/batch_insert_keygen_mysql/BatchInsertKeyGenMysqlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_insert_keygen_mysql/BatchInsertKeyGenMysqlTest.java
@@ -1,0 +1,147 @@
+/*
+ *    Copyright 2009-2023 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.batch_insert_keygen_mysql;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.Reader;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class BatchInsertKeyGenMysqlTest {
+
+  private SqlSessionFactory sqlSessionFactory;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/batch_insert_keygen_mysql/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+      "org/apache/ibatis/submitted/batch_insert_keygen_mysql/CreateDB.sql");
+  }
+
+  @Test
+  void testMysqlConnectorGeneratedKeys1() throws Exception {
+    try (Connection conn = sqlSessionFactory.getConfiguration().getEnvironment().getDataSource().getConnection()) {
+      String sql = "insert into users values(?,?)";
+      PreparedStatement stmt = conn.prepareStatement(sql, Statement.RETURN_GENERATED_KEYS);
+      conn.setAutoCommit(false);
+      // 1,2,3,4,5
+      for (int i = 1; i <= 5; i++) {
+        stmt.setInt(1, i);
+        stmt.setString(2, "name" + i);
+        stmt.addBatch();
+      }
+      stmt.executeBatch();
+      ResultSet rs = stmt.getGeneratedKeys();
+
+      // 5,6,7,8,9
+      System.out.print("ids generated: ");
+      while (rs.next()) {
+        Object value = rs.getObject(1);
+        System.out.print(value + " ");
+      }
+      conn.commit();
+    }
+  }
+
+
+  @Test
+  void shouldIdNotChangedAfterBatchInsert1() {
+    List<User> userList = new ArrayList<>();
+    for (int i = 1; i <= 5; i++) {
+      User user = new User();
+      user.setId(i);
+      user.setName(i + "name");
+      userList.add(user);
+    }
+    // ids before insert: 1,2,3,4,5
+    System.out.println("before insert, id list: " + userList);
+    try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      userList.forEach(user -> {
+        mapper.insert(user);
+      });
+      sqlSession.commit();
+    }
+
+    // ids after insert: 5,6,7,8,9,not expected
+    System.out.println("after insert, id list: " + userList);
+    for (int i = 1; i <= 5; i++) {
+      assertEquals(Integer.valueOf(i), userList.get(i - 1).getId());
+    }
+
+    // db data: correct as expected
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<User> dbUsers = mapper.listUsers();
+      System.out.println("after insert, id list in db: " + dbUsers);
+      assertEquals(dbUsers.size(), userList.size());
+    }
+  }
+
+
+  @Test
+  void shouldIdNotChangedAfterBatchInsert2() {
+    List<User> userList = new ArrayList<>();
+    for (int i = 1; i <= 5; i++) {
+      User user = new User();
+      user.setId(i);
+      if (i == 2 || i == 4) {
+        user.setId(null);
+      }
+      user.setName(i + "name");
+      userList.add(user);
+    }
+    // ids before insert: 1,null,3,null,5
+    System.out.println("before insert, id list: " + userList);
+    try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      userList.forEach(user -> {
+        mapper.insert(user);
+      });
+      sqlSession.commit();
+    }
+
+    // db data: 1,2,3,4,5
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<User> dbUsers = mapper.listUsers();
+      System.out.println("after insert, id list in db: " + dbUsers);
+      assertEquals(dbUsers.size(), userList.size());
+    }
+
+    // ids after insert: 2,3,4,5,6
+    System.out.println("after insert, id list: " + userList);
+    for (int i = 1; i <= 5; i++) {
+      assertEquals(Integer.valueOf(i), userList.get(i - 1).getId());
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/batch_insert_keygen_mysql/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_insert_keygen_mysql/Mapper.java
@@ -1,0 +1,26 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.batch_insert_keygen_mysql;
+
+import java.util.List;
+
+public interface Mapper {
+
+  void insert(User user);
+
+  List<User> listUsers();
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/batch_insert_keygen_mysql/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_insert_keygen_mysql/User.java
@@ -1,0 +1,52 @@
+/*
+ *    Copyright 2009-2022 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.batch_insert_keygen_mysql;
+
+public class User {
+  private Integer id;
+  private String name;
+
+  public User() {
+  }
+
+  public User(Integer id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public String toString() {
+    return "User{" +
+      "id=" + id +
+      '}';
+  }
+}

--- a/src/test/resources/org/apache/ibatis/submitted/batch_insert_keygen_mysql/CreateDB.sql
+++ b/src/test/resources/org/apache/ibatis/submitted/batch_insert_keygen_mysql/CreateDB.sql
@@ -1,0 +1,24 @@
+--
+--    Copyright 2009-2022 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       https://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table if exists users;
+
+create table users (
+  id int auto_increment primary key,
+  name varchar(20)
+);
+
+-- insert into users (id, name) values(1, 'User1');

--- a/src/test/resources/org/apache/ibatis/submitted/batch_insert_keygen_mysql/Mapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/batch_insert_keygen_mysql/Mapper.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2022 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.batch_insert_keygen_mysql.Mapper">
+
+    <select id="listUsers" resultType="org.apache.ibatis.submitted.batch_insert_keygen_mysql.User">
+        select * from users
+    </select>
+
+    <insert id="insert" parameterType="org.apache.ibatis.submitted.batch_insert_keygen_mysql.User" useGeneratedKeys="true" keyColumn="id" keyProperty="id">
+        insert into users values(#{id}, #{name})
+    </insert>
+
+</mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/batch_insert_keygen_mysql/mybatis-config.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/batch_insert_keygen_mysql/mybatis-config.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2022 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value="" />
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="com.mysql.jdbc.Driver" />
+                <property name="url" value="jdbc:mysql://localhost:3306/test?rewriteBatchedStatements=true&amp;useSSL=false&amp;serverTimezone=UTC" />
+                <property name="username" value="root" />
+                <property name="password" value="123456" />
+            </dataSource>
+        </environment>
+    </environments>
+
+    <mappers>
+        <mapper class="org.apache.ibatis.submitted.batch_insert_keygen_mysql.Mapper" />
+    </mappers>
+
+</configuration>


### PR DESCRIPTION
**bug report test**
1.mysql server：5.7
2.mysql-connector-j：8.0.32
3. connction url：rewriteBatchedStatements=true
4. table id：auto_increment primray key
5. useGeneratedKeys="true"
6. use BatchExecutor

for each entity in the list to be insert, if id value is set before insert, then id value will be changed after insert.