### PR TITLE
(fix): Only execute certain operations once while handling results

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -1107,8 +1107,9 @@ public class DefaultResultSetHandler implements ResultSetHandler {
       return false;
     }
     if (columnPrefix != null) {
+      final String upperCasePrefix = columnPrefix.toUpperCase(Locale.ENGLISH);
       for (String columnName : rsw.getColumnNames()) {
-        if (columnName.toUpperCase(Locale.ENGLISH).startsWith(columnPrefix.toUpperCase(Locale.ENGLISH))) {
+        if (columnName.toUpperCase(Locale.ENGLISH).startsWith(upperCasePrefix)) {
           return true;
         }
       }
@@ -1170,11 +1171,11 @@ public class DefaultResultSetHandler implements ResultSetHandler {
 
   private void createRowKeyForMappedProperties(ResultMap resultMap, ResultSetWrapper rsw, CacheKey cacheKey,
       List<ResultMapping> resultMappings, String columnPrefix) throws SQLException {
+    Set<String> mappedColumnNames = rsw.getMappedColumnNames(resultMap, columnPrefix);
     for (ResultMapping resultMapping : resultMappings) {
       if (resultMapping.isSimple()) {
         final String column = prependPrefix(resultMapping.getColumn(), columnPrefix);
         final TypeHandler<?> th = resultMapping.getTypeHandler();
-        Set<String> mappedColumnNames = rsw.getMappedColumnNames(resultMap, columnPrefix);
         // Issue #114
         if (column != null && mappedColumnNames.contains(column.toUpperCase(Locale.ENGLISH))) {
           final Object value = th.getResult(rsw.getResultSet(), column);


### PR DESCRIPTION
While creating benchmarks and profiling for the constructor injection ticket, I stumbled upon two cases which could be optimised, and both reduce memory allocation and runtime for very large result sets.

I did not want to include this in the previous PR as it is already huge, and these two improvements can be standalone.
Here are the benchmarking results using the same benchmark I created for the previously mentioned ticket.

```
Benchmark                                                                        Mode  Cnt  Score   Error  Units
PropertyVsConstructorInjectionBenchmark.retrieveAllUsingConstructorInjection     avgt    5  0.817 ± 0.036  ms/op
PropertyVsConstructorInjectionBenchmark.retrieveAllUsingPropertyInjection        avgt    5  1.067 ± 0.013  ms/op
PropertyVsConstructorInjectionBenchmark.retrieveSingleUsingConstructorInjection  avgt    5  0.046 ± 0.003  ms/op
PropertyVsConstructorInjectionBenchmark.retrieveSingleUsingPropertyInjection     avgt    5  0.037 ± 0.001  ms/op
```

For easy reference, here are the same benchmarks without this change:

```
Benchmark                                                                        Mode  Cnt  Score   Error  Units
PropertyVsConstructorInjectionBenchmark.retrieveAllUsingConstructorInjection     avgt    5  0.834 ± 0.015  ms/op
PropertyVsConstructorInjectionBenchmark.retrieveAllUsingPropertyInjection        avgt    5  1.164 ± 0.055  ms/op
PropertyVsConstructorInjectionBenchmark.retrieveSingleUsingConstructorInjection  avgt    5  0.045 ± 0.001  ms/op
PropertyVsConstructorInjectionBenchmark.retrieveSingleUsingPropertyInjection     avgt    5  0.038 ± 0.002  ms/op
```

As you can see, it does not really affect retrieving a single row, but improvements start to accumulate as our result set gets bigger