### PR TITLE
fix: Fix flaky test (testBlockingCache) on master/pr's

### DIFF
--- a/src/test/java/org/apache/ibatis/submitted/blocking_cache/BlockingCacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/blocking_cache/BlockingCacheTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,13 +18,14 @@ package org.apache.ibatis.submitted.blocking_cache;
 import java.io.Reader;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +48,7 @@ class BlockingCacheTest {
   }
 
   @Test
-  void testBlockingCache() {
+  void testBlockingCache() throws InterruptedException {
     ExecutorService defaultThreadPool = Executors.newFixedThreadPool(2);
 
     long init = System.currentTimeMillis();
@@ -57,13 +58,12 @@ class BlockingCacheTest {
     }
 
     defaultThreadPool.shutdown();
-
-    while (!defaultThreadPool.isTerminated()) {
-      continue;
+    if (!defaultThreadPool.awaitTermination(5, TimeUnit.SECONDS)) {
+      defaultThreadPool.shutdownNow();
     }
 
     long totalTime = System.currentTimeMillis() - init;
-    Assertions.assertTrue(totalTime > 1000);
+    Assertions.assertThat(totalTime).isGreaterThanOrEqualTo(1000);
   }
 
   private void accessDB() {


### PR DESCRIPTION
This test has been failing sporadically on some CI runners. 

- Use more modern approach to shut down thread pool, `awaitTermination` (prevent infinite loop in case of failure)
- Use assertJ so we can get the reason it failed if it does
- Change to `greaterThanOrEqualTo` as this test is successful if the calls blocked on each other and we know that with (500ms * 2)