### PR TITLE
`VendorDatabaseIdProvider#getDatabaseId()` should return product name when properties is empty

### DIFF
--- a/src/main/java/org/apache/ibatis/mapping/VendorDatabaseIdProvider.java
+++ b/src/main/java/org/apache/ibatis/mapping/VendorDatabaseIdProvider.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -55,11 +55,11 @@ public class VendorDatabaseIdProvider implements DatabaseIdProvider {
 
   private String getDatabaseName(DataSource dataSource) throws SQLException {
     String productName = getDatabaseProductName(dataSource);
-    if (this.properties != null) {
-      return properties.entrySet().stream().filter(entry -> productName.contains((String) entry.getKey()))
-          .map(entry -> (String) entry.getValue()).findFirst().orElse(null);
+    if (properties == null || properties.isEmpty()) {
+      return productName;
     }
-    return productName;
+    return properties.entrySet().stream().filter(entry -> productName.contains((String) entry.getKey()))
+        .map(entry -> (String) entry.getValue()).findFirst().orElse(null);
   }
 
   private String getDatabaseProductName(DataSource dataSource) throws SQLException {

--- a/src/test/java/org/apache/ibatis/mapping/VendorDatabaseIdProviderTest.java
+++ b/src/test/java/org/apache/ibatis/mapping/VendorDatabaseIdProviderTest.java
@@ -51,6 +51,13 @@ class VendorDatabaseIdProviderTest {
   }
 
   @Test
+  void shouldProductNameBeReturnedIfPropertiesIsEmpty() throws Exception {
+    VendorDatabaseIdProvider provider = new VendorDatabaseIdProvider();
+    provider.setProperties(new Properties());
+    assertEquals(PRODUCT_NAME, provider.getDatabaseId(mockDataSource()));
+  }
+
+  @Test
   void shouldProductNameBeTranslated() throws Exception {
     VendorDatabaseIdProvider provider = new VendorDatabaseIdProvider();
     Properties properties = new Properties();

--- a/src/test/java/org/apache/ibatis/submitted/databaseid_productname/DatabaseIdProductNameTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/databaseid_productname/DatabaseIdProductNameTest.java
@@ -1,0 +1,49 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.databaseid_productname;
+
+import java.io.Reader;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class DatabaseIdProductNameTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/databaseid_productname/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+  }
+
+  @Test
+  void shouldProductNameBeDatabaseIdIfDbVendorHasNoProperties() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      String result = mapper.select();
+      Assertions.assertEquals("hsql", result);
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/databaseid_productname/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/databaseid_productname/Mapper.java
@@ -1,0 +1,26 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.databaseid_productname;
+
+import org.apache.ibatis.annotations.Select;
+
+public interface Mapper {
+
+  @Select(value = "select 'mysql'", databaseId = "MySQL")
+  @Select(value = "select 'hsql' from (values(0))", databaseId = "HSQL Database Engine")
+  String select();
+
+}

--- a/src/test/resources/org/apache/ibatis/submitted/databaseid_productname/mybatis-config.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/databaseid_productname/mybatis-config.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2024 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+    <environments default="development">
+        <environment id="development">
+            <transactionManager type="JDBC">
+                <property name="" value="" />
+            </transactionManager>
+            <dataSource type="UNPOOLED">
+                <property name="driver" value="org.hsqldb.jdbcDriver" />
+                <property name="url" value="jdbc:hsqldb:mem:dbidprodname" />
+                <property name="username" value="sa" />
+            </dataSource>
+        </environment>
+    </environments>
+
+    <databaseIdProvider type="DB_VENDOR" />
+
+    <mappers>
+        <mapper class="org.apache.ibatis.submitted.databaseid_productname.Mapper" />
+    </mappers>
+
+</configuration>


### PR DESCRIPTION
`XMLConfigBuilder#databaseIdProviderElement()` sets an empty `Properties` rather than `null`.

fixes #3296
