### PR TITLE
Added PropertyCopier test case

### DIFF
--- a/src/test/java/org/apache/ibatis/reflection/property/PropertyCopierTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/property/PropertyCopierTest.java
@@ -24,15 +24,15 @@ public class PropertyCopierTest {
 
   @Test
   void copyBeanProperties() {
-    SourceBeanTestClass sourceBeanTestClass = new SourceBeanTestClass();
-    sourceBeanTestClass.setMyString("foo");
-    sourceBeanTestClass.setMyInteger(0);
-    sourceBeanTestClass.setMyList(Arrays.asList(1, 2, 3));
-    SourceBeanTestClass destinationBeanTestClass = new SourceBeanTestClass();
-    PropertyCopier.copyBeanProperties(sourceBeanTestClass.getClass(), sourceBeanTestClass, destinationBeanTestClass);
-    Assertions.assertEquals(sourceBeanTestClass.getMyString(), destinationBeanTestClass.getMyString());
-    Assertions.assertEquals(sourceBeanTestClass.getMyInteger(), destinationBeanTestClass.getMyInteger());
-    Assertions.assertEquals(sourceBeanTestClass.getMyList(), destinationBeanTestClass.getMyList());
+    SourceBeanCopierData sourceBeanCopierData = new SourceBeanCopierData();
+    sourceBeanCopierData.setMyString("foo");
+    sourceBeanCopierData.setMyInteger(0);
+    sourceBeanCopierData.setMyList(Arrays.asList(1, 2, 3));
+    SourceBeanCopierData destinationBeanTestClass = new SourceBeanCopierData();
+    PropertyCopier.copyBeanProperties(sourceBeanCopierData.getClass(), sourceBeanCopierData, destinationBeanTestClass);
+    Assertions.assertEquals(sourceBeanCopierData.getMyString(), destinationBeanTestClass.getMyString());
+    Assertions.assertEquals(sourceBeanCopierData.getMyInteger(), destinationBeanTestClass.getMyInteger());
+    Assertions.assertEquals(sourceBeanCopierData.getMyList(), destinationBeanTestClass.getMyList());
   }
 
 }

--- a/src/test/java/org/apache/ibatis/reflection/property/PropertyCopierTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/property/PropertyCopierTest.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.property;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class PropertyCopierTest {
+
+  @Test
+  void copyBeanProperties() {
+    SourceBeanTestClass sourceBeanTestClass = new SourceBeanTestClass();
+    sourceBeanTestClass.setMyString("foo");
+    sourceBeanTestClass.setMyInteger(0);
+    sourceBeanTestClass.setMyList(Arrays.asList(1, 2, 3));
+    SourceBeanTestClass destinationBeanTestClass = new SourceBeanTestClass();
+    PropertyCopier.copyBeanProperties(sourceBeanTestClass.getClass(), sourceBeanTestClass, destinationBeanTestClass);
+    Assertions.assertEquals(sourceBeanTestClass.getMyString(), destinationBeanTestClass.getMyString());
+    Assertions.assertEquals(sourceBeanTestClass.getMyInteger(), destinationBeanTestClass.getMyInteger());
+    Assertions.assertEquals(sourceBeanTestClass.getMyList(), destinationBeanTestClass.getMyList());
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/reflection/property/SourceBeanCopierData.java
+++ b/src/test/java/org/apache/ibatis/reflection/property/SourceBeanCopierData.java
@@ -17,7 +17,7 @@ package org.apache.ibatis.reflection.property;
 
 import java.util.List;
 
-public class SourceBeanTestClass {
+public class SourceBeanCopierData {
   private String myString;
 
   Integer myInteger;
@@ -48,7 +48,7 @@ public class SourceBeanTestClass {
     this.myList = myList;
   }
 
-  public SourceBeanTestClass() {
+  public SourceBeanCopierData() {
   }
 
 }

--- a/src/test/java/org/apache/ibatis/reflection/property/SourceBeanTestClass.java
+++ b/src/test/java/org/apache/ibatis/reflection/property/SourceBeanTestClass.java
@@ -1,0 +1,54 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.property;
+
+import java.util.List;
+
+public class SourceBeanTestClass {
+  private String myString;
+
+  Integer myInteger;
+
+  List<Integer> myList;
+
+  public String getMyString() {
+    return myString;
+  }
+
+  public void setMyString(String myString) {
+    this.myString = myString;
+  }
+
+  public Integer getMyInteger() {
+    return myInteger;
+  }
+
+  public void setMyInteger(Integer myInteger) {
+    this.myInteger = myInteger;
+  }
+
+  public List<Integer> getMyList() {
+    return myList;
+  }
+
+  public void setMyList(List<Integer> myList) {
+    this.myList = myList;
+  }
+
+  public SourceBeanTestClass() {
+  }
+
+}


### PR DESCRIPTION
When I read the PropertyCopier class in the reflection package, I wanted to test, but there was no test class, so I added the corresponding test class