### PR TITLE
Optimize `SystemMetaObject.forObject` Usage by Reusing `DefaultReflectorFactory`

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/SystemMetaObject.java
+++ b/src/main/java/org/apache/ibatis/reflection/SystemMetaObject.java
@@ -29,6 +29,7 @@ public final class SystemMetaObject {
   public static final ObjectWrapperFactory DEFAULT_OBJECT_WRAPPER_FACTORY = new DefaultObjectWrapperFactory();
   public static final MetaObject NULL_META_OBJECT = MetaObject.forObject(new NullObject(), DEFAULT_OBJECT_FACTORY,
       DEFAULT_OBJECT_WRAPPER_FACTORY, new DefaultReflectorFactory());
+  public static final ReflectorFactory DEFAULT_REFLECTOR_FACTORY = new DefaultReflectorFactory();
 
   private SystemMetaObject() {
     // Prevent Instantiation of Static Class
@@ -39,7 +40,11 @@ public final class SystemMetaObject {
 
   public static MetaObject forObject(Object object) {
     return MetaObject.forObject(object, DEFAULT_OBJECT_FACTORY, DEFAULT_OBJECT_WRAPPER_FACTORY,
-        new DefaultReflectorFactory());
+      DEFAULT_REFLECTOR_FACTORY);
   }
 
+  public static MetaObject forObject(Object object, ReflectorFactory reflectorFactory) {
+    return MetaObject.forObject(object, DEFAULT_OBJECT_FACTORY, DEFAULT_OBJECT_WRAPPER_FACTORY,
+      reflectorFactory);
+  }
 }

--- a/src/main/java/org/apache/ibatis/reflection/SystemMetaObject.java
+++ b/src/main/java/org/apache/ibatis/reflection/SystemMetaObject.java
@@ -43,6 +43,13 @@ public final class SystemMetaObject {
       DEFAULT_REFLECTOR_FACTORY);
   }
 
+  /**
+   * get MetaObject use manual reflectorFactory
+   *
+   * @param object           obj
+   * @param reflectorFactory manual reflectorFactory {@link org.apache.ibatis.session.Configuration#getReflectorFactory} is recommended especially in Interceptor
+   * @return MetaObject
+   */
   public static MetaObject forObject(Object object, ReflectorFactory reflectorFactory) {
     return MetaObject.forObject(object, DEFAULT_OBJECT_FACTORY, DEFAULT_OBJECT_WRAPPER_FACTORY,
       reflectorFactory);


### PR DESCRIPTION
Hi,
 While using `SystemMetaObject.forObject` inside the Interceptor, I discovered that each call creates a new `DefaultReflectorFactory` instance,  which prevents the reuse of the reflector cache. 

To address this, I defined a default `DEFAULT_REFLECTOR_FACTORY` to facilitate cache reuse. Additionally, I added support for custom parameters, allowing users to pass the DefaultReflectorFactory from Configuration to maximize cache efficiency.

here is the detail from JFR
![WechatIMG131](https://github.com/user-attachments/assets/99205998-1cbe-473d-bcfe-72f42176b316)
