### PR TITLE
Throw helpful error instead of IndexOutOfBoundsException when there are not enough columns for constructor auto-mapping

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -784,11 +784,10 @@ public class DefaultResultSetHandler implements ResultSetHandler {
       List<Object> constructorArgs, Constructor<?> constructor, boolean foundValues) throws SQLException {
     Class<?>[] parameterTypes = constructor.getParameterTypes();
 
-    // constructor parameter is allowed to be less than or equal to the number of result set columns, but not greater than
     if (parameterTypes.length > rsw.getClassNames().size()) {
       throw new ExecutorException(MessageFormat.format(
-          "Column order based constructor auto-mapping of ''{0}'' failed. Because result set type is ''{1}''.",
-          constructor, rsw.getClassNames()));
+          "Constructor auto-mapping of ''{0}'' failed. The constructor takes ''{1}'' arguments, but there are only ''{2}'' columns in the result set.",
+          constructor, parameterTypes.length, rsw.getClassNames().size()));
     }
 
     for (int i = 0; i < parameterTypes.length; i++) {

--- a/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
+++ b/src/main/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandler.java
@@ -783,6 +783,14 @@ public class DefaultResultSetHandler implements ResultSetHandler {
   private boolean applyColumnOrderBasedConstructorAutomapping(ResultSetWrapper rsw, List<Class<?>> constructorArgTypes,
       List<Object> constructorArgs, Constructor<?> constructor, boolean foundValues) throws SQLException {
     Class<?>[] parameterTypes = constructor.getParameterTypes();
+
+    // constructor parameter is allowed to be less than or equal to the number of result set columns, but not greater than
+    if (parameterTypes.length > rsw.getClassNames().size()) {
+      throw new ExecutorException(MessageFormat.format(
+          "Column order based constructor auto-mapping of ''{0}'' failed. Because result set type is ''{1}''.",
+          constructor, rsw.getClassNames()));
+    }
+
     for (int i = 0; i < parameterTypes.length; i++) {
       Class<?> parameterType = parameterTypes[i];
       String columnName = rsw.getColumnNames().get(i);

--- a/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/ColumnOrderBasedConstructorAutomappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/ColumnOrderBasedConstructorAutomappingTest.java
@@ -1,0 +1,129 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.column_order_based_constructor_automapping;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.io.Reader;
+import java.util.List;
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.exceptions.PersistenceException;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class ColumnOrderBasedConstructorAutomappingTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    try (Reader reader = Resources.getResourceAsReader(
+            "org/apache/ibatis/submitted/column_order_based_constructor_automapping/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().setArgNameBasedConstructorAutoMapping(false);
+    }
+
+    // populate in-memory database
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+            "org/apache/ibatis/submitted/column_order_based_constructor_automapping/CreateDB.sql");
+  }
+
+  @Test
+  void shouldHandleNoArgsConstructor() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<UserNoArgsConstructor> userList = mapper.finaAllByNoArgsConstructor();
+
+      assertEquals(2, userList.size());
+      UserNoArgsConstructor user1 = userList.get(0);
+      UserNoArgsConstructor user2 = userList.get(1);
+
+      assertEquals(1, user1.getId());
+      assertEquals("Tom", user1.getName());
+      assertEquals(7, user1.getAge());
+      assertNull(user1.getEmail());
+
+      assertEquals(2, user2.getId());
+      assertEquals("Cat", user2.getName());
+      assertEquals(3, user2.getAge());
+      assertNull(user2.getEmail());
+    }
+  }
+
+  @Test
+  void shouldHandleConstructorEqualsResultSet() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<UserConstructorEqualsResultSet> userList = mapper.finaAllByConstructorEqualsResultSet();
+
+      assertEquals(2, userList.size());
+      UserConstructorEqualsResultSet user1 = userList.get(0);
+      UserConstructorEqualsResultSet user2 = userList.get(1);
+
+      assertEquals(1, user1.getId());
+      assertEquals("Tom", user1.getName());
+      assertEquals(7, user1.getAge());
+      assertNull(user1.getEmail());
+
+      assertEquals(2, user2.getId());
+      assertEquals("Cat", user2.getName());
+      assertEquals(3, user2.getAge());
+      assertNull(user2.getEmail());
+    }
+  }
+
+  @Test
+  void shouldHandleConstructorLessThanResultSet() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+      List<UserConstructorLessThanResultSet> userList = mapper.finaAllByConstructorLessThanResultSet();
+
+      assertEquals(2, userList.size());
+      UserConstructorLessThanResultSet user1 = userList.get(0);
+      UserConstructorLessThanResultSet user2 = userList.get(1);
+
+      assertEquals(1, user1.getId());
+      assertEquals("Tom", user1.getName());
+      assertEquals(7, user1.getAge());
+      assertNull(user1.getEmail());
+
+      assertEquals(2, user2.getId());
+      assertEquals("Cat", user2.getName());
+      assertEquals(3, user2.getAge());
+      assertNull(user2.getEmail());
+    }
+  }
+
+  @Test
+  void shouldNotHandleConstructorGreaterThanResultSet() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      Mapper mapper = sqlSession.getMapper(Mapper.class);
+
+      PersistenceException persistenceException = assertThrows(PersistenceException.class, mapper::finaAllByConstructorGreaterThanResultSet);
+      assertNotNull(persistenceException);
+      assertNotNull(persistenceException.getMessage());
+      assertTrue(persistenceException.getMessage().contains("Column order based constructor auto-mapping of"));
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/ColumnOrderBasedConstructorAutomappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/ColumnOrderBasedConstructorAutomappingTest.java
@@ -20,8 +20,11 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.Reader;
+import java.text.MessageFormat;
 import java.util.List;
+
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.exceptions.PersistenceException;
 import org.apache.ibatis.io.Resources;
@@ -39,14 +42,14 @@ class ColumnOrderBasedConstructorAutomappingTest {
   static void setUp() throws Exception {
     // create an SqlSessionFactory
     try (Reader reader = Resources.getResourceAsReader(
-            "org/apache/ibatis/submitted/column_order_based_constructor_automapping/mybatis-config.xml")) {
+        "org/apache/ibatis/submitted/column_order_based_constructor_automapping/mybatis-config.xml")) {
       sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
       sqlSessionFactory.getConfiguration().setArgNameBasedConstructorAutoMapping(false);
     }
 
     // populate in-memory database
     BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
-            "org/apache/ibatis/submitted/column_order_based_constructor_automapping/CreateDB.sql");
+        "org/apache/ibatis/submitted/column_order_based_constructor_automapping/CreateDB.sql");
   }
 
   @Test
@@ -120,10 +123,14 @@ class ColumnOrderBasedConstructorAutomappingTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
 
-      PersistenceException persistenceException = assertThrows(PersistenceException.class, mapper::finaAllByConstructorGreaterThanResultSet);
+      PersistenceException persistenceException = assertThrows(PersistenceException.class,
+          mapper::finaAllByConstructorGreaterThanResultSet);
       assertNotNull(persistenceException);
-      assertNotNull(persistenceException.getMessage());
-      assertTrue(persistenceException.getMessage().contains("Column order based constructor auto-mapping of"));
+      String message = persistenceException.getMessage();
+      assertNotNull(message);
+      assertTrue(message.contains(MessageFormat.format(
+          "Constructor auto-mapping of ''{0}'' failed. The constructor takes ''{1}'' arguments, but there are only ''{2}'' columns in the result set.",
+          UserConstructorGreaterThanResultSet.class.getConstructors()[0], 4, 3)));
     }
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/Mapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/Mapper.java
@@ -1,0 +1,29 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.column_order_based_constructor_automapping;
+
+import java.util.List;
+
+public interface Mapper {
+
+  List<UserNoArgsConstructor> finaAllByNoArgsConstructor();
+
+  List<UserConstructorEqualsResultSet> finaAllByConstructorEqualsResultSet();
+
+  List<UserConstructorLessThanResultSet> finaAllByConstructorLessThanResultSet();
+
+  List<UserConstructorGreaterThanResultSet> finaAllByConstructorGreaterThanResultSet();
+}

--- a/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/UserConstructorEqualsResultSet.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/UserConstructorEqualsResultSet.java
@@ -1,0 +1,62 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.column_order_based_constructor_automapping;
+
+public class UserConstructorEqualsResultSet {
+
+  private Integer id;
+  private String name;
+  private Integer age;
+  private String email;
+
+  public UserConstructorEqualsResultSet(Integer id, String name, Integer age) {
+    this.id = id;
+    this.name = name;
+    this.age = age;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Integer getAge() {
+    return age;
+  }
+
+  public void setAge(Integer age) {
+    this.age = age;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/UserConstructorGreaterThanResultSet.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/UserConstructorGreaterThanResultSet.java
@@ -1,0 +1,63 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.column_order_based_constructor_automapping;
+
+public class UserConstructorGreaterThanResultSet {
+
+  private Integer id;
+  private String name;
+  private Integer age;
+  private String email;
+
+  public UserConstructorGreaterThanResultSet(Integer id, String name, Integer age, String email) {
+    this.id = id;
+    this.name = name;
+    this.age = age;
+    this.email = email;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Integer getAge() {
+    return age;
+  }
+
+  public void setAge(Integer age) {
+    this.age = age;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/UserConstructorLessThanResultSet.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/UserConstructorLessThanResultSet.java
@@ -1,0 +1,61 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.column_order_based_constructor_automapping;
+
+public class UserConstructorLessThanResultSet {
+
+  private Integer id;
+  private String name;
+  private Integer age;
+  private String email;
+
+  public UserConstructorLessThanResultSet(Integer id, String name) {
+    this.id = id;
+    this.name = name;
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Integer getAge() {
+    return age;
+  }
+
+  public void setAge(Integer age) {
+    this.age = age;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/UserNoArgsConstructor.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_order_based_constructor_automapping/UserNoArgsConstructor.java
@@ -1,0 +1,59 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.column_order_based_constructor_automapping;
+
+public class UserNoArgsConstructor {
+
+  private Integer id;
+  private String name;
+  private Integer age;
+  private String email;
+
+  public UserNoArgsConstructor() {
+  }
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Integer getAge() {
+    return age;
+  }
+
+  public void setAge(Integer age) {
+    this.age = age;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+}

--- a/src/test/resources/org/apache/ibatis/submitted/column_order_based_constructor_automapping/CreateDB.sql
+++ b/src/test/resources/org/apache/ibatis/submitted/column_order_based_constructor_automapping/CreateDB.sql
@@ -1,0 +1,27 @@
+--
+--    Copyright 2009-2024 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       https://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+drop table users if exists;
+
+create table users (
+  id int,
+  name varchar(50),
+  age int
+);
+
+insert into users (id, name, age) values
+(1, 'Tom', 7),
+(2, 'Cat', 3);

--- a/src/test/resources/org/apache/ibatis/submitted/column_order_based_constructor_automapping/Mapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/column_order_based_constructor_automapping/Mapper.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2024 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper
+  namespace="org.apache.ibatis.submitted.column_order_based_constructor_automapping.Mapper">
+
+  <select id="finaAllByNoArgsConstructor"
+          resultType="org.apache.ibatis.submitted.column_order_based_constructor_automapping.UserNoArgsConstructor">
+    select * from users
+  </select>
+
+  <select id="finaAllByConstructorEqualsResultSet"
+          resultType="org.apache.ibatis.submitted.column_order_based_constructor_automapping.UserConstructorEqualsResultSet">
+    select * from users
+  </select>
+
+  <select id="finaAllByConstructorLessThanResultSet"
+          resultType="org.apache.ibatis.submitted.column_order_based_constructor_automapping.UserConstructorLessThanResultSet">
+    select * from users
+  </select>
+
+  <select id="finaAllByConstructorGreaterThanResultSet"
+          resultType="org.apache.ibatis.submitted.column_order_based_constructor_automapping.UserConstructorGreaterThanResultSet">
+    select * from users
+  </select>
+</mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/column_order_based_constructor_automapping/mybatis-config.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/column_order_based_constructor_automapping/mybatis-config.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2024 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url" value="jdbc:hsqldb:mem:constructorautomapping" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper class="org.apache.ibatis.submitted.column_order_based_constructor_automapping.Mapper" />
+  </mappers>
+
+</configuration>


### PR DESCRIPTION
Hi, I have noticed that some people, when using `Lombok`, only have one constructor with all parameters due to the use of `@Data` and `@Builder` annotations. If the class property of the resultType does not match the query result, an `IndexOutOfBoundsException` exception will be thrown.
I have had several colleagues who have encountered this issue and spent some time troubleshooting it. Although it is indeed the user's problem, I think perhaps we should optimize the prompt to clearly indicate that this is the cause of the constructor, so that users can quickly find the problem when they encounter it.

Abnormal example: https://github.com/luozongle01/mybatis_index_out_of_bounds

</br>

>The following is the abnormal prompt after the problem occurs
<img width="1296" alt="image" src="https://github.com/user-attachments/assets/7b9ce7b6-bb45-40d9-845a-062eb5bede5b" />

</br>
</br>

>The following is the modified exception prompt
<img width="1329" alt="image" src="https://github.com/user-attachments/assets/aa54ca37-2653-442c-b354-db2d0cf26fcf" />

