### PR TITLE
Fixed an incorrect test method

### DIFF
--- a/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlConfigBuilderTest.java
@@ -190,7 +190,7 @@ class XmlConfigBuilderTest {
       assertThat(config.getAutoMappingBehavior()).isEqualTo(AutoMappingBehavior.NONE);
       assertThat(config.getAutoMappingUnknownColumnBehavior()).isEqualTo(AutoMappingUnknownColumnBehavior.WARNING);
       assertThat(config.isCacheEnabled()).isFalse();
-      assertThat(config.getProxyFactory()).isInstanceOf(CglibProxyFactory.class);
+      assertThat(config.getProxyFactory()).isInstanceOf(JavassistProxyFactory.class);
       assertThat(config.isLazyLoadingEnabled()).isTrue();
       assertThat(config.isAggressiveLazyLoading()).isTrue();
       assertThat(config.isMultipleResultSetsEnabled()).isFalse();

--- a/src/test/resources/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
+++ b/src/test/resources/org/apache/ibatis/builder/CustomizedSettingsMapperConfig.xml
@@ -31,7 +31,7 @@
     <setting name="autoMappingBehavior" value="NONE"/>
     <setting name="autoMappingUnknownColumnBehavior" value="WARNING"/>
     <setting name="cacheEnabled" value="false"/>
-    <setting name="proxyFactory" value="CGLIB"/>
+    <setting name="proxyFactory" value="JAVASSIST"/>
     <setting name="lazyLoadingEnabled" value="true"/>
     <setting name="aggressiveLazyLoading" value="true"/>
     <setting name="multipleResultSetsEnabled" value="false"/>


### PR DESCRIPTION
I'm testing XmlConfigBuilderTest#shouldSuccessfullyLoadXMLConfigFile() , throws the error
![1697193985613_C901D413-94FB-4fa1-AB03-DA56217CB481](https://github.com/mybatis/mybatis-3/assets/74135536/97c7f2aa-ea54-4290-91b7-009a1819d05b)

It's actually it throwing an exception here
![1697193985613_C901D413-94FB-4fa1-AB03-DA56217CB481](https://github.com/mybatis/mybatis-3/assets/74135536/ccb9181f-b1d8-4922-bfd9-a5ee0ec2f90c)

When I switch to JAVASSIST, this is correct
But I don't know why
