### PR TITLE
Fix code scanning alert no. 6: Resolving XML external entity in user-controlled data

### DIFF
--- a/src/main/java/org/apache/ibatis/parsing/XPathParser.java
+++ b/src/main/java/org/apache/ibatis/parsing/XPathParser.java
@@ -231,6 +231,9 @@ public class XPathParser {
     try {
       DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
       factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+      factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+      factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
       factory.setValidating(validation);
 
       factory.setNamespaceAware(false);


### PR DESCRIPTION
Fixes [https://github.com/mybatis/mybatis-3/security/code-scanning/6](https://github.com/mybatis/mybatis-3/security/code-scanning/6)

To fix the problem, we need to disable the parsing of external entities and DTDs in the `DocumentBuilderFactory` configuration. This can be achieved by setting the appropriate features on the `DocumentBuilderFactory` instance. Specifically, we need to set the `http://apache.org/xml/features/disallow-doctype-decl` feature to `true` and the `http://xml.org/sax/features/external-general-entities` and `http://xml.org/sax/features/external-parameter-entities` features to `false`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
