### PR TITLE
Fix code scanning alert no. 7: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/main/java/org/apache/ibatis/io/DefaultVFS.java
+++ b/src/main/java/org/apache/ibatis/io/DefaultVFS.java
@@ -79,9 +79,14 @@ public class DefaultVFS extends VFS {
               if (log.isDebugEnabled()) {
                 log.debug("Listing " + url);
               }
+              File destinationDir = new File(path);
               for (JarEntry entry; (entry = jarInput.getNextJarEntry()) != null;) {
                 if (log.isDebugEnabled()) {
                   log.debug("Jar entry: " + entry.getName());
+                }
+                File entryFile = new File(destinationDir, entry.getName()).getCanonicalFile();
+                if (!entryFile.getPath().startsWith(destinationDir.getCanonicalPath())) {
+                  throw new IOException("Bad zip entry: " + entry.getName());
                 }
                 children.add(entry.getName());
               }


### PR DESCRIPTION
Fixes [https://github.com/mybatis/mybatis-3/security/code-scanning/7](https://github.com/mybatis/mybatis-3/security/code-scanning/7)

To fix the problem, we need to ensure that the paths extracted from the JAR entries are validated to prevent directory traversal attacks. This can be done by normalizing the paths and ensuring they remain within the intended directory.

1. **Normalize the path**: Convert the path to its canonical form to resolve any `..` sequences.
2. **Check the path**: Ensure that the normalized path starts with the intended base directory path.

We will implement these changes in the `listResources` method where the JAR entries are processed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
