### PR TITLE
Fixed the removeObject method key-value pair removal issue

### DIFF
--- a/src/main/java/org/apache/ibatis/cache/decorators/LruCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/LruCache.java
@@ -75,6 +75,7 @@ public class LruCache implements Cache {
 
   @Override
   public Object removeObject(Object key) {
+    keyMap.remove(key);
     return delegate.removeObject(key);
   }
 

--- a/src/test/java/org/apache/ibatis/cache/LruCacheTest.java
+++ b/src/test/java/org/apache/ibatis/cache/LruCacheTest.java
@@ -23,6 +23,9 @@ import org.apache.ibatis.cache.decorators.LruCache;
 import org.apache.ibatis.cache.impl.PerpetualCache;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Field;
+import java.util.Map;
+
 class LruCacheTest {
 
   @Test
@@ -58,6 +61,20 @@ class LruCacheTest {
     cache.clear();
     assertNull(cache.getObject(0));
     assertNull(cache.getObject(4));
+  }
+
+  @Test
+  void shouldCacheSizeEqualsKeyMapSize() throws Exception {
+    LruCache cache = new LruCache(new PerpetualCache("default"));
+    cache.setSize(5);
+    for (int i = 0; i < 5; i++) {
+      cache.putObject(i, i);
+    }
+    cache.removeObject(1);
+    Field keyMap = cache.getClass().getDeclaredField("keyMap");
+    keyMap.setAccessible(true);
+    Map<Object, Object> map = (Map<Object, Object>) keyMap.get(cache);
+    assertEquals(map.size(), cache.getSize());
   }
 
 }


### PR DESCRIPTION
In my opinion,  should also delete the key-value pairs in the keyMap.