### PR TITLE
Add another way to like placeholder

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/SqlSourceBuilder.java
@@ -34,7 +34,7 @@ import org.apache.ibatis.type.JdbcType;
  */
 public class SqlSourceBuilder extends BaseBuilder {
 
-  private static final String PARAMETER_PROPERTIES = "javaType,jdbcType,mode,numericScale,resultMap,typeHandler,jdbcTypeName";
+  private static final String PARAMETER_PROPERTIES = "javaType,jdbcType,mode,numericScale,resultMap,typeHandler,jdbcTypeName,like";
 
   public SqlSourceBuilder(Configuration configuration) {
     super(configuration);
@@ -131,6 +131,8 @@ public class SqlSourceBuilder extends BaseBuilder {
           typeHandlerAlias = value;
         } else if ("jdbcTypeName".equals(name)) {
           builder.jdbcTypeName(value);
+        } else if ("like".equals(name)) {
+          builder.like(value);
         } else if ("property".equals(name)) {
           // Do Nothing
         } else if ("expression".equals(name)) {

--- a/src/main/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandler.java
+++ b/src/main/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandler.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -82,6 +82,9 @@ public class DefaultParameterHandler implements ParameterHandler {
           JdbcType jdbcType = parameterMapping.getJdbcType();
           if (value == null && jdbcType == null) {
             jdbcType = configuration.getJdbcTypeForNull();
+          }
+          if (parameterMapping.getLike() != null && value instanceof String) {
+            value = parameterMapping.getLike().format((String) value);
           }
           try {
             typeHandler.setParameter(ps, i + 1, value, jdbcType);

--- a/src/test/java/org/apache/ibatis/submitted/select_with_like/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/select_with_like/Mapper.java
@@ -1,0 +1,16 @@
+package org.apache.ibatis.submitted.select_with_like;
+
+import org.apache.ibatis.annotations.Insert;
+
+interface Mapper {
+
+    @Insert({ "<script>", "select * from test where name like #{name, like = RIGHT}", "</script>" })
+    void selectWithLikeRight(String name);
+
+    @Insert({ "<script>", "select * from test where name like #{name}", "</script>" })
+    void selectWithNoLike(String name);
+
+    @Insert({ "<script>", "select * from test where name like #{name, like = placeHolder}", "</script>" })
+    void selectWithOodLike(String name);
+
+  }

--- a/src/test/java/org/apache/ibatis/submitted/select_with_like/SelectWithLikeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/select_with_like/SelectWithLikeTest.java
@@ -1,0 +1,77 @@
+package org.apache.ibatis.submitted.select_with_like;
+
+
+import org.apache.ibatis.mapping.BoundSql;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.scripting.defaults.DefaultParameterHandler;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.PreparedStatement;
+
+public class SelectWithLikeTest {
+
+
+  private static Configuration configuration;
+
+  @BeforeAll
+  static void setUp() {
+    configuration = new Configuration();
+    configuration.addMapper(Mapper.class);
+  }
+
+
+  @Test
+  void testSelectWithLikeLeft() {
+    Object parameterObject = "jack";
+    MappedStatement mappedStatement = configuration.getMappedStatement("selectWithLikeRight");
+    PreparedStatement preparedStatement = (PreparedStatement) Proxy.newProxyInstance(
+      SelectWithLikeTest.class.getClassLoader(), new Class[] { PreparedStatement.class }, (proxy, method, args) -> {
+        if (method.getName().equals("setString")) {
+          Assertions.assertEquals(args[1], parameterObject + "%");
+        }
+        return null;
+      });
+
+    BoundSql boundSql = mappedStatement.getBoundSql(parameterObject);
+    DefaultParameterHandler parameterHandler = new DefaultParameterHandler(mappedStatement, parameterObject, boundSql);
+    parameterHandler.setParameters(preparedStatement);
+  }
+
+  @Test
+  void testSelectWithNoLike() {
+    Object parameterObject = "jack";
+    MappedStatement mappedStatement = configuration.getMappedStatement("selectWithNoLike");
+    PreparedStatement preparedStatement = (PreparedStatement) Proxy.newProxyInstance(
+      SelectWithLikeTest.class.getClassLoader(), new Class[] { PreparedStatement.class }, (proxy, method, args) -> {
+        if (method.getName().equals("setString")) {
+          Assertions.assertEquals(args[1], parameterObject);
+        }
+        return null;
+      });
+
+    BoundSql boundSql = mappedStatement.getBoundSql(parameterObject);
+    DefaultParameterHandler parameterHandler = new DefaultParameterHandler(mappedStatement, parameterObject, boundSql);
+    parameterHandler.setParameters(preparedStatement);
+  }
+
+  @Test
+  void testSelectWithOodLike() {
+    Object parameterObject = "jack";
+    MappedStatement mappedStatement = configuration.getMappedStatement("selectWithOodLike");
+    PreparedStatement preparedStatement = (PreparedStatement) Proxy.newProxyInstance(
+      SelectWithLikeTest.class.getClassLoader(), new Class[] { PreparedStatement.class }, (proxy, method, args) -> {
+        if (method.getName().equals("setString")) {
+          Assertions.assertEquals(args[1], parameterObject);
+        }
+        return null;
+      });
+
+    BoundSql boundSql = mappedStatement.getBoundSql(parameterObject);
+    DefaultParameterHandler parameterHandler = new DefaultParameterHandler(mappedStatement, parameterObject, boundSql);
+    parameterHandler.setParameters(preparedStatement);
+  }
+}


### PR DESCRIPTION
To add another way to shorter like fragment, making a new field in ParameterMapping named “like”, which is act as following:

`select * from test where name like #{name, like = RIGHT}`

Then the parameter of `#{name}` in PreparedStatement will be "value%" .

 I am very apprieciate to be able to add this sugar.