### PR TITLE
fix : Enhancing Readability and Reliability with isEmpty Check

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -416,7 +416,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
         foundValues = applyAutomaticMappings(rsw, resultMap, metaObject, columnPrefix) || foundValues;
       }
       foundValues = applyPropertyMappings(rsw, resultMap, metaObject, lazyLoader, columnPrefix) || foundValues;
-      foundValues = lazyLoader.size() > 0 || foundValues;
+      foundValues = !lazyLoader.isEmpty() || foundValues;
       rowValue = foundValues || configuration.isReturnInstanceForEmptyRow() ? rowValue : null;
     }
     return rowValue;
@@ -449,7 +449,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
         foundValues = applyNestedResultMappings(rsw, resultMap, metaObject, columnPrefix, combinedKey, true)
             || foundValues;
         ancestorObjects.remove(resultMapId);
-        foundValues = lazyLoader.size() > 0 || foundValues;
+        foundValues = !lazyLoader.isEmpty() || foundValues;
         rowValue = foundValues || configuration.isReturnInstanceForEmptyRow() ? rowValue : null;
       }
       if (combinedKey != CacheKey.NULL_CACHE_KEY) {

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -602,7 +602,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
     CacheKey parentKey = createKeyForMultipleResults(rs, parentMapping, parentMapping.getColumn(),
         parentMapping.getForeignColumn());
     List<PendingRelation> parents = pendingRelations.get(parentKey);
-    if (parents != null) {
+    if (!parents.isEmpty()) {
       for (PendingRelation parent : parents) {
         if (parent != null && rowValue != null) {
           linkObjects(parent.metaObject, parent.propertyMapping, rowValue);

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -602,7 +602,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
     CacheKey parentKey = createKeyForMultipleResults(rs, parentMapping, parentMapping.getColumn(),
         parentMapping.getForeignColumn());
     List<PendingRelation> parents = pendingRelations.get(parentKey);
-    if (!parents.isEmpty()) {
+    if (parents != null && !parents.isEmpty()) {
       for (PendingRelation parent : parents) {
         if (parent != null && rowValue != null) {
           linkObjects(parent.metaObject, parent.propertyMapping, rowValue);

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -540,7 +540,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
       final List<String> unmappedColumnNames = rsw.getUnmappedColumnNames(resultMap, columnPrefix);
       // Remove the entry to release the memory
       List<String> mappedInConstructorAutoMapping = constructorAutoMappingColumns.remove(mapKey);
-      if (mappedInConstructorAutoMapping != null) {
+      if (!mappedInConstructorAutoMapping.isEmpty()) {
         unmappedColumnNames.removeAll(mappedInConstructorAutoMapping);
       }
       for (String columnName : unmappedColumnNames) {

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -540,7 +540,7 @@ public class DefaultResultSetHandler implements ResultSetHandler {
       final List<String> unmappedColumnNames = rsw.getUnmappedColumnNames(resultMap, columnPrefix);
       // Remove the entry to release the memory
       List<String> mappedInConstructorAutoMapping = constructorAutoMappingColumns.remove(mapKey);
-      if (!mappedInConstructorAutoMapping.isEmpty()) {
+      if (mappedInConstructorAutoMapping != null && !mappedInConstructorAutoMapping.isEmpty()) {
         unmappedColumnNames.removeAll(mappedInConstructorAutoMapping);
       }
       for (String columnName : unmappedColumnNames) {


### PR DESCRIPTION
This PR aims to enhance readability and reliability by utilizing the isEmpty method generated from the ResultLoaderMap. By considering not only null but also whether the length is zero in the context flow, it prevents unnecessary advancement to the next block.