### PR TITLE
#3028 Add shaded javassist package to osgi.export

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
     <module.name>org.mybatis</module.name>
 
     <!-- OSGI Data -->
-    <osgi.export>org.apache.ibatis.*;version=${project.version};-noimport:=true</osgi.export>
+    <osgi.export>org.apache.ibatis.*;version=${project.version};-noimport:=true,org.apache.ibatis.javassist.util.proxy;version=${project.version};-noimport:=true</osgi.export>
     <osgi.import>*;resolution:=optional</osgi.import>
     <osgi.dynamicImport>*</osgi.dynamicImport>
 


### PR DESCRIPTION
#3028  NoClassDefFoundExceptions on Java 11 with OSGi

On Java 11 using Karaf with Felix when enhancing classes users need access to:
* org.apache.ibatis.executor.loader.WriteReplaceInterface
* org.apache.ibatis.javassist.util.proxy.ProxyObject

In the current build the `bnd-maven-plugin` is executed before shading thus the Javassist classes don't exist and aren't exported. In my local build bnd passed with this addition and I was able to use the SNAPSHOT bundle in my application successfully