### PR TITLE
Undo invalid code optimization

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -259,14 +259,18 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   private ResultSetWrapper getNextResultSet(Statement stmt) {
     // Making this method tolerant of bad JDBC drivers
     try {
-      // Crazy Standard JDBC way of determining if there are more results
-      if (stmt.getConnection().getMetaData().supportsMultipleResultSets()
-          && (stmt.getMoreResults() || (stmt.getUpdateCount() != -1))) {
-        ResultSet rs = stmt.getResultSet();
-        if (rs == null) {
-          return getNextResultSet(stmt);
+      if (stmt.getConnection().getMetaData().supportsMultipleResultSets()) {
+        // Crazy Standard JDBC way of determining if there are more results
+        // DO NOT try to 'imporove' the condition even if IDE tells you to!
+        // It's important that getUpdateCount() is called here.
+        if (!(!stmt.getMoreResults() && stmt.getUpdateCount() == -1)) {
+          ResultSet rs = stmt.getResultSet();
+          if (rs == null) {
+            return getNextResultSet(stmt);
+          } else {
+            return new ResultSetWrapper(rs, configuration);
+          }
         }
-        return new ResultSetWrapper(rs, configuration);
       }
     } catch (Exception e) {
       // Intentionally ignored.

--- a/src/main/java/org/apache/ibatis/jdbc/ScriptRunner.java
+++ b/src/main/java/org/apache/ibatis/jdbc/ScriptRunner.java
@@ -248,7 +248,9 @@ public class ScriptRunner {
       }
       try {
         boolean hasResults = statement.execute(sql);
-        while ((hasResults || (statement.getUpdateCount() != -1))) {
+        // DO NOT try to 'imporove' the condition even if IDE tells you to!
+        // It's important that getUpdateCount() is called here.
+        while (!(!hasResults && statement.getUpdateCount() == -1)) {
           checkWarnings(statement);
           printResults(statement, hasResults);
           hasResults = statement.getMoreResults();


### PR DESCRIPTION
It's a common mistake, but optimizing the condition breaks the contract. The code must check the results of `getMoreResults()` AND `getUpdateCount()`.
Here is an excerpt from the [javadoc](https://docs.oracle.com/en/java/javase/17/docs/api/java.sql/java/sql/Statement.html#getMoreResults()).

> There are no more results when the following is true:
> 
>    // stmt is a Statement object
>    ((stmt.getMoreResults() == false) && (stmt.getUpdateCount() == -1))


We have received several PRs with the same mistake.
e.g. #1095

Added a stronger comment.

