### PR TITLE
feat: ensure code is formatted and imports are sorted before commit

### DIFF
--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+#    Copyright 2009-2025 the original author or authors.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+set -e
+
+# ensure code is formatted correctly and that imports are sorted as some IDE's automatically change it before commit
+mvn formatter:format impsort:sort

--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -14,8 +14,22 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 #
+set -eo pipefail
 
-set -e
+function format_and_sort() {
+  # Run the validate and import check commands, suppressing all output and errors
+  if ! mvn formatter:validate impsort:check > /dev/null 2>&1; then
+      # If validation failed, fix it by ensuring code is formatted correctly
+      # and that imports are sorted as some IDEs automatically change it on save
+      mvn formatter:format impsort:sort
 
-# ensure code is formatted correctly and that imports are sorted as some IDE's automatically change it before commit
-mvn formatter:format impsort:sort
+      # Fail the commit, so the author can re-select what to commit
+      echo "Formatting and/or import sorting were required. Please check and make another commit."
+      exit 1
+  fi
+
+  # If no error occurred, print a success message
+  echo "All files are properly formatted and imports are sorted."
+}
+
+format_and_sort

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <mockito.version>5.15.2</mockito.version>
     <mssql-jdbc.version>12.8.1.jre11</mssql-jdbc.version>
     <testcontainers.version>1.20.4</testcontainers.version>
+    <git-build-hook.version>3.5.0</git-build-hook.version>
 
     <!-- Add slow test groups here and annotate classes similar to @Tag('groupName'). -->
     <!-- Excluded groups are ran on github ci, to force here, pass -d"excludedGroups=" -->
@@ -418,6 +419,24 @@
             </enforceBytecodeVersion>
           </rules>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.rudikershaw.gitbuildhook</groupId>
+        <artifactId>git-build-hook-maven-plugin</artifactId>
+        <version>${git-build-hook.version}</version>
+        <configuration>
+          <installHooks>
+            <pre-commit>hooks/pre-commit.sh</pre-commit>
+          </installHooks>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>install</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
I have noticed that there are commits (on master) that need to fix formatting and imports occasionally, this is due to authors not having run a `mvn clean install` on their PR's, even though the builds are successful.

This will help keep master consistent in that it would run a `format` & `sort` before commit, even though it makes the commit _slightly_ slower (on my machine 2 seconds), I believe the tradeoff is worth it. 