### PR TITLE
Try to fix issue#2892 by making sure that when using the JdbcTransact…

### DIFF
--- a/src/main/java/org/apache/ibatis/transaction/jdbc/JdbcTransactionFactory.java
+++ b/src/main/java/org/apache/ibatis/transaction/jdbc/JdbcTransactionFactory.java
@@ -48,7 +48,7 @@ public class JdbcTransactionFactory implements TransactionFactory {
 
   @Override
   public Transaction newTransaction(Connection conn) {
-    return new JdbcTransaction(conn);
+    return new JdbcTransaction(conn, skipSetAutoCommitOnClose);
   }
 
   @Override


### PR DESCRIPTION
Skip autoCommit reset logic: By adding the skipSetAutoCommitOnClose flag, you can control whether autoCommit is reset when closing the connection. If set to true, it means that you do not want to modify autoCommit on close to avoid accidental transaction commits. This is to give developers more flexible transaction management options, especially when they manually manage connections and transactions themselves.