### PR TITLE
Use isEmpty() instead of length()

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/keygen/SelectKeyGenerator.java
+++ b/src/main/java/org/apache/ibatis/executor/keygen/SelectKeyGenerator.java
@@ -65,7 +65,7 @@ public class SelectKeyGenerator implements KeyGenerator {
         // The transaction will be closed by parent executor.
         Executor keyExecutor = configuration.newExecutor(executor.getTransaction(), ExecutorType.SIMPLE);
         List<Object> values = keyExecutor.query(keyStatement, parameter, RowBounds.DEFAULT, Executor.NO_RESULT_HANDLER);
-        if (values.size() == 0) {
+        if (values.isEmpty()) {
           throw new ExecutorException("SelectKey returned no data.");
         }
         if (values.size() > 1) {


### PR DESCRIPTION
This pull request suggests using isEmpty() instead of length().

### Rationale:

- **Readability:** The isEmpty() method clearly conveys the intention of checking if the collection is empty. Therefore, it makes it easier for developers to understand the code.
- **Intended Behavior:** The isEmpty() method is designed to check if a collection is empty. This aligns better with the developer's intention and makes the code more expressive.
- **Common Convention:** In the Java collection framework, it's common to use the isEmpty() method to check if a collection is empty. Following this common convention helps maintain consistency in the codebase.

In conclusion, using the isEmpty() method improves code readability and aligns better with the intended behavior. It also adheres to the common convention in the Java collection framework.