### PR TITLE
fix parameter logging issue

### DIFF
--- a/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
@@ -21,7 +21,7 @@ import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -43,10 +43,7 @@ public abstract class BaseJdbcLogger {
   protected static final Set<String> SET_METHODS;
   protected static final Set<String> EXECUTE_METHODS = new HashSet<>();
 
-  private final Map<Object, Object> columnMap = new HashMap<>();
-
-  private final List<Object> columnNames = new ArrayList<>();
-  private final List<Object> columnValues = new ArrayList<>();
+  private final Map<Object, Object> columnMap = new LinkedHashMap<>();
 
   protected final Log statementLog;
   protected final int queryStack;
@@ -76,8 +73,6 @@ public abstract class BaseJdbcLogger {
 
   protected void setColumn(Object key, Object value) {
     columnMap.put(key, value);
-    columnNames.add(key);
-    columnValues.add(value);
   }
 
   protected Object getColumn(Object key) {
@@ -85,8 +80,8 @@ public abstract class BaseJdbcLogger {
   }
 
   protected String getParameterValueString() {
-    List<Object> typeList = new ArrayList<>(columnValues.size());
-    for (Object value : columnValues) {
+    List<Object> typeList = new ArrayList<>(columnMap.size());
+    for (Object value : columnMap.values()) {
       if (value == null) {
         typeList.add("null");
       } else {
@@ -109,13 +104,11 @@ public abstract class BaseJdbcLogger {
   }
 
   protected String getColumnString() {
-    return columnNames.toString();
+    return columnMap.keySet().toString();
   }
 
   protected void clearColumnInfo() {
     columnMap.clear();
-    columnNames.clear();
-    columnValues.clear();
   }
 
   protected String removeExtraWhitespace(String original) {


### PR DESCRIPTION
## MyBatis version
3.5.15

## Database vendor and version
MYSQL 5.7.36

## Test case or example project

This is the project link: https://github.com/qiaomengnan16/mybatis-log-bug

```java
public class Blog {

    private Integer id;

    private String name;
    // ... getter/setter
}
```

```java
public interface BlogMapper {
    List<Blog> selectBlog(Integer id);
}
```

```java
@Intercepts({@Signature(type = StatementHandler.class, method = "query", args = {Statement.class, ResultHandler.class})})
public class ParamInterceptor implements Interceptor {
    @Override
    public Object intercept(Invocation invocation) throws Throwable {
        Object target = invocation.getTarget();
        if (target != null && target instanceof StatementHandler) {
            StatementHandler statementHandler = (StatementHandler) target;
            statementHandler.getParameterHandler().setParameters((PreparedStatement) invocation.getArgs()[0]);
            statementHandler.getParameterHandler().setParameters((PreparedStatement) invocation.getArgs()[0]);
            statementHandler.getParameterHandler().setParameters((PreparedStatement) invocation.getArgs()[0]);
        }
        return invocation.proceed();
    }
}
```

```java
public static void main(String[] args) throws IOException {
    String resource = "mybatis-config.xml";
    InputStream inputStream = Resources.getResourceAsStream(resource);
    SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream);
    SqlSession session = sqlSessionFactory.openSession();
    BlogMapper blogMapper = session.getMapper(BlogMapper.class);
    System.out.println(blogMapper.selectBlog(1));
}
```

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<!DOCTYPE mapper
        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
<mapper namespace="org.example.mapper.BlogMapper">
    <select id="selectBlog" resultType="org.example.domain.Blog">
        select * from Blog where id = #{id}
    </select>
</mapper>
```

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE configuration>
<configuration>

    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
        <encoder>
            <pattern>%5level [%thread] - %msg%n</pattern>
        </encoder>
    </appender>

    <logger name="org.example.mapper.BlogMapper">
        <level value="debug"/>
    </logger>

    <root level="debug">
        <appender-ref ref="stdout"/>
    </root>

</configuration>
```

```xml
<?xml version="1.0" encoding="UTF-8" ?>
<!DOCTYPE configuration
        PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
        "https://mybatis.org/dtd/mybatis-3-config.dtd">
<configuration>
    <settings>
        <setting name="logImpl" value="SLF4J"/>
    </settings>
    <plugins>
        <plugin interceptor="org.example.interceptor.ParamInterceptor"/>
    </plugins>
    <environments default="development">
        <environment id="development">
            <transactionManager type="JDBC"/>
            <dataSource type="POOLED">
                <property name="driver" value="com.mysql.cj.jdbc.Driver"/>
                <property name="url" value="jdbc:mysql://localhost:3306/test-blog?useUnicode=true&amp;characterEncoding=utf-8&amp;useSSL=false&amp;serverTimezone=Asia/Shanghai&amp;allowMultiQueries=true"/>
                <property name="username" value="root"/>
                <property name="password" value="123456"/>
            </dataSource>
        </environment>
    </environments>
    <mappers>
        <mapper resource="mapper/BlogMapper.xml"/>
    </mappers>
</configuration>
```

```sql
-- ----------------------------
-- Table structure for blog
-- ----------------------------
DROP TABLE IF EXISTS `blog`;
CREATE TABLE `blog`  (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NULL DEFAULT NULL,
  PRIMARY KEY (`id`) USING BTREE
) ENGINE = InnoDB AUTO_INCREMENT = 2 CHARACTER SET = utf8mb4 COLLATE = utf8mb4_bin ROW_FORMAT = Dynamic;

-- ----------------------------
-- Records of blog
-- ----------------------------
INSERT INTO `blog` VALUES (1, 'xxxx');
```

## Steps to reproduce

I reset the parameter values in the ParameterIntercepts Plugin.

`statementHandler.getParameterHandler().setParameters((PreparedStatement) invocation.getArgs()[0]);`

However the parameter logging included both the old and new parameter values, which is the issue.


## Expected result

```
DEBUG [main] - ==>  Preparing: select * from Blog where id = ?
DEBUG [main] - ==> Parameters: 1(Integer)
DEBUG [main] - <==      Total: 1
```

## Actual result

```
DEBUG [main] - ==>  Preparing: select * from Blog where id = ?
DEBUG [main] - ==> Parameters: 1(Integer), 1(Integer), 1(Integer), 1(Integer)
DEBUG [main] - <==      Total: 1
```
