### PR TITLE
Added selectMapWithList to handle non-unique column as a key

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/result/DefaultMapResultHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/result/DefaultMapResultHandler.java
@@ -15,6 +15,7 @@
  */
 package org.apache.ibatis.executor.result;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.ibatis.reflection.MetaObject;
@@ -30,6 +31,7 @@ import org.apache.ibatis.session.ResultHandler;
 public class DefaultMapResultHandler<K, V> implements ResultHandler<V> {
 
   private final Map<K, V> mappedResults;
+  private final Map<K, List<V>> mappedResultsWithList;
   private final String mapKey;
   private final ObjectFactory objectFactory;
   private final ObjectWrapperFactory objectWrapperFactory;
@@ -42,6 +44,7 @@ public class DefaultMapResultHandler<K, V> implements ResultHandler<V> {
     this.objectWrapperFactory = objectWrapperFactory;
     this.reflectorFactory = reflectorFactory;
     this.mappedResults = objectFactory.create(Map.class);
+    this.mappedResultsWithList = objectFactory.create(Map.class);
     this.mapKey = mapKey;
   }
 
@@ -52,9 +55,14 @@ public class DefaultMapResultHandler<K, V> implements ResultHandler<V> {
     // TODO is that assignment always true?
     final K key = (K) mo.getValue(mapKey);
     mappedResults.put(key, value);
+    mappedResultsWithList.computeIfAbsent(key, k -> objectFactory.create(List.class)).add(value);
   }
 
   public Map<K, V> getMappedResults() {
     return mappedResults;
+  }
+
+  public Map<K, List<V>> getMappedResultsWithList() {
+    return mappedResultsWithList;
   }
 }

--- a/src/main/java/org/apache/ibatis/session/SqlSession.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSession.java
@@ -157,6 +157,63 @@ public interface SqlSession extends Closeable {
   <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, RowBounds rowBounds);
 
   /**
+   * The selectMapWithList is a special case in that it is designed to convert a list of results into a Map based on one of the
+   * properties not needed to be unique in the resulting objects. Eg. Return a of Map[Integer,List<Author>] for selectMap("selectAuthors","id")
+   *
+   * @param <K>
+   *          the returned Map keys type
+   * @param <V>
+   *          the returned Map values type
+   * @param statement
+   *          Unique identifier matching the statement to use.
+   * @param mapKey
+   *          The property to use as key for each value in the list.
+   *
+   * @return Map containing key pair data.
+   */
+  <K, V> Map<K, List<V>> selectMapWithList(String statement, String mapKey);
+
+  /**
+   * The selectMap is a special case in that it is designed to convert a list of results into a Map based on one of the
+   * properties not needed to be unique in the resulting objects.
+   *
+   * @param <K>
+   *          the returned Map keys type
+   * @param <V>
+   *          the returned Map values type
+   * @param statement
+   *          Unique identifier matching the statement to use.
+   * @param parameter
+   *          A parameter object to pass to the statement.
+   * @param mapKey
+   *          The property to use as key for each value in the list.
+   *
+   * @return Map containing key pair data.
+   */
+  <K, V> Map<K, List<V>> selectMapWithList(String statement, Object parameter, String mapKey);
+
+  /**
+   * The selectMap is a special case in that it is designed to convert a list of results into a Map based on one of the
+   * properties not needed to be unique in the resulting objects.
+   *
+   * @param <K>
+   *          the returned Map keys type
+   * @param <V>
+   *          the returned Map values type
+   * @param statement
+   *          Unique identifier matching the statement to use.
+   * @param parameter
+   *          A parameter object to pass to the statement.
+   * @param mapKey
+   *          The property to use as key for each value in the list.
+   * @param rowBounds
+   *          Bounds to limit object retrieval
+   *
+   * @return Map containing key pair data.
+   */
+  <K, V> Map<K, List<V>> selectMapWithList(String statement, Object parameter, String mapKey, RowBounds rowBounds);
+
+  /**
    * A Cursor offers the same results as a List, except it fetches data lazily using an Iterator.
    *
    * @param <T>

--- a/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
+++ b/src/main/java/org/apache/ibatis/session/SqlSessionManager.java
@@ -180,6 +180,21 @@ public class SqlSessionManager implements SqlSessionFactory, SqlSession {
   }
 
   @Override
+  public <K, V> Map<K, List<V>> selectMapWithList(String statement, String mapKey) {
+    return sqlSessionProxy.selectMapWithList(statement, mapKey);
+  }
+
+  @Override
+  public <K, V> Map<K, List<V>> selectMapWithList(String statement, Object parameter, String mapKey) {
+    return sqlSessionProxy.selectMapWithList(statement, parameter, mapKey);
+  }
+
+  @Override
+  public <K, V> Map<K, List<V>> selectMapWithList(String statement, Object parameter, String mapKey, RowBounds rowBounds) {
+    return sqlSessionProxy.selectMapWithList(statement, parameter, mapKey, rowBounds);
+  }
+
+  @Override
   public <T> Cursor<T> selectCursor(String statement) {
     return sqlSessionProxy.selectCursor(statement);
   }

--- a/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSession.java
+++ b/src/main/java/org/apache/ibatis/session/defaults/DefaultSqlSession.java
@@ -96,15 +96,34 @@ public class DefaultSqlSession implements SqlSession {
 
   @Override
   public <K, V> Map<K, V> selectMap(String statement, Object parameter, String mapKey, RowBounds rowBounds) {
+    return (Map<K, V>) executeSelectMap(statement, parameter, mapKey, rowBounds, false);
+  }
+
+  @Override
+  public <K, V> Map<K, List<V>> selectMapWithList(String statement, String mapKey) {
+    return this.selectMapWithList(statement, null, mapKey, RowBounds.DEFAULT);
+  }
+
+  @Override
+  public <K, V> Map<K, List<V>> selectMapWithList(String statement, Object parameter, String mapKey) {
+    return this.selectMapWithList(statement, parameter, mapKey, RowBounds.DEFAULT);
+  }
+
+  @Override
+  public <K, V> Map<K, List<V>> selectMapWithList(String statement, Object parameter, String mapKey, RowBounds rowBounds) {
+    return (Map<K, List<V>>) executeSelectMap(statement, parameter, mapKey, rowBounds, true);
+  }
+
+  private <K, V> Map<K, ?> executeSelectMap(String statement, Object parameter, String mapKey, RowBounds rowBounds, boolean useList) {
     final List<? extends V> list = selectList(statement, parameter, rowBounds);
     final DefaultMapResultHandler<K, V> mapResultHandler = new DefaultMapResultHandler<>(mapKey,
-        configuration.getObjectFactory(), configuration.getObjectWrapperFactory(), configuration.getReflectorFactory());
+      configuration.getObjectFactory(), configuration.getObjectWrapperFactory(), configuration.getReflectorFactory());
     final DefaultResultContext<V> context = new DefaultResultContext<>();
     for (V o : list) {
       context.nextResultObject(o);
       mapResultHandler.handleResult(context);
     }
-    return mapResultHandler.getMappedResults();
+    return useList ? mapResultHandler.getMappedResultsWithList() : mapResultHandler.getMappedResults();
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
+++ b/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
@@ -181,6 +181,26 @@ class SqlSessionTest extends BaseDataTest {
   }
 
   @Test
+  void shouldSelectAllAuthorsAsMapWithList() {
+    try (SqlSession session = sqlMapper.openSession(TransactionIsolationLevel.SERIALIZABLE)) {
+      Author author = new Author(103, "jim", "******", "jim@somewhere.com", "Something...", null);
+      session.insert("org.apache.ibatis.domain.blog.mappers.AuthorMapper.insertAuthor", author);
+
+      final Map<String, List<Author>> authors = session
+        .selectMapWithList("org.apache.ibatis.domain.blog.mappers.AuthorMapper.selectAllAuthors", "username");
+      authors.forEach((k, v) -> {
+        if (k.equals("jim")) {
+          assertEquals(2, v.size());
+          v.forEach(a -> assertEquals("jim", a.getUsername()));
+        } else if (k.equals("sally")) {
+          assertEquals(1, v.size());
+          v.forEach(a -> assertEquals("sally", a.getUsername()));
+        }
+      });
+    }
+  }
+
+  @Test
   void shouldSelectCountOfPosts() {
     try (SqlSession session = sqlMapper.openSession()) {
       Integer count = session.selectOne("org.apache.ibatis.domain.blog.mappers.BlogMapper.selectCountOfPosts");


### PR DESCRIPTION
Currently, when using `selectMap()` in MyBatis, the key column is expected to be unique. However, there are many use cases where the key column is not unique, and instead of overwriting existing values, we might want to collect the values into a `List`. This would provide more flexibility for handling cases where the column being used as the key is not guaranteed to be unique.

The method selectMapWithList() will allow us to use a non-unique column as a key like this,

```sql
Map<String, List<Author>> result = sqlSession.selectMap("selectAllAuthors", "firstName");
```