### PR TITLE
Fix namespace resolution for nested includes across different namespaces

### DIFF
--- a/src/test/java/org/apache/ibatis/submitted/includes/IncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/includes/IncludeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -57,4 +57,10 @@ class IncludeTest {
     }
   }
 
+  @Test
+  void testRelativeNamespaceIncludes() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      sqlSession.selectOne("org.apache.ibatis.submitted.includes.mapper.selectAll");
+    }
+  }
 }

--- a/src/test/resources/org/apache/ibatis/submitted/includes/Fragments.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/includes/Fragments.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2023 the original author or authors.
+       Copyright 2009-2024 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -29,5 +29,8 @@
   </sql>
   <sql id="values">
     VALUES (1);
+  </sql>
+  <sql id="selectAllFields">
+    <include refid="select" /> *
   </sql>
 </mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/includes/Mapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/includes/Mapper.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-       Copyright 2009-2022 the original author or authors.
+       Copyright 2009-2024 the original author or authors.
 
        Licensed under the Apache License, Version 2.0 (the "License");
        you may not use this file except in compliance with the License.
@@ -54,4 +54,15 @@
     Field3 = #{field3,jdbcType=VARCHAR},
     where field1 = #{field1,jdbcType=INTEGER}
   </update>
+
+  <select id="selectAll" resultType="map">
+    <include refid="someinclude">
+      <property name="include_target" value="${ns}.selectAllFields"/>
+    </include>
+    from
+    <include refid="someinclude">
+      <property name="prefix" value="Some"/>
+      <property name="include_target" value="sometable"/>
+    </include>
+  </select>
 </mapper>


### PR DESCRIPTION
## Description

During recursive processing of `<include>` tags, the parser would always use the initial namespace context, causing failures to find the correct SQL fragments in multi-level nested includes across different namespaces.

Since English is not my native language, to express it more clearly, I will directly describe the issue I found through code.

The following code will throw an exception because the namespace relative to the refid is not correctly resolved.

```xml
<mapper namespace="com.example.MapperA">
  <select id="selectSpecial" resultType="int">
    SELECT aaa FROM table1 WHERE
    <include refid="com.example.MapperB.specialCondition"/>
  </select>
</mapper>
```
```xml
<mapper namespace="com.example.MapperB">
  <sql id="commonCondition">
    field1 = 1 AND field2 = 2
  </sql>
  <sql id="specialCondition">
    <include refid="commonCondition"/> AND field3 = 3
  </select>
</mapper>
```
```java
sqlSession.selectList("com.example.MapperA.selectSpecial");
```

## The Fix

- Update the `applyIncludes` method:

  - Introduce a `currentNamespace` parameter to keep track of the namespace context during recursion.

  - When processing an `<include>`tag, check if the `refid`contains a namespace (indicated by a dot `.`).

    - If it does, extract the namespace from the refid and update `currentNamespace`.
    - If not, use the `currentNamespace` to fully qualify the `refid`.

  - After finding the included SQL fragment, recursively call `applyIncludes` with the updated `currentNamespace`.

- Ensure correct namespace resolution:

  - The `currentNamespace` is updated appropriately at each recursion level, ensuring that nested includes are resolved using the correct namespace context.

---

I think this change is more consistent with the default behavior where cross-namespace includes require the `refid` to include the namespace, and same-namespace includes can omit it.