### PR TITLE
Fix wrong anchor

### DIFF
--- a/src/site/es/xdoc/configuration.xml
+++ b/src/site/es/xdoc/configuration.xml
@@ -35,9 +35,9 @@
           <ul>
             <li><a href="#properties">properties</a></li>
             <li><a href="#settings">settings</a></li>
-            <li><a href="#typeAliases">typeAliases</a></li>
-            <li><a href="#typeHandlers">typeHandlers</a></li>
-            <li><a href="#objectFactory">objectFactory</a></li>
+            <li><a href="#typealiases">typeAliases</a></li>
+            <li><a href="#typehandlers">typeHandlers</a></li>
+            <li><a href="#objectfactory">objectFactory</a></li>
             <li><a href="#plugins">plugins</a></li>
             <li><a href="#environments">environments</a>
               <ul>
@@ -50,7 +50,7 @@
                 </li>
               </ul>
             </li>
-            <li><a href="#databaseIdProvider">databaseIdProvider</a></li>
+            <li><a href="#databaseidprovider">databaseIdProvider</a></li>
             <li><a href="#mappers">mappers</a></li>
           </ul>
         </li>

--- a/src/site/ja/xdoc/configuration.xml
+++ b/src/site/ja/xdoc/configuration.xml
@@ -37,9 +37,9 @@
           <ul>
             <li><a href="#properties">properties</a></li>
             <li><a href="#settings">settings</a></li>
-            <li><a href="#typeAliases">typeAliases</a></li>
-            <li><a href="#typeHandlers">typeHandlers</a></li>
-            <li><a href="#objectFactory">objectFactory</a></li>
+            <li><a href="#typealiases">typeAliases</a></li>
+            <li><a href="#typehandlers">typeHandlers</a></li>
+            <li><a href="#objectfactory">objectFactory</a></li>
             <li><a href="#plugins">plugins</a></li>
             <li><a href="#environments">environments</a>
               <ul>
@@ -52,7 +52,7 @@
                 </li>
               </ul>
             </li>
-            <li><a href="#databaseIdProvider">databaseIdProvider</a></li>
+            <li><a href="#databaseidprovider">databaseIdProvider</a></li>
             <li><a href="#mappers">mappers</a></li>
           </ul>
         </li>

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -35,9 +35,9 @@
           <ul>
             <li><a href="#properties">properties</a></li>
             <li><a href="#settings">settings</a></li>
-            <li><a href="#typeAliases">typeAliases</a></li>
-            <li><a href="#typeHandlers">typeHandlers</a></li>
-            <li><a href="#objectFactory">objectFactory</a></li>
+            <li><a href="#typealiases">typeAliases</a></li>
+            <li><a href="#typehandlers">typeHandlers</a></li>
+            <li><a href="#objectfactory">objectFactory</a></li>
             <li><a href="#plugins">plugins</a></li>
             <li><a href="#environments">environments</a>
               <ul>
@@ -50,7 +50,7 @@
                 </li>
               </ul>
             </li>
-            <li><a href="#databaseIdProvider">databaseIdProvider</a></li>
+            <li><a href="#databaseidprovider">databaseIdProvider</a></li>
             <li><a href="#mappers">mappers</a></li>
           </ul>
         </li>

--- a/src/site/markdown/configuration.md
+++ b/src/site/markdown/configuration.md
@@ -8,15 +8,15 @@ The MyBatis configuration contains settings and properties that have a dramatic 
 - configuration
   - [properties](#properties)
   - [settings](#settings)
-  - [typeAliases](#typeAliases)
-  - [typeHandlers](#typeHandlers)
-  - [objectFactory](#objectFactory)
+  - [typeAliases](#typealiases)
+  - [typeHandlers](#typehandlers)
+  - [objectFactory](#objectfactory)
   - [plugins](#plugins)
   - [environments](#environments)
     - environment
       - transactionManager
       - dataSource
-  - [databaseIdProvider](#databaseIdProvider)
+  - [databaseIdProvider](#databaseidprovider)
   - [mappers](#mappers)
 
 ### properties

--- a/src/site/site_es.xml
+++ b/src/site/site_es.xml
@@ -26,12 +26,12 @@
       <item name="Configuración" href="configuration.html" collapse="true">
         <item href="configuration.html#properties" name="properties" />
         <item href="configuration.html#settings" name="settings" />
-        <item href="configuration.html#typeAliases" name="typeAliases" />
-        <item href="configuration.html#typeHandlers" name="typeHandlers" />
-        <item href="configuration.html#objectFactory" name="objectFactory" />
+        <item href="configuration.html#typealiases" name="typeAliases" />
+        <item href="configuration.html#typehandlers" name="typeHandlers" />
+        <item href="configuration.html#objectfactory" name="objectFactory" />
         <item href="configuration.html#plugins" name="plugins" />
         <item href="configuration.html#environments" name="environments" />
-        <item href="configuration.html#databaseIdProvider" name="databaseIdProvider" />
+        <item href="configuration.html#databaseidprovider" name="databaseIdProvider" />
         <item href="configuration.html#mappers" name="mappers" />
       </item>
       <item name="Ficheros XML de mapeo" href="sqlmap-xml.html" collapse="true">

--- a/src/site/site_fr.xml
+++ b/src/site/site_fr.xml
@@ -26,12 +26,12 @@
       <item name="Configuration XML" href="configuration.html" collapse="true">
         <item href="configuration.html#properties" name="properties" />
         <item href="configuration.html#settings" name="settings" />
-        <item href="configuration.html#typeAliases" name="typeAliases" />
-        <item href="configuration.html#typeHandlers" name="typeHandlers" />
-        <item href="configuration.html#objectFactory" name="objectFactory" />
+        <item href="configuration.html#typealiases" name="typeAliases" />
+        <item href="configuration.html#typehandlers" name="typeHandlers" />
+        <item href="configuration.html#objectfactory" name="objectFactory" />
         <item href="configuration.html#plugins" name="plugins" />
         <item href="configuration.html#environments" name="environments" />
-        <item href="configuration.html#databaseIdProvider" name="databaseIdProvider" />
+        <item href="configuration.html#databaseidprovider" name="databaseIdProvider" />
         <item href="configuration.html#mappers" name="mappers" />
       </item>
       <item name="Fichiers Mappers XML" href="sqlmap-xml.html" collapse="true">

--- a/src/site/site_ja.xml
+++ b/src/site/site_ja.xml
@@ -26,9 +26,9 @@
       <item name="設定" href="configuration.html" collapse="true">
         <item href="configuration.html#properties" name="properties" />
         <item href="configuration.html#settings" name="settings" />
-        <item href="configuration.html#typeAliases" name="typeAliases" />
-        <item href="configuration.html#typeHandlers" name="typeHandlers" />
-        <item href="configuration.html#objectFactory" name="objectFactory" />
+        <item href="configuration.html#typealiases" name="typeAliases" />
+        <item href="configuration.html#typehandlers" name="typeHandlers" />
+        <item href="configuration.html#objectfactory" name="objectFactory" />
         <item href="configuration.html#plugins" name="plugins" />
         <item href="configuration.html#environments" name="environments" />
         <item href="configuration.html#mappers" name="mappers" />

--- a/src/site/site_ja.xml
+++ b/src/site/site_ja.xml
@@ -31,6 +31,7 @@
         <item href="configuration.html#objectfactory" name="objectFactory" />
         <item href="configuration.html#plugins" name="plugins" />
         <item href="configuration.html#environments" name="environments" />
+        <item href="configuration.html#databaseidprovider" name="databaseIdProvider" />
         <item href="configuration.html#mappers" name="mappers" />
       </item>
       <item name="Mapper XML ファイル" href="sqlmap-xml.html" collapse="true">

--- a/src/site/site_ko.xml
+++ b/src/site/site_ko.xml
@@ -26,12 +26,12 @@
       <item name="매퍼 설정" href="configuration.html" collapse="true">
         <item href="configuration.html#properties" name="properties" />
         <item href="configuration.html#settings" name="settings" />
-        <item href="configuration.html#typeAliases" name="typeAliases" />
-        <item href="configuration.html#typeHandlers" name="typeHandlers" />
-        <item href="configuration.html#objectFactory" name="objectFactory" />
+        <item href="configuration.html#typealiases" name="typeAliases" />
+        <item href="configuration.html#typehandlers" name="typeHandlers" />
+        <item href="configuration.html#objectfactory" name="objectFactory" />
         <item href="configuration.html#plugins" name="plugins" />
         <item href="configuration.html#environments" name="environments" />
-        <item href="configuration.html#databaseIdProvider" name="databaseIdProvider" />
+        <item href="configuration.html#databaseidprovider" name="databaseIdProvider" />
         <item href="configuration.html#mappers" name="mappers" />
       </item>
       <item name="Mapper XML 파일" href="sqlmap-xml.html" collapse="true">

--- a/src/site/site_zh.xml
+++ b/src/site/site_zh.xml
@@ -26,12 +26,12 @@
       <item name="XML 配置" href="configuration.html" collapse="true">
         <item href="configuration.html#properties" name="属性" />
         <item href="configuration.html#settings" name="设置" />
-        <item href="configuration.html#typeAliases" name="类型别名" />
-        <item href="configuration.html#typeHandlers" name="类型处理器" />
-        <item href="configuration.html#objectFactory" name="对象工厂" />
+        <item href="configuration.html#typealiases" name="类型别名" />
+        <item href="configuration.html#typehandlers" name="类型处理器" />
+        <item href="configuration.html#objectfactory" name="对象工厂" />
         <item href="configuration.html#plugins" name="插件" />
         <item href="configuration.html#environments" name="环境配置" />
-        <item href="configuration.html#databaseIdProvider" name="数据库厂商标识" />
+        <item href="configuration.html#databaseidprovider" name="数据库厂商标识" />
         <item href="configuration.html#mappers" name="映射器" />
       </item>
       <item name="XML 映射文件" href="sqlmap-xml.html" collapse="true">

--- a/src/site/zh_CN/xdoc/configuration.xml
+++ b/src/site/zh_CN/xdoc/configuration.xml
@@ -37,9 +37,9 @@
           <ul>
             <li><a href="#properties">properties（属性）</a></li>
             <li><a href="#settings">settings（设置）</a></li>
-            <li><a href="#typeAliases">typeAliases（类型别名）</a></li>
-            <li><a href="#typeHandlers">typeHandlers（类型处理器）</a></li>
-            <li><a href="#objectFactory">objectFactory（对象工厂）</a></li>
+            <li><a href="#typealiases">typeAliases（类型别名）</a></li>
+            <li><a href="#typehandlers">typeHandlers（类型处理器）</a></li>
+            <li><a href="#objectfactory">objectFactory（对象工厂）</a></li>
             <li><a href="#plugins">plugins（插件）</a></li>
             <li><a href="#environments">environments（环境配置）</a>
               <ul>
@@ -52,7 +52,7 @@
                 </li>
               </ul>
             </li>
-            <li><a href="#databaseIdProvider">databaseIdProvider（数据库厂商标识）</a></li>
+            <li><a href="#databaseidprovider">databaseIdProvider（数据库厂商标识）</a></li>
             <li><a href="#mappers">mappers（映射器）</a></li>
           </ul>
         </li>


### PR DESCRIPTION
Some anchor tags are not working on https://mybatis.org/mybatis-3/configuration.html.
`typeAliases`, `typeHandlers`, `objectFactory`, and `databaseidprovider` are linked to ids with wrong capitalization. 
So I fixed it. 😄 

Also, add missing `databaseIdProvider` menu on japanese language.
