### PR TITLE
fix: Double-checked locking for logConstructor

### DIFF
--- a/src/main/java/org/apache/ibatis/logging/LogFactory.java
+++ b/src/main/java/org/apache/ibatis/logging/LogFactory.java
@@ -30,7 +30,7 @@ public final class LogFactory {
   public static final String MARKER = "MYBATIS";
 
   private static final ReentrantLock lock = new ReentrantLock();
-  private static Constructor<? extends Log> logConstructor;
+  private static volatile Constructor<? extends Log> logConstructor;
 
   static {
     tryImplementation(LogFactory::useSlf4jLogging);
@@ -95,10 +95,14 @@ public final class LogFactory {
 
   private static void tryImplementation(Runnable runnable) {
     if (logConstructor == null) {
-      try {
-        runnable.run();
-      } catch (Throwable t) {
-        // ignore
+      synchronized (LogFactory.class) {
+        if (logConstructor == null) {
+          try {
+            runnable.run();
+          } catch (Throwable t) {
+            // ignore
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
When the `tryImplementation` method is called concurrently, the value of `logConstructor` may be overwritten. So I'm going to use DCL to solve this problem.