### PR TITLE
Fixed numericScale attribute not being consistent with file(dtd xsd) …

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLMapperBuilder.java
@@ -235,7 +235,7 @@ public class XMLMapperBuilder extends BaseBuilder {
         String resultMap = parameterNode.getStringAttribute("resultMap");
         String mode = parameterNode.getStringAttribute("mode");
         String typeHandler = parameterNode.getStringAttribute("typeHandler");
-        Integer numericScale = parameterNode.getIntAttribute("numericScale");
+        Integer numericScale = parameterNode.getIntAttribute("scale");
         ParameterMode modeEnum = resolveParameterMode(mode);
         Class<?> javaTypeClass = resolveClass(javaType);
         JdbcType jdbcTypeEnum = resolveJdbcType(jdbcType);


### PR DESCRIPTION
**Question: Mapper parameter Setting scale does not take effect.**



**The error code references the address and number of lines**
org.apache.ibatis.builder.xml.XMLMapperBuilder#parameterMapElement(238)

```java
private void parameterMapElement(List<XNode> list) {
    for (XNode parameterMapNode : list) {
      String id = parameterMapNode.getStringAttribute("id");
      String type = parameterMapNode.getStringAttribute("type");
      Class<?> parameterClass = resolveClass(type);
      List<XNode> parameterNodes = parameterMapNode.evalNodes("parameter");
      List<ParameterMapping> parameterMappings = new ArrayList<>();
      for (XNode parameterNode : parameterNodes) {
        String property = parameterNode.getStringAttribute("property");
        String javaType = parameterNode.getStringAttribute("javaType");
        String jdbcType = parameterNode.getStringAttribute("jdbcType");
        String resultMap = parameterNode.getStringAttribute("resultMap");
        String mode = parameterNode.getStringAttribute("mode");
        String typeHandler = parameterNode.getStringAttribute("typeHandler");
        // this line 238
        Integer numericScale = parameterNode.getIntAttribute("numericScale");
        ParameterMode modeEnum = resolveParameterMode(mode);
        Class<?> javaTypeClass = resolveClass(javaType);
        JdbcType jdbcTypeEnum = resolveJdbcType(jdbcType);
        Class<? extends TypeHandler<?>> typeHandlerClass = resolveClass(typeHandler);
        ParameterMapping parameterMapping = builderAssistant.buildParameterMapping(parameterClass, property,
            javaTypeClass, jdbcTypeEnum, resultMap, modeEnum, typeHandlerClass, numericScale);
        parameterMappings.add(parameterMapping);
      }
      builderAssistant.addParameterMap(id, parameterClass, parameterMappings);
    }
  }
```

**DTD Definition**

```dtd
<!ELEMENT parameter EMPTY>
<!ATTLIST parameter
property CDATA #REQUIRED
javaType CDATA #IMPLIED
jdbcType CDATA #IMPLIED
mode (IN | OUT | INOUT) #IMPLIED
resultMap CDATA #IMPLIED
scale CDATA #IMPLIED
typeHandler CDATA #IMPLIED
```

**XSD Definition**

```dtd
  <xs:element name="parameter">
    <xs:complexType>
      <xs:attribute name="property" use="required"/>
      <xs:attribute name="javaType"/>
      <xs:attribute name="jdbcType"/>
      <xs:attribute name="mode">
        <xs:simpleType>
          <xs:restriction base="xs:token">
            <xs:enumeration value="IN"/>
            <xs:enumeration value="OUT"/>
            <xs:enumeration value="INOUT"/>
          </xs:restriction>
        </xs:simpleType>
      </xs:attribute>
      <xs:attribute name="resultMap"/>
      <xs:attribute name="scale"/>
      <xs:attribute name="typeHandler"/>
    </xs:complexType>
  </xs:element>
```



**Fixed numericScale attribute not being consistent with file(dtd xsd) attribute definition**

```java
Integer numericScale = parameterNode.getIntAttribute("scale");
```