### PR TITLE
Allow custom map wrapper to handle keys with dots or brackets

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/MetaObject.java
+++ b/src/main/java/org/apache/ibatis/reflection/MetaObject.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -112,31 +112,11 @@ public class MetaObject {
 
   public Object getValue(String name) {
     PropertyTokenizer prop = new PropertyTokenizer(name);
-    if (!prop.hasNext()) {
-      return objectWrapper.get(prop);
-    }
-    MetaObject metaValue = metaObjectForProperty(prop.getIndexedName());
-    if (metaValue == SystemMetaObject.NULL_META_OBJECT) {
-      return null;
-    }
-    return metaValue.getValue(prop.getChildren());
+    return objectWrapper.get(prop);
   }
 
   public void setValue(String name, Object value) {
-    PropertyTokenizer prop = new PropertyTokenizer(name);
-    if (prop.hasNext()) {
-      MetaObject metaValue = metaObjectForProperty(prop.getIndexedName());
-      if (metaValue == SystemMetaObject.NULL_META_OBJECT) {
-        if (value == null) {
-          // don't instantiate child path if value is null
-          return;
-        }
-        metaValue = objectWrapper.instantiatePropertyValue(name, prop, objectFactory);
-      }
-      metaValue.setValue(prop.getChildren(), value);
-    } else {
-      objectWrapper.set(prop, value);
-    }
+    objectWrapper.set(new PropertyTokenizer(name), value);
   }
 
   public MetaObject metaObjectForProperty(String name) {

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/BaseWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/BaseWrapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.ReflectionException;
+import org.apache.ibatis.reflection.SystemMetaObject;
 import org.apache.ibatis.reflection.property.PropertyTokenizer;
 
 /**
@@ -104,4 +105,23 @@ public abstract class BaseWrapper implements ObjectWrapper {
     }
   }
 
+  protected Object getChildValue(PropertyTokenizer prop) {
+    MetaObject metaValue = metaObject.metaObjectForProperty(prop.getIndexedName());
+    if (metaValue == SystemMetaObject.NULL_META_OBJECT) {
+      return null;
+    }
+    return metaValue.getValue(prop.getChildren());
+  }
+
+  protected void setChildValue(PropertyTokenizer prop, Object value) {
+    MetaObject metaValue = metaObject.metaObjectForProperty(prop.getIndexedName());
+    if (metaValue == SystemMetaObject.NULL_META_OBJECT) {
+      if (value == null) {
+        // don't instantiate child path if value is null
+        return;
+      }
+      metaValue = instantiatePropertyValue(null, new PropertyTokenizer(prop.getName()), metaObject.getObjectFactory());
+    }
+    metaValue.setValue(prop.getChildren(), value);
+  }
 }

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/BaseWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/BaseWrapper.java
@@ -43,6 +43,10 @@ public abstract class BaseWrapper implements ObjectWrapper {
   }
 
   protected Object getCollectionValue(PropertyTokenizer prop, Object collection) {
+    if (collection == null) {
+      throw new ReflectionException("Cannot get the value '" + prop.getIndexedName() + "' because the property '"
+          + prop.getName() + "' is null.");
+    }
     if (collection instanceof Map) {
       return ((Map) collection).get(prop.getIndex());
     }
@@ -68,12 +72,16 @@ public abstract class BaseWrapper implements ObjectWrapper {
     } else if (collection instanceof short[]) {
       return ((short[]) collection)[i];
     } else {
-      throw new ReflectionException(
-          "The '" + prop.getName() + "' property of " + collection + " is not a List or Array.");
+      throw new ReflectionException("Cannot get the value '" + prop.getIndexedName() + "' because the property '"
+          + prop.getName() + "' is not Map, List or Array.");
     }
   }
 
   protected void setCollectionValue(PropertyTokenizer prop, Object collection, Object value) {
+    if (collection == null) {
+      throw new ReflectionException("Cannot set the value '" + prop.getIndexedName() + "' because the property '"
+          + prop.getName() + "' is null.");
+    }
     if (collection instanceof Map) {
       ((Map) collection).put(prop.getIndex(), value);
     } else {
@@ -99,8 +107,8 @@ public abstract class BaseWrapper implements ObjectWrapper {
       } else if (collection instanceof short[]) {
         ((short[]) collection)[i] = (Short) value;
       } else {
-        throw new ReflectionException(
-            "The '" + prop.getName() + "' property of " + collection + " is not a List or Array.");
+        throw new ReflectionException("Cannot set the value '" + prop.getIndexedName() + "' because the property '"
+            + prop.getName() + "' is not Map, List or Array.");
       }
     }
   }

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/BeanWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/BeanWrapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -42,18 +42,21 @@ public class BeanWrapper extends BaseWrapper {
 
   @Override
   public Object get(PropertyTokenizer prop) {
-    if (prop.getIndex() != null) {
-      Object collection = resolveCollection(prop, object);
-      return getCollectionValue(prop, collection);
+    if (prop.hasNext()) {
+      return getChildValue(prop);
+    } else if (prop.getIndex() != null) {
+      return getCollectionValue(prop, resolveCollection(prop, object));
+    } else {
+      return getBeanProperty(prop, object);
     }
-    return getBeanProperty(prop, object);
   }
 
   @Override
   public void set(PropertyTokenizer prop, Object value) {
-    if (prop.getIndex() != null) {
-      Object collection = resolveCollection(prop, object);
-      setCollectionValue(prop, collection, value);
+    if (prop.hasNext()) {
+      setChildValue(prop, value);
+    } else if (prop.getIndex() != null) {
+      setCollectionValue(prop, resolveCollection(prop, object), value);
     } else {
       setBeanProperty(prop, object, value);
     }

--- a/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
+++ b/src/main/java/org/apache/ibatis/reflection/wrapper/MapWrapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.apache.ibatis.reflection.property.PropertyTokenizer;
  */
 public class MapWrapper extends BaseWrapper {
 
-  private final Map<String, Object> map;
+  protected final Map<String, Object> map;
 
   public MapWrapper(MetaObject metaObject, Map<String, Object> map) {
     super(metaObject);
@@ -38,18 +38,21 @@ public class MapWrapper extends BaseWrapper {
 
   @Override
   public Object get(PropertyTokenizer prop) {
-    if (prop.getIndex() != null) {
-      Object collection = resolveCollection(prop, map);
-      return getCollectionValue(prop, collection);
+    if (prop.hasNext()) {
+      return getChildValue(prop);
+    } else if (prop.getIndex() != null) {
+      return getCollectionValue(prop, resolveCollection(prop, map));
+    } else {
+      return map.get(prop.getName());
     }
-    return map.get(prop.getName());
   }
 
   @Override
   public void set(PropertyTokenizer prop, Object value) {
-    if (prop.getIndex() != null) {
-      Object collection = resolveCollection(prop, map);
-      setCollectionValue(prop, collection, value);
+    if (prop.hasNext()) {
+      setChildValue(prop, value);
+    } else if (prop.getIndex() != null) {
+      setCollectionValue(prop, resolveCollection(prop, map), value);
     } else {
       map.put(prop.getName(), value);
     }

--- a/src/test/java/org/apache/ibatis/reflection/wrapper/BeanWrapperTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/wrapper/BeanWrapperTest.java
@@ -1,0 +1,227 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.reflection.wrapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.ibatis.reflection.DefaultReflectorFactory;
+import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.reflection.ReflectionException;
+import org.apache.ibatis.reflection.factory.DefaultObjectFactory;
+import org.junit.jupiter.api.Test;
+
+class BeanWrapperTest {
+
+  @Test
+  void assertBasicOperations() {
+    Bean1 bean = new Bean1();
+    MetaObject metaObj = MetaObject.forObject(bean, new DefaultObjectFactory(), new DefaultObjectWrapperFactory(),
+        new DefaultReflectorFactory());
+    assertFalse(metaObj.isCollection());
+    assertTrue(metaObj.hasGetter("id"));
+    assertTrue(metaObj.hasSetter("id"));
+    assertTrue(metaObj.hasGetter("bean2.id"));
+    assertTrue(metaObj.hasSetter("bean2.id"));
+    assertEquals("id", metaObj.findProperty("id", false));
+    assertNull(metaObj.findProperty("attr_val", false));
+    assertEquals("attrVal", metaObj.findProperty("attr_val", true));
+    String[] getterNames = metaObj.getGetterNames();
+    Arrays.sort(getterNames);
+    assertArrayEquals(new String[] { "attrVal", "bean2", "bean2List", "id", "nums" }, getterNames);
+    String[] setterNames = metaObj.getSetterNames();
+    Arrays.sort(setterNames);
+    assertArrayEquals(new String[] { "attrVal", "bean2", "bean2List", "id", "nums" }, setterNames);
+    assertEquals(String.class, metaObj.getGetterType("attrVal"));
+    assertEquals(String.class, metaObj.getSetterType("attrVal"));
+    assertEquals(String.class, metaObj.getGetterType("bean2.name"));
+    assertEquals(String.class, metaObj.getSetterType("bean2.name"));
+
+    assertTrue(metaObj.hasGetter("bean2List[0]"));
+    try {
+      metaObj.getValue("bean2List[0]");
+      fail();
+    } catch (ReflectionException e) {
+      // TODO: more accurate message
+      assertEquals("The 'bean2List' property of null is not a List or Array.", e.getMessage());
+    }
+    assertTrue(metaObj.hasSetter("bean2List[0]"));
+
+    List<Bean2> bean2List = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      Bean2 bean2 = new Bean2();
+      bean2.setId(i);
+      bean2.setName("name_" + i);
+      bean2List.add(bean2);
+    }
+    bean.setBean2List(bean2List);
+
+    assertEquals(0, metaObj.getValue("bean2List[0].id"));
+
+    metaObj.setValue("attrVal", "value");
+    assertEquals("value", bean.getAttrVal());
+
+    metaObj.setValue("bean2List[1].name", "new name 1");
+    assertEquals("new name 1", bean.getBean2List().get(1).getName());
+
+    try {
+      metaObj.getValue("nums[0]");
+      fail();
+    } catch (ReflectionException e) {
+      // pass
+    }
+    metaObj.setValue("nums", new Integer[] { 5, 6, 7 });
+    assertTrue(metaObj.hasGetter("bean2List[0].child.id"));
+    assertTrue(metaObj.hasSetter("bean2List[0].child.id"));
+
+    {
+      Bean2 bean2 = new Bean2();
+      bean2.setId(100);
+      bean2.setName("name_100");
+      metaObj.setValue("bean2", bean2);
+      assertEquals(String.class, metaObj.getGetterType("bean2.name"));
+      assertEquals(String.class, metaObj.getSetterType("bean2.name"));
+    }
+
+    try {
+      metaObj.setValue("bean2.child.bean2", "bogus");
+      fail();
+    } catch (ReflectionException e) {
+      // pass
+    }
+
+    {
+      Bean2 bean2 = new Bean2();
+      bean2.setId(101);
+      bean2.setName("name_101");
+      metaObj.setValue("bean2.child.bean2", bean2);
+      assertEquals(101, bean.getBean2().getChild().getBean2().getId());
+    }
+
+    metaObj.setValue("bean2.child.nums", new Integer[] { 8, 9 });
+    metaObj.setValue("bean2.child.nums[0]", 88);
+    assertEquals(88, bean.getBean2().getChild().getNums()[0]);
+
+    assertFalse(metaObj.hasSetter("x[0].y"));
+    assertFalse(metaObj.hasGetter("x[0].y"));
+
+    try {
+      metaObj.getValue("x");
+      fail();
+    } catch (ReflectionException e) {
+      // pass
+    }
+    // assertEquals(Integer.class, metaObj.getSetterType("my_name"));
+    // assertEquals("100", metaObj.getValue("a"));
+    // assertNull(metaObj.getValue("b"));
+    // assertEquals(Integer.valueOf(200), metaObj.getValue("my_name"));
+    try {
+      metaObj.add("x");
+      fail();
+    } catch (UnsupportedOperationException e) {
+      // pass
+    }
+    try {
+      metaObj.addAll(Arrays.asList("x", "y"));
+      fail();
+    } catch (UnsupportedOperationException e) {
+      // pass
+    }
+
+  }
+
+  static class Bean1 {
+    private Integer id;
+    private String attrVal;
+    private Integer[] nums;
+    private Bean2 bean2;
+    private List<Bean2> bean2List;
+
+    public Integer getId() {
+      return id;
+    }
+
+    public void setId(Integer id) {
+      this.id = id;
+    }
+
+    public String getAttrVal() {
+      return attrVal;
+    }
+
+    public void setAttrVal(String attrVal) {
+      this.attrVal = attrVal;
+    }
+
+    public Integer[] getNums() {
+      return nums;
+    }
+
+    public void setNums(Integer[] nums) {
+      this.nums = nums;
+    }
+
+    public Bean2 getBean2() {
+      return bean2;
+    }
+
+    public void setBean2(Bean2 bean2) {
+      this.bean2 = bean2;
+    }
+
+    public List<Bean2> getBean2List() {
+      return bean2List;
+    }
+
+    public void setBean2List(List<Bean2> bean2List) {
+      this.bean2List = bean2List;
+    }
+  }
+
+  static class Bean2 {
+    private Integer id;
+    private String name;
+    private Bean1 child;
+
+    public Integer getId() {
+      return id;
+    }
+
+    public void setId(Integer id) {
+      this.id = id;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public Bean1 getChild() {
+      return child;
+    }
+
+    public void setChild(Bean1 child) {
+      this.child = child;
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/reflection/wrapper/BeanWrapperTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/wrapper/BeanWrapperTest.java
@@ -59,8 +59,13 @@ class BeanWrapperTest {
       metaObj.getValue("bean2List[0]");
       fail();
     } catch (ReflectionException e) {
-      // TODO: more accurate message
-      assertEquals("The 'bean2List' property of null is not a List or Array.", e.getMessage());
+      assertEquals("Cannot get the value 'bean2List[0]' because the property 'bean2List' is null.", e.getMessage());
+    }
+    try {
+      metaObj.setValue("bean2List[0]", new Bean2());
+      fail();
+    } catch (ReflectionException e) {
+      assertEquals("Cannot set the value 'bean2List[0]' because the property 'bean2List' is null.", e.getMessage());
     }
     assertTrue(metaObj.hasSetter("bean2List[0]"));
 
@@ -77,6 +82,20 @@ class BeanWrapperTest {
 
     metaObj.setValue("attrVal", "value");
     assertEquals("value", bean.getAttrVal());
+    try {
+      metaObj.getValue("attrVal[0]");
+      fail();
+    } catch (ReflectionException e) {
+      assertEquals("Cannot get the value 'attrVal[0]' because the property 'attrVal' is not Map, List or Array.",
+          e.getMessage());
+    }
+    try {
+      metaObj.setValue("attrVal[0]", "blur");
+      fail();
+    } catch (ReflectionException e) {
+      assertEquals("Cannot set the value 'attrVal[0]' because the property 'attrVal' is not Map, List or Array.",
+          e.getMessage());
+    }
 
     metaObj.setValue("bean2List[1].name", "new name 1");
     assertEquals("new name 1", bean.getBean2List().get(1).getName());
@@ -144,7 +163,6 @@ class BeanWrapperTest {
     } catch (UnsupportedOperationException e) {
       // pass
     }
-
   }
 
   static class Bean1 {

--- a/src/test/java/org/apache/ibatis/reflection/wrapper/MapWrapperTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/wrapper/MapWrapperTest.java
@@ -1,0 +1,195 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.reflection.wrapper;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ibatis.reflection.DefaultReflectorFactory;
+import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.reflection.factory.DefaultObjectFactory;
+import org.junit.jupiter.api.Test;
+
+class MapWrapperTest {
+
+  @Test
+  void assertBasicOperations() {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("a", "100");
+    map.put("b", null);
+    map.put("my_name", Integer.valueOf(200));
+    MetaObject metaObj = MetaObject.forObject(map, new DefaultObjectFactory(), new DefaultObjectWrapperFactory(),
+        new DefaultReflectorFactory());
+    assertFalse(metaObj.isCollection());
+    assertTrue(metaObj.hasGetter("a"));
+    assertTrue(metaObj.hasSetter("a"));
+    assertTrue(metaObj.hasGetter("b.anykey"));
+    assertEquals("a", metaObj.findProperty("a", false));
+    assertEquals("b", metaObj.findProperty("b", false));
+    assertEquals("my_name", metaObj.findProperty("my_name", false));
+    assertEquals("my_name", metaObj.findProperty("my_name", true));
+    assertArrayEquals(new String[] { "a", "b", "my_name" }, metaObj.getGetterNames());
+    assertArrayEquals(new String[] { "a", "b", "my_name" }, metaObj.getSetterNames());
+    assertEquals(String.class, metaObj.getGetterType("a"));
+    assertEquals(Object.class, metaObj.getGetterType("b"));
+    assertEquals(Integer.class, metaObj.getGetterType("my_name"));
+    assertEquals(String.class, metaObj.getSetterType("a"));
+    assertEquals(Object.class, metaObj.getSetterType("b"));
+    assertEquals(Integer.class, metaObj.getSetterType("my_name"));
+    assertEquals("100", metaObj.getValue("a"));
+    assertNull(metaObj.getValue("b"));
+    assertEquals(Integer.valueOf(200), metaObj.getValue("my_name"));
+    try {
+      metaObj.add("x");
+      fail();
+    } catch (UnsupportedOperationException e) {
+      // pass
+    }
+    try {
+      metaObj.addAll(Arrays.asList("x", "y"));
+      fail();
+    } catch (UnsupportedOperationException e) {
+      // pass
+    }
+    metaObj.setValue("a", Long.valueOf(900L));
+    assertEquals(Long.valueOf(900L), map.get("a"));
+  }
+
+  @Test
+  void assertNonExistentKey() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("a", "100");
+    MetaObject metaObj = MetaObject.forObject(map, new DefaultObjectFactory(), new DefaultObjectWrapperFactory(),
+        new DefaultReflectorFactory());
+    assertEquals("anykey", metaObj.findProperty("anykey", false));
+    assertFalse(metaObj.hasGetter("anykey"));
+    assertFalse(metaObj.hasGetter("child.anykey"));
+    assertEquals(Object.class, metaObj.getGetterType("anykey"));
+    assertEquals(Object.class, metaObj.getGetterType("child.anykey"));
+    assertTrue(metaObj.hasSetter("anykey"));
+    assertTrue(metaObj.hasSetter("child.anykey"));
+    assertEquals(Object.class, metaObj.getSetterType("anykey"));
+    assertEquals(Object.class, metaObj.getSetterType("child.anykey"));
+    assertNull(metaObj.getValue("anykey"));
+
+    metaObj.setValue("anykey", Integer.valueOf(200));
+    metaObj.setValue("child.anykey", Integer.valueOf(300));
+    assertEquals(3, map.size());
+    assertEquals(Integer.valueOf(200), map.get("anykey"));
+    @SuppressWarnings("unchecked")
+    Map<String, Object> childMap = (Map<String, Object>) map.get("child");
+    assertEquals(Integer.valueOf(300), childMap.get("anykey"));
+  }
+
+  @Test
+  void assertChildBean() {
+    Map<String, Object> map = new HashMap<>();
+    TestBean bean = new TestBean();
+    bean.setPropA("aaa");
+    map.put("bean", bean);
+    MetaObject metaObj = MetaObject.forObject(map, new DefaultObjectFactory(), new DefaultObjectWrapperFactory(),
+        new DefaultReflectorFactory());
+    assertTrue(metaObj.hasGetter("bean.propA"));
+    assertEquals(String.class, metaObj.getGetterType("bean.propA"));
+    assertEquals(String.class, metaObj.getSetterType("bean.propA"));
+    assertEquals("aaa", metaObj.getValue("bean.propA"));
+
+    assertNull(metaObj.getValue("bean.propB"));
+    metaObj.setValue("bean.propB", "bbb");
+    assertEquals("bbb", bean.getPropB());
+
+    metaObj.setValue("bean.propA", "ccc");
+    assertEquals("ccc", bean.getPropA());
+  }
+
+  static class TestBean {
+    private String propA;
+    private String propB;
+
+    public String getPropA() {
+      return propA;
+    }
+
+    public void setPropA(String propA) {
+      this.propA = propA;
+    }
+
+    public String getPropB() {
+      return propB;
+    }
+
+    public void setPropB(String propB) {
+      this.propB = propB;
+    }
+  }
+
+  @Test
+  void accessIndexedList() {
+    Map<String, Object> map = new HashMap<>();
+    List<String> list = Arrays.asList("a", "b", "c");
+    map.put("list", list);
+    MetaObject metaObj = MetaObject.forObject(map, new DefaultObjectFactory(), new DefaultObjectWrapperFactory(),
+        new DefaultReflectorFactory());
+    assertEquals("b", metaObj.getValue("list[1]"));
+
+    metaObj.setValue("list[2]", "x");
+    assertEquals("x", list.get(2));
+
+    try {
+      metaObj.setValue("list[3]", "y");
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      // pass
+    }
+
+    assertTrue(metaObj.hasGetter("list[1]"));
+    assertTrue(metaObj.hasSetter("list[1]"));
+    // this one looks wrong
+    // assertFalse(metaObj.hasSetter("list[3]"));
+  }
+
+  @Test
+  void accessIndexedMap() {
+    Map<String, Object> map = new HashMap<>();
+    Map<String, String> submap = new HashMap<>();
+    submap.put("a", "100");
+    submap.put("b", "200");
+    submap.put("c", "300");
+    map.put("submap", submap);
+    MetaObject metaObj = MetaObject.forObject(map, new DefaultObjectFactory(), new DefaultObjectWrapperFactory(),
+        new DefaultReflectorFactory());
+    assertEquals("200", metaObj.getValue("submap[b]"));
+
+    metaObj.setValue("submap[c]", "999");
+    assertEquals("999", submap.get("c"));
+
+    metaObj.setValue("submap[d]", "400");
+    assertEquals(4, submap.size());
+    assertEquals("400", submap.get("d"));
+
+    assertTrue(metaObj.hasGetter("submap[b]"));
+    assertTrue(metaObj.hasGetter("submap[anykey]"));
+    assertTrue(metaObj.hasSetter("submap[d]"));
+    assertTrue(metaObj.hasSetter("submap[anykey]"));
+  }
+
+}


### PR DESCRIPTION
Also, users can now extend the built-in `MapWrapper` to write a custom one.

Should fix #13 #2298 #3062