### PR TITLE
Improve SoftCache, WeakCache, and FifoCache

### DIFF
--- a/src/main/java/org/apache/ibatis/cache/decorators/FifoCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/FifoCache.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ public class FifoCache implements Cache {
 
   public void setSize(int size) {
     this.size = size;
+    resizeKeyList();
   }
 
   @Override
@@ -77,6 +78,13 @@ public class FifoCache implements Cache {
   private void cycleKeyList(Object key) {
     keyList.addLast(key);
     if (keyList.size() > size) {
+      Object oldestKey = keyList.removeFirst();
+      delegate.removeObject(oldestKey);
+    }
+  }
+
+  private void resizeKeyList() {
+    while (keyList.size() > size) {
       Object oldestKey = keyList.removeFirst();
       delegate.removeObject(oldestKey);
     }

--- a/src/main/java/org/apache/ibatis/cache/decorators/WeakCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/WeakCache.java
@@ -57,6 +57,7 @@ public class WeakCache implements Cache {
 
   public void setSize(int size) {
     this.numberOfHardLinks = size;
+    resizeHardLinks();
   }
 
   @Override
@@ -77,6 +78,7 @@ public class WeakCache implements Cache {
       } else {
         lock.lock();
         try {
+          hardLinksToAvoidGarbageCollection.remove(result);
           hardLinksToAvoidGarbageCollection.addFirst(result);
           if (hardLinksToAvoidGarbageCollection.size() > numberOfHardLinks) {
             hardLinksToAvoidGarbageCollection.removeLast();
@@ -113,6 +115,17 @@ public class WeakCache implements Cache {
     WeakEntry sv;
     while ((sv = (WeakEntry) queueOfGarbageCollectedEntries.poll()) != null) {
       delegate.removeObject(sv.key);
+    }
+  }
+
+  private void resizeHardLinks() {
+    lock.lock();
+    try {
+      while (hardLinksToAvoidGarbageCollection.size() > numberOfHardLinks) {
+        hardLinksToAvoidGarbageCollection.removeLast();
+      }
+    } finally {
+      lock.unlock();
     }
   }
 

--- a/src/test/java/org/apache/ibatis/cache/FifoCacheTest.java
+++ b/src/test/java/org/apache/ibatis/cache/FifoCacheTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -70,6 +70,21 @@ class FifoCacheTest {
     cache.removeObject(1);
     cache.putObject(1, 1);
     assertNotNull(cache.getObject(0));
+  }
+
+  @Test
+  void shouldResizeKeyList() {
+    FifoCache cache = new FifoCache(new PerpetualCache("default"));
+    cache.setSize(5);
+    for (int i = 0; i < 5; i++) {
+      cache.putObject(i, i);
+    }
+    cache.setSize(3);
+    assertNull(cache.getObject(0));
+    assertNull(cache.getObject(1));
+    assertNotNull(cache.getObject(2));
+    assertNotNull(cache.getObject(3));
+    assertNotNull(cache.getObject(4));
   }
 
 }


### PR DESCRIPTION
1. Resize the Queue when executing the setSize method of SoftCache, WeakCache, and FifoCache.
2. To avoid multiple identical objects being generated in the `hardLinksToAvoidGarbageCollection `when the same key is used for consecutive getObjects, it is necessary to first execute reomve.