### PR TITLE
`VendorDatabaseIdProvider` should throw exception if DB error occurs

### DIFF
--- a/src/main/java/org/apache/ibatis/mapping/VendorDatabaseIdProvider.java
+++ b/src/main/java/org/apache/ibatis/mapping/VendorDatabaseIdProvider.java
@@ -21,8 +21,7 @@ import java.util.Properties;
 
 import javax.sql.DataSource;
 
-import org.apache.ibatis.logging.Log;
-import org.apache.ibatis.logging.LogFactory;
+import org.apache.ibatis.builder.BuilderException;
 
 /**
  * Vendor DatabaseId provider.
@@ -44,10 +43,9 @@ public class VendorDatabaseIdProvider implements DatabaseIdProvider {
     }
     try {
       return getDatabaseName(dataSource);
-    } catch (Exception e) {
-      LogHolder.log.error("Could not get a databaseId from dataSource", e);
+    } catch (SQLException e) {
+      throw new BuilderException("Error occurred when getting DB product name.", e);
     }
-    return null;
   }
 
   @Override
@@ -68,10 +66,6 @@ public class VendorDatabaseIdProvider implements DatabaseIdProvider {
     try (Connection con = dataSource.getConnection()) {
       return con.getMetaData().getDatabaseProductName();
     }
-  }
-
-  private static class LogHolder {
-    private static final Log log = LogFactory.getLog(VendorDatabaseIdProvider.class);
   }
 
 }

--- a/src/test/java/org/apache/ibatis/mapping/VendorDatabaseIdProviderTest.java
+++ b/src/test/java/org/apache/ibatis/mapping/VendorDatabaseIdProviderTest.java
@@ -17,7 +17,8 @@
 package org.apache.ibatis.mapping;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -26,6 +27,7 @@ import java.util.Properties;
 
 import javax.sql.DataSource;
 
+import org.apache.ibatis.builder.BuilderException;
 import org.junit.jupiter.api.Test;
 
 class VendorDatabaseIdProviderTest {
@@ -77,7 +79,12 @@ class VendorDatabaseIdProviderTest {
     VendorDatabaseIdProvider provider = new VendorDatabaseIdProvider();
     Properties properties = new Properties();
     properties.put("Ewok DB", "ewok");
-    assertNull(provider.getDatabaseId(dataSource));
+    try {
+      provider.getDatabaseId(dataSource);
+      fail("Should BuilderException be thrown.");
+    } catch (BuilderException e) {
+      // pass
+    }
   }
 
   private DataSource mockDataSource() throws SQLException {

--- a/src/test/java/org/apache/ibatis/mapping/VendorDatabaseIdProviderTest.java
+++ b/src/test/java/org/apache/ibatis/mapping/VendorDatabaseIdProviderTest.java
@@ -1,0 +1,93 @@
+/*
+ *    Copyright 2009-2023 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.mapping;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.Properties;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Test;
+
+class VendorDatabaseIdProviderTest {
+
+  private static final String PRODUCT_NAME = "Chewbacca DB";
+
+  @Test
+  void shouldNpeBeThrownIfDataSourceIsNull() {
+    VendorDatabaseIdProvider provider = new VendorDatabaseIdProvider();
+    try {
+      provider.getDatabaseId(null);
+      fail("Should NullPointerException be thrown.");
+    } catch (NullPointerException e) {
+      // pass
+    }
+  }
+
+  @Test
+  void shouldProductNameBeReturnedIfPropertiesIsNull() throws Exception {
+    VendorDatabaseIdProvider provider = new VendorDatabaseIdProvider();
+    assertEquals(PRODUCT_NAME, provider.getDatabaseId(mockDataSource()));
+  }
+
+  @Test
+  void shouldProductNameBeTranslated() throws Exception {
+    VendorDatabaseIdProvider provider = new VendorDatabaseIdProvider();
+    Properties properties = new Properties();
+    String partialProductName = "Chewbacca";
+    String id = "chewie";
+    properties.put(partialProductName, id);
+    provider.setProperties(properties);
+    assertEquals(id, provider.getDatabaseId(mockDataSource()));
+  }
+
+  @Test
+  void shouldNullBeReturnedIfNoMatch() throws Exception {
+    VendorDatabaseIdProvider provider = new VendorDatabaseIdProvider();
+    Properties properties = new Properties();
+    properties.put("Ewok DB", "ewok");
+    provider.setProperties(properties);
+    assertNull(provider.getDatabaseId(mockDataSource()));
+  }
+
+  @Test
+  void shouldNullBeReturnedOnDbError() throws Exception {
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getConnection()).thenThrow(SQLException.class);
+
+    VendorDatabaseIdProvider provider = new VendorDatabaseIdProvider();
+    Properties properties = new Properties();
+    properties.put("Ewok DB", "ewok");
+    assertNull(provider.getDatabaseId(dataSource));
+  }
+
+  private DataSource mockDataSource() throws SQLException {
+    DatabaseMetaData metaData = mock(DatabaseMetaData.class);
+    when(metaData.getDatabaseProductName()).thenReturn(PRODUCT_NAME);
+    Connection connection = mock(Connection.class);
+    when(connection.getMetaData()).thenReturn(metaData);
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getConnection()).thenReturn(connection);
+    return dataSource;
+  }
+
+}


### PR DESCRIPTION
As reported in #3040, swallowing the `SQLException` could cause runtime errors because 1) no statement is picked up or 2) statement without `databaseId` is incorrectly chosen.

I don't think `getDatabasename()` throws other exceptions than `SQLException`, but I'll make further adjustment if I'm wrong.

