### PR TITLE
Optimize the code of the xml configuration file parsing process

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/BaseBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/BaseBuilder.java
@@ -64,33 +64,24 @@ public abstract class BaseBuilder {
   }
 
   protected JdbcType resolveJdbcType(String alias) {
-    if (alias == null) {
-      return null;
-    }
     try {
-      return JdbcType.valueOf(alias);
+      return alias == null ? null : JdbcType.valueOf(alias);
     } catch (IllegalArgumentException e) {
       throw new BuilderException("Error resolving JdbcType. Cause: " + e, e);
     }
   }
 
   protected ResultSetType resolveResultSetType(String alias) {
-    if (alias == null) {
-      return null;
-    }
     try {
-      return ResultSetType.valueOf(alias);
+      return alias == null ? null : ResultSetType.valueOf(alias);
     } catch (IllegalArgumentException e) {
       throw new BuilderException("Error resolving ResultSetType. Cause: " + e, e);
     }
   }
 
   protected ParameterMode resolveParameterMode(String alias) {
-    if (alias == null) {
-      return null;
-    }
     try {
-      return ParameterMode.valueOf(alias);
+      return alias == null ? null : ParameterMode.valueOf(alias);
     } catch (IllegalArgumentException e) {
       throw new BuilderException("Error resolving ParameterMode. Cause: " + e, e);
     }
@@ -98,22 +89,16 @@ public abstract class BaseBuilder {
 
   protected Object createInstance(String alias) {
     Class<?> clazz = resolveClass(alias);
-    if (clazz == null) {
-      return null;
-    }
     try {
-      return clazz.getDeclaredConstructor().newInstance();
+      return clazz == null ? null : clazz.getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       throw new BuilderException("Error creating instance. Cause: " + e, e);
     }
   }
 
   protected <T> Class<? extends T> resolveClass(String alias) {
-    if (alias == null) {
-      return null;
-    }
     try {
-      return resolveAlias(alias);
+      return alias == null ? null : resolveAlias(alias);
     } catch (Exception e) {
       throw new BuilderException("Error resolving class. Cause: " + e, e);
     }
@@ -139,11 +124,8 @@ public abstract class BaseBuilder {
     }
     // javaType ignored for injected handlers see issue #746 for full detail
     TypeHandler<?> handler = typeHandlerRegistry.getMappingTypeHandler(typeHandlerType);
-    if (handler == null) {
-      // not in registry, create a new one
-      handler = typeHandlerRegistry.getInstance(javaType, typeHandlerType);
-    }
-    return handler;
+    // if handler not in registry, create a new one, otherwise return directly
+    return handler == null ? typeHandlerRegistry.getInstance(javaType, typeHandlerType) : handler;
   }
 
   protected <T> Class<? extends T> resolveAlias(String alias) {

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -152,14 +152,15 @@ public class XMLConfigBuilder extends BaseBuilder {
 
   private void loadCustomVfs(Properties props) throws ClassNotFoundException {
     String value = props.getProperty("vfsImpl");
-    if (value != null) {
-      String[] clazzes = value.split(",");
-      for (String clazz : clazzes) {
-        if (!clazz.isEmpty()) {
-          @SuppressWarnings("unchecked")
-          Class<? extends VFS> vfsImpl = (Class<? extends VFS>) Resources.classForName(clazz);
-          configuration.setVfsImpl(vfsImpl);
-        }
+    if(value == null) {
+      return;
+    }
+    String[] clazzes = value.split(",");
+    for (String clazz : clazzes) {
+      if (!clazz.isEmpty()) {
+        @SuppressWarnings("unchecked")
+        Class<? extends VFS> vfsImpl = (Class<? extends VFS>) Resources.classForName(clazz);
+        configuration.setVfsImpl(vfsImpl);
       }
     }
   }
@@ -169,37 +170,37 @@ public class XMLConfigBuilder extends BaseBuilder {
     configuration.setLogImpl(logImpl);
   }
 
-  private void typeAliasesElement(XNode parent) {
-    if (parent != null) {
-      for (XNode child : parent.getChildren()) {
-        if ("package".equals(child.getName())) {
-          String typeAliasPackage = child.getStringAttribute("name");
-          configuration.getTypeAliasRegistry().registerAliases(typeAliasPackage);
-        } else {
-          String alias = child.getStringAttribute("alias");
-          String type = child.getStringAttribute("type");
-          try {
-            Class<?> clazz = Resources.classForName(type);
-            if (alias == null) {
-              typeAliasRegistry.registerAlias(clazz);
-            } else {
-              typeAliasRegistry.registerAlias(alias, clazz);
-            }
-          } catch (ClassNotFoundException e) {
-            throw new BuilderException("Error registering typeAlias for '" + alias + "'. Cause: " + e, e);
+  private void typeAliasesElement(XNode context) {
+    if(context == null) {
+      return;
+    }
+    for (XNode child : context.getChildren()) {
+      if ("package".equals(child.getName())) {
+        String typeAliasPackage = child.getStringAttribute("name");
+        configuration.getTypeAliasRegistry().registerAliases(typeAliasPackage);
+      } else {
+        String alias = child.getStringAttribute("alias");
+        String type = child.getStringAttribute("type");
+        try {
+          Class<?> clazz = Resources.classForName(type);
+          if (alias == null) {
+            typeAliasRegistry.registerAlias(clazz);
+          } else {
+            typeAliasRegistry.registerAlias(alias, clazz);
           }
+        } catch (ClassNotFoundException e) {
+          throw new BuilderException("Error registering typeAlias for '" + alias + "'. Cause: " + e, e);
         }
       }
     }
   }
 
-  private void pluginElement(XNode parent) throws Exception {
-    if (parent != null) {
-      for (XNode child : parent.getChildren()) {
+  private void pluginElement(XNode context) throws Exception {
+    if (context != null) {
+      for (XNode child : context.getChildren()) {
         String interceptor = child.getStringAttribute("interceptor");
         Properties properties = child.getChildrenAsProperties();
-        Interceptor interceptorInstance = (Interceptor) resolveClass(interceptor).getDeclaredConstructor()
-            .newInstance();
+        Interceptor interceptorInstance = (Interceptor) resolveClass(interceptor).getDeclaredConstructor().newInstance();
         interceptorInstance.setProperties(properties);
         configuration.addInterceptor(interceptorInstance);
       }
@@ -233,26 +234,27 @@ public class XMLConfigBuilder extends BaseBuilder {
   }
 
   private void propertiesElement(XNode context) throws Exception {
-    if (context != null) {
-      Properties defaults = context.getChildrenAsProperties();
-      String resource = context.getStringAttribute("resource");
-      String url = context.getStringAttribute("url");
-      if (resource != null && url != null) {
-        throw new BuilderException(
-            "The properties element cannot specify both a URL and a resource based property file reference.  Please specify one or the other.");
-      }
-      if (resource != null) {
-        defaults.putAll(Resources.getResourceAsProperties(resource));
-      } else if (url != null) {
-        defaults.putAll(Resources.getUrlAsProperties(url));
-      }
-      Properties vars = configuration.getVariables();
-      if (vars != null) {
-        defaults.putAll(vars);
-      }
-      parser.setVariables(defaults);
-      configuration.setVariables(defaults);
+    if(context == null) {
+      return;
     }
+    Properties defaults = context.getChildrenAsProperties();
+    String resource = context.getStringAttribute("resource");
+    String url = context.getStringAttribute("url");
+    if (resource != null && url != null) {
+      throw new BuilderException(
+          "The properties element cannot specify both a URL and a resource based property file reference.  Please specify one or the other.");
+    }
+    if (resource != null) {
+      defaults.putAll(Resources.getResourceAsProperties(resource));
+    } else if (url != null) {
+      defaults.putAll(Resources.getUrlAsProperties(url));
+    }
+    Properties vars = configuration.getVariables();
+    if (vars != null) {
+      defaults.putAll(vars);
+    }
+    parser.setVariables(defaults);
+    configuration.setVariables(defaults);
   }
 
   private void settingsElement(Properties props) {
@@ -293,21 +295,22 @@ public class XMLConfigBuilder extends BaseBuilder {
   }
 
   private void environmentsElement(XNode context) throws Exception {
-    if (context != null) {
-      if (environment == null) {
-        environment = context.getStringAttribute("default");
-      }
-      for (XNode child : context.getChildren()) {
-        String id = child.getStringAttribute("id");
-        if (isSpecifiedEnvironment(id)) {
-          TransactionFactory txFactory = transactionManagerElement(child.evalNode("transactionManager"));
-          DataSourceFactory dsFactory = dataSourceElement(child.evalNode("dataSource"));
-          DataSource dataSource = dsFactory.getDataSource();
-          Environment.Builder environmentBuilder = new Environment.Builder(id).transactionFactory(txFactory)
-              .dataSource(dataSource);
-          configuration.setEnvironment(environmentBuilder.build());
-          break;
-        }
+    if (context == null) {
+      return;
+    }
+    if (environment == null) {
+      environment = context.getStringAttribute("default");
+    }
+    for (XNode child : context.getChildren()) {
+      String id = child.getStringAttribute("id");
+      if (isSpecifiedEnvironment(id)) {
+        TransactionFactory txFactory = transactionManagerElement(child.evalNode("transactionManager"));
+        DataSourceFactory dsFactory = dataSourceElement(child.evalNode("dataSource"));
+        DataSource dataSource = dsFactory.getDataSource();
+        Environment.Builder environmentBuilder = new Environment.Builder(id).transactionFactory(txFactory)
+            .dataSource(dataSource);
+        configuration.setEnvironment(environmentBuilder.build());
+        break;
       }
     }
   }
@@ -353,64 +356,66 @@ public class XMLConfigBuilder extends BaseBuilder {
     throw new BuilderException("Environment declaration requires a DataSourceFactory.");
   }
 
-  private void typeHandlerElement(XNode parent) {
-    if (parent != null) {
-      for (XNode child : parent.getChildren()) {
-        if ("package".equals(child.getName())) {
-          String typeHandlerPackage = child.getStringAttribute("name");
-          typeHandlerRegistry.register(typeHandlerPackage);
-        } else {
-          String javaTypeName = child.getStringAttribute("javaType");
-          String jdbcTypeName = child.getStringAttribute("jdbcType");
-          String handlerTypeName = child.getStringAttribute("handler");
-          Class<?> javaTypeClass = resolveClass(javaTypeName);
-          JdbcType jdbcType = resolveJdbcType(jdbcTypeName);
-          Class<?> typeHandlerClass = resolveClass(handlerTypeName);
-          if (javaTypeClass != null) {
-            if (jdbcType == null) {
-              typeHandlerRegistry.register(javaTypeClass, typeHandlerClass);
-            } else {
-              typeHandlerRegistry.register(javaTypeClass, jdbcType, typeHandlerClass);
-            }
+  private void typeHandlerElement(XNode context) {
+    if (context == null) {
+      return;
+    }
+    for (XNode child : context.getChildren()) {
+      if ("package".equals(child.getName())) {
+        String typeHandlerPackage = child.getStringAttribute("name");
+        typeHandlerRegistry.register(typeHandlerPackage);
+      } else {
+        String javaTypeName = child.getStringAttribute("javaType");
+        String jdbcTypeName = child.getStringAttribute("jdbcType");
+        String handlerTypeName = child.getStringAttribute("handler");
+        Class<?> javaTypeClass = resolveClass(javaTypeName);
+        JdbcType jdbcType = resolveJdbcType(jdbcTypeName);
+        Class<?> typeHandlerClass = resolveClass(handlerTypeName);
+        if (javaTypeClass != null) {
+          if (jdbcType == null) {
+            typeHandlerRegistry.register(javaTypeClass, typeHandlerClass);
           } else {
-            typeHandlerRegistry.register(typeHandlerClass);
+            typeHandlerRegistry.register(javaTypeClass, jdbcType, typeHandlerClass);
           }
+        } else {
+          typeHandlerRegistry.register(typeHandlerClass);
         }
       }
     }
   }
 
-  private void mapperElement(XNode parent) throws Exception {
-    if (parent != null) {
-      for (XNode child : parent.getChildren()) {
-        if ("package".equals(child.getName())) {
-          String mapperPackage = child.getStringAttribute("name");
-          configuration.addMappers(mapperPackage);
-        } else {
-          String resource = child.getStringAttribute("resource");
-          String url = child.getStringAttribute("url");
-          String mapperClass = child.getStringAttribute("class");
-          if (resource != null && url == null && mapperClass == null) {
-            ErrorContext.instance().resource(resource);
-            try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
-              XMLMapperBuilder mapperParser = new XMLMapperBuilder(inputStream, configuration, resource,
-                  configuration.getSqlFragments());
-              mapperParser.parse();
-            }
-          } else if (resource == null && url != null && mapperClass == null) {
-            ErrorContext.instance().resource(url);
-            try (InputStream inputStream = Resources.getUrlAsStream(url)) {
-              XMLMapperBuilder mapperParser = new XMLMapperBuilder(inputStream, configuration, url,
-                  configuration.getSqlFragments());
-              mapperParser.parse();
-            }
-          } else if (resource == null && url == null && mapperClass != null) {
-            Class<?> mapperInterface = Resources.classForName(mapperClass);
-            configuration.addMapper(mapperInterface);
-          } else {
-            throw new BuilderException(
-                "A mapper element may only specify a url, resource or class, but not more than one.");
+  private void mapperElement(XNode context) throws Exception {
+    if (context == null) {
+      return;
+    }
+    for (XNode child : context.getChildren()) {
+      if ("package".equals(child.getName())) {
+        String mapperPackage = child.getStringAttribute("name");
+        configuration.addMappers(mapperPackage);
+      } else {
+        String resource = child.getStringAttribute("resource");
+        String url = child.getStringAttribute("url");
+        String mapperClass = child.getStringAttribute("class");
+        if (resource != null && url == null && mapperClass == null) {
+          ErrorContext.instance().resource(resource);
+          try (InputStream inputStream = Resources.getResourceAsStream(resource)) {
+            XMLMapperBuilder mapperParser = new XMLMapperBuilder(inputStream, configuration, resource,
+                configuration.getSqlFragments());
+            mapperParser.parse();
           }
+        } else if (resource == null && url != null && mapperClass == null) {
+          ErrorContext.instance().resource(url);
+          try (InputStream inputStream = Resources.getUrlAsStream(url)) {
+            XMLMapperBuilder mapperParser = new XMLMapperBuilder(inputStream, configuration, url,
+                configuration.getSqlFragments());
+            mapperParser.parse();
+          }
+        } else if (resource == null && url == null && mapperClass != null) {
+          Class<?> mapperInterface = Resources.classForName(mapperClass);
+          configuration.addMapper(mapperInterface);
+        } else {
+          throw new BuilderException(
+              "A mapper element may only specify a url, resource or class, but not more than one.");
         }
       }
     }

--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -152,7 +152,7 @@ public class XMLConfigBuilder extends BaseBuilder {
 
   private void loadCustomVfs(Properties props) throws ClassNotFoundException {
     String value = props.getProperty("vfsImpl");
-    if(value == null) {
+    if (value == null) {
       return;
     }
     String[] clazzes = value.split(",");
@@ -171,7 +171,7 @@ public class XMLConfigBuilder extends BaseBuilder {
   }
 
   private void typeAliasesElement(XNode context) {
-    if(context == null) {
+    if (context == null) {
       return;
     }
     for (XNode child : context.getChildren()) {
@@ -200,7 +200,8 @@ public class XMLConfigBuilder extends BaseBuilder {
       for (XNode child : context.getChildren()) {
         String interceptor = child.getStringAttribute("interceptor");
         Properties properties = child.getChildrenAsProperties();
-        Interceptor interceptorInstance = (Interceptor) resolveClass(interceptor).getDeclaredConstructor().newInstance();
+        Interceptor interceptorInstance = (Interceptor) resolveClass(interceptor).getDeclaredConstructor()
+            .newInstance();
         interceptorInstance.setProperties(properties);
         configuration.addInterceptor(interceptorInstance);
       }
@@ -234,7 +235,7 @@ public class XMLConfigBuilder extends BaseBuilder {
   }
 
   private void propertiesElement(XNode context) throws Exception {
-    if(context == null) {
+    if (context == null) {
       return;
     }
     Properties defaults = context.getChildrenAsProperties();


### PR DESCRIPTION
1. I think the author AVE! handles the code at the beginning of settingsAsProperties very well, which can make the code hierarchy look less and more elegant. So I made a little tweak to XMLConfigBuilder's parsing code.
2. Unify the name of the parent XNode called context.
3. Keep the code style in BaseBuilder consistent with Maves to make it look more elegant.