### PR TITLE
Add ObjectWrapper test

### DIFF
--- a/src/test/java/org/apache/ibatis/reflection/wrapper/BeanWrapperUnitTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/wrapper/BeanWrapperUnitTest.java
@@ -1,0 +1,213 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.wrapper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ibatis.domain.blog.Author;
+import org.apache.ibatis.domain.misc.RichType;
+import org.apache.ibatis.reflection.SystemMetaObject;
+import org.apache.ibatis.reflection.property.PropertyTokenizer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @author <a href="1181963012mw@gmail.com">mawen12</a>
+ * @see BeanWrapper
+ */
+class BeanWrapperUnitTest extends ObjectWrapperBaseTest {
+
+  private RichType richType;
+
+  private ObjectWrapper wrapper;
+
+  @BeforeEach
+  void setup() {
+    this.richType = new RichType();
+    this.wrapper = new BeanWrapper(SystemMetaObject.forObject(richType), richType);
+  }
+
+  @Test
+  @Override
+  void shouldGet() {
+    richType.setRichProperty("mybatis");
+
+    Object value = wrapper.get(new PropertyTokenizer("richProperty"));
+
+    assertEquals("mybatis", value);
+  }
+
+  @Test
+  void shouldGetWhichContainsDelim() {
+    RichType nested = new RichType();
+    nested.setRichProperty("mybatis");
+    richType.setRichType(nested);
+
+    Object value = wrapper.get(new PropertyTokenizer("richType.richProperty"));
+
+    assertEquals("mybatis", value);
+  }
+
+  @Test
+  void shouldGetWhichContainsIndex() {
+    richType.setRichList(Arrays.asList(1L, "abc"));
+    richType.setRichMap(new HashMap<String, Object>(){{
+      put("key1", "value1");
+      put("key2", "value2");
+    }});
+
+    assertEquals("abc", wrapper.get(new PropertyTokenizer("richList[1]")));
+    assertEquals("value2", wrapper.get(new PropertyTokenizer("richMap[key2]")));
+
+  }
+
+  @Test
+  @Override
+  void shouldSet() {
+    wrapper.set(new PropertyTokenizer("richProperty"), "mybatis");
+
+    assertEquals("mybatis", richType.getRichProperty());
+  }
+
+  @Test
+  void shouldSetWhichContainsDelim() {
+    wrapper.set(new PropertyTokenizer("richType.richProperty"), "mybatis");
+
+    assertEquals("mybatis", richType.getRichType().getRichProperty());
+  }
+
+  @Test
+  void shouldSetWhichContainsIndex() {
+    List<Object> list = Arrays.asList(1L, 2L);
+    richType.setRichList(list);
+
+    wrapper.set(new PropertyTokenizer("richList[0]"), "mybatis");
+
+    assertEquals("mybatis", list.get(0));
+  }
+
+  @Test
+  @Override
+  void shouldFindProperty() {
+    String property = wrapper.findProperty("richProperty", false);
+
+    assertEquals("richProperty", property);
+  }
+
+  @Test
+  void shouldFindPropertyContainsDelim() {
+    String property = wrapper.findProperty("richType.richProperty", false);
+
+    assertEquals("richType.richProperty", property);
+  }
+
+  @Test
+  void shouldFindPropertyContainsIndex() {
+    String property = wrapper.findProperty("richList[0]", false);
+
+    assertNull(property);
+  }
+
+  @Test
+  @Override
+  void shouldGetGetterNames() {
+    String[] getterNames = wrapper.getGetterNames();
+
+    assertThat(getterNames).containsExactlyInAnyOrder("richType", "richProperty", "richList", "richMap", "richField");
+  }
+
+  @Test
+  @Override
+  void shouldGetSetterNames() {
+    String[] setterNames = wrapper.getSetterNames();
+
+    assertThat(setterNames).containsExactlyInAnyOrder("richType", "richProperty", "richList", "richMap", "richField");
+  }
+
+  @Test
+  @Override
+  void shouldGetGetterType() {
+    assertEquals(RichType.class, wrapper.getGetterType("richType"));
+    assertEquals(String.class, wrapper.getGetterType("richField"));
+    assertEquals(String.class, wrapper.getGetterType("richProperty"));
+    assertEquals(Map.class, wrapper.getGetterType("richMap"));
+    assertEquals(List.class, wrapper.getGetterType("richList"));
+  }
+
+  @Test
+  @Override
+  void shouldGetSetterType() {
+    assertEquals(RichType.class, wrapper.getSetterType("richType"));
+    assertEquals(String.class, wrapper.getSetterType("richField"));
+    assertEquals(String.class, wrapper.getSetterType("richProperty"));
+    assertEquals(Map.class, wrapper.getSetterType("richMap"));
+    assertEquals(List.class, wrapper.getSetterType("richList"));
+  }
+
+  @Test
+  @Override
+  void shouldHasGetter() {
+    assertTrue(wrapper.hasGetter("richType"));
+    assertTrue(wrapper.hasGetter("richField"));
+    assertTrue(wrapper.hasGetter("richProperty"));
+    assertTrue(wrapper.hasGetter("richMap"));
+    assertTrue(wrapper.hasGetter("richList"));
+  }
+
+  @Test
+  @Override
+  void shouldHasSetter() {
+    assertTrue(wrapper.hasGetter("richType"));
+    assertTrue(wrapper.hasGetter("richField"));
+    assertTrue(wrapper.hasGetter("richProperty"));
+    assertTrue(wrapper.hasGetter("richMap"));
+    assertTrue(wrapper.hasGetter("richList"));
+  }
+
+  @Test
+  @Override
+  void shouldIsCollection() {
+    assertFalse(wrapper.isCollection());
+  }
+
+  @Test
+  @Override
+  void shouldInstantiatePropertyValue() {
+    // Nothing
+  }
+
+  @Test
+  @Override
+  void shouldAddElement() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.add("1"));
+  }
+
+  @Test
+  @Override
+  void shouldAddAll() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.addAll(new ArrayList<>()));
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/reflection/wrapper/CollectionWrapperUnitTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/wrapper/CollectionWrapperUnitTest.java
@@ -1,0 +1,152 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.wrapper;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.reflection.SystemMetaObject;
+import org.apache.ibatis.reflection.property.PropertyTokenizer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author <a href="1181963012mw@gmail.com">mawen12</a>
+ * @see CollectionWrapper
+ */
+@ExtendWith(MockitoExtension.class)
+class CollectionWrapperUnitTest extends ObjectWrapperBaseTest {
+
+  @Mock
+  private Collection<Object> collection;
+
+  @Mock
+  private PropertyTokenizer tokenizer;
+
+  private ObjectWrapper wrapper;
+
+  @BeforeEach
+  void setup() {
+    MetaObject metaObject = SystemMetaObject.forObject(collection);
+    this.wrapper = new CollectionWrapper(metaObject, collection);
+  }
+
+  @Test
+  @Override
+  void shouldGet() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.get(tokenizer));
+  }
+
+  @Test
+  @Override
+  void shouldSet() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.set(tokenizer, null));
+  }
+
+  @Test
+  @Override
+  void shouldFindProperty() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.findProperty("abc", true));
+  }
+
+  @Test
+  @Override
+  void shouldGetGetterNames() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.getGetterNames());
+  }
+
+  @Test
+  @Override
+  void shouldGetSetterNames() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.getSetterNames());
+  }
+
+  @Test
+  @Override
+  void shouldGetGetterType() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.getGetterType("abc"));
+  }
+
+  @Test
+  @Override
+  void shouldGetSetterType() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.getSetterType("abc"));
+  }
+
+  @Test
+  @Override
+  void shouldHasGetter() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.hasGetter("abc"));
+  }
+
+  @Test
+  @Override
+  void shouldHasSetter() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.hasSetter("abc"));
+  }
+
+  @Test
+  @Override
+  void shouldIsCollection() {
+    assertTrue(wrapper.isCollection());
+  }
+
+  @Test
+  @Override
+  void shouldInstantiatePropertyValue() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.instantiatePropertyValue("abc", tokenizer, null));
+  }
+
+  @Test
+  @Override
+  void shouldAddElement() {
+    wrapper.add("bdc");
+
+    verify(collection).add("bdc");
+  }
+
+  @Test
+  @Override
+  void shouldAddAll() {
+    List<Object> list = new ArrayList<>() {{
+      add("1");
+      add("2");
+      add("3");
+    }};
+    wrapper.addAll(list);
+
+    verify(collection).addAll(list);
+  }
+}

--- a/src/test/java/org/apache/ibatis/reflection/wrapper/MapWrapperUnitTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/wrapper/MapWrapperUnitTest.java
@@ -1,0 +1,240 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.wrapper;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.ibatis.domain.blog.Author;
+import org.apache.ibatis.reflection.MetaObject;
+import org.apache.ibatis.reflection.SystemMetaObject;
+import org.apache.ibatis.reflection.property.PropertyTokenizer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * @author <a href="1181963012mw@gmail.com">mawen12</a>
+ * @see MapWrapper
+ */
+class MapWrapperUnitTest extends ObjectWrapperBaseTest {
+
+  @Mock
+  private Map<String, Object> map;
+
+  @Mock
+  private List<Integer> list;
+
+  private MetaObject metaObject;
+
+  private ObjectWrapper wrapper;
+
+  @BeforeEach
+  void setup() {
+    this.metaObject = SystemMetaObject.forObject(map);
+    this.wrapper = new MapWrapper(metaObject, map);
+  }
+
+  @Test
+  @Override
+  void shouldGet() {
+    when(map.get("key")).thenReturn("value");
+
+    Object value = wrapper.get(new PropertyTokenizer("key"));
+
+    assertEquals("value", value);
+    verify(map).get("key");
+  }
+
+  @Test
+  void shouldNotGetWhichContainsDelim() {
+    Author author = new Author(1);
+    when(map.get("author")).thenReturn(author);
+
+    Object value = wrapper.get(new PropertyTokenizer("author.id"));
+
+    assertEquals(1, value);
+  }
+
+  @Test
+  void shouldGetWhichContainsIndex() {
+    when(list.get(0)).thenReturn(1);
+    when(map.get("key")).thenReturn(list);
+
+    Object value = wrapper.get(new PropertyTokenizer("key[0]"));
+
+    assertEquals(1, value);
+  }
+
+  @Test
+  @Override
+  void shouldSet() {
+    wrapper.set(new PropertyTokenizer("key"), "value");
+
+    verify(map).put("key", "value");
+  }
+
+  @Test
+  void shouldSetWhichContainsDelim() {
+    wrapper.set(new PropertyTokenizer("author.id"), 1);
+
+    verify(map).put("author", new HashMap<>() {{
+      put("id", 1);
+    }});
+  }
+
+  @Test
+  void shouldSetWhichContainsIndex() {
+    when(map.get("key")).thenReturn(list);
+
+    wrapper.set(new PropertyTokenizer("key[0]"), 1);
+
+    verify(list).set(0, 1);
+  }
+
+  @Test
+  @Override
+  void shouldFindProperty() {
+    assertEquals("abc", wrapper.findProperty("abc", true));
+    assertEquals("abc", wrapper.findProperty("abc", false));
+  }
+
+  @Test
+  @Override
+  void shouldGetGetterNames() {
+    Set<String> sets = new HashSet<>() {{
+      add("key1");
+      add("key2");
+    }};
+    when(map.keySet()).thenReturn(sets);
+
+    String[] getterNames = wrapper.getGetterNames();
+
+    assertEquals(2, getterNames.length);
+    assertThat(getterNames).containsExactlyInAnyOrder("key1", "key2");
+  }
+
+  @Test
+  @Override
+  void shouldGetSetterNames() {
+    Set<String> sets = new HashSet<>() {{
+      add("key1");
+      add("key2");
+    }};
+    when(map.keySet()).thenReturn(sets);
+
+    String[] setterNames = wrapper.getSetterNames();
+
+    assertEquals(2, setterNames.length);
+    assertThat(setterNames).containsExactlyInAnyOrder("key1", "key2");
+  }
+
+  @Test
+  @Override
+  void shouldGetGetterType() {
+    when(map.get("key")).thenReturn("abc");
+
+    Class<?> type = wrapper.getGetterType("key");
+
+    assertEquals(String.class, type);
+  }
+
+  @Test
+  void shouldGetGetterTypeWhichContainsIndex() {
+    when(map.get("key")).thenReturn(list);
+
+    Class<?> collectionType = wrapper.getGetterType("key");
+    Class<?> type = wrapper.getGetterType("key[0]");
+
+    assertEquals(list.getClass(), collectionType);
+    assertEquals(Object.class, type);
+  }
+
+  @Test
+  @Override
+  void shouldGetSetterType() {
+    when(map.get("key")).thenReturn("abc");
+
+    Class<?> type = wrapper.getSetterType("key");
+
+    assertEquals(String.class, type);
+  }
+
+  @Test
+  void shouldGetSetterTypeWhichContainsIndex() {
+    when(map.get("key")).thenReturn(list);
+
+    Class<?> collectionType = wrapper.getSetterType("key");
+    Class<?> type = wrapper.getSetterType("key[0]");
+
+    assertEquals(list.getClass(), collectionType);
+    assertEquals(Object.class, type);
+  }
+
+  @Test
+  @Override
+  void shouldHasGetter() {
+    when(map.containsKey("key")).thenReturn(false);
+
+    assertFalse(wrapper.hasGetter("key"));
+
+    when(map.containsKey("key")).thenReturn(true);
+
+    assertTrue(wrapper.hasGetter("key"));
+  }
+
+  @Test
+  @Override
+  void shouldHasSetter() {
+    assertTrue(wrapper.hasSetter("abc"));
+  }
+
+  @Test
+  @Override
+  void shouldIsCollection() {
+    assertFalse(wrapper.isCollection());
+  }
+
+  @Test
+  @Override
+  void shouldInstantiatePropertyValue() {
+    MetaObject result = wrapper.instantiatePropertyValue("abc", new PropertyTokenizer("key"), SystemMetaObject.DEFAULT_OBJECT_FACTORY);
+
+    assertFalse(result.hasGetter("key"));
+  }
+
+  @Test
+  @Override
+  void shouldAddElement() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.add("1"));
+  }
+
+  @Test
+  @Override
+  void shouldAddAll() {
+    assertThatExceptionOfType(UnsupportedOperationException.class)
+      .isThrownBy(() -> wrapper.addAll(new ArrayList<>()));
+  }
+}

--- a/src/test/java/org/apache/ibatis/reflection/wrapper/ObjectWrapperBaseTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/wrapper/ObjectWrapperBaseTest.java
@@ -1,0 +1,53 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection.wrapper;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * @author <a href="1181963012mw@gmail.com">mawen12</a>
+ * @see ObjectWrapper
+ */
+@ExtendWith(MockitoExtension.class)
+abstract class ObjectWrapperBaseTest {
+
+  abstract void shouldGet();
+
+  abstract void shouldSet();
+
+  abstract void shouldFindProperty();
+
+  abstract void shouldGetGetterNames();
+
+  abstract void shouldGetSetterNames();
+
+  abstract void shouldGetGetterType();
+
+  abstract void shouldGetSetterType();
+
+  abstract void shouldHasGetter();
+
+  abstract void shouldHasSetter();
+
+  abstract void shouldIsCollection();
+
+  abstract void shouldInstantiatePropertyValue();
+
+  abstract void shouldAddElement();
+
+  abstract void shouldAddAll();
+}


### PR DESCRIPTION
Supplement the missing unit test cases for `ObjectWrapper`.

The already exists test class `BeanWrapperTest` is to test `MetaObject`, but not `BeanWrapper`.