### PR TITLE
Recommend using isEmpty() instead of size().

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/loader/ResultLoaderMap.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/ResultLoaderMap.java
@@ -70,6 +70,10 @@ public class ResultLoaderMap {
   public int size() {
     return loaderMap.size();
   }
+  
+  public boolean isEmpty() {
+    return loaderMap.isEmpty();
+  }
 
   public boolean hasLoader(String property) {
     return loaderMap.containsKey(property.toUpperCase(Locale.ENGLISH));

--- a/src/main/java/org/apache/ibatis/executor/loader/javassist/JavassistProxyFactory.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/javassist/JavassistProxyFactory.java
@@ -143,14 +143,14 @@ public class JavassistProxyFactory implements org.apache.ibatis.executor.loader.
             original = objectFactory.create(type, constructorArgTypes, constructorArgs);
           }
           PropertyCopier.copyBeanProperties(type, enhanced, original);
-          if (lazyLoader.size() > 0) {
+          if (!lazyLoader.isEmpty()) {
             return new JavassistSerialStateHolder(original, lazyLoader.getProperties(), objectFactory,
                 constructorArgTypes, constructorArgs);
           } else {
             return original;
           }
         }
-        if (lazyLoader.size() > 0 && !FINALIZE_METHOD.equals(methodName)) {
+        if (!lazyLoader.isEmpty() && !FINALIZE_METHOD.equals(methodName)) {
           if (aggressive || lazyLoadTriggerMethods.contains(methodName)) {
             lazyLoader.loadAll();
           } else if (PropertyNamer.isSetter(methodName)) {


### PR DESCRIPTION
In Java, it is recommended to use `isEmpty()` instead of comparing the `size()` of a collection object with 0.
 
- Added isEmpty() method to the ResultLoaderMap object