### PR TITLE
Cleanup tests with open rewrite help

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,6 +232,14 @@
       <artifactId>junit-jupiter</artifactId>
       <version>${testcontainers.version}</version>
       <scope>test</scope>
+      <!--Only Mysqlcontainer is allowed to use junit 4: Uncomment to test
+      <exclusions>
+          <exclusion>
+              <groupId>junit</groupId>
+              <artifactId>junit</artifactId>
+          </exclusion>
+      </exclusions>
+      -->
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>

--- a/src/test/java/org/apache/ibatis/binding/BindingTest.java
+++ b/src/test/java/org/apache/ibatis/binding/BindingTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/binding/WrongMapperTest.java
+++ b/src/test/java/org/apache/ibatis/binding/WrongMapperTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,9 +24,7 @@ class WrongMapperTest {
   @Test
   void shouldFailForBothOneAndMany() {
     Configuration configuration = new Configuration();
-    Assertions.assertThrows(RuntimeException.class, () -> {
-      configuration.addMapper(MapperWithOneAndMany.class);
-    });
+    Assertions.assertThrows(RuntimeException.class, () -> configuration.addMapper(MapperWithOneAndMany.class));
   }
 
 }

--- a/src/test/java/org/apache/ibatis/binding/WrongNamespacesTest.java
+++ b/src/test/java/org/apache/ibatis/binding/WrongNamespacesTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/builder/ParameterExpressionTest.java
+++ b/src/test/java/org/apache/ibatis/builder/ParameterExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/builder/SqlSourceBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/SqlSourceBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class SqlSourceBuilderTest {
+class SqlSourceBuilderTest {
 
   private static Configuration configuration;
   private static SqlSourceBuilder sqlSourceBuilder;
@@ -36,7 +36,7 @@ public class SqlSourceBuilderTest {
   }
 
   @Test
-  void testShrinkWhitespacesInSqlIsFalse() {
+  void shrinkWhitespacesInSqlIsFalse() {
     SqlSource sqlSource = sqlSourceBuilder.parse(sqlFromXml, null, null);
     BoundSql boundSql = sqlSource.getBoundSql(null);
     String actual = boundSql.getSql();
@@ -44,7 +44,7 @@ public class SqlSourceBuilderTest {
   }
 
   @Test
-  void testShrinkWhitespacesInSqlIsTrue() {
+  void shrinkWhitespacesInSqlIsTrue() {
     configuration.setShrinkWhitespacesInSql(true);
     SqlSource sqlSource = sqlSourceBuilder.parse(sqlFromXml, null, null);
     BoundSql boundSql = sqlSource.getBoundSql(null);

--- a/src/test/java/org/apache/ibatis/builder/XmlMapperBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/XmlMapperBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/builder/xml/dynamic/DynamicSqlSourceTest.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/dynamic/DynamicSqlSourceTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/builder/xsd/XmlMapperBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/builder/xsd/XmlMapperBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/cache/CacheKeyTest.java
+++ b/src/test/java/org/apache/ibatis/cache/CacheKeyTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -112,9 +112,7 @@ class CacheKeyTest {
   void serializationExceptionTest() {
     CacheKey cacheKey = new CacheKey();
     cacheKey.update(new Object());
-    assertThrows(NotSerializableException.class, () -> {
-      serialize(cacheKey);
-    });
+    assertThrows(NotSerializableException.class, () -> serialize(cacheKey));
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/cache/SerializedCacheTest.java
+++ b/src/test/java/org/apache/ibatis/cache/SerializedCacheTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.cache;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.Serializable;
@@ -45,7 +46,7 @@ class SerializedCacheTest {
       cache.putObject(i, null);
     }
     for (int i = 0; i < 5; i++) {
-      assertEquals(null, cache.getObject(i));
+      assertNull(cache.getObject(i));
     }
   }
 

--- a/src/test/java/org/apache/ibatis/datasource/pooled/MysqlTimeoutTest.java
+++ b/src/test/java/org/apache/ibatis/datasource/pooled/MysqlTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("TestcontainersTests")
-public class MysqlTimeoutTest {
+class MysqlTimeoutTest {
 
   @Test
   void shouldReconnectWhenServerKilledLeakedConnection() throws Exception {

--- a/src/test/java/org/apache/ibatis/datasource/unpooled/NetworkTimeoutTest.java
+++ b/src/test/java/org/apache/ibatis/datasource/unpooled/NetworkTimeoutTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 class NetworkTimeoutTest {
 
   @Test
-  void testNetworkTimeout_UnpooledDataSource() throws Exception {
+  void networkTimeoutUnpooledDataSource() throws Exception {
     UnpooledDataSource dataSource = (UnpooledDataSource) PgContainer.getUnpooledDataSource();
     dataSource.setDefaultNetworkTimeout(5000);
     try (Connection connection = dataSource.getConnection()) {
@@ -37,7 +37,7 @@ class NetworkTimeoutTest {
   }
 
   @Test
-  void testNetworkTimeout_PooledDataSource() throws Exception {
+  void networkTimeoutPooledDataSource() throws Exception {
     UnpooledDataSource unpooledDataSource = (UnpooledDataSource) PgContainer.getUnpooledDataSource();
     PooledDataSource dataSource = new PooledDataSource(unpooledDataSource);
     dataSource.setDefaultNetworkTimeout(5000);

--- a/src/test/java/org/apache/ibatis/executor/BaseExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/BaseExecutorTest.java
@@ -478,7 +478,7 @@ class BaseExecutorTest extends BaseDataTest {
   }
 
   @Test
-  void testCreateCacheKeyWithAdditionalParameter() {
+  void createCacheKeyWithAdditionalParameter() {
     TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
 
     MappedStatement mappedStatement = new MappedStatement.Builder(config, "testSelect",
@@ -510,7 +510,7 @@ class BaseExecutorTest extends BaseDataTest {
   }
 
   @Test
-  void testCreateCacheKeyWithNull() {
+  void createCacheKeyWithNull() {
     TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
 
     MappedStatement mappedStatement = new MappedStatement.Builder(config, "testSelect",
@@ -538,7 +538,7 @@ class BaseExecutorTest extends BaseDataTest {
   }
 
   @Test
-  void testCreateCacheKeyWithTypeHandler() {
+  void createCacheKeyWithTypeHandler() {
     TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
 
     MappedStatement mappedStatement = new MappedStatement.Builder(config, "testSelect",
@@ -566,7 +566,7 @@ class BaseExecutorTest extends BaseDataTest {
   }
 
   @Test
-  void testCreateCacheKeyWithMetaObject() {
+  void createCacheKeyWithMetaObject() {
     TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
 
     MappedStatement mappedStatement = new MappedStatement.Builder(config, "testSelect",

--- a/src/test/java/org/apache/ibatis/executor/ResultExtractorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/ResultExtractorTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -93,7 +92,7 @@ class ResultExtractorTest {
 
   @Test
   void shouldExtractSingleObject() {
-    final List<Object> list = Collections.singletonList("single object");
+    final List<Object> list = List.of("single object");
     assertThat((String) resultExtractor.extractObjectFromList(list, String.class)).isEqualTo("single object");
     assertThat((String) resultExtractor.extractObjectFromList(list, null)).isEqualTo("single object");
     assertThat((String) resultExtractor.extractObjectFromList(list, Integer.class)).isEqualTo("single object");

--- a/src/test/java/org/apache/ibatis/executor/ReuseExecutorTest.java
+++ b/src/test/java/org/apache/ibatis/executor/ReuseExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/executor/loader/CglibProxyTest.java
+++ b/src/test/java/org/apache/ibatis/executor/loader/CglibProxyTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/executor/loader/JavassistProxyTest.java
+++ b/src/test/java/org/apache/ibatis/executor/loader/JavassistProxyTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/executor/loader/SerializableProxyTest.java
+++ b/src/test/java/org/apache/ibatis/executor/loader/SerializableProxyTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 package org.apache.ibatis.executor.loader;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -134,11 +135,9 @@ public abstract class SerializableProxyTest {
   void shouldNotGenerateWriteReplaceItThereIsAlreadyOne() {
     AuthorWithWriteReplaceMethod beanWithWriteReplace = new AuthorWithWriteReplaceMethod(999, "someone", "!@#@!#!@#",
         "someone@somewhere.com", "blah", Section.NEWS);
-    try {
+    Assertions.assertDoesNotThrow(() -> {
       beanWithWriteReplace.getClass().getDeclaredMethod("writeReplace");
-    } catch (NoSuchMethodException e) {
-      fail("Bean should declare a writeReplace method");
-    }
+    }, "Bean should declare a writeReplace method");
     Object proxy = proxyFactory.createProxy(beanWithWriteReplace, new ResultLoaderMap(), new Configuration(),
         new DefaultObjectFactory(), new ArrayList<>(), new ArrayList<>());
     Class<?>[] interfaces = proxy.getClass().getInterfaces();

--- a/src/test/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/executor/resultset/DefaultResultSetHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Types;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -118,7 +117,7 @@ class DefaultResultSetHandlerTest {
     when(resultMapping.getColumn()).thenReturn("column");
     when(resultMapping.getTypeHandler()).thenReturn(typeHandler);
     when(typeHandler.getResult(any(ResultSet.class), any(String.class))).thenThrow(new SQLException("exception"));
-    List<ResultMapping> constructorMappings = Collections.singletonList(resultMapping);
+    List<ResultMapping> constructorMappings = List.of(resultMapping);
 
     try {
       defaultResultSetHandler.createParameterizedResultObject(rsw, null/* resultType */, constructorMappings,

--- a/src/test/java/org/apache/ibatis/io/ClassLoaderWrapperTest.java
+++ b/src/test/java/org/apache/ibatis/io/ClassLoaderWrapperTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/io/ExternalResourcesTest.java
+++ b/src/test/java/org/apache/ibatis/io/ExternalResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ class ExternalResourcesTest {
   }
 
   @Test
-  void testGetConfiguredTemplate() {
+  void getConfiguredTemplate() {
     String templateName = "";
 
     try (FileWriter fileWriter = new FileWriter(tempFile, StandardCharsets.UTF_8)) {

--- a/src/test/java/org/apache/ibatis/io/ResolverUtilTest.java
+++ b/src/test/java/org/apache/ibatis/io/ResolverUtilTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ class ResolverUtilTest {
 
   @Test
   void getClasses() {
-    assertEquals(new ResolverUtil<>().getClasses().size(), 0);
+    assertEquals(0, new ResolverUtil<>().getClasses().size());
   }
 
   @Test
@@ -70,7 +70,7 @@ class ResolverUtilTest {
   void findImplementationsWithNullPackageName() {
     ResolverUtil<VFS> resolverUtil = new ResolverUtil<>();
     resolverUtil.findImplementations(VFS.class, (String[]) null);
-    assertEquals(resolverUtil.getClasses().size(), 0);
+    assertEquals(0, resolverUtil.getClasses().size());
   }
 
   @Test
@@ -81,7 +81,7 @@ class ResolverUtilTest {
     // org.apache.ibatis.io.VFS
     // org.apache.ibatis.io.DefaultVFS
     // org.apache.ibatis.io.JBoss6VFS
-    assertEquals(classSets.size(), 3); // fail if add a new VFS implementation in this package!!!
+    assertEquals(3, classSets.size()); // fail if add a new VFS implementation in this package!!!
     classSets.forEach(c -> assertTrue(VFS.class.isAssignableFrom(c)));
   }
 
@@ -89,7 +89,7 @@ class ResolverUtilTest {
   void findAnnotatedWithNullPackageName() {
     ResolverUtil<Object> resolverUtil = new ResolverUtil<>();
     resolverUtil.findAnnotated(CacheNamespace.class, (String[]) null);
-    assertEquals(resolverUtil.getClasses().size(), 0);
+    assertEquals(0, resolverUtil.getClasses().size());
   }
 
   @Test
@@ -98,7 +98,7 @@ class ResolverUtilTest {
     resolverUtil.findAnnotated(CacheNamespace.class, this.getClass().getPackage().getName());
     Set<Class<?>> classSets = resolverUtil.getClasses();
     // org.apache.ibatis.io.ResolverUtilTest.TestMapper
-    assertEquals(classSets.size(), 1);
+    assertEquals(1, classSets.size());
     classSets.forEach(c -> assertNotNull(c.getAnnotation(CacheNamespace.class)));
   }
 
@@ -110,7 +110,7 @@ class ResolverUtilTest {
     // org.apache.ibatis.io.VFS
     // org.apache.ibatis.io.DefaultVFS
     // org.apache.ibatis.io.JBoss6VFS
-    assertEquals(classSets.size(), 3);
+    assertEquals(3, classSets.size());
     classSets.forEach(c -> assertTrue(VFS.class.isAssignableFrom(c)));
   }
 
@@ -118,7 +118,7 @@ class ResolverUtilTest {
   void getPackagePath() {
     ResolverUtil resolverUtil = new ResolverUtil();
     assertNull(resolverUtil.getPackagePath(null));
-    assertEquals(resolverUtil.getPackagePath("org.apache.ibatis.io"), "org/apache/ibatis/io");
+    assertEquals("org/apache/ibatis/io", resolverUtil.getPackagePath("org.apache.ibatis.io"));
   }
 
   @Test
@@ -127,7 +127,7 @@ class ResolverUtilTest {
     resolverUtil.addIfMatching(new ResolverUtil.IsA(VFS.class), "org/apache/ibatis/io/DefaultVFS.class");
     resolverUtil.addIfMatching(new ResolverUtil.IsA(VFS.class), "org/apache/ibatis/io/VFS.class");
     Set<Class<? extends VFS>> classSets = resolverUtil.getClasses();
-    assertEquals(classSets.size(), 2);
+    assertEquals(2, classSets.size());
     classSets.forEach(c -> assertTrue(VFS.class.isAssignableFrom(c)));
   }
 
@@ -135,7 +135,7 @@ class ResolverUtilTest {
   void addIfNotMatching() {
     ResolverUtil<VFS> resolverUtil = new ResolverUtil<>();
     resolverUtil.addIfMatching(new ResolverUtil.IsA(VFS.class), "org/apache/ibatis/io/Xxx.class");
-    assertEquals(resolverUtil.getClasses().size(), 0);
+    assertEquals(0, resolverUtil.getClasses().size());
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/io/ResourcesTest.java
+++ b/src/test/java/org/apache/ibatis/io/ResourcesTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/io/VFSTest.java
+++ b/src/test/java/org/apache/ibatis/io/VFSTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/jdbc/PooledDataSourceTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/PooledDataSourceTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/jdbc/SQLTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/SQLTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -490,7 +490,7 @@ class SQLTest {
   }
 
   @Test
-  void testValues() {
+  void values() {
     final String sql = new SQL() {
       {
         INSERT_INTO("PERSON");
@@ -504,7 +504,7 @@ class SQLTest {
   }
 
   @Test
-  void testApplyIf() {
+  void applyIf() {
     Bean bean = new Bean();
     // @formatter:off
     String sqlString = new SQL()
@@ -519,7 +519,7 @@ class SQLTest {
   }
 
   @Test
-  void testApplyForEach() {
+  void applyForEach() {
     List<Bean> beans = new ArrayList<>();
     beans.add(new Bean());
     beans.add(new Bean());

--- a/src/test/java/org/apache/ibatis/jdbc/ScriptRunnerTest.java
+++ b/src/test/java/org/apache/ibatis/jdbc/ScriptRunnerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -164,7 +164,7 @@ class ScriptRunnerTest extends BaseDataTest {
   }
 
   @Test
-  void testLogging() throws Exception {
+  void logging() throws Exception {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
     try (Connection conn = ds.getConnection()) {
       ScriptRunner runner = new ScriptRunner(conn);
@@ -185,7 +185,7 @@ class ScriptRunnerTest extends BaseDataTest {
   }
 
   @Test
-  void testLoggingFullScipt() throws Exception {
+  void loggingFullScipt() throws Exception {
     DataSource ds = createUnpooledDataSource(JPETSTORE_PROPERTIES);
     try (Connection conn = ds.getConnection()) {
       ScriptRunner runner = new ScriptRunner(conn);

--- a/src/test/java/org/apache/ibatis/logging/jdbc/ConnectionLoggerTest.java
+++ b/src/test/java/org/apache/ibatis/logging/jdbc/ConnectionLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.apache.ibatis.logging.jdbc;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -69,6 +69,6 @@ class ConnectionLoggerTest {
   void shouldNotPrintCreateStatement() throws SQLException {
     conn.createStatement();
     conn.close();
-    verify(log, times(0)).debug(anyString());
+    verify(log, never()).debug(anyString());
   }
 }

--- a/src/test/java/org/apache/ibatis/logging/jdbc/PreparedStatementLoggerTest.java
+++ b/src/test/java/org/apache/ibatis/logging/jdbc/PreparedStatementLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.apache.ibatis.logging.jdbc;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -83,7 +83,7 @@ class PreparedStatementLoggerTest {
     ps.getResultSet();
     ps.getParameterMetaData();
 
-    verify(log, times(0)).debug(anyString());
+    verify(log, never()).debug(anyString());
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/logging/jdbc/StatementLoggerTest.java
+++ b/src/test/java/org/apache/ibatis/logging/jdbc/StatementLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.apache.ibatis.logging.jdbc;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -71,6 +71,6 @@ class StatementLoggerTest {
   void shouldNotPrintLog() throws SQLException {
     st.getResultSet();
     st.close();
-    verify(log, times(0)).debug(anyString());
+    verify(log, never()).debug(anyString());
   }
 }

--- a/src/test/java/org/apache/ibatis/mapping/BoundSqlTest.java
+++ b/src/test/java/org/apache/ibatis/mapping/BoundSqlTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 class BoundSqlTest {
 
   @Test
-  void testHasAdditionalParameter() {
+  void hasAdditionalParameter() {
     List<ParameterMapping> params = Collections.emptyList();
     BoundSql boundSql = new BoundSql(new Configuration(), "some sql", params, new Object());
 

--- a/src/test/java/org/apache/ibatis/mapping/CacheBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/mapping/CacheBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -31,14 +31,14 @@ import org.junit.jupiter.api.Test;
 class CacheBuilderTest {
 
   @Test
-  void testInitializing() {
+  void initializing() {
     InitializingCache cache = unwrap(new CacheBuilder("test").implementation(InitializingCache.class).build());
 
     Assertions.assertThat(cache.initialized).isTrue();
   }
 
   @Test
-  void testInitializingFailure() {
+  void initializingFailure() {
     when(() -> new CacheBuilder("test").implementation(InitializingFailureCache.class).build());
     then(caughtException()).isInstanceOf(CacheException.class).hasMessage(
         "Failed cache initialization for 'test' on 'org.apache.ibatis.mapping.CacheBuilderTest$InitializingFailureCache'");

--- a/src/test/java/org/apache/ibatis/mapping/ResultMappingTest.java
+++ b/src/test/java/org/apache/ibatis/mapping/ResultMappingTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -30,10 +30,8 @@ class ResultMappingTest {
   // Issue 697: Association with both a resultMap and a select attribute should throw exception
   @Test
   void shouldThrowErrorWhenBothResultMapAndNestedSelectAreSet() {
-    Assertions.assertThrows(IllegalStateException.class, () -> {
-      new ResultMapping.Builder(configuration, "prop").nestedQueryId("nested query ID")
-          .nestedResultMapId("nested resultMap").build();
-    });
+    Assertions.assertThrows(IllegalStateException.class, () -> new ResultMapping.Builder(configuration, "prop")
+        .nestedQueryId("nested query ID").nestedResultMapId("nested resultMap").build());
   }
 
   // Issue 4: column is mandatory on nested queries

--- a/src/test/java/org/apache/ibatis/parsing/GenericTokenParserTest.java
+++ b/src/test/java/org/apache/ibatis/parsing/GenericTokenParserTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/parsing/XNodeTest.java
+++ b/src/test/java/org/apache/ibatis/parsing/XNodeTest.java
@@ -162,7 +162,7 @@ class XNodeTest {
   }
 
   @Test
-  void testXnodeToStringVariables() throws Exception {
+  void xnodeToStringVariables() throws Exception {
     String src = "<root attr='${x}'>y = ${y}<sub attr='${y}'>x = ${x}</sub></root>";
     String expected = "<root attr=\"foo\">\n  y = bar\n  <sub attr=\"bar\">\n    x = foo\n  </sub>\n</root>\n";
     Properties vars = new Properties();

--- a/src/test/java/org/apache/ibatis/reflection/MetaClassTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/MetaClassTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.apache.ibatis.reflection;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 import java.util.Map;
@@ -42,7 +43,7 @@ class MetaClassTest {
       ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
       MetaClass meta = MetaClass.forClass(RichType.class, reflectorFactory);
       meta.getGetterType("aString");
-      org.junit.jupiter.api.Assertions.fail("should have thrown ReflectionException");
+      fail("should have thrown ReflectionException");
     } catch (ReflectionException expected) {
       assertEquals(
           "There is no getter for property named \'aString\' in \'class org.apache.ibatis.domain.misc.RichType\'",

--- a/src/test/java/org/apache/ibatis/reflection/MetaObjectTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/MetaObjectTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -262,7 +262,7 @@ class MetaObjectTest {
   @Test
   void shouldNotUseObjectWrapperFactoryByDefault() {
     MetaObject meta = SystemMetaObject.forObject(new Author());
-    assertTrue(!meta.getObjectWrapper().getClass().equals(CustomBeanWrapper.class));
+    assertNotEquals(CustomBeanWrapper.class, meta.getObjectWrapper().getClass());
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -33,14 +33,14 @@ import org.junit.jupiter.api.Test;
 class ReflectorTest {
 
   @Test
-  void testGetSetterType() {
+  void getSetterType() {
     ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
     Reflector reflector = reflectorFactory.findForClass(Section.class);
     Assertions.assertEquals(Long.class, reflector.getSetterType("id"));
   }
 
   @Test
-  void testGetGetterType() {
+  void getGetterType() {
     ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
     Reflector reflector = reflectorFactory.findForClass(Section.class);
     Assertions.assertEquals(Long.class, reflector.getGetterType("id"));

--- a/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test;
 
 class TypeParameterResolverTest {
   @Test
-  void testReturn_Lv0SimpleClass() throws Exception {
+  void returnLv0SimpleClass() throws Exception {
     Class<?> clazz = Level0Mapper.class;
     Method method = clazz.getMethod("simpleSelect");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -49,7 +49,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_SimpleVoid() throws Exception {
+  void returnSimpleVoid() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("simpleSelectVoid", Integer.class);
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -57,7 +57,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_SimplePrimitive() throws Exception {
+  void returnSimplePrimitive() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("simpleSelectPrimitive", int.class);
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -65,7 +65,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_SimpleClass() throws Exception {
+  void returnSimpleClass() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("simpleSelect");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -73,7 +73,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_SimpleList() throws Exception {
+  void returnSimpleList() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("simpleSelectList");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -85,7 +85,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_SimpleMap() throws Exception {
+  void returnSimpleMap() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("simpleSelectMap");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -98,7 +98,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_SimpleWildcard() throws Exception {
+  void returnSimpleWildcard() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("simpleSelectWildcard");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -112,7 +112,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_SimpleArray() throws Exception {
+  void returnSimpleArray() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("simpleSelectArray");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -123,7 +123,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_SimpleArrayOfArray() throws Exception {
+  void returnSimpleArrayOfArray() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("simpleSelectArrayOfArray");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -135,7 +135,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_SimpleTypeVar() throws Exception {
+  void returnSimpleTypeVar() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("simpleSelectTypeVar");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -147,7 +147,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_Lv1Class() throws Exception {
+  void returnLv1Class() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("select", Object.class);
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -155,7 +155,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_Lv2CustomClass() throws Exception {
+  void returnLv2CustomClass() throws Exception {
     Class<?> clazz = Level2Mapper.class;
     Method method = clazz.getMethod("selectCalculator", Calculator.class);
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -167,7 +167,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_Lv2CustomClassList() throws Exception {
+  void returnLv2CustomClassList() throws Exception {
     Class<?> clazz = Level2Mapper.class;
     Method method = clazz.getMethod("selectCalculatorList");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -181,7 +181,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_Lv0InnerClass() throws Exception {
+  void returnLv0InnerClass() throws Exception {
     Class<?> clazz = Level0InnerMapper.class;
     Method method = clazz.getMethod("select", Object.class);
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -189,7 +189,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_Lv2Class() throws Exception {
+  void returnLv2Class() throws Exception {
     Class<?> clazz = Level2Mapper.class;
     Method method = clazz.getMethod("select", Object.class);
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -197,7 +197,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_Lv1List() throws Exception {
+  void returnLv1List() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("selectList", Object.class, Object.class);
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -209,7 +209,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_Lv1Array() throws Exception {
+  void returnLv1Array() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("selectArray", List[].class);
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -220,7 +220,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_Lv2ArrayOfArray() throws Exception {
+  void returnLv2ArrayOfArray() throws Exception {
     Class<?> clazz = Level2Mapper.class;
     Method method = clazz.getMethod("selectArrayOfArray");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -233,7 +233,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_Lv2ArrayOfList() throws Exception {
+  void returnLv2ArrayOfList() throws Exception {
     Class<?> clazz = Level2Mapper.class;
     Method method = clazz.getMethod("selectArrayOfList");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -246,7 +246,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_Lv2WildcardList() throws Exception {
+  void returnLv2WildcardList() throws Exception {
     Class<?> clazz = Level2Mapper.class;
     Method method = clazz.getMethod("selectWildcardList");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -262,7 +262,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_LV1Map() throws Exception {
+  void returnLV1Map() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("selectMap");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -275,7 +275,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_LV2Map() throws Exception {
+  void returnLV2Map() throws Exception {
     Class<?> clazz = Level2Mapper.class;
     Method method = clazz.getMethod("selectMap");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -288,7 +288,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_Subclass() throws Exception {
+  void returnSubclass() throws Exception {
     Class<?> clazz = SubCalculator.class;
     Method method = clazz.getMethod("getId");
     Type result = TypeParameterResolver.resolveReturnType(method, clazz);
@@ -296,7 +296,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testParam_Primitive() throws Exception {
+  void paramPrimitive() throws Exception {
     Class<?> clazz = Level2Mapper.class;
     Method method = clazz.getMethod("simpleSelectPrimitive", int.class);
     Type[] result = TypeParameterResolver.resolveParamTypes(method, clazz);
@@ -305,7 +305,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testParam_Simple() throws Exception {
+  void paramSimple() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("simpleSelectVoid", Integer.class);
     Type[] result = TypeParameterResolver.resolveParamTypes(method, clazz);
@@ -314,7 +314,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testParam_Lv1Single() throws Exception {
+  void paramLv1Single() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("select", Object.class);
     Type[] result = TypeParameterResolver.resolveParamTypes(method, clazz);
@@ -323,7 +323,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testParam_Lv2Single() throws Exception {
+  void paramLv2Single() throws Exception {
     Class<?> clazz = Level2Mapper.class;
     Method method = clazz.getMethod("select", Object.class);
     Type[] result = TypeParameterResolver.resolveParamTypes(method, clazz);
@@ -332,7 +332,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testParam_Lv2Multiple() throws Exception {
+  void paramLv2Multiple() throws Exception {
     Class<?> clazz = Level2Mapper.class;
     Method method = clazz.getMethod("selectList", Object.class, Object.class);
     Type[] result = TypeParameterResolver.resolveParamTypes(method, clazz);
@@ -342,7 +342,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testParam_Lv2CustomClass() throws Exception {
+  void paramLv2CustomClass() throws Exception {
     Class<?> clazz = Level2Mapper.class;
     Method method = clazz.getMethod("selectCalculator", Calculator.class);
     Type[] result = TypeParameterResolver.resolveParamTypes(method, clazz);
@@ -355,7 +355,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testParam_Lv1Array() throws Exception {
+  void paramLv1Array() throws Exception {
     Class<?> clazz = Level1Mapper.class;
     Method method = clazz.getMethod("selectArray", List[].class);
     Type[] result = TypeParameterResolver.resolveParamTypes(method, clazz);
@@ -368,7 +368,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testParam_Subclass() throws Exception {
+  void paramSubclass() throws Exception {
     Class<?> clazz = SubCalculator.class;
     Method method = clazz.getMethod("setId", Object.class);
     Type[] result = TypeParameterResolver.resolveParamTypes(method, clazz);
@@ -376,7 +376,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturn_Anonymous() throws Exception {
+  void returnAnonymous() throws Exception {
     Calculator<?> instance = new Calculator<Integer>();
     Class<?> clazz = instance.getClass();
     Method method = clazz.getMethod("getId");
@@ -385,7 +385,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testField_GenericField() throws Exception {
+  void fieldGenericField() throws Exception {
     Class<?> clazz = SubCalculator.class;
     Class<?> declaredClass = Calculator.class;
     Field field = declaredClass.getDeclaredField("fld");
@@ -394,7 +394,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testReturnParam_WildcardWithUpperBounds() throws Exception {
+  void returnParamWildcardWithUpperBounds() throws Exception {
     class Key {
     }
     @SuppressWarnings("unused")
@@ -430,7 +430,7 @@ class TypeParameterResolverTest {
   }
 
   @Test
-  void testDeepHierarchy() throws Exception {
+  void deepHierarchy() throws Exception {
     @SuppressWarnings("unused")
     abstract class A<S> {
       protected S id;

--- a/src/test/java/org/apache/ibatis/reflection/factory/DefaultObjectFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/factory/DefaultObjectFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.apache.ibatis.reflection.factory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -52,8 +51,7 @@ class DefaultObjectFactoryTest {
   void createClassThrowsProperErrorMsg() {
     DefaultObjectFactory defaultObjectFactory = new DefaultObjectFactory();
     try {
-      defaultObjectFactory.create(TestClass.class, Collections.singletonList(String.class),
-          Collections.singletonList("foo"));
+      defaultObjectFactory.create(TestClass.class, List.of(String.class), List.of("foo"));
       Assertions.fail("Should have thrown ReflectionException");
     } catch (Exception e) {
       Assertions.assertTrue(e instanceof ReflectionException, "Should be ReflectionException");

--- a/src/test/java/org/apache/ibatis/reflection/property/PropertyCopierTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/property/PropertyCopierTest.java
@@ -20,7 +20,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class PropertyCopierTest {
+class PropertyCopierTest {
 
   @Test
   void copyBeanProperties() {

--- a/src/test/java/org/apache/ibatis/reflection/wrapper/MapWrapperTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/wrapper/MapWrapperTest.java
@@ -197,7 +197,7 @@ class MapWrapperTest {
 
   @ParameterizedTest
   @CsvSource({ "abc[def]", "abc.def", "abc.def.ghi", "abc[d.ef].ghi" })
-  void testCustomMapWrapper(String key) {
+  void customMapWrapper(String key) {
     Map<String, Object> map = new HashMap<>();
     MetaObject metaObj = MetaObject.forObject(map, new DefaultObjectFactory(), new FlatMapWrapperFactory(),
         new DefaultReflectorFactory());

--- a/src/test/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/scripting/defaults/DefaultParameterHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
@@ -73,7 +72,7 @@ class DefaultParameterHandlerTest {
         any(JdbcType.class));
     ParameterMapping parameterMapping = new ParameterMapping.Builder(mappedStatement.getConfiguration(), "prop",
         typeHandler).build();
-    List<ParameterMapping> parameterMappings = Collections.singletonList(parameterMapping);
+    List<ParameterMapping> parameterMappings = List.of(parameterMapping);
     when(boundSql.getParameterMappings()).thenReturn(parameterMappings);
 
     DefaultParameterHandler defaultParameterHandler = new DefaultParameterHandler(mappedStatement, parameterObject,
@@ -111,7 +110,7 @@ class DefaultParameterHandlerTest {
   }
 
   @Test
-  void testParameterObjectGetPropertyValueWithAdditionalParameter() throws SQLException {
+  void parameterObjectGetPropertyValueWithAdditionalParameter() throws SQLException {
     Configuration config = new Configuration();
     TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
 
@@ -141,7 +140,7 @@ class DefaultParameterHandlerTest {
   }
 
   @Test
-  void testParameterObjectGetPropertyValueWithNull() throws SQLException {
+  void parameterObjectGetPropertyValueWithNull() throws SQLException {
     Configuration config = new Configuration();
     TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
 
@@ -167,7 +166,7 @@ class DefaultParameterHandlerTest {
   }
 
   @Test
-  void testParameterObjectGetPropertyValueWithTypeHandler() throws SQLException {
+  void parameterObjectGetPropertyValueWithTypeHandler() throws SQLException {
     Configuration config = new Configuration();
     TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
 
@@ -193,7 +192,7 @@ class DefaultParameterHandlerTest {
   }
 
   @Test
-  void testParameterObjectGetPropertyValueWithMetaObject() throws SQLException {
+  void parameterObjectGetPropertyValueWithMetaObject() throws SQLException {
     Configuration config = new Configuration();
     TypeHandlerRegistry registry = config.getTypeHandlerRegistry();
 
@@ -231,7 +230,7 @@ class DefaultParameterHandlerTest {
   }
 
   @Test
-  void testParameterObjectGetPropertyValueWithMetaObjectAndCreateOnce() {
+  void parameterObjectGetPropertyValueWithMetaObjectAndCreateOnce() {
     Author parameterObject = mock(Author.class);
 
     Configuration mockConfig = mock(Configuration.class);

--- a/src/test/java/org/apache/ibatis/scripting/xmltags/ChooseSqlNodeTest.java
+++ b/src/test/java/org/apache/ibatis/scripting/xmltags/ChooseSqlNodeTest.java
@@ -85,7 +85,7 @@ class ChooseSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldAppendSecond() throws Exception {
+  void shouldAppendSecond() throws Exception {
     when(context.getBindings()).thenReturn(new HashMap<>() {
       {
         put("author", new Author(1, "mybatis", "***", null, null, null));
@@ -99,7 +99,7 @@ class ChooseSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldAppendOtherwise() throws Exception {
+  void shouldAppendOtherwise() throws Exception {
     when(context.getBindings()).thenReturn(new HashMap<>());
 
     boolean result = sqlNode.apply(context);

--- a/src/test/java/org/apache/ibatis/scripting/xmltags/IfSqlNodeTest.java
+++ b/src/test/java/org/apache/ibatis/scripting/xmltags/IfSqlNodeTest.java
@@ -66,7 +66,7 @@ class IfSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldAppendNone() {
+  void shouldAppendNone() {
     when(context.getBindings()).thenReturn(new HashMap<>() {
       {
         put("title", null);

--- a/src/test/java/org/apache/ibatis/scripting/xmltags/SetSqlNodeTest.java
+++ b/src/test/java/org/apache/ibatis/scripting/xmltags/SetSqlNodeTest.java
@@ -76,7 +76,7 @@ class SetSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldAppendOnlyUsername() throws Exception {
+  void shouldAppendOnlyUsername() throws Exception {
     when(context.getBindings()).thenReturn(new HashMap<>() {
       {
         put("username", "Jack");
@@ -90,7 +90,7 @@ class SetSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldAppendOnlyPassword() throws Exception {
+  void shouldAppendOnlyPassword() throws Exception {
     when(context.getBindings()).thenReturn(new HashMap<>() {
       {
         put("password", "***");
@@ -104,7 +104,7 @@ class SetSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldAppendNone() throws Exception {
+  void shouldAppendNone() throws Exception {
     when(context.getBindings()).thenReturn(new HashMap<>());
 
     boolean result = sqlNode.apply(context);

--- a/src/test/java/org/apache/ibatis/scripting/xmltags/TextSqlNodeTest.java
+++ b/src/test/java/org/apache/ibatis/scripting/xmltags/TextSqlNodeTest.java
@@ -48,7 +48,7 @@ class TextSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldApplyDynamic() {
+  void shouldApplyDynamic() {
     // given
     TextSqlNode sqlNode = new TextSqlNode(DYNAMIC_TEXT);
     when(context.getBindings()).thenReturn(new HashMap<>() {

--- a/src/test/java/org/apache/ibatis/scripting/xmltags/TrimSqlNodeTest.java
+++ b/src/test/java/org/apache/ibatis/scripting/xmltags/TrimSqlNodeTest.java
@@ -78,7 +78,7 @@ class TrimSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldAppendOnlyId() throws Exception {
+  void shouldAppendOnlyId() throws Exception {
     when(context.getBindings()).thenReturn(new HashMap<>() {
       {
         put("id", 1);
@@ -92,7 +92,7 @@ class TrimSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldAppendOnlyName() throws Exception {
+  void shouldAppendOnlyName() throws Exception {
     when(context.getBindings()).thenReturn(new HashMap<>() {
       {
         put("name", "mybatis");
@@ -106,7 +106,7 @@ class TrimSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldAppendNone() throws Exception {
+  void shouldAppendNone() throws Exception {
     when(context.getBindings()).thenReturn(new HashMap<>());
 
     boolean result = sqlNode.apply(context);

--- a/src/test/java/org/apache/ibatis/scripting/xmltags/WhereSqlNodeTest.java
+++ b/src/test/java/org/apache/ibatis/scripting/xmltags/WhereSqlNodeTest.java
@@ -76,7 +76,7 @@ class WhereSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldAppendOnlyId() throws Exception {
+  void shouldAppendOnlyId() throws Exception {
     when(context.getBindings()).thenReturn(new HashMap<>() {
       {
         put("id", 1);
@@ -90,7 +90,7 @@ class WhereSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldAppendOnlyName() throws Exception {
+  void shouldAppendOnlyName() throws Exception {
     when(context.getBindings()).thenReturn(new HashMap<>() {
       {
         put("name", "mybatis");
@@ -104,7 +104,7 @@ class WhereSqlNodeTest extends SqlNodeBase {
   }
 
   @Test
-  public void shouldAppendNone() throws Exception {
+  void shouldAppendNone() throws Exception {
     when(context.getBindings()).thenReturn(new HashMap<>());
 
     boolean result = sqlNode.apply(context);

--- a/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
+++ b/src/test/java/org/apache/ibatis/session/SqlSessionTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -162,9 +162,8 @@ class SqlSessionTest extends BaseDataTest {
   @Test
   void shouldFailWithTooManyResultsException() {
     try (SqlSession session = sqlMapper.openSession(TransactionIsolationLevel.SERIALIZABLE)) {
-      Assertions.assertThrows(TooManyResultsException.class, () -> {
-        session.selectOne("org.apache.ibatis.domain.blog.mappers.AuthorMapper.selectAllAuthors");
-      });
+      Assertions.assertThrows(TooManyResultsException.class,
+          () -> session.selectOne("org.apache.ibatis.domain.blog.mappers.AuthorMapper.selectAllAuthors"));
     }
   }
 
@@ -570,9 +569,7 @@ class SqlSessionTest extends BaseDataTest {
     try (SqlSession session = sqlMapper.openSession()) {
       DefaultResultHandler handler = new DefaultResultHandler();
       AuthorMapper mapper = session.getMapper(AuthorMapper.class);
-      Assertions.assertThrows(BindingException.class, () -> {
-        mapper.selectAuthor2(101, handler);
-      });
+      Assertions.assertThrows(BindingException.class, () -> mapper.selectAuthor2(101, handler));
     }
   }
 

--- a/src/test/java/org/apache/ibatis/session/defaults/ExtendedSqlSessionFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/session/defaults/ExtendedSqlSessionFactoryTest.java
@@ -22,12 +22,12 @@ import org.apache.ibatis.io.Resources;
 import org.apache.ibatis.session.SqlSession;
 import org.apache.ibatis.session.SqlSessionFactory;
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class ExtendedSqlSessionFactoryTest extends BaseDataTest {
+class ExtendedSqlSessionFactoryTest extends BaseDataTest {
 
   @Test
-  public void testCanUseExtendedSqlSessionUsingDefaults() throws Exception {
+  void canUseExtendedSqlSessionUsingDefaults() throws Exception {
     createBlogDataSource();
 
     final String resource = "org/apache/ibatis/builder/MapperConfig.xml";

--- a/src/test/java/org/apache/ibatis/submitted/ancestor_ref/AncestorRefTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ancestor_ref/AncestorRefTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class AncestorRefTest {
   }
 
   @Test
-  void testCircularAssociation() {
+  void circularAssociation() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = mapper.getUserAssociation(1);
@@ -52,7 +52,7 @@ class AncestorRefTest {
   }
 
   @Test
-  void testCircularCollection() {
+  void circularCollection() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = mapper.getUserCollection(2);
@@ -62,7 +62,7 @@ class AncestorRefTest {
   }
 
   @Test
-  void testAncestorRef() {
+  void ancestorRef() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       Blog blog = mapper.selectBlog(1);

--- a/src/test/java/org/apache/ibatis/submitted/association_nested/FolderMapperTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/association_nested/FolderMapperTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Test;
 class FolderMapperTest {
 
   @Test
-  void testFindWithChildren() throws Exception {
+  void findWithChildren() throws Exception {
     try (Connection conn = DriverManager.getConnection("jdbc:hsqldb:mem:association_nested", "SA", "");
         Statement stmt = conn.createStatement()) {
       stmt.execute("create table folder (id int, name varchar(100), parent_id int)");

--- a/src/test/java/org/apache/ibatis/submitted/associationtest/AssociationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/associationtest/AssociationTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/autodiscover/AutodiscoverTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/autodiscover/AutodiscoverTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -42,19 +42,19 @@ class AutodiscoverTest {
   }
 
   @Test
-  void testTypeAlias() {
+  void typeAlias() {
     TypeAliasRegistry typeAliasRegistry = sqlSessionFactory.getConfiguration().getTypeAliasRegistry();
     assertNotNull(typeAliasRegistry.resolveAlias("testAlias"));
   }
 
   @Test
-  void testTypeHandler() {
+  void typeHandler() {
     TypeHandlerRegistry typeHandlerRegistry = sqlSessionFactory.getConfiguration().getTypeHandlerRegistry();
     assertTrue(typeHandlerRegistry.hasTypeHandler(BigInteger.class));
   }
 
   @Test
-  void testMapper() {
+  void mapper() {
     assertTrue(sqlSessionFactory.getConfiguration().hasMapper(DummyMapper.class));
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/automapping/AutomappingTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -153,7 +153,7 @@ class AutomappingTest {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       // no errors throw
       List<Book> books = mapper.getBooks();
-      Assertions.assertTrue(!books.isEmpty(), "should return results,no errors throw");
+      Assertions.assertFalse(books.isEmpty(), "should return results,no errors throw");
     }
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/awful_table/AwfulTableTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/awful_table/AwfulTableTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class AwfulTableTest {
   }
 
   @Test
-  void testAwfulTableInsert() {
+  void awfulTableInsert() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       AwfulTableMapper mapper = sqlSession.getMapper(AwfulTableMapper.class);
       AwfulTable record = new AwfulTable();

--- a/src/test/java/org/apache/ibatis/submitted/basetest/BaseTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/basetest/BaseTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/batch_keys/BatchKeysTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_keys/BatchKeysTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -73,7 +73,7 @@ class BatchKeysTest {
   }
 
   @Test
-  void testInsert() {
+  void insert() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
       User user1 = new User(null, "Pocoyo");
       sqlSession.insert("insert", user1);
@@ -91,7 +91,7 @@ class BatchKeysTest {
   }
 
   @Test
-  void testInsertJdbc3() {
+  void insertJdbc3() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
       User user1 = new User(null, "Pocoyo");
       sqlSession.insert("insertIdentity", user1);
@@ -110,7 +110,7 @@ class BatchKeysTest {
   }
 
   @Test
-  void testInsertWithMapper() {
+  void insertWithMapper() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
       Mapper userMapper = sqlSession.getMapper(Mapper.class);
       User user1 = new User(null, "Pocoyo");
@@ -130,7 +130,7 @@ class BatchKeysTest {
   }
 
   @Test
-  void testInsertMapperJdbc3() {
+  void insertMapperJdbc3() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
       Mapper userMapper = sqlSession.getMapper(Mapper.class);
       User user1 = new User(null, "Pocoyo");
@@ -150,7 +150,7 @@ class BatchKeysTest {
   }
 
   @Test
-  void testInsertMapperNoBatchJdbc3() {
+  void insertMapperNoBatchJdbc3() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper userMapper = sqlSession.getMapper(Mapper.class);
       User user1 = new User(null, "Pocoyo");

--- a/src/test/java/org/apache/ibatis/submitted/batch_test/BatchTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/batch_test/BatchTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/blobtest/BlobTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/blobtest/BlobTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ class BlobTest {
   /*
    * This test demonstrates the use of type aliases for primitive types in constructor based result maps
    */
-  void testInsertBlobThenSelectAll() {
+  void insertBlobThenSelectAll() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       BlobMapper blobMapper = sqlSession.getMapper(BlobMapper.class);
 
@@ -69,7 +69,7 @@ class BlobTest {
   /*
    * This test demonstrates the use of type aliases for primitive types in constructor based result maps
    */
-  void testInsertBlobObjectsThenSelectAll() {
+  void insertBlobObjectsThenSelectAll() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       BlobMapper blobMapper = sqlSession.getMapper(BlobMapper.class);
 

--- a/src/test/java/org/apache/ibatis/submitted/blocking_cache/BlockingCacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/blocking_cache/BlockingCacheTest.java
@@ -48,7 +48,7 @@ class BlockingCacheTest {
   }
 
   @Test
-  void testBlockingCache() throws InterruptedException {
+  void blockingCache() throws InterruptedException {
     ExecutorService defaultThreadPool = Executors.newFixedThreadPool(2);
 
     long init = System.currentTimeMillis();

--- a/src/test/java/org/apache/ibatis/submitted/bringrags/SimpleObjectTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/bringrags/SimpleObjectTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -62,7 +62,7 @@ class SimpleObjectTest {
   }
 
   @Test
-  void testGetById() {
+  void getById() {
     SimpleChildObject sc = simpleChildObjectMapper.getSimpleChildObjectById("20000");
     Assertions.assertNotNull(sc);
     Assertions.assertNotNull(sc.getSimpleObject());

--- a/src/test/java/org/apache/ibatis/submitted/cache/CacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cache/CacheTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/CallSettersOnNullsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/CallSettersOnNullsTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/DoNotCallSettersOnNullsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls/DoNotCallSettersOnNullsTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls_again/MyBatisTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/call_setters_on_nulls_again/MyBatisTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/camelcase/CamelCaseMappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/camelcase/CamelCaseMappingTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class CamelCaseMappingTest {
   }
 
   @Test
-  void testList() {
+  void list() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Camel> list = sqlSession.selectList("org.apache.ibatis.submitted.camel.doSelect");
       Assertions.assertTrue(list.size() > 0);
@@ -53,7 +53,7 @@ class CamelCaseMappingTest {
   }
 
   @Test
-  void testMap() {
+  void map() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Map<String, Object>> list = sqlSession.selectList("org.apache.ibatis.submitted.camel.doSelectMap");
       Assertions.assertTrue(list.size() > 0);

--- a/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/CglibNPELazyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/CglibNPELazyTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class CglibNPELazyTest {
   }
 
   @Test
-  void testNoParent() {
+  void noParent() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.selectById(1);
@@ -55,7 +55,7 @@ class CglibNPELazyTest {
   }
 
   @Test
-  void testAncestorSelf() {
+  void ancestorSelf() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.selectById(1);
@@ -66,7 +66,7 @@ class CglibNPELazyTest {
   }
 
   @Test
-  void testAncestorAfterQueryingParents() {
+  void ancestorAfterQueryingParents() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person expectedAncestor = personMapper.selectById(1);
@@ -80,7 +80,7 @@ class CglibNPELazyTest {
   }
 
   @Test
-  void testGrandParent() {
+  void grandParent() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person expectedParent = personMapper.selectById(2);
@@ -95,7 +95,7 @@ class CglibNPELazyTest {
   }
 
   @Test
-  void testAncestor() {
+  void ancestor() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person expectedAncestor = personMapper.selectById(1);

--- a/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/CglibNPETest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cglib_lazy_error/CglibNPETest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ class CglibNPETest {
   }
 
   @Test
-  void testNoParent() {
+  void noParent() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.selectById(1);
@@ -53,7 +53,7 @@ class CglibNPETest {
   }
 
   @Test
-  void testAncestorSelf() {
+  void ancestorSelf() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.selectById(1);
@@ -77,7 +77,7 @@ class CglibNPETest {
   }
 
   @Test
-  void testAncestor() {
+  void ancestor() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person expectedAncestor = personMapper.selectById(1);
@@ -88,7 +88,7 @@ class CglibNPETest {
   }
 
   @Test
-  void testAncestorAfterQueryingParents() {
+  void ancestorAfterQueryingParents() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person expectedAncestor = personMapper.selectById(1);
@@ -102,7 +102,7 @@ class CglibNPETest {
   }
 
   @Test
-  void testInsertBetweenTwoSelects() {
+  void insertBetweenTwoSelects() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person selected1 = personMapper.selectById(1);
@@ -123,7 +123,7 @@ class CglibNPETest {
   }
 
   @Test
-  void testSelectWithStringSQLInjection() {
+  void selectWithStringSQLInjection() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person selected1 = personMapper.selectByStringId("1");

--- a/src/test/java/org/apache/ibatis/submitted/collectionparameters/CollectionParametersTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/collectionparameters/CollectionParametersTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/column_forwarding/ColumnForwardingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_forwarding/ColumnForwardingTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/column_prefix/ColumnPrefixAutoMappingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_prefix/ColumnPrefixAutoMappingTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ class ColumnPrefixAutoMappingTest extends ColumnPrefixTest {
   }
 
   @Test
-  void testCaseInsensitivity() {
+  void caseInsensitivity() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Brand brand = sqlSession
           .selectOne("org.apache.ibatis.submitted.column_prefix.MapperAutoMapping.selectBrandWithProducts", 1);

--- a/src/test/java/org/apache/ibatis/submitted/column_prefix/ColumnPrefixTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/column_prefix/ColumnPrefixTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class ColumnPrefixTest {
   }
 
   @Test
-  void testSelectPetAndRoom() {
+  void selectPetAndRoom() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Pet> pets = getPetAndRoom(sqlSession);
       assertEquals(3, pets.size());
@@ -55,7 +55,7 @@ class ColumnPrefixTest {
   }
 
   @Test
-  void testComplexPerson() {
+  void complexPerson() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Person> list = getPersons(sqlSession);
       Person person1 = list.get(0);

--- a/src/test/java/org/apache/ibatis/submitted/complex_column/ComplexColumnTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_column/ComplexColumnTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class ComplexColumnTest {
   }
 
   @Test
-  void testWithoutComplex() {
+  void withoutComplex() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.getWithoutComplex(2L);
@@ -56,7 +56,7 @@ class ComplexColumnTest {
   }
 
   @Test
-  void testWithComplex() {
+  void withComplex() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.getWithComplex(2L);
@@ -71,7 +71,7 @@ class ComplexColumnTest {
   }
 
   @Test
-  void testWithComplex2() {
+  void withComplex2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.getWithComplex2(2L);
@@ -86,7 +86,7 @@ class ComplexColumnTest {
   }
 
   @Test
-  void testWithComplex3() {
+  void withComplex3() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.getWithComplex3(2L);
@@ -101,7 +101,7 @@ class ComplexColumnTest {
   }
 
   @Test
-  void testWithComplex4() {
+  void withComplex4() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person criteria = new Person();
@@ -119,7 +119,7 @@ class ComplexColumnTest {
   }
 
   @Test
-  void testWithParamAttributes() {
+  void withParamAttributes() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.getComplexWithParamAttributes(2L);

--- a/src/test/java/org/apache/ibatis/submitted/complex_type/ComplexTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/complex_type/ComplexTypeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/count/CountTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/count/CountTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ class CountTest {
   }
 
   @Test
-  void testCount() {
+  void count() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       CountMapper mapper = sqlSession.getMapper(CountMapper.class);
       int answer = mapper.count();

--- a/src/test/java/org/apache/ibatis/submitted/criterion/CriterionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/criterion/CriterionTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class CriterionTest {
   }
 
   @Test
-  void testSimpleSelect() {
+  void simpleSelect() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Criterion criterion = new Criterion();
       criterion.setTest("firstName =");

--- a/src/test/java/org/apache/ibatis/submitted/cursor_cache_oom/CursorOomTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_cache_oom/CursorOomTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_nested/CursorNestedTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -90,7 +90,7 @@ class CursorNestedTest {
   }
 
   @Test
-  void testCursorWithRowBound() {
+  void cursorWithRowBound() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Cursor<User> usersCursor = sqlSession.selectCursor("getAllUsers", null, new RowBounds(2, 1));
 

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
@@ -31,9 +31,11 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
+@TestMethodOrder(MethodOrderer.MethodName.class)
 class CursorSimpleTest {
 
   private static SqlSessionFactory sqlSessionFactory;
@@ -130,8 +132,6 @@ class CursorSimpleTest {
     Assertions.assertFalse(usersCursor.isConsumed());
   }
 
-  // TODO 12/28/2024 JWL Unstable test
-  @Disabled
   @Test
   void cursorWithRowBound() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
@@ -31,6 +31,7 @@ import org.apache.ibatis.session.SqlSessionFactory;
 import org.apache.ibatis.session.SqlSessionFactoryBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class CursorSimpleTest {
@@ -129,6 +130,8 @@ class CursorSimpleTest {
     Assertions.assertFalse(usersCursor.isConsumed());
   }
 
+  // TODO 12/28/2024 JWL Unstable test
+  @Disabled
   @Test
   void cursorWithRowBound() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
@@ -160,7 +163,6 @@ class CursorSimpleTest {
 
   @Test
   void cursorIteratorNoSuchElementExceptionWithHasNext() throws IOException {
-
     try (SqlSession sqlSession = sqlSessionFactory.openSession();
         Cursor<User> usersCursor = sqlSession.selectCursor("getAllUsers", null, new RowBounds(1, 1))) {
       try {

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/CursorSimpleTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -99,7 +99,7 @@ class CursorSimpleTest {
   }
 
   @Test
-  void testCursorClosedOnSessionClose() {
+  void cursorClosedOnSessionClose() {
     Cursor<User> usersCursor;
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
@@ -130,7 +130,7 @@ class CursorSimpleTest {
   }
 
   @Test
-  void testCursorWithRowBound() {
+  void cursorWithRowBound() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       // RowBound starting at offset 1 and limiting to 2 items
       Cursor<User> usersCursor = sqlSession.selectCursor("getAllUsers", null, new RowBounds(1, 3));
@@ -159,7 +159,7 @@ class CursorSimpleTest {
   }
 
   @Test
-  void testCursorIteratorNoSuchElementExceptionWithHasNext() throws IOException {
+  void cursorIteratorNoSuchElementExceptionWithHasNext() throws IOException {
 
     try (SqlSession sqlSession = sqlSessionFactory.openSession();
         Cursor<User> usersCursor = sqlSession.selectCursor("getAllUsers", null, new RowBounds(1, 1))) {
@@ -181,7 +181,7 @@ class CursorSimpleTest {
   }
 
   @Test
-  void testCursorIteratorNoSuchElementExceptionNoHasNext() throws IOException {
+  void cursorIteratorNoSuchElementExceptionNoHasNext() throws IOException {
     try (SqlSession sqlSession = sqlSessionFactory.openSession();
         Cursor<User> usersCursor = sqlSession.selectCursor("getAllUsers", null, new RowBounds(1, 1))) {
       try {
@@ -201,7 +201,7 @@ class CursorSimpleTest {
   }
 
   @Test
-  void testCursorWithBadRowBound() {
+  void cursorWithBadRowBound() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       // Trying to start at offset 10 (which does not exist, since there is only 4 items)
       Cursor<User> usersCursor = sqlSession.selectCursor("getAllUsers", null, new RowBounds(10, 2));
@@ -214,7 +214,7 @@ class CursorSimpleTest {
   }
 
   @Test
-  void testCursorMultipleHasNextCall() {
+  void cursorMultipleHasNextCall() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       Cursor<User> usersCursor = mapper.getAllUsers();
@@ -236,7 +236,7 @@ class CursorSimpleTest {
   }
 
   @Test
-  void testCursorMultipleIteratorCall() {
+  void cursorMultipleIteratorCall() {
     Iterator<User> iterator2 = null;
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
@@ -258,7 +258,7 @@ class CursorSimpleTest {
   }
 
   @Test
-  void testCursorMultipleCloseCall() throws IOException {
+  void cursorMultipleCloseCall() throws IOException {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       Cursor<User> usersCursor = mapper.getAllUsers();
@@ -288,7 +288,7 @@ class CursorSimpleTest {
   }
 
   @Test
-  void testCursorUsageAfterClose() throws IOException {
+  void cursorUsageAfterClose() throws IOException {
 
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/cursor_simple/MysqlCursorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/cursor_simple/MysqlCursorTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ class MysqlCursorTest {
   }
 
   @Test
-  void testMySqlStreamResultSet() throws IOException {
+  void mySqlStreamResultSet() throws IOException {
     // #1654 and https://bugs.mysql.com/bug.php?id=96786
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
@@ -68,7 +68,7 @@ class MysqlCursorTest {
   }
 
   @Test
-  void testMySqlStreamResultSetBatch() throws IOException {
+  void mySqlStreamResultSetBatch() throws IOException {
     // #1654 and https://bugs.mysql.com/bug.php?id=96786
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomCollectionHandlingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/custom_collection_handling/CustomCollectionHandlingTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class CustomCollectionHandlingTest {
    * Custom collections with nested resultMap.
    */
   @Test
-  void testSelectListWithNestedResultMap() throws Exception {
+  void selectListWithNestedResultMap() throws Exception {
     String xmlConfig = "org/apache/ibatis/submitted/custom_collection_handling/MapperConfig.xml";
     SqlSessionFactory sqlSessionFactory = getSqlSessionFactoryXmlConfig(xmlConfig);
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
@@ -52,7 +52,7 @@ class CustomCollectionHandlingTest {
    * Custom collections with nested select.
    */
   @Test
-  void testSelectListWithNestedSelect() throws Exception {
+  void selectListWithNestedSelect() throws Exception {
     String xmlConfig = "org/apache/ibatis/submitted/custom_collection_handling/MapperConfig.xml";
     SqlSessionFactory sqlSessionFactory = getSqlSessionFactoryXmlConfig(xmlConfig);
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {

--- a/src/test/java/org/apache/ibatis/submitted/deferload_common_property/CommonPropertyDeferLoadTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/deferload_common_property/CommonPropertyDeferLoadTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ class CommonPropertyDeferLoadTest {
   }
 
   @Test
-  void testDeferLoadAfterResultHandler() {
+  void deferLoadAfterResultHandler() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       class MyResultHandler implements ResultHandler {
         private final List<Child> children = new ArrayList<>();
@@ -72,7 +72,7 @@ class CommonPropertyDeferLoadTest {
   }
 
   @Test
-  void testDeferLoadDuringResultHandler() {
+  void deferLoadDuringResultHandler() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       class MyResultHandler implements ResultHandler {
         @Override
@@ -87,7 +87,7 @@ class CommonPropertyDeferLoadTest {
   }
 
   @Test
-  void testDeferLoadAfterResultHandlerWithLazyLoad() {
+  void deferLoadAfterResultHandlerWithLazyLoad() {
     try (SqlSession sqlSession = lazyLoadSqlSessionFactory.openSession()) {
       class MyResultHandler implements ResultHandler {
         private final List<Child> children = new ArrayList<>();
@@ -107,7 +107,7 @@ class CommonPropertyDeferLoadTest {
   }
 
   @Test
-  void testDeferLoadDuringResultHandlerWithLazyLoad() {
+  void deferLoadDuringResultHandlerWithLazyLoad() {
     try (SqlSession sqlSession = lazyLoadSqlSessionFactory.openSession()) {
       class MyResultHandler implements ResultHandler {
         @Override

--- a/src/test/java/org/apache/ibatis/submitted/disallowdotsonnames/DisallowDotsOnNamesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/disallowdotsonnames/DisallowDotsOnNamesTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 class DisallowDotsOnNamesTest {
 
   @Test
-  void testShouldNotAllowMappedStatementsWithDots() throws IOException {
+  void shouldNotAllowMappedStatementsWithDots() throws IOException {
     Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/disallowdotsonnames/ibatisConfig.xml");
     Assertions.assertThrows(PersistenceException.class, () -> new SqlSessionFactoryBuilder().build(reader));
   }

--- a/src/test/java/org/apache/ibatis/submitted/dml_return_types/DmlMapperReturnTypesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dml_return_types/DmlMapperReturnTypesTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/duplicate_resource_loaded/DuplicateResourceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/duplicate_resource_loaded/DuplicateResourceTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/duplicate_statements/DuplicateStatementsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/duplicate_statements/DuplicateStatementsTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/dynsql/DynSqlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dynsql/DynSqlTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ class DynSqlTest {
   }
 
   @Test
-  void testSelect() {
+  void select() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Integer> ids = new ArrayList<>();
       ids.add(1);
@@ -73,7 +73,7 @@ class DynSqlTest {
   }
 
   @Test
-  void testSelectSimple() {
+  void selectSimple() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Integer> ids = new ArrayList<>();
       ids.add(1);
@@ -92,7 +92,7 @@ class DynSqlTest {
   }
 
   @Test
-  void testSelectLike() {
+  void selectLike() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
 
       List<Map<String, Object>> answer = sqlSession.selectList("org.apache.ibatis.submitted.dynsql.selectLike", "Ba");
@@ -104,7 +104,7 @@ class DynSqlTest {
   }
 
   @Test
-  void testNumerics() {
+  void numerics() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<NumericRow> answer = sqlSession.selectList("org.apache.ibatis.submitted.dynsql.selectNumerics");
 
@@ -125,7 +125,7 @@ class DynSqlTest {
   }
 
   @Test
-  void testOgnlStaticMethodCall() {
+  void ognlStaticMethodCall() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Map<String, Object>> answer = sqlSession
           .selectList("org.apache.ibatis.submitted.dynsql.ognlStaticMethodCall", "Rock 'n Roll");
@@ -135,7 +135,7 @@ class DynSqlTest {
   }
 
   @Test
-  void testBindNull() {
+  void bindNull() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       DynSqlMapper mapper = sqlSession.getMapper(DynSqlMapper.class);
       String description = mapper.selectDescription(null);
@@ -150,7 +150,7 @@ class DynSqlTest {
    * https://github.com/mybatis/mybatis-3/issues/1486
    */
   @Test
-  void testValueObjectWithoutParamAnnotation() {
+  void valueObjectWithoutParamAnnotation() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       DynSqlMapper mapper = sqlSession.getMapper(DynSqlMapper.class);
       List<String> descriptions = mapper.selectDescriptionById(3);
@@ -165,7 +165,7 @@ class DynSqlTest {
    * Variations for with https://github.com/mybatis/mybatis-3/issues/1486
    */
   @Test
-  void testNonValueObjectWithoutParamAnnotation() {
+  void nonValueObjectWithoutParamAnnotation() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       DynSqlMapper mapper = sqlSession.getMapper(DynSqlMapper.class);
       DynSqlMapper.Conditions conditions = new DynSqlMapper.Conditions();
@@ -210,7 +210,7 @@ class DynSqlTest {
    * Variations for with https://github.com/mybatis/mybatis-3/issues/1486
    */
   @Test
-  void testCustomValueObjectWithoutParamAnnotation() throws IOException {
+  void customValueObjectWithoutParamAnnotation() throws IOException {
     SqlSessionFactory sqlSessionFactory;
     try (Reader configReader = Resources.getResourceAsReader("org/apache/ibatis/submitted/dynsql/MapperConfig.xml")) {
       sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);

--- a/src/test/java/org/apache/ibatis/submitted/dynsql2/DynSqlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/dynsql2/DynSqlTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class DynSqlTest {
   }
 
   @Test
-  void testDynamicSelectWithTypeHandler() {
+  void dynamicSelectWithTypeHandler() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Name> names = new ArrayList<>();
 
@@ -70,13 +70,13 @@ class DynSqlTest {
   }
 
   @Test
-  void testSimpleSelect() {
+  void simpleSelect() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Map<String, Object> answer = sqlSession.selectOne("org.apache.ibatis.submitted.dynsql2.simpleSelect", 1);
 
-      assertEquals(answer.get("ID"), 1);
-      assertEquals(answer.get("FIRSTNAME"), "Fred");
-      assertEquals(answer.get("LASTNAME"), "Flintstone");
+      assertEquals(1, answer.get("ID"));
+      assertEquals("Fred", answer.get("FIRSTNAME"));
+      assertEquals("Flintstone", answer.get("LASTNAME"));
     }
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/empty_namespace/EmptyNamespaceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/empty_namespace/EmptyNamespaceTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 
 class EmptyNamespaceTest {
   @Test
-  void testEmptyNamespace() throws Exception {
+  void emptyNamespace() throws Exception {
     try (
         Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/empty_namespace/ibatisConfig.xml")) {
       Assertions.assertThrows(PersistenceException.class, () -> new SqlSessionFactoryBuilder().build(reader));

--- a/src/test/java/org/apache/ibatis/submitted/empty_row/ReturnInstanceForEmptyRowTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/empty_row/ReturnInstanceForEmptyRowTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -123,7 +123,7 @@ class ReturnInstanceForEmptyRowTest {
   }
 
   @Test
-  void testCollection() {
+  void collection() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       Parent parent = mapper.getCollection(1);
@@ -143,7 +143,7 @@ class ReturnInstanceForEmptyRowTest {
   }
 
   @Test
-  void testConstructorAutomapping() {
+  void constructorAutomapping() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       ImmutableParent parent = mapper.selectImmutable(1);
@@ -152,7 +152,7 @@ class ReturnInstanceForEmptyRowTest {
   }
 
   @Test
-  void testArgNameBasedConstructorAutomapping() {
+  void argNameBasedConstructorAutomapping() {
     sqlSessionFactory.getConfiguration().setArgNameBasedConstructorAutoMapping(true);
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/emptycollection/DaoTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/emptycollection/DaoTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ class DaoTest {
   }
 
   @Test
-  void testWithEmptyList() {
+  void withEmptyList() {
     final List<TodoLists> actual = dao.selectWithEmptyList();
     Assertions.assertEquals(1, actual.size());
     final List<TodoItem> todoItems = actual.get(0).getTodoItems();
@@ -62,13 +62,13 @@ class DaoTest {
   }
 
   @Test
-  void testWithNonEmptyList() {
+  void withNonEmptyList() {
     final List<TodoLists> actual = dao.selectWithNonEmptyList();
     checkNonEmptyList(actual);
   }
 
   @Test
-  void testWithNonEmptyList_noCollectionId() {
+  void withNonEmptyListNoCollectionId() {
     final List<TodoLists> actual = dao.selectWithNonEmptyList_noCollectionId();
 
     checkNonEmptyList(actual);

--- a/src/test/java/org/apache/ibatis/submitted/encoding/EncodingTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/encoding/EncodingTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ class EncodingTest {
   }
 
   @Test
-  void testEncoding1() {
+  void encoding1() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       EncodingMapper mapper = sqlSession.getMapper(EncodingMapper.class);
       String answer = mapper.select1();
@@ -59,7 +59,7 @@ class EncodingTest {
   }
 
   @Test
-  void testEncoding2() {
+  void encoding2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       EncodingMapper mapper = sqlSession.getMapper(EncodingMapper.class);
       String answer = mapper.select2();

--- a/src/test/java/org/apache/ibatis/submitted/enum_with_method/EnumWithMethodTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/enum_with_method/EnumWithMethodTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_annotation/EnumTypeHandlerUsingAnnotationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_annotation/EnumTypeHandlerUsingAnnotationTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -68,7 +68,7 @@ class EnumTypeHandlerUsingAnnotationTest {
   }
 
   @Test
-  void testForArg() {
+  void forArg() {
     PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
     {
       Person person = personMapper.findOneUsingConstructor(1);
@@ -87,7 +87,7 @@ class EnumTypeHandlerUsingAnnotationTest {
   }
 
   @Test
-  void testForResult() {
+  void forResult() {
     PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
     {
       Person person = personMapper.findOneUsingSetter(1);
@@ -106,7 +106,7 @@ class EnumTypeHandlerUsingAnnotationTest {
   }
 
   @Test
-  void testForTypeDiscriminator() {
+  void forTypeDiscriminator() {
     PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
     {
       Person person = personMapper.findOneUsingTypeDiscriminator(1);

--- a/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/EnumTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/enumtypehandler_on_map/EnumTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class EnumTypeHandlerTest {
   }
 
   @Test
-  void testEnumWithParam() {
+  void enumWithParam() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       List<Person> persons = personMapper.getByType(Person.Type.PERSON, "");
@@ -55,7 +55,7 @@ class EnumTypeHandlerTest {
   }
 
   @Test
-  void testEnumWithoutParam() {
+  void enumWithoutParam() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       List<Person> persons = personMapper.getByTypeNoParam(new TypeName() {

--- a/src/test/java/org/apache/ibatis/submitted/extend/ExtendTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/extend/ExtendTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -42,11 +42,11 @@ class ExtendTest {
   }
 
   @Test
-  void testExtend() {
+  void extend() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       ExtendMapper mapper = sqlSession.getMapper(ExtendMapper.class);
       Child answer = mapper.selectChild();
-      assertEquals(answer.getMyProperty(), "last");
+      assertEquals("last", answer.getMyProperty());
     }
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/extendresultmap/ExtendResultMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/extendresultmap/ExtendResultMapTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/NpeExtendsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/NpeExtendsTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ class NpeExtendsTest {
   }
 
   @Test
-  void testNoConstructorConfiguration() {
+  void noConstructorConfiguration() {
     Configuration configuration = new Configuration();
     configuration.addMapper(StudentMapper.class);
     configuration.addMapper(TeacherMapper.class);
@@ -57,7 +57,7 @@ class NpeExtendsTest {
   }
 
   @Test
-  void testWithConstructorConfiguration() {
+  void withConstructorConfiguration() {
     Configuration configuration = new Configuration();
     configuration.addMapper(StudentConstructorMapper.class);
     configuration.addMapper(TeacherMapper.class);
@@ -85,7 +85,7 @@ class NpeExtendsTest {
   }
 
   @Test
-  void testSelectWithTeacher() {
+  void selectWithTeacher() {
     SqlSessionFactory sqlSessionFactory = getSqlSessionFactoryWithConstructor();
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       StudentConstructorMapper studentConstructorMapper = sqlSession.getMapper(StudentConstructorMapper.class);
@@ -96,7 +96,7 @@ class NpeExtendsTest {
   }
 
   @Test
-  void testSelectNoName() {
+  void selectNoName() {
     SqlSessionFactory sqlSessionFactory = getSqlSessionFactoryWithConstructor();
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       StudentConstructorMapper studentConstructorMapper = sqlSession.getMapper(StudentConstructorMapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/FlushStatementNpeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/flush_statement_npe/FlushStatementNpeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ class FlushStatementNpeTest {
   }
 
   @Test
-  void testSameUpdateAfterCommitSimple() {
+  void sameUpdateAfterCommitSimple() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.SIMPLE)) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.selectById(1);
@@ -59,7 +59,7 @@ class FlushStatementNpeTest {
   }
 
   @Test
-  void testSameUpdateAfterCommitReuse() {
+  void sameUpdateAfterCommitReuse() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.REUSE)) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.selectById(1);
@@ -76,7 +76,7 @@ class FlushStatementNpeTest {
   }
 
   @Test
-  void testSameUpdateAfterCommitBatch() {
+  void sameUpdateAfterCommitBatch() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.selectById(1);

--- a/src/test/java/org/apache/ibatis/submitted/force_flush_on_select/ForceFlushOnSelectTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/force_flush_on_select/ForceFlushOnSelectTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ class ForceFlushOnSelectTest {
   }
 
   @Test
-  void testShouldFlushLocalSessionCacheOnQuery() throws SQLException {
+  void shouldFlushLocalSessionCacheOnQuery() throws SQLException {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.SIMPLE)) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       personMapper.selectByIdFlush(1);
@@ -62,7 +62,7 @@ class ForceFlushOnSelectTest {
   }
 
   @Test
-  void testShouldNotFlushLocalSessionCacheOnQuery() throws SQLException {
+  void shouldNotFlushLocalSessionCacheOnQuery() throws SQLException {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.SIMPLE)) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       personMapper.selectByIdNoFlush(1);
@@ -74,7 +74,7 @@ class ForceFlushOnSelectTest {
   }
 
   @Test
-  void testShouldFlushLocalSessionCacheOnQueryForList() throws SQLException {
+  void shouldFlushLocalSessionCacheOnQueryForList() throws SQLException {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.SIMPLE)) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       List<Person> people = personMapper.selectAllFlush();
@@ -86,7 +86,7 @@ class ForceFlushOnSelectTest {
   }
 
   @Test
-  void testShouldNotFlushLocalSessionCacheOnQueryForList() throws SQLException {
+  void shouldNotFlushLocalSessionCacheOnQueryForList() throws SQLException {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.SIMPLE)) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       List<Person> people = personMapper.selectAllNoFlush();
@@ -104,7 +104,7 @@ class ForceFlushOnSelectTest {
   }
 
   @Test
-  void testUpdateShouldFlushLocalCache() {
+  void updateShouldFlushLocalCache() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.SIMPLE)) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.selectByIdNoFlush(1);
@@ -118,7 +118,7 @@ class ForceFlushOnSelectTest {
   }
 
   @Test
-  void testSelectShouldFlushLocalCacheIfFlushLocalCacheAtferEachStatementIsTrue() throws SQLException {
+  void selectShouldFlushLocalCacheIfFlushLocalCacheAtferEachStatementIsTrue() throws SQLException {
     sqlSessionFactory.getConfiguration().setLocalCacheScope(LocalCacheScope.STATEMENT);
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.SIMPLE)) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/foreach/ForEachTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/foreach/ForEachTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import java.io.Reader;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.ibatis.BaseDataTest;
@@ -118,7 +117,7 @@ class ForEachTest {
   void shouldReportMissingPropertyName() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
-      when(() -> mapper.typoInItemProperty(Collections.singletonList(new User())));
+      when(() -> mapper.typoInItemProperty(List.of(new User())));
       then(caughtException()).isInstanceOf(PersistenceException.class).hasMessageContaining(
           "There is no getter for property named 'idd' in 'class org.apache.ibatis.submitted.foreach.User'");
     }

--- a/src/test/java/org/apache/ibatis/submitted/foreach_map/ForEachMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/foreach_map/ForEachMapTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/generictypes/GenericTypesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/generictypes/GenericTypesTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class GenericTypesTest {
   }
 
   @Test
-  void testShouldGetAListOfMaps() {
+  void shouldGetAListOfMaps() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       Group group = mapper.getGroup();

--- a/src/test/java/org/apache/ibatis/submitted/global_variables/BaseTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/global_variables/BaseTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/hashmaptypehandler/HashMapTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/hashmaptypehandler/HashMapTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/heavy_initial_load/HeavyInitialLoadTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/heavy_initial_load/HeavyInitialLoadTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/immutable_constructor/ImmutablePOJOTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/include_property/IncludePropertyErrorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/include_property/IncludePropertyErrorTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/include_property/IncludePropertyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/include_property/IncludePropertyTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ class IncludePropertyTest {
   }
 
   @Test
-  void testSimpleProperty() {
+  void simpleProperty() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<String> results = sqlSession.selectList("org.apache.ibatis.submitted.include_property.Mapper.selectSimpleA");
       assertEquals("col_a value", results.get(0));
@@ -58,7 +58,7 @@ class IncludePropertyTest {
   }
 
   @Test
-  void testPropertyContext() {
+  void propertyContext() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Map<String, String>> results = sqlSession
           .selectList("org.apache.ibatis.submitted.include_property.Mapper.selectPropertyContext");
@@ -70,7 +70,7 @@ class IncludePropertyTest {
   }
 
   @Test
-  void testNestedDynamicValue() {
+  void nestedDynamicValue() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<String> results = sqlSession
           .selectList("org.apache.ibatis.submitted.include_property.Mapper.selectNestedDynamicValue");
@@ -79,7 +79,7 @@ class IncludePropertyTest {
   }
 
   @Test
-  void testEmptyString() {
+  void emptyString() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<String> results = sqlSession
           .selectList("org.apache.ibatis.submitted.include_property.Mapper.selectEmptyProperty");
@@ -88,7 +88,7 @@ class IncludePropertyTest {
   }
 
   @Test
-  void testPropertyInRefid() {
+  void propertyInRefid() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<String> results = sqlSession
           .selectList("org.apache.ibatis.submitted.include_property.Mapper.selectPropertyInRefid");
@@ -97,7 +97,7 @@ class IncludePropertyTest {
   }
 
   @Test
-  void testConfigVar() {
+  void configVar() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<String> results = sqlSession
           .selectList("org.apache.ibatis.submitted.include_property.Mapper.selectConfigVar");
@@ -106,7 +106,7 @@ class IncludePropertyTest {
   }
 
   @Test
-  void testRuntimeVar() {
+  void runtimeVar() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Map<String, String> params = new HashMap<>();
       params.put("suffix", "b");
@@ -117,7 +117,7 @@ class IncludePropertyTest {
   }
 
   @Test
-  void testNestedInclude() {
+  void nestedInclude() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<String> results = sqlSession
           .selectList("org.apache.ibatis.submitted.include_property.Mapper.selectNestedInclude");
@@ -126,7 +126,7 @@ class IncludePropertyTest {
   }
 
   @Test
-  void testParametersInAttribute() {
+  void parametersInAttribute() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Map<String, String>> results = sqlSession
           .selectList("org.apache.ibatis.submitted.include_property.Mapper.selectPropertyInAttribute");

--- a/src/test/java/org/apache/ibatis/submitted/includes/IncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/includes/IncludeTest.java
@@ -43,7 +43,7 @@ class IncludeTest {
   }
 
   @Test
-  void testIncludes() {
+  void includes() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       final Integer result = sqlSession.selectOne("org.apache.ibatis.submitted.includes.mapper.selectWithProperty");
       Assertions.assertEquals(Integer.valueOf(1), result);
@@ -51,7 +51,7 @@ class IncludeTest {
   }
 
   @Test
-  void testParametrizedIncludes() {
+  void parametrizedIncludes() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       sqlSession.selectOne("org.apache.ibatis.submitted.includes.mapper.select");
     }

--- a/src/test/java/org/apache/ibatis/submitted/inheritance/InheritanceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/inheritance/InheritanceTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/integer_enum/IntegerEnumTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/integer_enum/IntegerEnumTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/javassist/JavassistTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/javassist/JavassistTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/keycolumn/InsertTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/keycolumn/InsertTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ class InsertTest {
   }
 
   @Test
-  void testInsertAnnotated() {
+  void insertAnnotated() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       InsertMapper mapper = sqlSession.getMapper(InsertMapper.class);
       Name name = new Name();
@@ -71,7 +71,7 @@ class InsertTest {
   }
 
   @Test
-  void testInsertMapped() {
+  void insertMapped() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       InsertMapper mapper = sqlSession.getMapper(InsertMapper.class);
       Name name = new Name();
@@ -86,7 +86,7 @@ class InsertTest {
   }
 
   @Test
-  void testInsertMappedBatch() {
+  void insertMappedBatch() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.BATCH)) {
       InsertMapper mapper = sqlSession.getMapper(InsertMapper.class);
       Name name = new Name();

--- a/src/test/java/org/apache/ibatis/submitted/language/LanguageTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/language/LanguageTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ class LanguageTest {
   }
 
   @Test
-  void testDynamicSelectWithPropertyParams() {
+  void dynamicSelectWithPropertyParams() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
 
       Parameter p = new Parameter(true, "Fli%");
@@ -76,7 +76,7 @@ class LanguageTest {
   }
 
   @Test
-  void testDynamicSelectWithExpressionParams() {
+  void dynamicSelectWithExpressionParams() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
 
       Parameter p = new Parameter(true, "Fli");
@@ -103,7 +103,7 @@ class LanguageTest {
   }
 
   @Test
-  void testDynamicSelectWithIteration() {
+  void dynamicSelectWithIteration() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
 
       int[] ids = { 2, 4, 5 };
@@ -118,7 +118,7 @@ class LanguageTest {
   }
 
   @Test
-  void testLangRaw() {
+  void langRaw() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter p = new Parameter(true, "Fli%");
       List<Name> answer = sqlSession.selectList("selectRaw", p);
@@ -130,7 +130,7 @@ class LanguageTest {
   }
 
   @Test
-  void testLangRawWithInclude() {
+  void langRawWithInclude() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter p = new Parameter(true, "Fli%");
       List<Name> answer = sqlSession.selectList("selectRawWithInclude", p);
@@ -142,7 +142,7 @@ class LanguageTest {
   }
 
   @Test
-  void testLangRawWithIncludeAndCData() {
+  void langRawWithIncludeAndCData() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter p = new Parameter(true, "Fli%");
       List<Name> answer = sqlSession.selectList("selectRawWithIncludeAndCData", p);
@@ -154,7 +154,7 @@ class LanguageTest {
   }
 
   @Test
-  void testLangXmlTags() {
+  void langXmlTags() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter p = new Parameter(true, "Fli%");
       List<Name> answer = sqlSession.selectList("selectXml", p);
@@ -166,7 +166,7 @@ class LanguageTest {
   }
 
   @Test
-  void testLangRawWithMapper() {
+  void langRawWithMapper() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter p = new Parameter(true, "Fli%");
       Mapper m = sqlSession.getMapper(Mapper.class);
@@ -179,7 +179,7 @@ class LanguageTest {
   }
 
   @Test
-  void testLangVelocityWithMapper() {
+  void langVelocityWithMapper() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter p = new Parameter(true, "Fli%");
       Mapper m = sqlSession.getMapper(Mapper.class);
@@ -192,7 +192,7 @@ class LanguageTest {
   }
 
   @Test
-  void testLangXmlWithMapper() {
+  void langXmlWithMapper() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter p = new Parameter(true, "Fli%");
       Mapper m = sqlSession.getMapper(Mapper.class);
@@ -205,7 +205,7 @@ class LanguageTest {
   }
 
   @Test
-  void testLangXmlWithMapperAndSqlSymbols() {
+  void langXmlWithMapperAndSqlSymbols() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter p = new Parameter(true, "Fli%");
       Mapper m = sqlSession.getMapper(Mapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/lazy_deserialize/LazyDeserializeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazy_deserialize/LazyDeserializeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -63,7 +63,7 @@ class LazyDeserializeTest {
   }
 
   @Test
-  void testLoadLazyDeserialize() throws Exception {
+  void loadLazyDeserialize() throws Exception {
     factory.getConfiguration().setConfigurationFactory(this.getClass());
     try (SqlSession session = factory.openSession()) {
       final Mapper mapper = session.getMapper(Mapper.class);
@@ -80,7 +80,7 @@ class LazyDeserializeTest {
   }
 
   @Test
-  void testLoadLazyDeserializeWithoutConfigurationFactory() throws Exception {
+  void loadLazyDeserializeWithoutConfigurationFactory() throws Exception {
     try (SqlSession session = factory.openSession()) {
       final Mapper mapper = session.getMapper(Mapper.class);
       final LazyObjectFoo foo = mapper.loadFoo(FOO_ID);

--- a/src/test/java/org/apache/ibatis/submitted/lazy_immutable/ImmutablePOJOTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazy_immutable/ImmutablePOJOTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ final class ImmutablePOJOTest {
   }
 
   @Test
-  void testLoadLazyImmutablePOJO() {
+  void loadLazyImmutablePOJO() {
     try (SqlSession session = factory.openSession()) {
       final ImmutablePOJOMapper mapper = session.getMapper(ImmutablePOJOMapper.class);
       final ImmutablePOJO pojo = mapper.getImmutablePOJO(POJO_ID);

--- a/src/test/java/org/apache/ibatis/submitted/lazy_properties/LazyPropertiesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazy_properties/LazyPropertiesTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.Reader;
-import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.executor.loader.ProxyFactory;
@@ -139,7 +139,7 @@ class LazyPropertiesTest {
   void verifyCustomLazyLoadTriggerMethods() {
     Configuration configuration = sqlSessionFactory.getConfiguration();
     configuration.setAggressiveLazyLoading(false);
-    configuration.setLazyLoadTriggerMethods(new HashSet<>(Collections.singleton("trigger")));
+    configuration.setLazyLoadTriggerMethods(new HashSet<>(Set.of("trigger")));
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = mapper.getUser(1);

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/CommonPropertyLazyLoadTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_common_property/CommonPropertyLazyLoadTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ class CommonPropertyLazyLoadTest {
   }
 
   @Test
-  void testLazyLoadWithNoAncestor() {
+  void lazyLoadWithNoAncestor() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       ChildMapper childMapper = sqlSession.getMapper(ChildMapper.class);
 
@@ -50,7 +50,7 @@ class CommonPropertyLazyLoadTest {
   }
 
   @Test
-  void testLazyLoadWithFirstAncestor() {
+  void lazyLoadWithFirstAncestor() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
       ChildMapper childMapper = sqlSession.getMapper(ChildMapper.class);
@@ -61,7 +61,7 @@ class CommonPropertyLazyLoadTest {
   }
 
   @Test
-  void testLazyLoadWithAllAncestors() {
+  void lazyLoadWithAllAncestors() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       GrandFatherMapper grandFatherMapper = sqlSession.getMapper(GrandFatherMapper.class);
       FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
@@ -74,7 +74,7 @@ class CommonPropertyLazyLoadTest {
   }
 
   @Test
-  void testLazyLoadSkipFirstAncestor() {
+  void lazyLoadSkipFirstAncestor() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       GrandFatherMapper grandFatherMapper = sqlSession.getMapper(GrandFatherMapper.class);
       ChildMapper childMapper = sqlSession.getMapper(ChildMapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/AbstractLazyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/lazyload_proxyfactory_comparison/AbstractLazyTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/manyanno/ManyAnnoTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/manyanno/ManyAnnoTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 class ManyAnnoTest extends BaseDataTest {
 
   @Test
-  void testGetMessageForEmptyDatabase() throws Exception {
+  void getMessageForEmptyDatabase() throws Exception {
     final Environment environment = new Environment("test", new JdbcTransactionFactory(),
         BaseDataTest.createBlogDataSource());
     final Configuration config = new Configuration(environment);

--- a/src/test/java/org/apache/ibatis/submitted/map_class_name_conflict/MapperNameTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/map_class_name_conflict/MapperNameTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/mapper_extend/MapperExtendTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/mapper_extend/MapperExtendTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/mapper_type_parameter/MapperTypeParameterTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/mapper_type_parameter/MapperTypeParameterTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.Reader;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -102,7 +101,7 @@ class MapperTypeParameterTest {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper mapper = sqlSession.getMapper(PersonMapper.class);
       Person person1 = new Person("James");
-      assertEquals(1, mapper.insert(Collections.singletonList(person1)));
+      assertEquals(1, mapper.insert(List.of(person1)));
       assertNotNull(person1.getId());
     }
   }

--- a/src/test/java/org/apache/ibatis/submitted/maptypehandler/MapTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/maptypehandler/MapTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/missing_id_property/MissingIdPropertyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/missing_id_property/MissingIdPropertyTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/MultipleDiscriminatorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_discriminator/MultipleDiscriminatorTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class MultipleDiscriminatorTest {
   }
 
   @Test
-  void testMultipleDiscriminator() {
+  void multipleDiscriminator() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.get(1L);
@@ -53,7 +53,7 @@ class MultipleDiscriminatorTest {
   }
 
   @Test
-  void testMultipleDiscriminator2() {
+  void multipleDiscriminator2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       Person person = personMapper.get2(1L);
@@ -63,7 +63,7 @@ class MultipleDiscriminatorTest {
   }
 
   @Test
-  void testMultipleDiscriminatorLoop() {
+  void multipleDiscriminatorLoop() {
     Assertions.assertTimeout(Duration.ofMillis(20000), () -> {
       try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
         PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/multiple_resultsets/MultipleResultTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multiple_resultsets/MultipleResultTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/multipleiterates/MultipleIteratesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multipleiterates/MultipleIteratesTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/MultipleResultSetTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multipleresultsetswithassociation/MultipleResultSetTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/nested/NestedForEachTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested/NestedForEachTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class NestedForEachTest {
   }
 
   @Test
-  void testSimpleSelect() {
+  void simpleSelect() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setLastName("Flintstone");
@@ -60,7 +60,7 @@ class NestedForEachTest {
   }
 
   @Test
-  void testSimpleSelectWithPrimitives() {
+  void simpleSelectWithPrimitives() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Map<String, Object> parameter = new HashMap<>();
       int[] array = { 1, 3, 5 };
@@ -74,7 +74,7 @@ class NestedForEachTest {
   }
 
   @Test
-  void testSimpleSelectWithMapperAndPrimitives() {
+  void simpleSelectWithMapperAndPrimitives() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       List<Map<String, Object>> answer = mapper.simpleSelectWithMapperAndPrimitives(1, 3, 5);
@@ -83,7 +83,7 @@ class NestedForEachTest {
   }
 
   @Test
-  void testNestedSelect() {
+  void nestedSelect() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setLastName("Flintstone");
@@ -101,7 +101,7 @@ class NestedForEachTest {
   }
 
   @Test
-  void testNestedSelect2() {
+  void nestedSelect2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setLastName("Flintstone");

--- a/src/test/java/org/apache/ibatis/submitted/nested_query_cache/NestedQueryCacheTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nested_query_cache/NestedQueryCacheTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class NestedQueryCacheTest extends BaseDataTest {
   }
 
   @Test
-  void testThatNestedQueryItemsAreRetrievedFromCache() {
+  void thatNestedQueryItemsAreRetrievedFromCache() {
     final Author author;
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       final AuthorMapper authorMapper = sqlSession.getMapper(AuthorMapper.class);
@@ -67,7 +67,7 @@ class NestedQueryCacheTest extends BaseDataTest {
   }
 
   @Test
-  void testThatNestedQueryItemsAreRetrievedIfNotInCache() {
+  void thatNestedQueryItemsAreRetrievedIfNotInCache() {
     Author author;
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       final BlogMapper blogMapper = sqlSession.getMapper(BlogMapper.class);

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/NestedResultHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler/NestedResultHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class NestedResultHandlerTest {
   }
 
   @Test
-  void testGetPerson() {
+  void getPerson() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
 
@@ -72,7 +72,7 @@ class NestedResultHandlerTest {
 
   @Test
   // issue #542
-  void testGetPersonWithHandler() {
+  void getPersonWithHandler() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       sqlSession.select("getPersons", context -> {
         Person person = (Person) context.getResultObject();
@@ -84,7 +84,7 @@ class NestedResultHandlerTest {
   }
 
   @Test
-  void testUnorderedGetPersonWithHandler() {
+  void unorderedGetPersonWithHandler() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Assertions.assertThrows(PersistenceException.class,
           () -> sqlSession.select("getPersonsWithItemsOrdered", context -> {
@@ -101,7 +101,7 @@ class NestedResultHandlerTest {
    * some records and end up with duplicates instead.
    */
   @Test
-  void testGetPersonOrderedByItem() {
+  void getPersonOrderedByItem() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
 
@@ -127,7 +127,7 @@ class NestedResultHandlerTest {
   }
 
   @Test // reopen issue 39? (not a bug?)
-  void testGetPersonItemPairs() {
+  void getPersonItemPairs() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       List<PersonItemPair> pairs = mapper.getPersonItemPairs();

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler_gh1551/NestedResultHandlerGh1551Test.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler_gh1551/NestedResultHandlerGh1551Test.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/nestedresulthandler_multiple_association/NestedResultHandlerMultipleAssociationTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nestedresulthandler_multiple_association/NestedResultHandlerMultipleAssociationTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/no_result_type_map/NoResultTypeMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/no_result_type_map/NoResultTypeMapTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/nonexistentvariables/NonExistentVariablesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/nonexistentvariables/NonExistentVariablesTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class NonExistentVariablesTest {
   }
 
   @Test
-  void testWrongParameter() {
+  void wrongParameter() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       Assertions.assertThrows(PersistenceException.class, () -> mapper.count(1, "John"));

--- a/src/test/java/org/apache/ibatis/submitted/not_null_column/NotNullColumnTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/not_null_column/NotNullColumnTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class NotNullColumnTest {
   }
 
   @Test
-  void testNotNullColumnWithChildrenNoFid() {
+  void notNullColumnWithChildrenNoFid() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
 
@@ -57,7 +57,7 @@ class NotNullColumnTest {
   }
 
   @Test
-  void testNotNullColumnWithoutChildrenNoFid() {
+  void notNullColumnWithoutChildrenNoFid() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
 
@@ -69,7 +69,7 @@ class NotNullColumnTest {
   }
 
   @Test
-  void testNotNullColumnWithoutChildrenFid() {
+  void notNullColumnWithoutChildrenFid() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
 
@@ -81,7 +81,7 @@ class NotNullColumnTest {
   }
 
   @Test
-  void testNotNullColumnWithoutChildrenWithInternalResultMap() {
+  void notNullColumnWithoutChildrenWithInternalResultMap() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
 
@@ -93,7 +93,7 @@ class NotNullColumnTest {
   }
 
   @Test
-  void testNotNullColumnWithoutChildrenWithRefResultMap() {
+  void notNullColumnWithoutChildrenWithRefResultMap() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
 
@@ -105,7 +105,7 @@ class NotNullColumnTest {
   }
 
   @Test
-  void testNotNullColumnWithoutChildrenFidMultipleNullColumns() {
+  void notNullColumnWithoutChildrenFidMultipleNullColumns() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
 
@@ -117,7 +117,7 @@ class NotNullColumnTest {
   }
 
   @Test
-  void testNotNullColumnWithoutChildrenFidMultipleNullColumnsAndBrackets() {
+  void notNullColumnWithoutChildrenFidMultipleNullColumnsAndBrackets() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
 
@@ -129,7 +129,7 @@ class NotNullColumnTest {
   }
 
   @Test
-  void testNotNullColumnWithoutChildrenFidWorkaround() {
+  void notNullColumnWithoutChildrenFidWorkaround() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       FatherMapper fatherMapper = sqlSession.getMapper(FatherMapper.class);
 

--- a/src/test/java/org/apache/ibatis/submitted/null_associations/FooMapperTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/null_associations/FooMapperTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ class FooMapperTest {
   }
 
   @Test
-  void testNullAssociation() {
+  void nullAssociation() {
     final FooMapper mapper = session.getMapper(FooMapper.class);
     final Foo foo = new Foo(1L, null, true);
     mapper.insertFoo(foo);
@@ -66,7 +66,7 @@ class FooMapperTest {
   }
 
   @Test
-  void testNotNullAssociation() {
+  void notNullAssociation() {
     final FooMapper mapper = session.getMapper(FooMapper.class);
     final Bar bar = new Bar(1L, 2L, 3L);
     final Foo foo = new Foo(1L, bar, true);

--- a/src/test/java/org/apache/ibatis/submitted/ognl_enum/EnumWithOgnlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognl_enum/EnumWithOgnlTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class EnumWithOgnlTest {
   }
 
   @Test
-  void testEnumWithOgnl() {
+  void enumWithOgnl() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       List<Person> persons = personMapper.selectAllByType(null);
@@ -53,7 +53,7 @@ class EnumWithOgnlTest {
   }
 
   @Test
-  void testEnumWithOgnlDirector() {
+  void enumWithOgnlDirector() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       List<Person> persons = personMapper.selectAllByType(Person.Type.DIRECTOR);
@@ -63,7 +63,7 @@ class EnumWithOgnlTest {
 
   @Tag("RequireIllegalAccess")
   @Test
-  void testEnumWithOgnlDirectorNameAttribute() {
+  void enumWithOgnlDirectorNameAttribute() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       List<Person> persons = personMapper.selectAllByTypeNameAttribute(Person.Type.DIRECTOR);
@@ -72,7 +72,7 @@ class EnumWithOgnlTest {
   }
 
   @Test
-  void testEnumWithOgnlDirectorWithInterface() {
+  void enumWithOgnlDirectorWithInterface() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       List<Person> persons = personMapper.selectAllByTypeWithInterface(() -> Type.DIRECTOR);
@@ -81,7 +81,7 @@ class EnumWithOgnlTest {
   }
 
   @Test
-  void testEnumWithOgnlDirectorNameAttributeWithInterface() {
+  void enumWithOgnlDirectorNameAttributeWithInterface() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
       List<Person> persons = personMapper.selectAllByTypeNameAttributeWithInterface(() -> Type.DIRECTOR);

--- a/src/test/java/org/apache/ibatis/submitted/ognlstatic/OgnlStaticTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/ognlstatic/OgnlStaticTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/OrderPrefixRemovedTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/order_prefix_removed/OrderPrefixRemovedTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class OrderPrefixRemovedTest {
   }
 
   @Test
-  void testOrderPrefixNotRemoved() {
+  void orderPrefixNotRemoved() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession(ExecutorType.SIMPLE)) {
       PersonMapper personMapper = sqlSession.getMapper(PersonMapper.class);
 

--- a/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/OrphanResultMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/orphan_result_maps/OrphanResultMapTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ class OrphanResultMapTest {
   private static final String RESULT_MAP_INNER = "mapper_resultMap[BlogResultMap]_collection[posts]";
 
   @Test
-  void testSeparateResultMaps() {
+  void separateResultMaps() {
     // given
     Configuration configuration = new Configuration();
     configuration.getTypeAliasRegistry().registerAlias(Blog.class);
@@ -52,7 +52,7 @@ class OrphanResultMapTest {
   }
 
   @Test
-  void testNestedResultMap() {
+  void nestedResultMap() {
     // given
     Configuration configuration = new Configuration();
     configuration.getTypeAliasRegistry().registerAlias(Blog.class);

--- a/src/test/java/org/apache/ibatis/submitted/overwritingproperties/FooMapperTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/overwritingproperties/FooMapperTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.apache.ibatis.submitted.overwritingproperties;
 
 import java.sql.Connection;
-import java.sql.SQLException;
 
 import org.apache.ibatis.BaseDataTest;
 import org.apache.ibatis.io.Resources;
@@ -57,7 +56,7 @@ class FooMapperTest {
   }
 
   @Test
-  void testOverwriteWithDefault() {
+  void overwriteWithDefault() {
     final FooMapper mapper = session.getMapper(FooMapper.class);
     final Bar bar = new Bar(2L);
     final Foo inserted = new Foo(1L, bar, 3, 4);
@@ -87,11 +86,9 @@ class FooMapperTest {
 
   @AfterAll
   static void tearDownAfterClass() {
-    try {
+    Assertions.assertDoesNotThrow(() -> {
       conn.close();
-    } catch (SQLException e) {
-      Assertions.fail(e.getMessage());
-    }
+    });
     session.close();
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/param_name_resolve/ActualParamNameTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/param_name_resolve/ActualParamNameTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.apache.ibatis.submitted.param_name_resolve;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.Reader;
 import java.sql.Connection;
@@ -55,7 +55,7 @@ class ActualParamNameTest {
   }
 
   @Test
-  void testSingleListParameterWhenUseActualParamNameIsTrue() {
+  void singleListParameterWhenUseActualParamNameIsTrue() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       // use actual name
@@ -82,7 +82,7 @@ class ActualParamNameTest {
   }
 
   @Test
-  void testSingleArrayParameterWhenUseActualParamNameIsTrue() {
+  void singleArrayParameterWhenUseActualParamNameIsTrue() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       // use actual name

--- a/src/test/java/org/apache/ibatis/submitted/param_name_resolve/NoActualParamNameTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/param_name_resolve/NoActualParamNameTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.apache.ibatis.submitted.param_name_resolve;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.Reader;
 import java.sql.Connection;
@@ -57,7 +57,7 @@ class NoActualParamNameTest {
   }
 
   @Test
-  void testSingleListParameterWhenUseActualParamNameIsFalse() {
+  void singleListParameterWhenUseActualParamNameIsFalse() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       // use actual name -> no available and index parameter("0") is not available too

--- a/src/test/java/org/apache/ibatis/submitted/parametrizedlist/ParametrizedListTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/parametrizedlist/ParametrizedListTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class ParametrizedListTest {
   }
 
   @Test
-  void testShouldDetectUsersAsParameterInsideAList() {
+  void shouldDetectUsersAsParameterInsideAList() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       List<User<String>> list = mapper.getAListOfUsers();
@@ -52,7 +52,7 @@ class ParametrizedListTest {
   }
 
   @Test
-  void testShouldDetectUsersAsParameterInsideAMap() {
+  void shouldDetectUsersAsParameterInsideAMap() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       Map<Integer, User<String>> map = mapper.getAMapOfUsers();
@@ -61,7 +61,7 @@ class ParametrizedListTest {
   }
 
   @Test
-  void testShouldGetAUserAsAMap() {
+  void shouldGetAUserAsAMap() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       Map<String, Object> map = mapper.getUserAsAMap();
@@ -70,7 +70,7 @@ class ParametrizedListTest {
   }
 
   @Test
-  void testShouldGetAListOfMaps() {
+  void shouldGetAListOfMaps() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       List<Map<String, Object>> map = mapper.getAListOfMaps();

--- a/src/test/java/org/apache/ibatis/submitted/parent_childs/ParentChildTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/parent_childs/ParentChildTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/BlogTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/parent_reference_3level/BlogTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ class BlogTest {
   }
 
   @Test
-  void testSelectBlogWithPosts() {
+  void selectBlogWithPosts() {
     try (SqlSession session = sqlSessionFactory.openSession()) {
       Mapper mapper = session.getMapper(Mapper.class);
       Blog result = mapper.selectBlogByPrimaryKey(1);
@@ -65,7 +65,7 @@ class BlogTest {
   }
 
   @Test
-  void testSelectBlogWithoutPosts() {
+  void selectBlogWithoutPosts() {
     try (SqlSession session = sqlSessionFactory.openSession()) {
       Mapper mapper = session.getMapper(Mapper.class);
       Blog result = mapper.selectBlogByPrimaryKey(2);
@@ -76,7 +76,7 @@ class BlogTest {
   }
 
   @Test
-  void testSelectBlogWithPostsColumnPrefix() {
+  void selectBlogWithPostsColumnPrefix() {
     try (SqlSession session = sqlSessionFactory.openSession()) {
       Mapper mapper = session.getMapper(Mapper.class);
       Blog result = mapper.selectBlogByPrimaryKeyColumnPrefix(1);
@@ -93,7 +93,7 @@ class BlogTest {
   }
 
   @Test
-  void testSelectBlogWithoutPostsColumnPrefix() {
+  void selectBlogWithoutPostsColumnPrefix() {
     try (SqlSession session = sqlSessionFactory.openSession()) {
       Mapper mapper = session.getMapper(Mapper.class);
       Blog result = mapper.selectBlogByPrimaryKeyColumnPrefix(2);

--- a/src/test/java/org/apache/ibatis/submitted/postgres_genkeys/PostgresGeneratedKeysTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/postgres_genkeys/PostgresGeneratedKeysTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ class PostgresGeneratedKeysTest {
   }
 
   @Test
-  void testInsertIntoTableWithNoSerialColumn() {
+  void insertIntoTableWithNoSerialColumn() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       Section section = new Section();
@@ -61,7 +61,7 @@ class PostgresGeneratedKeysTest {
   }
 
   @Test
-  void testUpdateTableWithSerial() {
+  void updateTableWithSerial() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = new User();
@@ -73,7 +73,7 @@ class PostgresGeneratedKeysTest {
   }
 
   @Test
-  void testUnusedGeneratedKey() {
+  void unusedGeneratedKey() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       int result = mapper.insertUser("John");

--- a/src/test/java/org/apache/ibatis/submitted/primitive_array/PrimitiveArrayTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitive_array/PrimitiveArrayTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/primitive_result_type/PrimitiveResultTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitive_result_type/PrimitiveResultTypeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.apache.ibatis.submitted.primitive_result_type;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
@@ -41,7 +42,7 @@ class PrimitiveResultTypeTest {
     }
     List<Long> lcodes = ProductDAO.selectProductCodesL();
     for (Object lcode : lcodes) {
-      assertTrue(!(lcode instanceof Integer));
+      assertFalse((lcode instanceof Integer));
     }
     List<BigDecimal> bcodes = ProductDAO.selectProductCodesB();
     for (Object bcode : bcodes) {

--- a/src/test/java/org/apache/ibatis/submitted/primitives/PrimitivesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/primitives/PrimitivesTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/propertiesinmapperfiles/PropertiesInMappersTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/propertiesinmapperfiles/PropertiesInMappersTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/quotedcolumnnames/QuotedColumnNamesTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/quotedcolumnnames/QuotedColumnNamesTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -44,7 +44,7 @@ class QuotedColumnNamesTest {
   }
 
   @Test
-  void testIt() {
+  void it() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Map<String, Object>> list = sqlSession
           .selectList("org.apache.ibatis.submitted.quotedcolumnnames.Map.doSelect");
@@ -54,7 +54,7 @@ class QuotedColumnNamesTest {
   }
 
   @Test
-  void testItWithResultMap() {
+  void itWithResultMap() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Map<String, Object>> list = sqlSession
           .selectList("org.apache.ibatis.submitted.quotedcolumnnames.Map.doSelectWithResultMap");

--- a/src/test/java/org/apache/ibatis/submitted/raw_sql_source/RawSqlSourceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/raw_sql_source/RawSqlSourceTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/record_type/RecordTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/record_type/RecordTypeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ class RecordTypeTest {
   }
 
   @Test
-  void testSelectRecord() {
+  void selectRecord() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       RecordTypeMapper mapper = sqlSession.getMapper(RecordTypeMapper.class);
       Property prop = mapper.selectProperty(1);
@@ -53,7 +53,7 @@ class RecordTypeTest {
   }
 
   @Test
-  void testSelectRecordAutomapping() {
+  void selectRecordAutomapping() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       RecordTypeMapper mapper = sqlSession.getMapper(RecordTypeMapper.class);
       Property prop = mapper.selectPropertyAutomapping(1);
@@ -63,7 +63,7 @@ class RecordTypeTest {
   }
 
   @Test
-  void testInsertRecord() {
+  void insertRecord() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       RecordTypeMapper mapper = sqlSession.getMapper(RecordTypeMapper.class);
       assertEquals(1, mapper.insertProperty(new Property(2, "Val2", "https://mybatis.org")));
@@ -78,7 +78,7 @@ class RecordTypeTest {
   }
 
   @Test
-  void testSelectNestedRecord() {
+  void selectNestedRecord() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       RecordTypeMapper mapper = sqlSession.getMapper(RecordTypeMapper.class);
       Item item = mapper.selectItem(100);

--- a/src/test/java/org/apache/ibatis/submitted/refcursor/RefCursorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/refcursor/RefCursorTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ class RefCursorTest {
   }
 
   @Test
-  void testRefCursor1() {
+  void refCursor1() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       OrdersMapper mapper = sqlSession.getMapper(OrdersMapper.class);
       Map<String, Object> parameter = new HashMap<>();
@@ -77,7 +77,7 @@ class RefCursorTest {
   }
 
   @Test
-  void testRefCursor2() {
+  void refCursor2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       OrdersMapper mapper = sqlSession.getMapper(OrdersMapper.class);
       Map<String, Object> parameter = new HashMap<>();

--- a/src/test/java/org/apache/ibatis/submitted/refid_resolution/ExternalRefidResolutionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/refid_resolution/ExternalRefidResolutionTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
  */
 class ExternalRefidResolutionTest {
   @Test
-  void testExternalRefAfterSelectKey() throws Exception {
+  void externalRefAfterSelectKey() throws Exception {
     String resource = "org/apache/ibatis/submitted/refid_resolution/ExternalMapperConfig.xml";
     try (Reader reader = Resources.getResourceAsReader(resource)) {
       SqlSessionFactoryBuilder builder = new SqlSessionFactoryBuilder();

--- a/src/test/java/org/apache/ibatis/submitted/refid_resolution/RefidResolutionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/refid_resolution/RefidResolutionTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,13 +26,12 @@ import org.junit.jupiter.api.Test;
 
 class RefidResolutionTest {
   @Test
-  void testIncludes() throws Exception {
+  void includes() throws Exception {
     String resource = "org/apache/ibatis/submitted/refid_resolution/MapperConfig.xml";
     Reader reader = Resources.getResourceAsReader(resource);
     SqlSessionFactoryBuilder builder = new SqlSessionFactoryBuilder();
     SqlSessionFactory sqlSessionFactory = builder.build(reader);
-    Assertions.assertThrows(PersistenceException.class, () -> {
-      sqlSessionFactory.getConfiguration().getMappedStatementNames();
-    });
+    Assertions.assertThrows(PersistenceException.class,
+        () -> sqlSessionFactory.getConfiguration().getMappedStatementNames());
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/repeatable/RepeatableDeleteTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/repeatable/RepeatableDeleteTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/repeatable/RepeatableErrorTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/repeatable/RepeatableErrorTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/repeatable/RepeatableInsertTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/repeatable/RepeatableInsertTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/repeatable/RepeatableSelectTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/repeatable/RepeatableSelectTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/repeatable/RepeatableUpdateTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/repeatable/RepeatableUpdateTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/CacheRefFromXmlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cachereffromxml/CacheRefFromXmlTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/CacheRefsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/cacherefs/CacheRefsTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/DeepResultMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/deepresultmap/DeepResultMapTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/JavaMethodsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/resolution/javamethods/JavaMethodsTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/result_handler/ResulthandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/result_handler/ResulthandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/result_handler_type/DefaultResultHandlerTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/result_handler_type/DefaultResultHandlerTypeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -31,37 +31,37 @@ import org.junit.jupiter.api.Test;
 class DefaultResultHandlerTypeTest {
 
   @Test
-  void testSelectList() throws Exception {
+  void selectList() throws Exception {
     String xmlConfig = "org/apache/ibatis/submitted/result_handler_type/MapperConfig.xml";
     SqlSessionFactory sqlSessionFactory = getSqlSessionFactoryXmlConfig(xmlConfig);
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       List<Person> list = sqlSession
           .selectList("org.apache.ibatis.submitted.result_handler_type.PersonMapper.doSelect");
-      assertEquals(list.size(), 2);
+      assertEquals(2, list.size());
       assertEquals("java.util.LinkedList", list.getClass().getCanonicalName());
     }
   }
 
   @Test
-  void testSelectMap() throws Exception {
+  void selectMap() throws Exception {
     String xmlConfig = "org/apache/ibatis/submitted/result_handler_type/MapperConfig.xml";
     SqlSessionFactory sqlSessionFactory = getSqlSessionFactoryXmlConfig(xmlConfig);
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Map<Integer, Person> map = sqlSession
           .selectMap("org.apache.ibatis.submitted.result_handler_type.PersonMapper.doSelect", "id");
-      assertEquals(map.size(), 2);
+      assertEquals(2, map.size());
       assertEquals("java.util.LinkedHashMap", map.getClass().getCanonicalName());
     }
   }
 
   @Test
-  void testSelectMapAnnotation() throws Exception {
+  void selectMapAnnotation() throws Exception {
     String xmlConfig = "org/apache/ibatis/submitted/result_handler_type/MapperConfig.xml";
     SqlSessionFactory sqlSessionFactory = getSqlSessionFactoryXmlConfig(xmlConfig);
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       PersonMapper mapper = sqlSession.getMapper(PersonMapper.class);
       Map<Integer, Person> map = mapper.selectAsMap();
-      assertEquals(map.size(), 2);
+      assertEquals(2, map.size());
       assertEquals("java.util.LinkedHashMap", map.getClass().getCanonicalName());
     }
   }

--- a/src/test/java/org/apache/ibatis/submitted/result_set_type/ResultSetTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/result_set_type/ResultSetTypeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ class ResultSetTypeTest {
   }
 
   @Test
-  void testWithStatement() {
+  void withStatement() {
     test(mapper -> mapper.getUserWithStatementAndUnset(new RowBounds(5, 3)), 0);
     test(mapper -> mapper.getUserWithStatementAndDefault(new RowBounds(4, 3)), 1);
     test(mapper -> mapper.getUserWithStatementAndForwardOnly(new RowBounds(3, 3)), 2);
@@ -61,7 +61,7 @@ class ResultSetTypeTest {
   }
 
   @Test
-  void testWithPrepared() {
+  void withPrepared() {
     test(mapper -> mapper.getUserWithPreparedAndUnset(new RowBounds(5, 3)), 0);
     test(mapper -> mapper.getUserWithPreparedAndDefault(new RowBounds(4, 3)), 1);
     test(mapper -> mapper.getUserWithPreparedAndForwardOnly(new RowBounds(3, 3)), 2);
@@ -70,7 +70,7 @@ class ResultSetTypeTest {
   }
 
   @Test
-  void testWithCallable() {
+  void withCallable() {
     test(mapper -> mapper.getUserWithCallableAndUnset(new RowBounds(5, 3)), 0);
     test(mapper -> mapper.getUserWithCallableAndDefault(new RowBounds(4, 3)), 1);
     test(mapper -> mapper.getUserWithCallableAndForwardOnly(new RowBounds(3, 3)), 2);

--- a/src/test/java/org/apache/ibatis/submitted/resultmapwithassociationstest/ResultMapWithAssociationsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/resultmapwithassociationstest/ResultMapWithAssociationsTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/results_id/ResultsIdTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/results_id/ResultsIdTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ class ResultsIdTest {
   }
 
   @Test
-  void testNamingResults() {
+  void namingResults() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = mapper.getUserByName("User2");
@@ -55,7 +55,7 @@ class ResultsIdTest {
   }
 
   @Test
-  void testResultsOnlyForNaming() {
+  void resultsOnlyForNaming() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       User user = mapper.getUserByNameConstructor("User2");
@@ -65,7 +65,7 @@ class ResultsIdTest {
   }
 
   @Test
-  void testReuseNamedResultsFromAnotherMapper() {
+  void reuseNamedResultsFromAnotherMapper() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       AnotherMapper mapper = sqlSession.getMapper(AnotherMapper.class);
       List<User> users = mapper.getUsers();
@@ -78,7 +78,7 @@ class ResultsIdTest {
   }
 
   @Test
-  void testReuseNamedResultsFromXmlMapper() {
+  void reuseNamedResultsFromXmlMapper() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       AnotherMapper mapper = sqlSession.getMapper(AnotherMapper.class);
       User user = mapper.getUser(1);

--- a/src/test/java/org/apache/ibatis/submitted/selectkey/SelectKeyTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/selectkey/SelectKeyTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testSelectKey() throws Exception {
+  void selectKey() throws Exception {
     // this test checks to make sure that we can have select keys with the same
     // insert id in different namespaces
     String resource = "org/apache/ibatis/submitted/selectkey/MapperConfig.xml";
@@ -60,7 +60,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testInsertTable1() {
+  void insertTable1() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Map<String, Object> parms = new HashMap<>();
       parms.put("name", "Fred");
@@ -71,7 +71,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testInsertTable2() {
+  void insertTable2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Map<String, Object> parms = new HashMap<>();
       parms.put("name", "Fred");
@@ -82,7 +82,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testSeleckKeyReturnsNoData() {
+  void seleckKeyReturnsNoData() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Map<String, String> parms = new HashMap<>();
       parms.put("name", "Fred");
@@ -92,7 +92,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testSeleckKeyReturnsTooManyData() {
+  void seleckKeyReturnsTooManyData() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Map<String, String> parms = new HashMap<>();
       parms.put("name", "Fred");
@@ -103,7 +103,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedInsertTable2() {
+  void annotatedInsertTable2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -115,7 +115,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedInsertTable2WithGeneratedKey() {
+  void annotatedInsertTable2WithGeneratedKey() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -129,7 +129,7 @@ class SelectKeyTest {
 
   @Test
   @Disabled("HSQLDB is not returning the generated column after the update")
-  void testAnnotatedUpdateTable2WithGeneratedKey() {
+  void annotatedUpdateTable2WithGeneratedKey() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -149,7 +149,7 @@ class SelectKeyTest {
 
   @Test
   @Disabled("HSQLDB is not returning the generated column after the update")
-  void testAnnotatedUpdateTable2WithGeneratedKeyXml() {
+  void annotatedUpdateTable2WithGeneratedKeyXml() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -168,7 +168,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedInsertTable2WithGeneratedKeyXml() {
+  void annotatedInsertTable2WithGeneratedKeyXml() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -181,7 +181,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedInsertTable2WithSelectKeyWithKeyMap() {
+  void annotatedInsertTable2WithSelectKeyWithKeyMap() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -194,7 +194,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedUpdateTable2WithSelectKeyWithKeyMap() {
+  void annotatedUpdateTable2WithSelectKeyWithKeyMap() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -213,7 +213,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedInsertTable2WithSelectKeyWithKeyMapXml() {
+  void annotatedInsertTable2WithSelectKeyWithKeyMapXml() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -226,7 +226,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedUpdateTable2WithSelectKeyWithKeyMapXml() {
+  void annotatedUpdateTable2WithSelectKeyWithKeyMapXml() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -245,7 +245,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedInsertTable2WithSelectKeyWithKeyObject() {
+  void annotatedInsertTable2WithSelectKeyWithKeyObject() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -258,7 +258,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedUpdateTable2WithSelectKeyWithKeyObject() {
+  void annotatedUpdateTable2WithSelectKeyWithKeyObject() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -277,7 +277,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedUpdateTable2WithSelectKeyWithKeyObjectXml() {
+  void annotatedUpdateTable2WithSelectKeyWithKeyObjectXml() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -296,7 +296,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedInsertTable2WithSelectKeyWithKeyObjectXml() {
+  void annotatedInsertTable2WithSelectKeyWithKeyObjectXml() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -309,7 +309,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedInsertTable3() {
+  void annotatedInsertTable3() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -321,7 +321,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testAnnotatedInsertTable3_2() {
+  void annotatedInsertTable32() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("barney");
@@ -333,7 +333,7 @@ class SelectKeyTest {
   }
 
   @Test
-  void testSeleckKeyWithWrongKeyProperty() {
+  void seleckKeyWithWrongKeyProperty() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Name name = new Name();
       name.setName("Kyoto");

--- a/src/test/java/org/apache/ibatis/submitted/serializecircular/SerializeCircularTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/serializecircular/SerializeCircularTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/simplelistparameter/SimpleListParameterTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/simplelistparameter/SimpleListParameterTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/sptests/SPTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sptests/SPTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ class SPTest {
    * This test shows using a multi-property parameter.
    */
   @Test
-  void testAdderAsSelect() {
+  void adderAsSelect() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter parameter = new Parameter();
       parameter.setAddend1(2);
@@ -80,7 +80,7 @@ class SPTest {
    * This test shows using a multi-property parameter.
    */
   @Test
-  void testAdderAsSelectDoubleCall1() {
+  void adderAsSelectDoubleCall1() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter parameter = new Parameter();
       parameter.setAddend1(2);
@@ -106,7 +106,7 @@ class SPTest {
    * This test shows using a multi-property parameter.
    */
   @Test
-  void testAdderAsSelectDoubleCall2() {
+  void adderAsSelectDoubleCall2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter parameter = new Parameter();
       parameter.setAddend1(2);
@@ -132,7 +132,7 @@ class SPTest {
    * This test shows using a multi-property parameter.
    */
   @Test
-  void testAdderAsUpdate() {
+  void adderAsUpdate() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter parameter = new Parameter();
       parameter.setAddend1(2);
@@ -153,7 +153,7 @@ class SPTest {
 
   // issue #145
   @Test
-  void testEchoDate() {
+  void echoDate() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       HashMap<String, Object> parameter = new HashMap<>();
       Date now = new Date();
@@ -172,7 +172,7 @@ class SPTest {
    * more intuitive (no pesky question marks), but a parameter map will work.
    */
   @Test
-  void testAdderAsUpdateWithParameterMap() {
+  void adderAsUpdateWithParameterMap() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Map<String, Object> parms = new HashMap<>();
       parms.put("addend1", 3);
@@ -197,7 +197,7 @@ class SPTest {
    * This test shows using a single value parameter.
    */
   @Test
-  void testCallWithResultSet1() {
+  void callWithResultSet1() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -213,7 +213,7 @@ class SPTest {
    * This test shows using a single value parameter.
    */
   @Test
-  void testCallWithResultSet2() {
+  void callWithResultSet2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -231,7 +231,7 @@ class SPTest {
    * This test shows using a Map parameter.
    */
   @Test
-  void testCallWithResultSet3() {
+  void callWithResultSet3() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -255,7 +255,7 @@ class SPTest {
    * This test shows using a Map parameter.
    */
   @Test
-  void testCallWithResultSet4() {
+  void callWithResultSet4() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -279,7 +279,7 @@ class SPTest {
    * @throws SQLException
    */
   @Test
-  void testGetNamesWithArray() throws SQLException {
+  void getNamesWithArray() throws SQLException {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -301,7 +301,7 @@ class SPTest {
    * @throws SQLException
    */
   @Test
-  void testGetNamesAndItems() {
+  void getNamesAndItems() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -319,7 +319,7 @@ class SPTest {
    * This test shows using annotations for stored procedures.
    */
   @Test
-  void testAdderAsSelectAnnotated() {
+  void adderAsSelectAnnotated() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter parameter = new Parameter();
       parameter.setAddend1(2);
@@ -339,7 +339,7 @@ class SPTest {
    * This test shows using annotations for stored procedures.
    */
   @Test
-  void testAdderAsSelectDoubleCallAnnotated1() {
+  void adderAsSelectDoubleCallAnnotated1() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter parameter = new Parameter();
       parameter.setAddend1(2);
@@ -369,7 +369,7 @@ class SPTest {
    * This test shows using annotations for stored procedures.
    */
   @Test
-  void testAdderAsSelectDoubleCallAnnotated2() {
+  void adderAsSelectDoubleCallAnnotated2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter parameter = new Parameter();
       parameter.setAddend1(2);
@@ -397,7 +397,7 @@ class SPTest {
    * This test shows using annotations for stored procedures.
    */
   @Test
-  void testAdderAsUpdateAnnotated() {
+  void adderAsUpdateAnnotated() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Parameter parameter = new Parameter();
       parameter.setAddend1(2);
@@ -424,7 +424,7 @@ class SPTest {
    * This test shows using annotations for stored procedures.
    */
   @Test
-  void testCallWithResultSet1Annotated() {
+  void callWithResultSet1Annotated() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -442,7 +442,7 @@ class SPTest {
    * This test shows using annotations for stored procedures and using a resultMap in XML.
    */
   @Test
-  void testCallWithResultSet1_a2() {
+  void callWithResultSet1A2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -460,7 +460,7 @@ class SPTest {
    * This test shows using annotations for stored procedures.
    */
   @Test
-  void testCallWithResultSet2_a1() {
+  void callWithResultSet2A1() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -480,7 +480,7 @@ class SPTest {
    * This test shows using annotations for stored procedures and using a resultMap in XML.
    */
   @Test
-  void testCallWithResultSet2_a2() {
+  void callWithResultSet2A2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -500,7 +500,7 @@ class SPTest {
    * This test shows using annotations for stored procedures.
    */
   @Test
-  void testCallWithResultSet3_a1() {
+  void callWithResultSet3A1() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -526,7 +526,7 @@ class SPTest {
    * This test shows using annotations for stored procedures and using a resultMap in XML.
    */
   @Test
-  void testCallWithResultSet3_a2() {
+  void callWithResultSet3A2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -552,7 +552,7 @@ class SPTest {
    * This test shows using annotations for stored procedures.
    */
   @Test
-  void testCallWithResultSet4_a1() {
+  void callWithResultSet4A1() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -578,7 +578,7 @@ class SPTest {
    * This test shows using annotations for stored procedures and using a resultMap in XML.
    */
   @Test
-  void testCallWithResultSet4_a2() {
+  void callWithResultSet4A2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -602,7 +602,7 @@ class SPTest {
    * This test shows using annotations for stored procedures and using a resultMap in XML
    */
   @Test
-  void testCallLowHighWithResultSet() {
+  void callLowHighWithResultSet() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
       List<Name> names = spMapper.getNamesAnnotatedLowHighWithXMLResultMap(1, 1);
@@ -618,7 +618,7 @@ class SPTest {
    * @throws SQLException
    */
   @Test
-  void testGetNamesWithArray_a1() throws SQLException {
+  void getNamesWithArrayA1() throws SQLException {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -642,7 +642,7 @@ class SPTest {
    * @throws SQLException
    */
   @Test
-  void testGetNamesWithArray_a2() throws SQLException {
+  void getNamesWithArrayA2() throws SQLException {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -666,7 +666,7 @@ class SPTest {
    * @throws SQLException
    */
   @Test
-  void testGetNamesAndItems_a2() {
+  void getNamesAndItemsA2() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -678,7 +678,7 @@ class SPTest {
   }
 
   @Test
-  void testGetNamesAndItems_a3() {
+  void getNamesAndItemsA3() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -690,7 +690,7 @@ class SPTest {
   }
 
   @Test
-  void testGetNamesAndItemsLinked() {
+  void getNamesAndItemsLinked() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -704,7 +704,7 @@ class SPTest {
   }
 
   @Test
-  void testGetNamesAndItemsLinkedWithNoMatchingInfo() {
+  void getNamesAndItemsLinkedWithNoMatchingInfo() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
 
@@ -715,7 +715,7 @@ class SPTest {
   }
 
   @Test
-  void testMultipleForeignKeys() {
+  void multipleForeignKeys() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SPMapper spMapper = sqlSession.getMapper(SPMapper.class);
       List<Book> books = spMapper.getBookAndGenre();

--- a/src/test/java/org/apache/ibatis/submitted/sql/HsqldbSQLTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sql/HsqldbSQLTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ class HsqldbSQLTest {
   }
 
   @Test
-  void testFetchFirst() {
+  void fetchFirst() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       {

--- a/src/test/java/org/apache/ibatis/submitted/sql/PostgresSQLTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sql/PostgresSQLTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ class PostgresSQLTest {
   }
 
   @Test
-  void testFetchFirst() {
+  void fetchFirst() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       Mapper mapper = sqlSession.getMapper(Mapper.class);
       {

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/ProviderMethodResolutionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/ProviderMethodResolutionTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/sqlprovider/SqlProviderTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -640,8 +640,7 @@ class SqlProviderTest {
   void multipleMap() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       StaticMethodSqlProviderMapper mapper = sqlSession.getMapper(StaticMethodSqlProviderMapper.class);
-      assertEquals("123456",
-          mapper.multipleMap(Collections.singletonMap("value", "123"), Collections.singletonMap("value", "456")));
+      assertEquals("123456", mapper.multipleMap(Map.of("value", "123"), Map.of("value", "456")));
     }
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/stringlist/StringListTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/stringlist/StringListTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/substitution_in_annots/SubstitutionInAnnotsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/substitution_in_annots/SubstitutionInAnnotsTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ class SubstitutionInAnnotsTest {
   }
 
   @Test
-  void testSubstitutionWithXml() {
+  void substitutionWithXml() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SubstitutionInAnnotsMapper mapper = sqlSession.getMapper(SubstitutionInAnnotsMapper.class);
       assertEquals("Barney", mapper.getPersonNameByIdWithXml(4));
@@ -54,7 +54,7 @@ class SubstitutionInAnnotsTest {
   }
 
   @Test
-  void testSubstitutionWithAnnotsValue() {
+  void substitutionWithAnnotsValue() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SubstitutionInAnnotsMapper mapper = sqlSession.getMapper(SubstitutionInAnnotsMapper.class);
       assertEquals("Barney", mapper.getPersonNameByIdWithAnnotsValue(4));
@@ -62,7 +62,7 @@ class SubstitutionInAnnotsTest {
   }
 
   @Test
-  void testSubstitutionWithAnnotsParameter() {
+  void substitutionWithAnnotsParameter() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SubstitutionInAnnotsMapper mapper = sqlSession.getMapper(SubstitutionInAnnotsMapper.class);
       assertEquals("Barney", mapper.getPersonNameByIdWithAnnotsParameter(4));
@@ -70,7 +70,7 @@ class SubstitutionInAnnotsTest {
   }
 
   @Test
-  void testSubstitutionWithAnnotsParamAnnot() {
+  void substitutionWithAnnotsParamAnnot() {
     try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
       SubstitutionInAnnotsMapper mapper = sqlSession.getMapper(SubstitutionInAnnotsMapper.class);
       assertEquals("Barney", mapper.getPersonNameByIdWithAnnotsParamAnnot(4));

--- a/src/test/java/org/apache/ibatis/submitted/typehandler/TypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/typehandler/TypeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/typehandlerinjection/TypeHandlerInjectionTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/typehandlerinjection/TypeHandlerInjectionTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/unknownobject/UnknownObjectTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/unknownobject/UnknownObjectTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/unmatched_prop_type/UnmatchedPropTypeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/unmatched_prop_type/UnmatchedPropTypeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/uuid_test/UUIDTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/uuid_test/UUIDTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/valueinmap/ValueInMapTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/valueinmap/ValueInMapTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -38,17 +38,17 @@ import org.junit.jupiter.api.Test;
 class MultipleCrossIncludeTest {
 
   @Test
-  void testMultipleCrossIncludeXmlConfig() throws Exception {
+  void multipleCrossIncludeXmlConfig() throws Exception {
     testCrossReference(getSqlSessionFactoryXmlConfig());
   }
 
   @Test
-  void testMultipleCrossIncludeJavaConfig() throws Exception {
+  void multipleCrossIncludeJavaConfig() throws Exception {
     testCrossReference(getSqlSessionFactoryJavaConfig());
   }
 
   @Test
-  void testMappedStatementCache() throws Exception {
+  void mappedStatementCache() throws Exception {
     try (Reader configReader = Resources
         .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MultipleCrossIncludeMapperConfig.xml")) {
       SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleIncludeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,12 +35,12 @@ import org.junit.jupiter.api.Test;
 class MultipleIncludeTest {
 
   @Test
-  void testMultipleIncludeXmlConfig() throws Exception {
+  void multipleIncludeXmlConfig() throws Exception {
     testMultipleIncludes(getSqlSessionFactoryXmlConfig());
   }
 
   @Test
-  void testMultipleIncludeJavaConfig() throws Exception {
+  void multipleIncludeJavaConfig() throws Exception {
     testMultipleIncludes(getSqlSessionFactoryJavaConfig());
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleReverseIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/MultipleReverseIncludeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,12 +35,12 @@ import org.junit.jupiter.api.Test;
 class MultipleReverseIncludeTest {
 
   @Test
-  void testMultipleReverseIncludeXmlConfig() throws Exception {
+  void multipleReverseIncludeXmlConfig() throws Exception {
     testMultipleReverseIncludes(getSqlSessionFactoryXmlConfig());
   }
 
   @Test
-  void testMultipleReverseIncludeJavaConfig() throws Exception {
+  void multipleReverseIncludeJavaConfig() throws Exception {
     testMultipleReverseIncludes(getSqlSessionFactoryJavaConfig());
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/NonFullyQualifiedNamespaceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/NonFullyQualifiedNamespaceTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 
 class NonFullyQualifiedNamespaceTest {
   @Test
-  void testCrossReferenceXmlConfig() throws Exception {
+  void crossReferenceXmlConfig() throws Exception {
     try (Reader configReader = Resources
         .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/NonFullyQualifiedNamespaceConfig.xml")) {
       SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ParameterMapReferenceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ParameterMapReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,12 +35,12 @@ import org.junit.jupiter.api.Test;
 class ParameterMapReferenceTest {
 
   @Test
-  void testCrossReferenceXmlConfig() throws Exception {
+  void crossReferenceXmlConfig() throws Exception {
     testCrossReference(getSqlSessionFactoryXmlConfig());
   }
 
   @Test
-  void testCrossReferenceJavaConfig() throws Exception {
+  void crossReferenceJavaConfig() throws Exception {
     testCrossReference(getSqlSessionFactoryJavaConfig());
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ResultMapExtendsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ResultMapExtendsTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,12 +35,12 @@ import org.junit.jupiter.api.Test;
 class ResultMapExtendsTest {
 
   @Test
-  void testExternalExtendsXmlConfig() throws Exception {
+  void externalExtendsXmlConfig() throws Exception {
     testCrossReference(getSqlSessionFactoryXmlConfig());
   }
 
   @Test
-  void testExternalExtendsJavaConfig() throws Exception {
+  void externalExtendsJavaConfig() throws Exception {
     testCrossReference(getSqlSessionFactoryJavaConfig());
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ResultMapReferenceTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ResultMapReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,12 +35,12 @@ import org.junit.jupiter.api.Test;
 class ResultMapReferenceTest {
 
   @Test
-  void testCrossReferenceXmlConfig() throws Exception {
+  void crossReferenceXmlConfig() throws Exception {
     testCrossReference(getSqlSessionFactoryXmlConfig());
   }
 
   @Test
-  void testCrossReferenceJavaConfig() throws Exception {
+  void crossReferenceJavaConfig() throws Exception {
     testCrossReference(getSqlSessionFactoryJavaConfig());
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ReverseIncludeTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ReverseIncludeTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,12 +35,12 @@ import org.junit.jupiter.api.Test;
 class ReverseIncludeTest {
 
   @Test
-  void testReverseIncludeXmlConfig() throws Exception {
+  void reverseIncludeXmlConfig() throws Exception {
     testReverseIncludes(getSqlSessionFactoryXmlConfig());
   }
 
   @Test
-  void testReverseIncludeJavaConfig() throws Exception {
+  void reverseIncludeJavaConfig() throws Exception {
     testReverseIncludes(getSqlSessionFactoryJavaConfig());
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/SameIdTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/SameIdTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,12 +35,12 @@ import org.junit.jupiter.api.Test;
 class SameIdTest {
 
   @Test
-  void testCrossReferenceXmlConfig() throws Exception {
+  void crossReferenceXmlConfig() throws Exception {
     testCrossReference(getSqlSessionFactoryXmlConfig());
   }
 
   @Test
-  void testCrossReferenceJavaConfig() throws Exception {
+  void crossReferenceJavaConfig() throws Exception {
     testCrossReference(getSqlSessionFactoryJavaConfig());
   }
 

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ShortNameTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/ShortNameTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/xml_external_ref/XmlExternalRefTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_external_ref/XmlExternalRefTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.apache.ibatis.submitted.xml_external_ref;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -41,40 +40,36 @@ import org.junit.jupiter.api.Test;
 class XmlExternalRefTest {
 
   @Test
-  void testCrossReferenceXmlConfig() throws Exception {
+  void crossReferenceXmlConfig() throws Exception {
     testCrossReference(getSqlSessionFactoryXmlConfig());
   }
 
   @Test
-  void testCrossReferenceJavaConfig() throws Exception {
+  void crossReferenceJavaConfig() throws Exception {
     testCrossReference(getSqlSessionFactoryJavaConfig());
   }
 
   @Test
-  void testFailFastOnBuildAll() {
+  void failFastOnBuildAll() {
     Configuration configuration = new Configuration();
-    try {
+    Assertions.assertDoesNotThrow(() -> {
       configuration.addMapper(InvalidMapper.class);
-    } catch (Exception e) {
-      fail("No exception should be thrown before parsing statement nodes.");
-    }
+    }, "No exception should be thrown before parsing statement nodes.");
     Assertions.assertThrows(BuilderException.class, configuration::getMappedStatementNames);
   }
 
   @Test
-  void testFailFastOnBuildAllWithInsert() {
+  void failFastOnBuildAllWithInsert() {
     Configuration configuration = new Configuration();
-    try {
+    Assertions.assertDoesNotThrow(() -> {
       configuration.addMapper(InvalidWithInsertMapper.class);
       configuration.addMapper(InvalidMapper.class);
-    } catch (Exception e) {
-      fail("No exception should be thrown before parsing statement nodes.");
-    }
+    }, "No exception should be thrown before parsing statement nodes.");
     Assertions.assertThrows(BuilderException.class, configuration::getMappedStatementNames);
   }
 
   @Test
-  void testMappedStatementCache() throws Exception {
+  void mappedStatementCache() throws Exception {
     try (Reader configReader = Resources
         .getResourceAsReader("org/apache/ibatis/submitted/xml_external_ref/MapperConfig.xml")) {
       SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(configReader);

--- a/src/test/java/org/apache/ibatis/submitted/xml_references/EnumWithOgnlTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/xml_references/EnumWithOgnlTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 class EnumWithOgnlTest {
 
   @Test
-  void testConfiguration() {
+  void configuration() {
     UnpooledDataSourceFactory dataSourceFactory = new UnpooledDataSourceFactory();
     Properties dataSourceProperties = new Properties();
     dataSourceProperties.put("driver", "org.hsqldb.jdbcDriver");
@@ -48,7 +48,7 @@ class EnumWithOgnlTest {
   }
 
   @Test
-  void testMixedConfiguration() throws Exception {
+  void mixedConfiguration() throws Exception {
     try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/xml_references/ibatisConfig.xml")) {
       SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
       sqlSessionFactory.getConfiguration().addMapper(PersonMapper2.class);

--- a/src/test/java/org/apache/ibatis/transaction/jdbc/JdbcTransactionFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/transaction/jdbc/JdbcTransactionFactoryTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package org.apache.ibatis.transaction.jdbc;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 class JdbcTransactionFactoryTest {
 
   @Test
-  void testNullProperties() throws Exception {
+  void nullProperties() throws Exception {
     TestConnection connection = new TestConnection(false);
     JdbcTransactionFactory factory = new JdbcTransactionFactory();
     factory.setProperties(null);
@@ -42,7 +42,7 @@ class JdbcTransactionFactoryTest {
   }
 
   @Test
-  void testSkipSetAutoCommitOnClose() throws Exception {
+  void skipSetAutoCommitOnClose() throws Exception {
     TestConnection connection = new TestConnection(false);
     DataSource ds = mock(DataSource.class);
     when(ds.getConnection()).thenReturn(connection);

--- a/src/test/java/org/apache/ibatis/transaction/jdbc/JdbcTransactionTest.java
+++ b/src/test/java/org/apache/ibatis/transaction/jdbc/JdbcTransactionTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 package org.apache.ibatis.transaction.jdbc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test;
 
 class JdbcTransactionTest {
   @Test
-  void testSetAutoCommitOnClose() throws Exception {
+  void setAutoCommitOnClose() throws Exception {
     testAutoCommit(true, false, true, false);
     testAutoCommit(false, false, true, false);
     testAutoCommit(true, true, true, false);

--- a/src/test/java/org/apache/ibatis/type/ArrayTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/ArrayTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ class ArrayTypeHandlerTest extends BaseTypeHandlerTest {
   }
 
   @Test
-  public void shouldSetStringArrayParameter() throws Exception {
+  void shouldSetStringArrayParameter() throws Exception {
     Connection connection = mock(Connection.class);
     when(ps.getConnection()).thenReturn(connection);
 
@@ -59,16 +59,14 @@ class ArrayTypeHandlerTest extends BaseTypeHandlerTest {
   }
 
   @Test
-  public void shouldSetNullParameter() throws Exception {
+  void shouldSetNullParameter() throws Exception {
     TYPE_HANDLER.setParameter(ps, 1, null, JdbcType.ARRAY);
     verify(ps).setNull(1, Types.ARRAY);
   }
 
   @Test
-  public void shouldFailForNonArrayParameter() {
-    assertThrows(TypeException.class, () -> {
-      TYPE_HANDLER.setParameter(ps, 1, "unsupported parameter type", null);
-    });
+  void shouldFailForNonArrayParameter() {
+    assertThrows(TypeException.class, () -> TYPE_HANDLER.setParameter(ps, 1, "unsupported parameter type", null));
   }
 
   @Override

--- a/src/test/java/org/apache/ibatis/type/CharacterTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/CharacterTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ class CharacterTypeHandlerTest extends BaseTypeHandlerTest {
   }
 
   @Test
-  public void shouldSetNullParameter() throws Exception {
+  void shouldSetNullParameter() throws Exception {
     TYPE_HANDLER.setParameter(ps, 1, null, JdbcType.VARCHAR);
     verify(ps).setNull(1, JdbcType.VARCHAR.TYPE_CODE);
   }
@@ -89,21 +89,21 @@ class CharacterTypeHandlerTest extends BaseTypeHandlerTest {
   }
 
   @Test
-  void testEmptyStringGetStringByName() throws Exception {
+  void emptyStringGetStringByName() throws Exception {
     when(rs.getString("column")).thenReturn("");
     assertNull(TYPE_HANDLER.getResult(rs, "column"));
     verify(rs, never()).wasNull();
   }
 
   @Test
-  void testEmptyStringGetStringByIndex() throws Exception {
+  void emptyStringGetStringByIndex() throws Exception {
     when(rs.getString(1)).thenReturn("");
     assertNull(TYPE_HANDLER.getResult(rs, 1));
     verify(rs, never()).wasNull();
   }
 
   @Test
-  void testEmptyStringCallableStatementGetStringByIndex() throws Exception {
+  void emptyStringCallableStatementGetStringByIndex() throws Exception {
     when(cs.getString(1)).thenReturn("");
     assertNull(TYPE_HANDLER.getResult(cs, 1));
     verify(cs, never()).wasNull();

--- a/src/test/java/org/apache/ibatis/type/EnumOrdinalTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/EnumOrdinalTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ class EnumOrdinalTypeHandlerTest extends BaseTypeHandlerTest {
   }
 
   @Test
-  public void shouldSetNullParameter() throws Exception {
+  void shouldSetNullParameter() throws Exception {
     TYPE_HANDLER.setParameter(ps, 1, null, JdbcType.VARCHAR);
     verify(ps).setNull(1, JdbcType.VARCHAR.TYPE_CODE);
   }

--- a/src/test/java/org/apache/ibatis/type/EnumTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/EnumTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ class EnumTypeHandlerTest extends BaseTypeHandlerTest {
   }
 
   @Test
-  public void shouldSetNullParameter() throws Exception {
+  void shouldSetNullParameter() throws Exception {
     TYPE_HANDLER.setParameter(ps, 1, null, JdbcType.VARCHAR);
     verify(ps).setNull(1, JdbcType.VARCHAR.TYPE_CODE);
   }

--- a/src/test/java/org/apache/ibatis/type/UnknownTypeHandlerTest.java
+++ b/src/test/java/org/apache/ibatis/type/UnknownTypeHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.


### PR DESCRIPTION
portion of what open rewrite did was accepted here.  rest was discarded.  one flakey test resolved by forcing method order.  the test due to naming with prefixed test didn't fail on prior usage but no other changes would cause failure so method order forced which resolved the issue.