### PR TITLE
optimize when get parameter property value create same MeteObject multiple times

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
@@ -207,6 +207,7 @@ public abstract class BaseExecutor implements Executor {
     List<ParameterMapping> parameterMappings = boundSql.getParameterMappings();
     TypeHandlerRegistry typeHandlerRegistry = ms.getConfiguration().getTypeHandlerRegistry();
     // mimic DefaultParameterHandler logic
+    MetaObject metaObject = null;
     for (ParameterMapping parameterMapping : parameterMappings) {
       if (parameterMapping.getMode() != ParameterMode.OUT) {
         Object value;
@@ -218,7 +219,9 @@ public abstract class BaseExecutor implements Executor {
         } else if (typeHandlerRegistry.hasTypeHandler(parameterObject.getClass())) {
           value = parameterObject;
         } else {
-          MetaObject metaObject = configuration.newMetaObject(parameterObject);
+          if (metaObject == null) {
+            metaObject = configuration.newMetaObject(parameterObject);
+          }
           value = metaObject.getValue(propertyName);
         }
         cacheKey.update(value);

--- a/src/test/java/org/apache/ibatis/executor/BaseExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/BaseExecutorTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,15 +30,22 @@ import javassist.util.proxy.Proxy;
 import javax.sql.DataSource;
 
 import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.builder.StaticSqlSource;
+import org.apache.ibatis.cache.CacheKey;
 import org.apache.ibatis.domain.blog.Author;
 import org.apache.ibatis.domain.blog.Blog;
 import org.apache.ibatis.domain.blog.Post;
 import org.apache.ibatis.domain.blog.Section;
+import org.apache.ibatis.mapping.BoundSql;
 import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.mapping.ParameterMapping;
+import org.apache.ibatis.mapping.SqlCommandType;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.session.RowBounds;
 import org.apache.ibatis.transaction.Transaction;
 import org.apache.ibatis.transaction.jdbc.JdbcTransaction;
+import org.apache.ibatis.type.JdbcType;
+import org.apache.ibatis.type.TypeHandlerRegistry;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -468,6 +476,128 @@ class BaseExecutorTest extends BaseDataTest {
       executor.rollback(true);
       executor.close(false);
     }
+  }
+
+  @Test
+  void testCreateCacheKeyWithAdditionalParameter() {
+    TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
+
+    MappedStatement mappedStatement = new MappedStatement.Builder(config, "testSelect", new StaticSqlSource(config, "some select statement"), SqlCommandType.SELECT).build();
+
+    Object parameterObject = 1;
+
+    BoundSql boundSql = new BoundSql(config, "some select statement", new ArrayList<ParameterMapping>() {
+      {
+        add(new ParameterMapping.Builder(config, "id", registry.getTypeHandler(int.class)).build());
+      }
+    }, parameterObject) {
+      {
+        setAdditionalParameter("id", 2);
+      }
+    };
+
+    Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
+    CacheKey cacheKey = executor.createCacheKey(mappedStatement, parameterObject, RowBounds.DEFAULT, boundSql);
+
+    CacheKey expected = new CacheKey();
+    expected.update(mappedStatement.getId());
+    expected.update(RowBounds.DEFAULT.getOffset());
+    expected.update(RowBounds.DEFAULT.getLimit());
+    expected.update(boundSql.getSql());
+    expected.update(2);
+
+    assertEquals(expected, cacheKey);
+  }
+
+  @Test
+  void testCreateCacheKeyWithNull() {
+    TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
+
+    MappedStatement mappedStatement = new MappedStatement.Builder(config, "testSelect", new StaticSqlSource(config, "some select statement"), SqlCommandType.SELECT).build();
+
+    Object parameterObject = null;
+
+    BoundSql boundSql = new BoundSql(config, "some select statement", new ArrayList<ParameterMapping>() {
+      {
+        add(new ParameterMapping.Builder(config, "id", registry.getTypeHandler(int.class)).build());
+      }
+    }, parameterObject);
+
+    Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
+    CacheKey cacheKey = executor.createCacheKey(mappedStatement, parameterObject, RowBounds.DEFAULT, boundSql);
+
+    CacheKey expected = new CacheKey();
+    expected.update(mappedStatement.getId());
+    expected.update(RowBounds.DEFAULT.getOffset());
+    expected.update(RowBounds.DEFAULT.getLimit());
+    expected.update(boundSql.getSql());
+    expected.update(null);
+
+    assertEquals(expected, cacheKey);
+  }
+
+  @Test
+  void testCreateCacheKeyWithTypeHandler() {
+    TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
+
+    MappedStatement mappedStatement = new MappedStatement.Builder(config, "testSelect", new StaticSqlSource(config, "some select statement"), SqlCommandType.SELECT).build();
+
+    Object parameterObject = 1;
+
+    BoundSql boundSql = new BoundSql(config, "some select statement", new ArrayList<ParameterMapping>() {
+      {
+        add(new ParameterMapping.Builder(config, "id", registry.getTypeHandler(int.class)).build());
+      }
+    }, parameterObject);
+
+    Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
+    CacheKey cacheKey = executor.createCacheKey(mappedStatement, parameterObject, RowBounds.DEFAULT, boundSql);
+
+    CacheKey expected = new CacheKey();
+    expected.update(mappedStatement.getId());
+    expected.update(RowBounds.DEFAULT.getOffset());
+    expected.update(RowBounds.DEFAULT.getLimit());
+    expected.update(boundSql.getSql());
+    expected.update(1);
+
+    assertEquals(expected, cacheKey);
+  }
+
+  @Test
+  void testCreateCacheKeyWithMetaObject() {
+    TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
+
+    MappedStatement mappedStatement = new MappedStatement.Builder(config, "testSelect", new StaticSqlSource(config, "some select statement"), SqlCommandType.SELECT).build();
+
+    Author parameterObject = new Author(-1, "cbegin", "******", "cbegin@nowhere.com", "N/A", Section.NEWS);
+
+    BoundSql boundSql = new BoundSql(config, "some select statement", new ArrayList<ParameterMapping>() {
+      {
+        add(new ParameterMapping.Builder(config, "id", registry.getTypeHandler(int.class)).build());
+        add(new ParameterMapping.Builder(config, "username", registry.getTypeHandler(String.class)).build());
+        add(new ParameterMapping.Builder(config, "password", registry.getTypeHandler(String.class)).build());
+        add(new ParameterMapping.Builder(config, "email", registry.getTypeHandler(String.class)).build());
+        add(new ParameterMapping.Builder(config, "bio", registry.getTypeHandler(String.class)).jdbcType(JdbcType.VARCHAR).build());
+        add(new ParameterMapping.Builder(config, "favouriteSection", registry.getTypeHandler(Section.class)).jdbcType(JdbcType.VARCHAR).build());
+      }
+    }, parameterObject);
+
+    Executor executor = createExecutor(new JdbcTransaction(ds, null, false));
+    CacheKey cacheKey = executor.createCacheKey(mappedStatement, parameterObject, RowBounds.DEFAULT, boundSql);
+
+    CacheKey expected = new CacheKey();
+    expected.update(mappedStatement.getId());
+    expected.update(RowBounds.DEFAULT.getOffset());
+    expected.update(RowBounds.DEFAULT.getLimit());
+    expected.update(boundSql.getSql());
+    expected.update(parameterObject.getId());
+    expected.update(parameterObject.getUsername());
+    expected.update(parameterObject.getPassword());
+    expected.update(parameterObject.getEmail());
+    expected.update(parameterObject.getBio());
+    expected.update(parameterObject.getFavouriteSection());
+
+    assertEquals(expected, cacheKey);
   }
 
   protected Executor createExecutor(Transaction transaction) {

--- a/src/test/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandlerTest.java
@@ -39,6 +39,14 @@ import org.apache.ibatis.mapping.ParameterMapping;
 import org.apache.ibatis.mapping.ResultMap;
 import org.apache.ibatis.mapping.ResultMapping;
 import org.apache.ibatis.mapping.SqlCommandType;
+import org.apache.ibatis.reflection.DefaultReflectorFactory;
+import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.reflection.ReflectorFactory;
+import org.apache.ibatis.reflection.factory.DefaultObjectFactory;
+import org.apache.ibatis.reflection.factory.ObjectFactory;
+import org.apache.ibatis.reflection.wrapper.DefaultObjectWrapperFactory;
+import org.apache.ibatis.reflection.wrapper.ObjectWrapperFactory;
+import org.apache.ibatis.scripting.xmltags.XMLLanguageDriver;
 import org.apache.ibatis.session.Configuration;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeException;
@@ -103,16 +111,93 @@ class DefaultParameterHandlerTest {
   }
 
   @Test
-  void testParameterObjectMetaObjectGetValue() {
+  void testParameterObjectGetPropertyValueWithAdditionalParameter() throws SQLException {
     Configuration config = new Configuration();
     TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
 
     MappedStatement mappedStatement = new MappedStatement.Builder(config, "testSelect", new StaticSqlSource(config, "some select statement"), SqlCommandType.SELECT).build();
 
-    Author parameterObject = mock(Author.class);
+    Object parameterObject = 1;
 
     BoundSql boundSql = new BoundSql(config, "some select statement", new ArrayList<ParameterMapping>() {
       {
+        add(new ParameterMapping.Builder(config, "id", registry.getTypeHandler(int.class)).build());
+      }
+    }, parameterObject) {
+      {
+        setAdditionalParameter("id", 2);
+      }
+    };
+
+    DefaultParameterHandler defaultParameterHandler = new DefaultParameterHandler(mappedStatement, parameterObject, boundSql);
+
+    PreparedStatement ps = mock(PreparedStatement.class);
+
+    defaultParameterHandler.setParameters(ps);
+
+    verify(ps, times(1)).setInt(1, 2);
+  }
+
+  @Test
+  void testParameterObjectGetPropertyValueWithNull() throws SQLException {
+    Configuration config = new Configuration();
+    TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
+
+    MappedStatement mappedStatement = new MappedStatement.Builder(config, "testSelect", new StaticSqlSource(config, "some select statement"), SqlCommandType.SELECT).build();
+
+    Object parameterObject = null;
+
+    BoundSql boundSql = new BoundSql(config, "some select statement", new ArrayList<ParameterMapping>() {
+      {
+        add(new ParameterMapping.Builder(config, "id", registry.getTypeHandler(int.class)).build());
+      }
+    }, parameterObject);
+
+    DefaultParameterHandler defaultParameterHandler = new DefaultParameterHandler(mappedStatement, parameterObject, boundSql);
+
+    PreparedStatement ps = mock(PreparedStatement.class);
+
+    defaultParameterHandler.setParameters(ps);
+
+    verify(ps, times(1)).setNull(1, config.getJdbcTypeForNull().TYPE_CODE);
+  }
+
+  @Test
+  void testParameterObjectGetPropertyValueWithTypeHandler() throws SQLException {
+    Configuration config = new Configuration();
+    TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
+
+    MappedStatement mappedStatement = new MappedStatement.Builder(config, "testSelect", new StaticSqlSource(config, "some select statement"), SqlCommandType.SELECT).build();
+
+    Object parameterObject = 1;
+
+    BoundSql boundSql = new BoundSql(config, "some select statement", new ArrayList<ParameterMapping>() {
+      {
+        add(new ParameterMapping.Builder(config, "id", registry.getTypeHandler(int.class)).build());
+      }
+    }, parameterObject);
+
+    DefaultParameterHandler defaultParameterHandler = new DefaultParameterHandler(mappedStatement, parameterObject, boundSql);
+
+    PreparedStatement ps = mock(PreparedStatement.class);
+
+    defaultParameterHandler.setParameters(ps);
+
+    verify(ps, times(1)).setInt(1, (Integer) parameterObject);
+  }
+
+  @Test
+  void testParameterObjectGetPropertyValueWithMetaObject() throws SQLException {
+    Configuration config = new Configuration();
+    TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
+
+    MappedStatement mappedStatement = new MappedStatement.Builder(config, "testSelect", new StaticSqlSource(config, "some select statement"), SqlCommandType.SELECT).build();
+
+    Author parameterObject = new Author(-1, "cbegin", "******", "cbegin@nowhere.com", "N/A", Section.NEWS);
+
+    BoundSql boundSql = new BoundSql(config, "some select statement", new ArrayList<ParameterMapping>() {
+      {
+        add(new ParameterMapping.Builder(config, "id", registry.getTypeHandler(int.class)).build());
         add(new ParameterMapping.Builder(config, "username", registry.getTypeHandler(String.class)).build());
         add(new ParameterMapping.Builder(config, "password", registry.getTypeHandler(String.class)).build());
         add(new ParameterMapping.Builder(config, "email", registry.getTypeHandler(String.class)).build());
@@ -127,10 +212,56 @@ class DefaultParameterHandlerTest {
 
     defaultParameterHandler.setParameters(ps);
 
+    verify(ps, times(1)).setInt(1, parameterObject.getId());
+    verify(ps, times(1)).setString(2, parameterObject.getUsername());
+    verify(ps, times(1)).setString(3, parameterObject.getPassword());
+    verify(ps, times(1)).setString(4, parameterObject.getEmail());
+    verify(ps, times(1)).setString(5, parameterObject.getBio());
+    verify(ps, times(1)).setObject(6, parameterObject.getFavouriteSection().name(), JdbcType.VARCHAR.TYPE_CODE);
+  }
+
+  @Test
+  void testParameterObjectGetPropertyValueWithMetaObjectAndCreateOnce() {
+    Author parameterObject = mock(Author.class);
+
+    Configuration mockConfig = mock(Configuration.class);
+
+    final ObjectFactory objectFactory = new DefaultObjectFactory();
+    final ObjectWrapperFactory objectWrapperFactory = new DefaultObjectWrapperFactory();
+    final ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
+
+    when(mockConfig.getTypeHandlerRegistry()).thenReturn(new TypeHandlerRegistry(mockConfig));
+    when(mockConfig.getDefaultScriptingLanguageInstance()).thenReturn(new XMLLanguageDriver());
+    when(mockConfig.newMetaObject(parameterObject)).thenReturn(MetaObject.forObject(parameterObject, objectFactory, objectWrapperFactory, reflectorFactory));
+
+    TypeHandlerRegistry registry = mockConfig.getTypeHandlerRegistry();
+
+    MappedStatement mappedStatement = new MappedStatement.Builder(mockConfig, "testSelect", new StaticSqlSource(mockConfig, "some select statement"), SqlCommandType.SELECT).build();
+
+    BoundSql boundSql = new BoundSql(mockConfig, "some select statement", new ArrayList<ParameterMapping>() {
+      {
+        add(new ParameterMapping.Builder(mockConfig, "id", registry.getTypeHandler(int.class)).jdbcType(JdbcType.INTEGER).build());
+        add(new ParameterMapping.Builder(mockConfig, "username", registry.getTypeHandler(String.class)).jdbcType(JdbcType.VARCHAR).build());
+        add(new ParameterMapping.Builder(mockConfig, "password", registry.getTypeHandler(String.class)).jdbcType(JdbcType.VARCHAR).build());
+        add(new ParameterMapping.Builder(mockConfig, "email", registry.getTypeHandler(String.class)).jdbcType(JdbcType.VARCHAR).build());
+        add(new ParameterMapping.Builder(mockConfig, "bio", registry.getTypeHandler(String.class)).jdbcType(JdbcType.VARCHAR).build());
+        add(new ParameterMapping.Builder(mockConfig, "favouriteSection", registry.getTypeHandler(Section.class)).jdbcType(JdbcType.VARCHAR).build());
+      }
+    }, parameterObject);
+
+    DefaultParameterHandler defaultParameterHandler = new DefaultParameterHandler(mappedStatement, parameterObject, boundSql);
+
+    PreparedStatement ps = mock(PreparedStatement.class);
+
+    defaultParameterHandler.setParameters(ps);
+
+    verify(parameterObject, times(1)).getId();
     verify(parameterObject, times(1)).getUsername();
     verify(parameterObject, times(1)).getPassword();
     verify(parameterObject, times(1)).getEmail();
     verify(parameterObject, times(1)).getBio();
     verify(parameterObject, times(1)).getFavouriteSection();
+
+    verify(mockConfig, times(1)).newMetaObject(parameterObject);
   }
 }


### PR DESCRIPTION
Last time I submitted an optimization for the DefaultParameterHandler (#2946 ), but I'm sorry, I missed one more point. Its logic is the same as the DefaultParameterHandler, so I try refactored it.