### PR TITLE
Add the @Options#timeoutString

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/Options.java
+++ b/src/main/java/org/apache/ibatis/annotations/Options.java
@@ -96,8 +96,25 @@ public @interface Options {
    * Returns the statement timeout.
    *
    * @return the statement timeout
+   *
+   * @see #timeoutString()
    */
   int timeout() default -1;
+
+  /**
+   * Returns the statement timeout string.
+   * <p>
+   * Can specify configuration's variables such as {@code ${timeout.select}}. If not resolve variable value, fallback
+   * the {@link #timeout()} value.
+   * </p>
+   *
+   * @return the statement timeout string
+   *
+   * @see #timeout()
+   *
+   * @since 3.5.14
+   */
+  String timeoutString() default "";
 
   /**
    * Returns whether use the generated keys feature supported by JDBC 3.0

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -80,6 +81,7 @@ import org.apache.ibatis.mapping.ResultSetType;
 import org.apache.ibatis.mapping.SqlCommandType;
 import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.mapping.StatementType;
+import org.apache.ibatis.parsing.GenericTokenParser;
 import org.apache.ibatis.parsing.PropertyParser;
 import org.apache.ibatis.reflection.TypeParameterResolver;
 import org.apache.ibatis.scripting.LanguageDriver;
@@ -100,6 +102,8 @@ public class MapperAnnotationBuilder {
       .of(Select.class, Update.class, Insert.class, Delete.class, SelectProvider.class, UpdateProvider.class,
           InsertProvider.class, DeleteProvider.class)
       .collect(Collectors.toSet());
+
+  private static final GenericTokenParser TOKEN_PARSER = new GenericTokenParser("${", "}", t -> t);
 
   private final Configuration configuration;
   private final MapperBuilderAssistant assistant;
@@ -345,7 +349,8 @@ public class MapperAnnotationBuilder {
         useCache = options.useCache();
         // issue #348
         fetchSize = options.fetchSize() > -1 || options.fetchSize() == Integer.MIN_VALUE ? options.fetchSize() : null;
-        timeout = options.timeout() > -1 ? options.timeout() : null;
+        Integer fallbackTimeout = options.timeout() > -1 ? options.timeout() : null;
+        timeout = parseStringValue(options.timeoutString(), fallbackTimeout, Integer::parseInt);
         statementType = options.statementType();
         if (options.resultSetType() != ResultSetType.DEFAULT) {
           resultSetType = options.resultSetType();
@@ -370,6 +375,20 @@ public class MapperAnnotationBuilder {
           // ResultSets
           options != null ? nullOrEmpty(options.resultSets()) : null, statementAnnotation.isDirtySelect());
     });
+  }
+
+  private <T> T parseStringValue(String valueString, T fallbackValue, Function<String, T> valueTypeConverter) {
+    if (valueString.isEmpty()) {
+      return fallbackValue;
+    } else {
+      Properties defaults = new Properties();
+      Optional.ofNullable(fallbackValue).map(String::valueOf)
+          .ifPresent(x -> defaults.setProperty(TOKEN_PARSER.parse(valueString), x));
+      Properties variables = new Properties(defaults);
+      variables.putAll(configuration.getVariables());
+      return Optional.ofNullable(PropertyParser.parse(valueString, variables)).map(valueTypeConverter)
+          .orElse(fallbackValue);
+    }
   }
 
   private LanguageDriver getLanguageDriver(Method method) {

--- a/src/main/java/org/apache/ibatis/parsing/PropertyParser.java
+++ b/src/main/java/org/apache/ibatis/parsing/PropertyParser.java
@@ -88,8 +88,9 @@ public class PropertyParser {
             return variables.getProperty(key, defaultValue);
           }
         }
-        if (variables.containsKey(key)) {
-          return variables.getProperty(key);
+        String value = variables.getProperty(key);
+        if (value != null) {
+          return value;
         }
       }
       return "${" + content + "}";


### PR DESCRIPTION
I propose to add a new attribute that specify the query timeout using configuration's variables such as `${timeout.query1}`.
There are cases that a timeout value want to specify other value per runtime environment.

```java
@Select("SELECT 1")
@Options(timeoutString = "${timeout.query1}")
int select();
```

```properties
timeout.query1=30
```

For example for using on MyBatis Spring Boot:

```yaml
mybatis:
  configuration:
    variables:
      timeout:
        query1: 30
```