### PR TITLE
Fix code scanning alert no. 6: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/apache/ibatis/parsing/XPathParser.java
+++ b/src/main/java/org/apache/ibatis/parsing/XPathParser.java
@@ -231,9 +231,6 @@ public class XPathParser {
     try {
       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
       factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
       factory.setValidating(validation);
 
       factory.setNamespaceAware(false);

--- a/src/main/java/org/apache/ibatis/parsing/XPathParser.java
+++ b/src/main/java/org/apache/ibatis/parsing/XPathParser.java
@@ -231,13 +231,16 @@ public class XPathParser {
     try {
       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
       factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
       factory.setValidating(validation);
 
       factory.setNamespaceAware(false);
       factory.setIgnoringComments(true);
       factory.setIgnoringElementContentWhitespace(false);
       factory.setCoalescing(false);
-      factory.setExpandEntityReferences(true);
+      factory.setExpandEntityReferences(false);
 
       DocumentBuilder builder = factory.newDocumentBuilder();
       builder.setEntityResolver(entityResolver);


### PR DESCRIPTION
Fixes [https://github.com/mybatis/mybatis-3/security/code-scanning/6](https://github.com/mybatis/mybatis-3/security/code-scanning/6)

To fix the problem, we need to disable the parsing of DTDs and external entities in the `DocumentBuilderFactory`. This can be done by setting specific features on the `DocumentBuilderFactory` instance. The changes should be made in the `createDocument` method of the `XPathParser` class.

1. Disable DTDs by setting the feature `http://apache.org/xml/features/disallow-doctype-decl` to `true`.
2. Disable external general entities by setting the feature `http://xml.org/sax/features/external-general-entities` to `false`.
3. Disable external parameter entities by setting the feature `http://xml.org/sax/features/external-parameter-entities` to `false`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
