### PR TITLE
Cleanup CI GHA an cleanup docs on test case ran

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,28 +20,14 @@ jobs:
       - name: Set up JDK ${{ matrix.java }} ${{ matrix.distribution }}
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java }}
+          cache: ${{ matrix.cache }}
           distribution: ${{ matrix.distribution }}
-      - name: Print JDK Version
-        run: java -version
-      - name: Cache local Maven m2
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-m2
-      - name: Skip tests that require illegal reflective access
+          java-version: ${{ matrix.java }}
+      - name: Setup skip tests that require illegal reflective access ubuntu
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: echo 'ARG_LINE=-D"excludedGroups=RequireIllegalAccess"' >> $GITHUB_ENV
-      - name: Skip tests that require illegal reflective access
+        run: echo 'ARG_LINE=-D"excludedGroups=RequireIllegalAccess" -Xmx2048m -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar' >> $GITHUB_ENV
+      - name: Setup skip tests that require illegal reflective access not ubuntu
         if: ${{ matrix.os != 'ubuntu-latest' }}
-        run: echo 'ARG_LINE=-D"excludedGroups=TestcontainersTests,RequireIllegalAccess"' >> $GITHUB_ENV
-      - name: Active Profiles
-        run: ./mvnw help:active-profiles
+        run: echo 'ARG_LINE=-D"excludedGroups=TestcontainersTests,RequireIllegalAccess" -Xmx2048m -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar' >> $GITHUB_ENV
       - name: Test with Maven
-        if: ${{ matrix.os != 'windows-latest' }}
         run: ./mvnw test -B -V  --no-transfer-progress -D"license.skip=true" -D"jacoco.skip=true" $ARG_LINE
-      - name: Test with Maven
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: ./mvnw test -B -V  --no-transfer-progress -D"license.skip=true" -D"jacoco.skip=true" -D"excludedGroups=TestcontainersTests,RequireIllegalAccess"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,7 @@ jobs:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
       - name: Setup testContainers profile for ubuntu
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         run: echo 'TEST_CONTAINERS_PROFILE=-PtestContainers' >> $GITHUB_ENV
       - name: Test with Maven
         run: ./mvnw test -B -V  --no-transfer-progress -D"license.skip=true" $TEST_CONTAINERS_PROFILE

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,5 +23,7 @@ jobs:
           cache: ${{ matrix.cache }}
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
+      - name: Setup testContainers profile for ubuntu
+        run: echo 'TEST_CONTAINERS_PROFILE=-PtestContainers' >> $GITHUB_ENV
       - name: Test with Maven
-        run: ./mvnw test -B -V  --no-transfer-progress -D"license.skip=true" -PtestContainers
+        run: ./mvnw test -B -V  --no-transfer-progress -D"license.skip=true" $TEST_CONTAINERS_PROFILE

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,4 +24,4 @@ jobs:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
       - name: Test with Maven
-        run: ./mvnw test -B -V  --no-transfer-progress -D"license.skip=true"
+        run: ./mvnw test -B -V  --no-transfer-progress -D"license.skip=true" -PtestContainers

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,11 +23,7 @@ jobs:
           cache: ${{ matrix.cache }}
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
-      - name: Setup skip tests that require illegal reflective access ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: echo 'ARG_LINE=-D"excludedGroups=RequireIllegalAccess" -Xmx2048m -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar' >> $GITHUB_ENV
-      - name: Setup skip tests that require illegal reflective access not ubuntu
-        if: ${{ matrix.os != 'ubuntu-latest' }}
-        run: echo 'ARG_LINE=-D"excludedGroups=TestcontainersTests,RequireIllegalAccess" -Xmx2048m -javaagent:${settings.localRepository}/net/bytebuddy/byte-buddy-agent/${byte-buddy.version}/byte-buddy-agent-${byte-buddy.version}.jar' >> $GITHUB_ENV
+      - name: Allow tests for TestcontainersTests
+        run: echo 'ARG_LINE=-D"excludedGroups=RequireIllegalAccess"' >> $GITHUB_ENV
       - name: Test with Maven
         run: ./mvnw test -B -V  --no-transfer-progress -D"license.skip=true" -D"jacoco.skip=true" $ARG_LINE

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,5 @@ jobs:
           cache: ${{ matrix.cache }}
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
-      - name: Allow tests for TestcontainersTests
-        run: echo 'ARG_LINE=-D"excludedGroups=RequireIllegalAccess"' >> $GITHUB_ENV
       - name: Test with Maven
-        run: ./mvnw test -B -V  --no-transfer-progress -D"license.skip=true" -D"jacoco.skip=true" $ARG_LINE
+        run: ./mvnw test -B -V  --no-transfer-progress -D"license.skip=true"

--- a/README.md
+++ b/README.md
@@ -37,38 +37,36 @@ Tests
 
 Mybatis-3 code runs more expressive testing depending on jdk usage and platform.
 
-By default, we set ```<excludedGroups>TestcontainersTests</excludedGroups>``` which will exclude a subset of tests with @Tag('TestcontainersTests').  Further, if pre jdk 16, we will further exclude record classes from executions further reducing tests.
-
-When using jdk 16+, we adjust the rule to ```<excludedGroups>TestcontainersTests,RequireIllegalAccess</excludedGroups>```.
+By default, we set ```<excludedGroups>TestcontainersTests,RequireIllegalAccess</excludedGroups>``` which will exclude a subset of tests with @Tag('TestcontainersTests') and @Tag('RequireIllegalAccess').
 
 When we run on ci platform, we further make adjustments as needed.  See [here](.github/workflows/ci.yaml) for details.
 
-As of 2/20/2023, using combined system + jdk will result in given number of tests ran.  This will change as tests are added or removed over time.
+As of 12/28/2024, using combined system + jdk will result in given number of tests ran.  This will change as tests are added or removed over time.
 
 without adjusting settings (ie use as is, platform does not matter)
 
-- any OS + jdk 11 = 1730 tests
-- any OS + jdk 17 = 1710 tests
-- any OS + jdk 19 = 1710 tests
-- any OS + jdk 20 = 1710 tests
-- any OS + jdk 21 = 1710 tests
+- any OS + jdk 17 = 1899 tests
+- any OS + jdk 21 = 1899 tests
+- any OS + jdk 23 = 1899 tests
+- any OS + jdk 24 = 1899 tests
+- any OS + jdk 25 = 1899 tests
 
 our adjustments for GH actions where platform does matter
 
-- windows + jdk 11 = 1730 tests
-- windows + jdk 17 = 1710 tests
-- windows + jdk 19 = 1710 tests
-- windows + jdk 20 = 1710 tests
-- windows + jdk 21 = 1710 tests
+- windows + jdk 17 = 1899 tests
+- windows + jdk 21 = 1899 tests
+- windows + jdk 23 = 1899 tests
+- windows + jdk 24 = 1899 tests
+- windows + jdk 25 = 1899 tests
 
-- linux + jdk 11 = 1765 tests
-- linux + jdk 17 = 1745 tests
-- linux + jdk 19 = 1745 tests
-- linux + jdk 20 = 1745 tests
-- linux + jdk 21 = 1745 tests
+- linux + jdk 17 = 1934 tests
+- linux + jdk 21 = 1934 tests
+- linux + jdk 23 = 1934 tests
+- linux + jdk 24 = 1934 tests
+- linux + jdk 25 = 1934 tests
 
-- mac + jdk 11 = 1730 tests
-- mac + jdk 17 = 1710 tests
-- mac + jdk 19 = 1710 tests
-- mac + jdk 20 = 1710 tests
-- mac + jdk 21 = 1710 tests
+- mac + jdk 17 = 1899 tests
+- mac + jdk 21 = 1899 tests
+- mac + jdk 23 = 1899 tests
+- mac + jdk 24 = 1899 tests
+- mac + jdk 25 = 1899 tests

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
 
     <!-- Add slow test groups here and annotate classes similar to @Tag('groupName'). -->
     <!-- Excluded groups are ran on github ci, to force here, pass -d"excludedGroups=" -->
+    <!-- Note: RequireIllegalAccess tests are now no longer valid as they only worked prior to java 16 -->
     <excludedGroups>TestcontainersTests,RequireIllegalAccess</excludedGroups>
 
     <!-- Automatic Module Name -->
@@ -422,6 +423,12 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>testContainers</id>
+      <properties>
+        <excludedGroups>RequireIllegalAccess</excludedGroups>
+      </properties>
+    </profile>
     <profile>
       <id>17</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -232,12 +232,12 @@
       <artifactId>junit-jupiter</artifactId>
       <version>${testcontainers.version}</version>
       <scope>test</scope>
-      <!--Only Mysqlcontainer is allowed to use junit 4: Uncomment to test
+      <!--Only Mysqlcontainer is allowed to use junit 4 due to testContainers coupling: Uncomment to test no other leakage
       <exclusions>
-          <exclusion>
-              <groupId>junit</groupId>
-              <artifactId>junit</artifactId>
-          </exclusion>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
       </exclusions>
       -->
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
     <!-- Add slow test groups here and annotate classes similar to @Tag('groupName'). -->
     <!-- Excluded groups are ran on github ci, to force here, pass -d"excludedGroups=" -->
-    <excludedGroups>TestcontainersTests</excludedGroups>
+    <excludedGroups>TestcontainersTests,RequireIllegalAccess</excludedGroups>
 
     <!-- Automatic Module Name -->
     <module.name>org.mybatis</module.name>
@@ -422,15 +422,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>16</id>
-      <activation>
-        <jdk>[16,)</jdk>
-      </activation>
-      <properties>
-        <excludedGroups>TestcontainersTests,RequireIllegalAccess</excludedGroups>
-      </properties>
-    </profile>
     <profile>
       <id>17</id>
       <activation>


### PR DESCRIPTION
Simplifies CI setup to use a profile to adjust the tag runner without having it do so for every OS known.  Rather only does it for ubuntu where required.  The pom then does the rest.  This ensures we are not blasting away argline when newer jdks need that set with information only available from within the pom for byte buddy.  There is also a setting for memory used on windows that seems to matter if removed on my local.  It didn't seem to matter on remote but it was being removed previously.  So now that is set.