### PR TITLE
Fixed the problem   that when the jdbc type is Array and Array.free() is called, the log parameter printed by BaseJdbcLogger is null.

### DIFF
--- a/src/test/java/org/apache/ibatis/logging/jdbc/BaseJdbcLoggerTest.java
+++ b/src/test/java/org/apache/ibatis/logging/jdbc/BaseJdbcLoggerTest.java
@@ -15,11 +15,6 @@
  */
 package org.apache.ibatis.logging.jdbc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
-
-import java.sql.Array;
-
 import org.apache.ibatis.logging.Log;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,12 +22,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.sql.Array;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
 @ExtendWith(MockitoExtension.class)
 class BaseJdbcLoggerTest {
 
   @Mock
   Log log;
-  @Mock
+  @Mock(strictness = Mock.Strictness.LENIENT)
   Array array;
   private BaseJdbcLogger logger;
 
@@ -54,5 +55,19 @@ class BaseJdbcLoggerTest {
     logger.setColumn("1", array);
     when(array.getArray()).thenReturn(new String[] { "one", "two", "three" });
     assertThat(logger.getParameterValueString()).startsWith("[one, two, three]");
+  }
+
+  @Test
+  void shouldDescribeObjectArrayCallFreeParameter() throws Exception {
+
+    when(array.getArray()).thenReturn(new String[] { "one", "two", "three" });
+    logger.setColumn("1", array);
+    doAnswer(e->{
+      when(array.getArray()).thenReturn(null);
+      return null;
+    }).when(array).free();
+    array.free();
+    assertThat(logger.getParameterValueString()).startsWith("[one, two, three]");
+
   }
 }


### PR DESCRIPTION
#3162 Fixed the problem that when the jdbc type is Array and Array.free() is called, the log parameter printed by BaseJdbcLogger is null.