### PR TITLE
`TrimSqlNode` should add an extra space when concatenating its contents like `MixedSqlNode` does

### DIFF
--- a/src/main/java/org/apache/ibatis/scripting/xmltags/TrimSqlNode.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/TrimSqlNode.java
@@ -90,7 +90,7 @@ public class TrimSqlNode implements SqlNode {
     public void applyAll() {
       sqlBuffer = new StringBuilder(sqlBuffer.toString().trim());
       String trimmedUppercaseSql = sqlBuffer.toString().toUpperCase(Locale.ENGLISH);
-      if (trimmedUppercaseSql.length() > 0) {
+      if (!trimmedUppercaseSql.isEmpty()) {
         applyPrefix(sqlBuffer, trimmedUppercaseSql);
         applySuffix(sqlBuffer, trimmedUppercaseSql);
       }
@@ -99,6 +99,9 @@ public class TrimSqlNode implements SqlNode {
 
     @Override
     public void appendSql(String sql) {
+      if (sqlBuffer.length() > 0) {
+        sqlBuffer.append(" ");
+      }
       sqlBuffer.append(sql);
     }
 

--- a/src/test/java/org/apache/ibatis/builder/xml/dynamic/DynamicSqlSourceTest.java
+++ b/src/test/java/org/apache/ibatis/builder/xml/dynamic/DynamicSqlSourceTest.java
@@ -214,7 +214,7 @@ class DynamicSqlSourceTest extends BaseDataTest {
 
   @Test
   void shouldTrimWHEREInsteadOfANDForBothConditions() throws Exception {
-    final String expected = "SELECT * FROM BLOG WHERE  ID = ?   OR NAME = ?";
+    final String expected = "SELECT * FROM BLOG WHERE  ID = ?    OR NAME = ?";
     DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("SELECT * FROM BLOG"),
         new WhereSqlNode(new Configuration(),
             mixedContents(new IfSqlNode(mixedContents(new TextSqlNode("   and ID = ?   ")), "true"),
@@ -236,7 +236,7 @@ class DynamicSqlSourceTest extends BaseDataTest {
 
   @Test
   void shouldTrimSETInsteadOfCOMMAForBothConditions() throws Exception {
-    final String expected = "UPDATE BLOG SET ID = ?,  NAME = ?";
+    final String expected = "UPDATE BLOG SET ID = ?,   NAME = ?";
     DynamicSqlSource source = createDynamicSqlSource(new TextSqlNode("UPDATE BLOG"),
         new SetSqlNode(new Configuration(),
             mixedContents(new IfSqlNode(mixedContents(new TextSqlNode(" ID = ?, ")), "true"),

--- a/src/test/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilderTest.java
@@ -30,16 +30,14 @@ class XMLScriptBuilderTest {
     String xml = """
         <script>
         select * from user
-        <where>
-        <if test="1==1">and id = 1</if>
-        <if test="1==1">and id > 0</if>
-        </where>
+        <where><if test="1==1">and id = 1</if><if test="1==1">and id > 0</if></where>
+        <if test="1==1">and id = 1</if><if test="1==1">and id > 0</if>
         </script>
         """;
     SqlSource sqlSource = new XMLScriptBuilder(new Configuration(), new XPathParser(xml).evalNode("/script"))
         .parseScriptNode();
-    assertThat(sqlSource.getBoundSql(1).getSql())
-        .containsPattern("(?m)^\\s*select \\* from user\\s+WHERE\\s+id = 1\\s+and id > 0\\s*$");
+    assertThat(sqlSource.getBoundSql(1).getSql()).containsPattern(
+        "(?m)^\\s*select \\* from user\\s+WHERE\\s+id = 1\\s+and id > 0\\s+and id = 1\\s+and id > 0\\s*$");
   }
 
 }


### PR DESCRIPTION
This was the [key difference](https://github.com/mybatis/mybatis-3/pull/3349#issuecomment-2567497103) that broke #3349 .
