### PR TITLE
Fixed issue #3062

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
@@ -55,7 +55,7 @@ public class MapWrapper extends BaseWrapper {
       Object collection = resolveCollection(prop, map);
       setCollectionValue(prop, collection, value);
     } else if (!prop.getIndexedName().equals(prop.getName())) {
-      map.put(prop.getName(), value);
+      map.put(prop.getIndexedName(), value);
     } else {
       map.put(prop.getName(), value);
     }

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
@@ -50,12 +50,14 @@ public class MapWrapper extends BaseWrapper {
 
   @Override
   public void set(PropertyTokenizer prop, Object value) {
-    // issue#3062  column alias name contain "[]"
-    if (prop.getIndex() != null && pattern.matcher(prop.getIndex()).matches()) {
+    if (prop.getIndex() != null) {
+      // issue#3062  column alias name contain "[]"
+      if (!pattern.matcher(prop.getIndex()).matches()) {
+        map.put(prop.getIndexedName(), value);
+        return;
+      }
       Object collection = resolveCollection(prop, map);
       setCollectionValue(prop, collection, value);
-    } else if (!prop.getIndexedName().equals(prop.getName())) {
-      map.put(prop.getIndexedName(), value);
     } else {
       map.put(prop.getName(), value);
     }


### PR DESCRIPTION
modify MapWrapper.class, Using regular expressions to determine index does not affect the original logic
```
  public void set(PropertyTokenizer prop, Object value) {
    if (prop.getIndex() != null) {
      // issue#3062  column alias name contain "[]"
      if (!pattern.matcher(prop.getIndex()).matches()) {
        map.put(prop.getIndexedName(), value);
        return;
      }
      Object collection = resolveCollection(prop, map);
      setCollectionValue(prop, collection, value);
    } else {
      map.put(prop.getName(), value);
    }
  }
```
