### PR TITLE
Added better error reporting to help debug issues with mapper files

### DIFF
--- a/src/main/java/org/apache/ibatis/type/BaseTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/BaseTypeHandler.java
@@ -66,7 +66,8 @@ public abstract class BaseTypeHandler<T> extends TypeReference<T> implements Typ
         ps.setNull(i, jdbcType.TYPE_CODE);
       } catch (SQLException e) {
         throw new TypeException("Error setting null for parameter #" + i + " with JdbcType " + jdbcType + " . "
-            + "Try setting a different JdbcType for this parameter or a different jdbcTypeForNull configuration property. "
+            + "Try setting a different JdbcType for this parameter or a different jdbcTypeForNull configuration property "
+            + "or check for other SQLExceptions. "
             + "Cause: " + e, e);
       }
     } else {
@@ -74,7 +75,8 @@ public abstract class BaseTypeHandler<T> extends TypeReference<T> implements Typ
         setNonNullParameter(ps, i, parameter, jdbcType);
       } catch (Exception e) {
         throw new TypeException("Error setting non null for parameter #" + i + " with JdbcType " + jdbcType + " . "
-            + "Try setting a different JdbcType for this parameter or a different configuration property. " + "Cause: "
+            + "Try setting a different JdbcType for this parameter or a different configuration property "
+            + "or check for other SQLExceptions. " + "Cause: "
             + e, e);
       }
     }


### PR DESCRIPTION
The exception thrown by the parameter setting method of PreparedStatement may not only be due to the current parameter setting error, but also due to the parameter setting being too long, or other internal exceptions in jdbc driver. It should not be uniformly described as an exception set for this parameter. This description will mislead people and make them think that it is an error set for the parameter type.

For example

`select id from table where id='#{it.id}' and name=#{it.name}`

Error report

`Caused by: org.apache.ibatis.type.TypeException: Could not set parameters for mapping: ParameterMapping{property='it.name', mode=IN, javaType=class java.lang.Object, jdbcType=null, numericScale=null, resultMapId='null', jdbcTypeName='null', expression='null'}. Cause: org.apache.ibatis.type.TypeException: Error setting null for parameter #2 with JdbcType OTHER . Try setting a different JdbcType for this parameter or a different jdbcTypeForNull configuration property. Cause: com.amazon.redshift.util.RedshiftException:The column index is out of range: {0}, number of columns: {1}`

Although this is an non-standard writing method, mybatis should not display an error in name