### PR TITLE
Drop jdk 19 on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        java: [11, 17, 19, 20, 21]
+        java: [11, 17, 20, 21]
         distribution: ['zulu']
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
JDK 19 has been EOL.