### PR TITLE
remove unnecessary convert from Object to ResultMap

### DIFF
--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -1078,15 +1078,11 @@ public class Configuration {
   protected void checkGloballyForDiscriminatedNestedResultMaps(ResultMap rm) {
     if (rm.hasNestedResultMaps()) {
       final String resultMapId = rm.getId();
-      for (Object resultMapObject : resultMaps.values()) {
-        if (resultMapObject instanceof ResultMap) {
-          ResultMap entryResultMap = (ResultMap) resultMapObject;
-          if (!entryResultMap.hasNestedResultMaps() && entryResultMap.getDiscriminator() != null) {
-            Collection<String> discriminatedResultMapNames = entryResultMap.getDiscriminator().getDiscriminatorMap()
-                .values();
-            if (discriminatedResultMapNames.contains(resultMapId)) {
-              entryResultMap.forceNestedResultMaps();
-            }
+      for (ResultMap entryResultMap : resultMaps.values()) {
+        if (!entryResultMap.hasNestedResultMaps() && entryResultMap.getDiscriminator() != null) {
+          Collection<String> discriminatedResultMapNames = entryResultMap.getDiscriminator().getDiscriminatorMap().values();
+          if (discriminatedResultMapNames.contains(resultMapId)) {
+            entryResultMap.forceNestedResultMaps();
           }
         }
       }


### PR DESCRIPTION
I have found the method `checkGloballyForDiscriminatedNestedResultMaps` in class `Configuration` contains unnecessary convert code.

```java
protected final Map<String, ResultMap> resultMaps = new StrictMap<>("Result Maps collection");

...

protected void checkGloballyForDiscriminatedNestedResultMaps(ResultMap rm) {
  if (rm.hasNestedResultMaps()) {
    ...
    for (Object resultMapObject : resultMaps.values()) {
     // here is unnecessary code
      if (resultMapObject instanceof ResultMap) {
        ResultMap entryResultMap = (ResultMap) resultMapObject;
        ...
      }
    }
  }
}
```
Because variable `resultMaps` is `Map<String, ResultMap>`, so it's value type is `ResultMap`, no need convert from `Object`.