### PR TITLE
Add support method for generating dynamic sql on SQL class

### DIFF
--- a/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
+++ b/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
 
 /**
  * @author Clinton Begin
@@ -526,6 +528,71 @@ public abstract class AbstractSQL<T> {
     return a;
   }
 
+  /**
+   * Apply sql phrases that provide by SQL consumer if condition is matches.
+   *
+   * @param applyCondition
+   *          if {@code true} apply sql phrases
+   * @param sqlConsumer
+   *          a consumer that append sql phrase to SQL instance
+   *
+   * @return a self instance
+   *
+   * @see #applyIf(BooleanSupplier, Consumer)
+   *
+   * @since 3.5.14
+   */
+  public T applyIf(boolean applyCondition, Consumer<T> sqlConsumer) {
+    T self = getSelf();
+    if (applyCondition) {
+      sqlConsumer.accept(self);
+    }
+    return self;
+  }
+
+  /**
+   * Apply sql phrases that provide by SQL consumer if condition is matches.
+   *
+   * @param applyConditionSupplier
+   *          if supplier return {@code true} apply sql phrases
+   * @param sqlConsumer
+   *          a consumer that append sql phrase to SQL instance
+   *
+   * @return a self instance
+   *
+   * @see #applyIf(boolean, Consumer)
+   *
+   * @since 3.5.14
+   */
+  public T applyIf(BooleanSupplier applyConditionSupplier, Consumer<T> sqlConsumer) {
+    return applyIf(applyConditionSupplier.getAsBoolean(), sqlConsumer);
+  }
+
+  /**
+   * Apply sql phrases that provide by SQL consumer for iterable.
+   *
+   * @param iterable
+   *          an iterable
+   * @param forEachSqlConsumer
+   *          a consumer that append sql phrase to SQL instance
+   *
+   * @return a self instance
+   *
+   * @param <E>
+   *          element type of iterable
+   *
+   * @since 3.5.14
+   */
+  public <E> T applyForEach(Iterable<E> iterable, ForEachConsumer<T, E> forEachSqlConsumer) {
+    T self = getSelf();
+    int elementIndex = 0;
+    for (E element : iterable) {
+      forEachSqlConsumer.accept(self, element, elementIndex);
+      elementIndex++;
+    }
+    return self;
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
@@ -737,4 +804,31 @@ public abstract class AbstractSQL<T> {
       return answer;
     }
   }
+
+  /**
+   * Consumer for 'forEach' operation.
+   *
+   * @param <T>
+   *          SQL type
+   * @param <E>
+   *          Element type of iterable
+   *
+   * @since 3.5.14
+   */
+  public interface ForEachConsumer<T, E> {
+
+    /**
+     * Accept an iterable element with index.
+     *
+     * @param sql
+     *          SQL instance
+     * @param element
+     *          an iterable element
+     * @param elementIndex
+     *          an element index
+     */
+    void accept(T sql, E element, int elementIndex);
+
+  }
+
 }


### PR DESCRIPTION
I propose to add following new method for generating dynamic sql on SQL.

* `applyIf` (similar `<if>` element in XML language driver)
* `applyForEach` (similar `<foreach>` element in XML language driver)



In this change, the developer can write dynamic sql using with fluent style as follow:

**applyIf**

```java
// Generate following SQL if b and c is null
// UPDATE test SET a=#{a} WHERE (id=#{id})
String sqlString = new SQL()
  .UPDATE("test")
  .applyIf(bean::hasA, sql -> sql.SET("a=#{a}"))
  .applyIf(bean::hasB, sql -> sql.SET("b=#{b}"))
  .applyIf(bean::hasC, sql -> sql.SET("c=#{c}"))
  .WHERE("id=#{id}")
  .toString();
```

**applyForEach**

```java
// Generate following SQL if beans has two element
// INSERT INTO test (a, b, c) VALUES (#{list[0].a}, #{list[0].b}, #{list[0].c}), (#{list[1].a}, #{list[1].b}, #{list[1].c})
String sqlString = new SQL()
  .INSERT_INTO("test")
  .INTO_COLUMNS("a", "b", "c")
  .applyForEach(beans, (sql, element, index) ->
    sql.INTO_VALUES(
      String.format("#{list[%s].a}", index),
      String.format("#{list[%s].b}", index),
      String.format("#{list[%s].c}", index)
    ).ADD_ROW())
  .toString();
```

@mybatis/committers  WDYT?
