### PR TITLE
Ignore empty text node when parsing XML nodes

### DIFF
--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -80,6 +80,9 @@ public class XMLScriptBuilder extends BaseBuilder {
       XNode child = node.newXNode(children.item(i));
       if (child.getNode().getNodeType() == Node.CDATA_SECTION_NODE || child.getNode().getNodeType() == Node.TEXT_NODE) {
         String data = child.getStringBody("");
+        if (data.trim().isEmpty()) {
+          continue;
+        }
         TextSqlNode textSqlNode = new TextSqlNode(data);
         if (textSqlNode.isDynamic()) {
           contents.add(textSqlNode);

--- a/src/test/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilderTest.java
@@ -1,0 +1,63 @@
+/*
+ *    Copyright 2009-2024 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.apache.ibatis.scripting.xmltags;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Field;
+import java.util.List;
+
+import org.apache.ibatis.mapping.SqlSource;
+import org.apache.ibatis.parsing.XPathParser;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+
+class XMLScriptBuilderTest {
+
+  @Test
+  void shouldEmptyTextNodesRemoved() throws Exception {
+    String xml = """
+        <script>
+          select * from user
+          <if test="_parameter != null">
+            where id = 1
+          </if>
+          <if test="_parameter == null">
+            where id > 0
+          </if>
+        </script>
+        """;
+    SqlSource sqlSource = new XMLScriptBuilder(new Configuration(), new XPathParser(xml).evalNode("/script"))
+        .parseScriptNode();
+
+    Field rootSqlNodeFld = DynamicSqlSource.class.getDeclaredField("rootSqlNode");
+    rootSqlNodeFld.setAccessible(true);
+    MixedSqlNode sqlNode = (MixedSqlNode) rootSqlNodeFld.get(sqlSource);
+
+    Field contentsFld = MixedSqlNode.class.getDeclaredField("contents");
+    contentsFld.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    List<SqlNode> contents = (List<SqlNode>) contentsFld.get(sqlNode);
+
+    assertEquals(3, contents.size());
+    assertThat(contents.get(0)).isInstanceOf(StaticTextSqlNode.class);
+    assertThat(contents.get(1)).isInstanceOf(IfSqlNode.class);
+    assertThat(contents.get(2)).isInstanceOf(IfSqlNode.class);
+  }
+
+}


### PR DESCRIPTION
When parsing XML, since nested nodes have line breaks by default, these nodes should not be parsed as text nodes and added, which will cause unnecessary heap space to be occupied.

![image](https://github.com/user-attachments/assets/2e3ad863-c383-4bd4-a765-42a4e668dbc1)

The test project reduces the creation of this node, and the space occupied by this node is reduced from 1625KB to 748KB

![Snipaste_2024-12-29_14-04-38](https://github.com/user-attachments/assets/6e676c0c-47f7-41e3-bf6a-1c6ebfeb78d1)
![Snipaste_2024-12-29_14-06-39](https://github.com/user-attachments/assets/38269cc0-165d-4d25-96d3-b5228e36a267)
