### PR TITLE
UUID type handler

### DIFF
--- a/src/main/java/org/apache/ibatis/type/UUIDTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/UUIDTypeHandler.java
@@ -1,0 +1,52 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+/**
+ * UUIDTypeHandler is a type handler for \`java.util.UUID\`.
+ */
+public class UUIDTypeHandler extends BaseTypeHandler<UUID> {
+
+    @Override
+    public void setNonNullParameter(PreparedStatement ps, int i, UUID parameter, JdbcType jdbcType)
+            throws SQLException {
+        ps.setString(i, parameter.toString());
+    }
+
+    @Override
+    public UUID getNullableResult(ResultSet rs, String columnName) throws SQLException {
+        String uuidString = rs.getString(columnName);
+        return uuidString == null ? null : UUID.fromString(uuidString);
+    }
+
+    @Override
+    public UUID getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
+        String uuidString = rs.getString(columnIndex);
+        return uuidString == null ? null : UUID.fromString(uuidString);
+    }
+
+    @Override
+    public UUID getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
+        String uuidString = cs.getString(columnIndex);
+        return uuidString == null ? null : UUID.fromString(uuidString);
+    }
+}

--- a/src/main/java/org/apache/ibatis/type/UUIDTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/UUIDTypeHandler.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2024  the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import java.util.UUID;
 
 /**
  * UUIDTypeHandler is a type handler for \`java.util.UUID\`.
+ *
+ * @author Girdhar Singh Rathore
  */
 public class UUIDTypeHandler extends BaseTypeHandler<UUID> {
 

--- a/src/test/java/org/apache/ibatis/type/UUIDTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/UUIDTypeHandlerTest.java
@@ -1,0 +1,87 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.type;
+
+import java.util.UUID;
+import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class UUIDTypeHandlerTest extends BaseTypeHandlerTest {
+
+  private static final TypeHandler<UUID> TYPE_HANDLER = new UUIDTypeHandler();
+
+  @Override
+  @Test
+  public void shouldSetParameter() throws Exception {
+    UUID uuid = UUID.randomUUID();
+    TYPE_HANDLER.setParameter(ps, 1, uuid, null);
+    verify(ps).setString(1, uuid.toString());
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByName() throws Exception {
+    UUID uuid = UUID.randomUUID();
+    when(rs.getString("column")).thenReturn(uuid.toString());
+    assertEquals(uuid, TYPE_HANDLER.getResult(rs, "column"));
+    verify(rs, never()).wasNull();
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByName() throws Exception {
+    when(rs.getString("column")).thenReturn(null);
+    assertEquals(null, TYPE_HANDLER.getResult(rs, "column"));
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromResultSetByPosition() throws Exception {
+    UUID uuid = UUID.randomUUID();
+    when(rs.getString(1)).thenReturn(uuid.toString());
+    assertEquals(uuid, TYPE_HANDLER.getResult(rs, 1));
+    verify(rs, never()).wasNull();
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromResultSetByPosition() throws Exception {
+    UUID uuid = UUID.randomUUID();
+    when(cs.getString(1)).thenReturn(uuid.toString());
+    assertEquals(uuid, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultFromCallableStatement() throws Exception {
+    UUID uuid = UUID.randomUUID();
+    when(cs.getString(1)).thenReturn(uuid.toString());
+    assertEquals(uuid, TYPE_HANDLER.getResult(cs, 1));
+    verify(cs, never()).wasNull();
+
+  }
+
+  @Override
+  @Test
+  public void shouldGetResultNullFromCallableStatement() throws Exception {
+    when(cs.getString(1)).thenReturn(null);
+    assertEquals(null, TYPE_HANDLER.getResult(cs, 1));
+  }
+}

--- a/src/test/java/org/apache/ibatis/type/UUIDTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/UUIDTypeHandlerTest.java
@@ -22,6 +22,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * @author Girdhar Singh Rathore
+ */
 public class UUIDTypeHandlerTest extends BaseTypeHandlerTest {
 
   private static final TypeHandler<UUID> TYPE_HANDLER = new UUIDTypeHandler();


### PR DESCRIPTION
In many database systems, UUIDs are commonly used as unique identifiers. However, developers often need to write their own custom type handlers to manage UUIDs effectively. To streamline this process and reduce the need for repetitive code, we have included a UUIDTypeHandler in our library. This type handler simplifies the handling of UUIDs in SQL operations, ensuring seamless integration and improved efficiency.