### PR TITLE
[GHA] 'site' should run on 'prepare release' commit

### DIFF
--- a/.github/workflows/site.yaml
+++ b/.github/workflows/site.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if: github.repository_owner == 'mybatis' && ! contains(toJSON(github.event.head_commit.message), '[maven-release-plugin]')
+    if: github.repository_owner == 'mybatis' && contains(toJSON(github.event.head_commit.message), '[maven-release-plugin] prepare release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We want to deploy the site when we release new version, however, with the current 'if' condition, the 'site' action does not run on the target commit.
The commit message of a release starts with "[maven-release-plugin] prepare release".
