### PR TITLE
Added new selectMap method to get map with specified property as key and value

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/result/DefaultMapResultHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/result/DefaultMapResultHandler.java
@@ -31,26 +31,36 @@ public class DefaultMapResultHandler<K, V> implements ResultHandler<V> {
 
   private final Map<K, V> mappedResults;
   private final String mapKey;
+  private final String mapValue;
   private final ObjectFactory objectFactory;
   private final ObjectWrapperFactory objectWrapperFactory;
   private final ReflectorFactory reflectorFactory;
 
   @SuppressWarnings("unchecked")
   public DefaultMapResultHandler(String mapKey, ObjectFactory objectFactory, ObjectWrapperFactory objectWrapperFactory,
+                                 ReflectorFactory reflectorFactory) {
+    this(mapKey, null, objectFactory, objectWrapperFactory, reflectorFactory);
+  }
+
+  @SuppressWarnings("unchecked")
+  public DefaultMapResultHandler(String mapKey, String mapValue, ObjectFactory objectFactory, ObjectWrapperFactory objectWrapperFactory,
       ReflectorFactory reflectorFactory) {
     this.objectFactory = objectFactory;
     this.objectWrapperFactory = objectWrapperFactory;
     this.reflectorFactory = reflectorFactory;
     this.mappedResults = objectFactory.create(Map.class);
     this.mapKey = mapKey;
+    this.mapValue = mapValue;
   }
 
   @Override
-  public void handleResult(ResultContext<? extends V> context) {
-    final V value = context.getResultObject();
-    final MetaObject mo = MetaObject.forObject(value, objectFactory, objectWrapperFactory, reflectorFactory);
+  public void handleResult(ResultContext context) {
+    final Object resultObject = context.getResultObject();
+    final MetaObject mo = MetaObject.forObject(resultObject, objectFactory, objectWrapperFactory, reflectorFactory);
     // TODO is that assignment always true?
     final K key = (K) mo.getValue(mapKey);
+    // TODO is that assignment always true?
+    final V value = mapValue == null || mapValue.isEmpty() ? (V) resultObject : (V) mo.getValue(mapValue);
     mappedResults.put(key, value);
   }
 

--- a/src/main/java/org/apache/ibatis/session/SqlSession.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSession.java
@@ -157,6 +157,69 @@ public interface SqlSession extends Closeable {
   <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, RowBounds rowBounds);
 
   /**
+   * The selectMap is a special case in that it is designed to convert a list of results into a Map based on one of the
+   * properties as key and one of the properties as value in the resulting objects. Eg. Return a Map[Integer,String]
+   * for selectMap("selectAuthors","id","username")
+   *
+   * @param <K>
+   *          the returned Map keys type
+   * @param <V>
+   *          the returned Map values type
+   * @param statement
+   *          Unique identifier matching the statement to use.
+   * @param mapKey
+   *          The property to use as key for each value in the list.
+   * @param mapValue
+   *          The property to use as value for each key in the list.
+   *
+   * @return Map containing key pair data.
+   */
+  <K, V> Map<K, V> selectMap(String statement, String mapKey, String mapValue);
+
+  /**
+   * The selectMap is a special case in that it is designed to convert a list of results into a Map based on one of the
+   * properties as key and one of the properties as value in the resulting objects.
+   *
+   * @param <K>
+   *          the returned Map keys type
+   * @param <V>
+   *          the returned Map values type
+   * @param statement
+   *          Unique identifier matching the statement to use.
+   * @param parameter
+   *          A parameter object to pass to the statement.
+   * @param mapKey
+   *          The property to use as key for each value in the list.
+   * @param mapValue
+   *          The property to use as value for each key in the list.
+   * @return Map containing key pair data.
+   */
+  <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, String mapValue);
+
+  /**
+   * The selectMap is a special case in that it is designed to convert a list of results into a Map based on one of the
+   * properties as key and one of the properties as value in the resulting objects.
+   *
+   * @param <K>
+   *          the returned Map keys type
+   * @param <V>
+   *          the returned Map values type
+   * @param statement
+   *          Unique identifier matching the statement to use.
+   * @param parameter
+   *          A parameter object to pass to the statement.
+   * @param mapKey
+   *          The property to use as key for each value in the list.
+   * @param mapValue
+   *          The property to use as value for each key in the list.
+   * @param rowBounds
+   *          Bounds to limit object retrieval
+   *
+   * @return Map containing key pair data.
+   */
+  <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, String mapValue, RowBounds rowBounds);
+
+  /**
    * A Cursor offers the same results as a List, except it fetches data lazily using an Iterator.
    *
    * @param <T>

--- a/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
@@ -180,6 +180,21 @@ public class SqlSessionManager implements SqlSessionFactory, SqlSession {
   }
 
   @Override
+  public <K, V> Map<K, V> selectMap(String statement, String mapKey, String mapValue) {
+    return sqlSessionProxy.selectMap(statement, mapKey, mapValue);
+  }
+
+  @Override
+  public <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, String mapValue) {
+    return sqlSessionProxy.selectMap(statement, parameter, mapKey, mapValue);
+  }
+
+  @Override
+  public <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, String mapValue, RowBounds rowBounds) {
+    return sqlSessionProxy.selectMap(statement, parameter, mapKey, mapValue, rowBounds);
+  }
+
+  @Override
   public <T> Cursor<T> selectCursor(String statement) {
     return sqlSessionProxy.selectCursor(statement);
   }

--- a/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSession.java
+++ b/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSession.java
@@ -108,6 +108,29 @@ public class DefaultSqlSession implements SqlSession {
   }
 
   @Override
+  public <K, V> Map<K, V> selectMap(String statement, String mapKey, String mapValue) {
+    return this.selectMap(statement, null, mapKey, mapValue, RowBounds.DEFAULT);
+  }
+
+  @Override
+  public <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, String mapValue) {
+    return this.selectMap(statement, parameter, mapKey, mapValue, RowBounds.DEFAULT);
+  }
+
+  @Override
+  public <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, String mapValue, RowBounds rowBounds) {
+    final List<?> list = selectList(statement, parameter, rowBounds);
+    final DefaultMapResultHandler<K, V> mapResultHandler = new DefaultMapResultHandler<>(mapKey, mapValue,
+        configuration.getObjectFactory(), configuration.getObjectWrapperFactory(), configuration.getReflectorFactory());
+    final DefaultResultContext<Object> context = new DefaultResultContext<>();
+    for (Object o : list) {
+      context.nextResultObject(o);
+      mapResultHandler.handleResult(context);
+    }
+    return mapResultHandler.getMappedResults();
+  }
+
+  @Override
   public <T> Cursor<T> selectCursor(String statement) {
     return selectCursor(statement, null);
   }

--- a/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
+++ b/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
@@ -181,6 +181,21 @@ class SqlSessionTest extends BaseDataTest {
   }
 
   @Test
+  void shouldSelectAllAuthorsAsSpecifiedKeyValueMap() {
+    try (SqlSession session = sqlMapper.openSession(TransactionIsolationLevel.SERIALIZABLE)) {
+      final Map<Integer, Author> authors = session
+        .selectMap("org.apache.ibatis.domain.blog.mappers.AuthorMapper.selectAllAuthors", "id");
+      final Map<Integer, String> authorsMap = session
+        .selectMap("org.apache.ibatis.domain.blog.mappers.AuthorMapper.selectAllAuthors", "id", "username");
+      assertEquals(2, authorsMap.size());
+      for (Map.Entry<Integer, String> authorEntry : authorsMap.entrySet()) {
+        assertEquals(authorEntry.getKey(), authors.get(authorEntry.getKey()).getId());
+        assertEquals(authorEntry.getValue(), authors.get(authorEntry.getKey()).getUsername());
+      }
+    }
+  }
+
+  @Test
   void shouldSelectCountOfPosts() {
     try (SqlSession session = sqlMapper.openSession()) {
       Integer count = session.selectOne("org.apache.ibatis.domain.blog.mappers.BlogMapper.selectCountOfPosts");


### PR DESCRIPTION
**Description**:
A new `selectMap()` method has been added to `SqlSession.java`. This enhancement allows the conversion of a list of results into a Map, where the key is one specified property, and the value is another specified property from the resulting objects.

**Background Story**:
While working on a recent project in our company, I encountered a scenario where I needed to retrieve database results as a Map, with the key and value being specific column values. However, the current implementation of MyBatis does not support such a method. To address this, I’ve added the new `selectMap()` method, which I believe would be a valuable addition to the framework.