### PR TITLE
DateOnlyTypeHandler should return java.util.Date

### DIFF
--- a/src/main/java/org/apache/ibatis/type/DateOnlyTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/DateOnlyTypeHandler.java
@@ -46,7 +46,7 @@ public class DateOnlyTypeHandler extends BaseTypeHandler<Date> {
     return toDate(cs.getDate(columnIndex));
   }
 
-  private Date toDate(Date date) {
+  private Date toDate(java.sql.Date date) {
     return date == null ? null : new Date(date.getTime());
   }
 

--- a/src/main/java/org/apache/ibatis/type/DateOnlyTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/DateOnlyTypeHandler.java
@@ -33,21 +33,21 @@ public class DateOnlyTypeHandler extends BaseTypeHandler<Date> {
 
   @Override
   public Date getNullableResult(ResultSet rs, String columnName) throws SQLException {
-    return toSqlDate(rs.getDate(columnName));
+    return toDate(rs.getDate(columnName));
   }
 
   @Override
   public Date getNullableResult(ResultSet rs, int columnIndex) throws SQLException {
-    return toSqlDate(rs.getDate(columnIndex));
+    return toDate(rs.getDate(columnIndex));
   }
 
   @Override
   public Date getNullableResult(CallableStatement cs, int columnIndex) throws SQLException {
-    return toSqlDate(cs.getDate(columnIndex));
+    return toDate(cs.getDate(columnIndex));
   }
 
-  private java.sql.Date toSqlDate(Date date) {
-    return date == null ? null : new java.sql.Date(date.getTime());
+  private Date toDate(Date date) {
+    return date == null ? null : new Date(date.getTime());
   }
 
 }


### PR DESCRIPTION
https://github.com/mybatis/mybatis-3/issues/3332

Fixing the change in return type of DateOnlyTypeHandler introduced [here](https://github.com/mybatis/mybatis-3/pull/3247/files#diff-3100284b93f6e47f7e09229bac897dc14edbb2e162002f24e804113f49d8b6a6L47)