### PR TITLE
[pom] Rework 'derby' and allow java 11 again

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        java: [17, 21, 22-ea]
+        java: [11, 17, 21, 22-ea]
         distribution: ['temurin']
       fail-fast: false
       max-parallel: 4

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 
   <properties>
     <clirr.comparisonVersion>3.4.6</clirr.comparisonVersion>
-    <derby.version>10.16.1.1</derby.version>
+    <derby.version>10.17.1.0</derby.version>
     <log4j.version>2.21.1</log4j.version>
 
     <!-- Add slow test groups here and annotate classes similar to @Tag('groupName'). -->
@@ -460,11 +460,21 @@
         <jdk>[16,)</jdk>
       </activation>
       <properties>
+        <derby.version>10.15.2.0</derby.version>
         <java.version>16</java.version>
         <java.release.version>16</java.release.version>
         <java.test.version>16</java.test.version>
         <java.test.release.version>16</java.test.release.version>
         <excludedGroups>TestcontainersTests,RequireIllegalAccess</excludedGroups>
+      </properties>
+    </profile>
+    <profile>
+      <id>17</id>
+      <activation>
+        <jdk>[17,)</jdk>
+      </activation>
+      <properties>
+          <derby.version>10.16.1.1</derby.version>
       </properties>
     </profile>
     <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
     <clirr.comparisonVersion>3.4.6</clirr.comparisonVersion>
     <derby.version>10.17.1.0</derby.version>
     <log4j.version>2.21.1</log4j.version>
+    <mssql-jdbc.version>12.4.2.jre11</mssql-jdbc.version>
 
     <!-- Add slow test groups here and annotate classes similar to @Tag('groupName'). -->
     <!-- Excluded groups are ran on github ci, to force here, pass -d"excludedGroups=" -->
@@ -317,7 +318,7 @@
     <dependency>
       <groupId>com.microsoft.sqlserver</groupId>
       <artifactId>mssql-jdbc</artifactId>
-      <version>12.4.2.jre11</version>
+      <version>${mssql-jdbc.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -430,6 +431,7 @@
       </activation>
       <properties>
           <derby.version>10.15.2.0</derby.version>
+          <mssql-jdbc.version>12.4.2.jre8</mssql-jdbc.version>
       </properties>
       <build>
         <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@
 
   <properties>
     <clirr.comparisonVersion>3.4.6</clirr.comparisonVersion>
+    <derby.version>10.16.1.1</derby.version>
     <log4j.version>2.21.1</log4j.version>
 
     <!-- Add slow test groups here and annotate classes similar to @Tag('groupName'). -->
@@ -224,19 +225,19 @@
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derby</artifactId>
-      <version>10.16.1.1</version>
+      <version>${derby.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derbyshared</artifactId>
-      <version>10.16.1.1</version>
+      <version>${derby.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.derby</groupId>
       <artifactId>derbyoptionaltools</artifactId>
-      <version>10.16.1.1</version>
+      <version>${derby.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -427,6 +428,9 @@
       <activation>
         <jdk>(,16)</jdk>
       </activation>
+      <properties>
+          <derby.version>10.15.2.0</derby.version>
+      </properties>
       <build>
         <pluginManagement>
           <plugins>
@@ -461,6 +465,15 @@
         <java.test.version>16</java.test.version>
         <java.test.release.version>16</java.test.release.version>
         <excludedGroups>TestcontainersTests,RequireIllegalAccess</excludedGroups>
+      </properties>
+    </profile>
+    <profile>
+      <id>19</id>
+      <activation>
+        <jdk>[19,)</jdk>
+      </activation>
+      <properties>
+          <derby.version>10.17.1.0</derby.version>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
not doing this will have impact due to our java 16+ switching to require java 16.