### PR TITLE
remove repeat param from log message

### DIFF
--- a/src/main/java/org/apache/ibatis/io/VFS.java
+++ b/src/main/java/org/apache/ibatis/io/VFS.java
@@ -145,7 +145,7 @@ public abstract class VFS {
       log.error("Security exception looking for method " + clazz.getName() + "." + methodName + ".  Cause: " + e);
       return null;
     } catch (NoSuchMethodException e) {
-      log.error("Method not found " + clazz.getName() + "." + methodName + "." + methodName + ".  Cause: " + e);
+      log.error("Method not found " + clazz.getName() + "." + methodName + ".  Cause: " + e);
       return null;
     }
   }


### PR DESCRIPTION
Hi, I have found the method `org.apache.ibatis.io.VFS#getMethod`  which log message contains repeat param. 

```java
protected static Method getMethod(Class<?> clazz, String methodName, Class<?>... parameterTypes) {
  ...
  try {
    ...
  } catch (SecurityException e) {
    ...
  } catch (NoSuchMethodException e) {
    // repeat methodName in log message
    log.error("Method not found " + clazz.getName() + "." + methodName + "." + methodName + ".  Cause: " + e);
    return null;
  }
}
```

If you run the unit class `org.apache.ibatis.io.VFSTest#getNotExistMethod`,  the console will show the log message.

```java
Method not found org.apache.ibatis.io.VFS.listXxx.listXxx.
```