### PR TITLE
关于DB_VENDOR使用默认的productName的建议

### DIFF
--- a/src/main/java/org/apache/ibatis/mapping/VendorDatabaseIdProvider.java
+++ b/src/main/java/org/apache/ibatis/mapping/VendorDatabaseIdProvider.java
@@ -57,7 +57,7 @@ public class VendorDatabaseIdProvider implements DatabaseIdProvider {
     String productName = getDatabaseProductName(dataSource);
     if (this.properties != null) {
       return properties.entrySet().stream().filter(entry -> productName.contains((String) entry.getKey()))
-          .map(entry -> (String) entry.getValue()).findFirst().orElse(null);
+          .map(entry -> (String) entry.getValue()).findFirst().orElse(productName);
     }
     return productName;
   }


### PR DESCRIPTION
如果只配置了DB_VENDOR标签，没有配置具体的properties，希望能根据DataSource默认的productName来使用对应的MapperStatement