### PR TITLE
Optimize the usuage of memory and cpu about BoundSql

### DIFF
--- a/src/main/java/org/apache/ibatis/mapping/BoundSql.java
+++ b/src/main/java/org/apache/ibatis/mapping/BoundSql.java
@@ -45,7 +45,7 @@ public class BoundSql {
     this.sql = sql;
     this.parameterMappings = parameterMappings;
     this.parameterObject = parameterObject;
-    this.additionalParameters = new HashMap<>();
+    this.additionalParameters = new HashMap<>(this.parameterMappings.size());
     this.metaParameters = configuration.newMetaObject(additionalParameters);
   }
 


### PR DESCRIPTION
Instantiating a  HashMap of  BoundSql with a specified map size, to avoid frequent the memory of allocation and deallocation. 
For example the foreach usage：

`<select id="selectPostIn" resultType="domain.blog.Post">
  SELECT *
  FROM POST P
  WHERE ID in
  <foreach item="item" index="index" collection="list"
      open="(" separator="," close=")">
        #{item}
  </foreach>
</select>`

The HashMap default initial size is 16, It will be cost more memory and cpu in expanding the capacity, using a designated size will reduce this process.