### PR TITLE
Fix scanSuperTypes function to return Object Class instead of generic types

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
+++ b/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
@@ -206,6 +206,9 @@ public class TypeParameterResolver {
       if (declaringClass == parentAsClass) {
         for (int i = 0; i < parentTypeVars.length; i++) {
           if (typeVar.equals(parentTypeVars[i])) {
+            if (parentAsType.getActualTypeArguments()[i] instanceof TypeVariable<?>) {
+              return Object.class;
+            }
             return parentAsType.getActualTypeArguments()[i];
           }
         }

--- a/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
+++ b/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -206,10 +206,8 @@ public class TypeParameterResolver {
       if (declaringClass == parentAsClass) {
         for (int i = 0; i < parentTypeVars.length; i++) {
           if (typeVar.equals(parentTypeVars[i])) {
-            if (parentAsType.getActualTypeArguments()[i] instanceof TypeVariable<?>) {
-              return Object.class;
-            }
-            return parentAsType.getActualTypeArguments()[i];
+            Type actualType = parentAsType.getActualTypeArguments()[i];
+            return actualType instanceof TypeVariable<?> ? Object.class : actualType;
           }
         }
       }

--- a/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
@@ -262,6 +262,19 @@ class TypeParameterResolverTest {
   }
 
   @Test
+  void testReturn_LV1Map() throws Exception {
+    Class<?> clazz = Level1Mapper.class;
+    Method method = clazz.getMethod("selectMap");
+    Type result = TypeParameterResolver.resolveReturnType(method, clazz);
+    assertTrue(result instanceof ParameterizedType);
+    ParameterizedType paramType = (ParameterizedType) result;
+    assertEquals(Map.class, paramType.getRawType());
+    assertEquals(2, paramType.getActualTypeArguments().length);
+    assertEquals(String.class, paramType.getActualTypeArguments()[0]);
+    assertEquals(Object.class, paramType.getActualTypeArguments()[1]);
+  }
+
+  @Test
   void testReturn_LV2Map() throws Exception {
     Class<?> clazz = Level2Mapper.class;
     Method method = clazz.getMethod("selectMap");


### PR DESCRIPTION
### Fix scanSuperTypes function to return Object Class instead of generic types


**Unit Test Code**
```java
@Test
void testReturn_LV1Map() throws Exception {
   Class<?> clazz = Level1Mapper.class;
   Method method = clazz.getMethod("selectMap");
   Type result = TypeParameterResolver.resolveReturnType(method, clazz);
   assertTrue(result instanceof ParameterizedType);
   ParameterizedType paramType = (ParameterizedType) result;
   assertEquals(Map.class, paramType.getRawType());
   assertEquals(2, paramType.getActualTypeArguments().length);
   assertEquals(String.class, paramType.getActualTypeArguments()[0]);
   assertEquals(Object.class, paramType.getActualTypeArguments()[1]);
}
```

**Expected** :class java.lang.Object
**Actual**: F