### PR TITLE
Display online english guide

### DIFF
--- a/src/site/es/markdown/index.md
+++ b/src/site/es/markdown/index.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | Introducción
 author: Clinton Begin, Eduardo Macarron
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## Introducción
 
 ### ¿Qué es MyBatis?

--- a/src/site/es/markdown/logging.md
+++ b/src/site/es/markdown/logging.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | Logging
 author: Clinton Begin, Eduardo Macarron
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## Logging
 
 MyBatis proporciona información de logging mediante el uso interno de una factoría. La factoría interna delega la información de logging en alguna de las siguientes implementaciones.

--- a/src/site/es/resources/css/site.css
+++ b/src/site/es/resources/css/site.css
@@ -28,3 +28,4 @@ li.ja {background: url('../../images/ja.png') left no-repeat;padding-left: 32px;
 li.fr {background: url('../../images/fr.png') left no-repeat;padding-left: 32px; margin: 10px}
 li.zh {background: url('../../images/zh.png') left no-repeat;padding-left: 32px; margin: 10px}
 li.ko {background: url('../../images/ko.png') left no-repeat;padding-left: 32px; margin: 10px}
+.d-none {display: none; margin: 0; padding: 0;}

--- a/src/site/fr/resources/css/site.css
+++ b/src/site/fr/resources/css/site.css
@@ -28,3 +28,4 @@ li.ja {background: url('../../images/ja.png') left no-repeat;padding-left: 32px;
 li.fr {background: url('../../images/fr.png') left no-repeat;padding-left: 32px; margin: 10px}
 li.zh {background: url('../../images/zh.png') left no-repeat;padding-left: 32px; margin: 10px}
 li.ko {background: url('../../images/ko.png') left no-repeat;padding-left: 32px; margin: 10px}
+.d-none {display: none; margin: 0; padding: 0;}

--- a/src/site/ja/markdown/index.md
+++ b/src/site/ja/markdown/index.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | イントロダクション
 author: Clinton Begin, Iwao AVE!
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## イントロダクション
 
 ### MyBatis とは？

--- a/src/site/ja/markdown/logging.md
+++ b/src/site/ja/markdown/logging.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | ロギング
 author: Clinton Begin, Iwao AVE!
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## ロギング
 
 MyBatis は、内部の Log Factory を通してログ情報を出力します。この Log Factory は、ログ情報を次に挙げる実装のいずれかに委譲（delegate）します。

--- a/src/site/ja/resources/css/site.css
+++ b/src/site/ja/resources/css/site.css
@@ -28,3 +28,4 @@ li.ja {background: url('../../images/ja.png') left no-repeat;padding-left: 32px;
 li.fr {background: url('../../images/fr.png') left no-repeat;padding-left: 32px; margin: 10px}
 li.zh {background: url('../../images/zh.png') left no-repeat;padding-left: 32px; margin: 10px}
 li.ko {background: url('../../images/ko.png') left no-repeat;padding-left: 32px; margin: 10px}
+.d-none {display: none; margin: 0; padding: 0;}

--- a/src/site/ko/markdown/getting-started.md
+++ b/src/site/ko/markdown/getting-started.md
@@ -1,6 +1,8 @@
 title: 마이바티스 3 | 시작하기
 author: Clinton Begin, 이동국(한국어 번역)
 
+<h1 class="d-none">Avoid blank site</h1>
+
 # 시작하기
 
 ## 설치

--- a/src/site/ko/markdown/getting-started.md
+++ b/src/site/ko/markdown/getting-started.md
@@ -1,8 +1,6 @@
 title: 마이바티스 3 | 시작하기
 author: Clinton Begin, 이동국(한국어 번역)
 
-<h1 class="d-none">Avoid blank site</h1>
-
 # 시작하기
 
 ## 설치

--- a/src/site/ko/markdown/index.md
+++ b/src/site/ko/markdown/index.md
@@ -1,6 +1,8 @@
 title: 마이바티스 3 | 소개
 author: Clinton Begin, 이동국(한국어 번역)
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## 소개
 
 ### 마이바티스는 무엇인가?

--- a/src/site/ko/markdown/logging.md
+++ b/src/site/ko/markdown/logging.md
@@ -1,6 +1,8 @@
 title: 마이바티스 3 | 로깅
 author: Clinton Begin, 이동국(한국어 번역)
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## Logging
 
 마이바티스는 내부 로그 팩토리를 사용하여 로깅 정보를 제공한다. 내부 로그 팩토리는 로깅 정보를 다른 로그 구현체 중 하나에 전달한다.

--- a/src/site/ko/resources/css/site.css
+++ b/src/site/ko/resources/css/site.css
@@ -28,3 +28,4 @@ li.ja {background: url('../../images/ja.png') left no-repeat;padding-left: 32px;
 li.fr {background: url('../../images/fr.png') left no-repeat;padding-left: 32px; margin: 10px}
 li.zh {background: url('../../images/zh.png') left no-repeat;padding-left: 32px; margin: 10px}
 li.ko {background: url('../../images/ko.png') left no-repeat;padding-left: 32px; margin: 10px}
+.d-none {display: none; margin: 0; padding: 0;}

--- a/src/site/markdown/configuration.md
+++ b/src/site/markdown/configuration.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | Configuration
 author: Clinton Begin
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## Configuration
 
 The MyBatis configuration contains settings and properties that have a dramatic effect on how MyBatis behaves. The high level structure of the document is as follows:

--- a/src/site/markdown/dynamic-sql.md
+++ b/src/site/markdown/dynamic-sql.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | Dynamic SQL
 author: Clinton Begin
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## Dynamic SQL
 
 One of the most powerful features of MyBatis has always been its Dynamic SQL capabilities. If you have any experience with JDBC or any similar framework, you understand how painful it is to conditionally concatenate strings of SQL together, making sure not to forget spaces or to omit a comma at the end of a list of columns. Dynamic SQL can be downright painful to deal with.

--- a/src/site/markdown/getting-started.md
+++ b/src/site/markdown/getting-started.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | Getting started
 author: Clinton Begin
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## Getting started
 
 ### Installation

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | Introduction
 author: Clinton Begin
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## Introduction
 
 ### What is MyBatis?

--- a/src/site/markdown/java-api.md
+++ b/src/site/markdown/java-api.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | Java API
 author: Clinton Begin
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## Java API
 
 Now that you know how to configure MyBatis and create mappings, you're ready for the good stuff. The MyBatis Java API is where you get to reap the rewards of your efforts. As you'll see, compared to JDBC, MyBatis greatly simplifies your code and keeps it clean, easy to understand and maintain. MyBatis 3 has introduced a number of significant improvements to make working with SQL Maps even better.

--- a/src/site/markdown/logging.md
+++ b/src/site/markdown/logging.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | Logging
 author: Clinton Begin
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## Logging
 
 MyBatis provides logging information through the use of an internal log factory. The internal log factory will delegate logging information to one of the following log implementations:

--- a/src/site/markdown/sqlmap-xml.md
+++ b/src/site/markdown/sqlmap-xml.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | Mapper XML Files
 author: Clinton Begin
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## Mapper XML Files
 
 The true power of MyBatis is in the Mapped Statements. This is where the magic happens. For all of their power, the Mapper XML files are relatively simple. Certainly if you were to compare them to the equivalent JDBC code, you would immediately see a savings of 95% of the code. MyBatis was built to focus on the SQL, and does its best to stay out of your way.

--- a/src/site/markdown/statement-builders.md
+++ b/src/site/markdown/statement-builders.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | The SQL Builder Class
 author: Clinton Begin
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## The SQL Builder Class
 
 ### The Problem

--- a/src/site/resources/css/site.css
+++ b/src/site/resources/css/site.css
@@ -28,3 +28,4 @@ li.ja {background: url('../images/ja.png') left no-repeat;padding-left: 32px; ma
 li.fr {background: url('../images/fr.png') left no-repeat;padding-left: 32px; margin: 10px}
 li.zh {background: url('../images/zh.png') left no-repeat;padding-left: 32px; margin: 10px}
 li.ko {background: url('../images/ko.png') left no-repeat;padding-left: 32px; margin: 10px}
+.d-none {display: none; margin: 0; padding: 0;}

--- a/src/site/zh_CN/markdown/getting-started.md
+++ b/src/site/zh_CN/markdown/getting-started.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | 入门
 author: Clinton Begin, Nan Lei, Dongxu Wang
 
+<h1 class="d-none">Avoid blank site</h1>
+
 # 入门
 
 ## 安装

--- a/src/site/zh_CN/markdown/getting-started.md
+++ b/src/site/zh_CN/markdown/getting-started.md
@@ -1,8 +1,6 @@
 title: MyBatis 3 | 入门
 author: Clinton Begin, Nan Lei, Dongxu Wang
 
-<h1 class="d-none">Avoid blank site</h1>
-
 # 入门
 
 ## 安装

--- a/src/site/zh_CN/markdown/index.md
+++ b/src/site/zh_CN/markdown/index.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | 简介
 author: Clinton Begin, Nan Lei, Dongxu Wang
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## 简介
 
 ### 什么是 MyBatis？

--- a/src/site/zh_CN/markdown/logging.md
+++ b/src/site/zh_CN/markdown/logging.md
@@ -1,6 +1,8 @@
 title: MyBatis 3 | 日志
 author: Clinton Begin, Nan Lei
 
+<h1 class="d-none">Avoid blank site</h1>
+
 ## 日志
 
 Mybatis 通过使用内置的日志工厂提供日志功能。内置日志工厂将会把日志工作委托给下面的实现之一：

--- a/src/site/zh_CN/resources/css/site.css
+++ b/src/site/zh_CN/resources/css/site.css
@@ -28,3 +28,4 @@ li.ja {background: url('../../images/ja.png') left no-repeat;padding-left: 32px;
 li.fr {background: url('../../images/fr.png') left no-repeat;padding-left: 32px; margin: 10px}
 li.zh {background: url('../../images/zh.png') left no-repeat;padding-left: 32px; margin: 10px}
 li.ko {background: url('../../images/ko.png') left no-repeat;padding-left: 32px; margin: 10px}
+.d-none {display: none; margin: 0; padding: 0;}


### PR DESCRIPTION

As report in

https://github.com/mybatis/mybatis-3/issues/3186

AFAIK, a newest maven version cause blank site.

>Markdown conflict with Velocity on ## syntax:
Since ## denotes a [single line comment](https://velocity.apache.org/engine/2.3/vtl-reference.html#single-line-comments) in Velocity, Markdown headers using this syntax are suppressed from generated content.
You can use [unparsed content syntax](https://velocity.apache.org/engine/2.3/vtl-reference.html#unparsed-content) #[[##]]# or [escape tool](https://velocity.apache.org/tools/3.1/apidocs/org/apache/velocity/tools/generic/EscapeTool.html) like ${esc.h}${esc.h}.

[More detail maven-site-plugin](https://maven.apache.org/plugins/maven-site-plugin/examples/creating-content.html)


But I found the another way.
If markdown file does not contains `# Title`, only add tag `h1`