### PR TITLE
feat: allow `DefaultSqlSessionFactory` to provide a custom `SqlSession`

### DIFF
--- a/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSession.java
+++ b/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSession.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSession.java
+++ b/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSession.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2023 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSessionFactory.java
+++ b/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSessionFactory.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -87,6 +87,10 @@ public class DefaultSqlSessionFactory implements SqlSessionFactory {
     return configuration;
   }
 
+  protected SqlSession createSqlSession(Configuration configuration, Executor executor, boolean autoCommit) {
+    return new DefaultSqlSession(configuration, executor, autoCommit);
+  }
+
   private SqlSession openSessionFromDataSource(ExecutorType execType, TransactionIsolationLevel level,
       boolean autoCommit) {
     Transaction tx = null;
@@ -95,7 +99,7 @@ public class DefaultSqlSessionFactory implements SqlSessionFactory {
       final TransactionFactory transactionFactory = getTransactionFactoryFromEnvironment(environment);
       tx = transactionFactory.newTransaction(environment.getDataSource(), level, autoCommit);
       final Executor executor = configuration.newExecutor(tx, execType);
-      return new DefaultSqlSession(configuration, executor, autoCommit);
+      return createSqlSession(configuration, executor, autoCommit);
     } catch (Exception e) {
       closeTransaction(tx); // may have fetched a connection so lets call close()
       throw ExceptionFactory.wrapException("Error opening session.  Cause: " + e, e);
@@ -118,7 +122,7 @@ public class DefaultSqlSessionFactory implements SqlSessionFactory {
       final TransactionFactory transactionFactory = getTransactionFactoryFromEnvironment(environment);
       final Transaction tx = transactionFactory.newTransaction(connection);
       final Executor executor = configuration.newExecutor(tx, execType);
-      return new DefaultSqlSession(configuration, executor, autoCommit);
+      return createSqlSession(configuration, executor, autoCommit);
     } catch (Exception e) {
       throw ExceptionFactory.wrapException("Error opening session.  Cause: " + e, e);
     } finally {

--- a/src/test/java/org/apache/ibatis/session/defaults/ExtendedSqlSession.java
+++ b/src/test/java/org/apache/ibatis/session/defaults/ExtendedSqlSession.java
@@ -1,0 +1,27 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.session.defaults;
+
+import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.session.Configuration;
+
+public class ExtendedSqlSession extends DefaultSqlSession {
+
+  public ExtendedSqlSession(Configuration configuration, Executor executor, boolean autoCommit) {
+    super(configuration, executor, autoCommit);
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/session/defaults/ExtendedSqlSessionFactory.java
+++ b/src/test/java/org/apache/ibatis/session/defaults/ExtendedSqlSessionFactory.java
@@ -1,0 +1,32 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.session.defaults;
+
+import org.apache.ibatis.executor.Executor;
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSession;
+
+public class ExtendedSqlSessionFactory extends DefaultSqlSessionFactory {
+
+  public ExtendedSqlSessionFactory(Configuration configuration) {
+    super(configuration);
+  }
+
+  @Override
+  protected SqlSession createSqlSession(Configuration configuration, Executor executor, boolean autoCommit) {
+    return new ExtendedSqlSession(configuration, executor, autoCommit);
+  }
+}

--- a/src/test/java/org/apache/ibatis/session/defaults/ExtendedSqlSessionFactoryBuilder.java
+++ b/src/test/java/org/apache/ibatis/session/defaults/ExtendedSqlSessionFactoryBuilder.java
@@ -1,0 +1,28 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.session.defaults;
+
+import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+
+public class ExtendedSqlSessionFactoryBuilder extends SqlSessionFactoryBuilder {
+
+  @Override
+  public SqlSessionFactory build(Configuration config) {
+    return new ExtendedSqlSessionFactory(config);
+  }
+}

--- a/src/test/java/org/apache/ibatis/session/defaults/ExtendedSqlSessionFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/session/defaults/ExtendedSqlSessionFactoryTest.java
@@ -1,0 +1,43 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.session.defaults;
+
+import java.io.Reader;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+public class ExtendedSqlSessionFactoryTest extends BaseDataTest {
+
+  @Test
+  public void testCanUseExtendedSqlSessionUsingDefaults() throws Exception {
+    createBlogDataSource();
+
+    final String resource = "org/apache/ibatis/builder/MapperConfig.xml";
+    final Reader reader = Resources.getResourceAsReader(resource);
+
+    SqlSessionFactory sessionFactory = new ExtendedSqlSessionFactoryBuilder().build(reader);
+    Assertions.assertThat(sessionFactory).isNotNull();
+
+    try (SqlSession sqlSession = sessionFactory.openSession()) {
+      Assertions.assertThat(sqlSession).isNotNull().isInstanceOf(ExtendedSqlSession.class);
+    };
+  }
+}

--- a/src/test/java/org/apache/ibatis/session/defaults/ExtendedSqlSessionFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/session/defaults/ExtendedSqlSessionFactoryTest.java
@@ -38,6 +38,6 @@ public class ExtendedSqlSessionFactoryTest extends BaseDataTest {
 
     try (SqlSession sqlSession = sessionFactory.openSession()) {
       Assertions.assertThat(sqlSession).isNotNull().isInstanceOf(ExtendedSqlSession.class);
-    };
+    }
   }
 }


### PR DESCRIPTION
Hi Maintainers! 

While extending `SqlSessionFactoryBuilder` allows users to _fully_ customise their implementations of `SqlSessionFactory` and `SqlSession`, the drawback is that you cannot use the safe defaults MyBatis provides anymore, which leaves two options:

* Duplicate (copy/paste) `DefaultSqlSession` and `DefaultSqlSessionFactory`, the drawbacks here are that you do not get upstream updates anymore and have to compare and update these files every release.
* Use reflection, the drawbacks here are that this is quite dirty and suffers from the same problems mentioned above.

I added a minimal test case which shows a structure  that would allow the use of the defaults while providing important extension points.

### Below is parked for future discussion:

Additionally, allow subclasses of `DefaultSqlSession` to call `selectList(...)`, which allows providing a system wide result handler if user code did not specify one.

I understand that this is definitely not a common use case, but believe the changes required are so minimal that it would provide a good tradeoff.

_PS_: note that the result handler is not the only reason here, we do quite some custom work (in our codebase) in the factory and session respectively.