### PR TITLE
Refactor code smells: Extract Class, Move Method, Pull-up Variable, and Implementation Improvements

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -107,6 +107,8 @@ public class MapperAnnotationBuilder {
   private final Configuration configuration;
   private final MapperBuilderAssistant assistant;
   private final Class<?> type;
+  private static final int expectedMapTypeCount = 2;
+
 
   public MapperAnnotationBuilder(Configuration configuration, Class<?> type) {
     String resource = type.getName().replace('.', '/') + ".java (best guess)";
@@ -424,7 +426,7 @@ public class MapperAnnotationBuilder {
       } else if (method.isAnnotationPresent(MapKey.class) && Map.class.isAssignableFrom(rawType)) {
         // (gcode issue 504) Do not look into Maps if there is not MapKey annotation
         Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
-        if (actualTypeArguments != null && actualTypeArguments.length == 2) {
+        if (actualTypeArguments != null && actualTypeArguments.length == expectedMapTypeCount) {
           Type returnTypeParameter = actualTypeArguments[1];
           if (returnTypeParameter instanceof Class<?>) {
             returnType = (Class<?>) returnTypeParameter;

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -109,7 +109,6 @@ public class MapperAnnotationBuilder {
   private final Class<?> type;
   private static final int expectedMapTypeCount = 2;
 
-
   public MapperAnnotationBuilder(Configuration configuration, Class<?> type) {
     String resource = type.getName().replace('.', '/') + ".java (best guess)";
     this.assistant = new MapperBuilderAssistant(configuration, resource);
@@ -118,10 +117,10 @@ public class MapperAnnotationBuilder {
   }
 
   public void parse() {
-    String resource = type.toString();
-    if (!configuration.isResourceLoaded(resource)) {
+    String typeSignature = type.toString();
+    if (!configuration.isResourceLoaded(typeSignature)) {
       loadXmlResource();
-      configuration.addLoadedResource(resource);
+      configuration.addLoadedResource(typeSignature);
       assistant.setCurrentNamespace(type.getName());
       parseCache();
       parseCacheRef();

--- a/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
+++ b/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
@@ -663,17 +663,18 @@ public abstract class AbstractSQL<T> {
 
     private String selectSQL(SafeAppendable builder) {
       if (distinct) {
-        sqlClause(builder, "SELECT DISTINCT", select, "", "", ", ");
+        sqlClause(builder, SQLKeywords.SELECT_DISTINCT, select, "", "", ", ");
       } else {
-        sqlClause(builder, "SELECT", select, "", "", ", ");
+        sqlClause(builder, SQLKeywords.SELECT, select, "", "", ", ");
       }
 
-      sqlClause(builder, "FROM", tables, "", "", ", ");
+      sqlClause(builder, SQLKeywords.FROM, tables, "", "", ", ");
       joins(builder);
-      sqlClause(builder, "WHERE", where, "(", ")", " AND ");
-      sqlClause(builder, "GROUP BY", groupBy, "", "", ", ");
-      sqlClause(builder, "HAVING", having, "(", ")", " AND ");
-      sqlClause(builder, "ORDER BY", orderBy, "", "", ", ");
+      sqlClause(builder, SQLKeywords.WHERE, where, "(", ")", " AND ");
+      sqlClause(builder, SQLKeywords.GROUP_BY, groupBy, "", "", ", ");
+      sqlClause(builder, SQLKeywords.HAVING, having, "(", ")", " AND ");
+      sqlClause(builder, SQLKeywords.ORDER_BY, orderBy, "", "", ", ");
+
       limitingRowsStrategy.applyLimitToSelect(builder, offset, limit);
       return builder.toString();
     }

--- a/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
+++ b/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package org.apache.ibatis.jdbc;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -385,7 +384,7 @@ public abstract class AbstractSQL<T> {
    */
   public T LIMIT(String variable) {
     sql().limit = variable;
-    sql().limitingRowsStrategy = SQLStatement.LimitingRowsStrategy.OFFSET_LIMIT;
+    sql().limitingRowsStrategy = LimitingRowsStrategy.OFFSET_LIMIT;
     return getSelf();
   }
 
@@ -419,7 +418,7 @@ public abstract class AbstractSQL<T> {
    */
   public T OFFSET(String variable) {
     sql().offset = variable;
-    sql().limitingRowsStrategy = SQLStatement.LimitingRowsStrategy.OFFSET_LIMIT;
+    sql().limitingRowsStrategy = LimitingRowsStrategy.OFFSET_LIMIT;
     return getSelf();
   }
 
@@ -453,7 +452,7 @@ public abstract class AbstractSQL<T> {
    */
   public T FETCH_FIRST_ROWS_ONLY(String variable) {
     sql().limit = variable;
-    sql().limitingRowsStrategy = SQLStatement.LimitingRowsStrategy.ISO;
+    sql().limitingRowsStrategy = LimitingRowsStrategy.ISO;
     return getSelf();
   }
 
@@ -487,7 +486,7 @@ public abstract class AbstractSQL<T> {
    */
   public T OFFSET_ROWS(String variable) {
     sql().offset = variable;
-    sql().limitingRowsStrategy = SQLStatement.LimitingRowsStrategy.ISO;
+    sql().limitingRowsStrategy = LimitingRowsStrategy.ISO;
     return getSelf();
   }
 
@@ -600,32 +599,6 @@ public abstract class AbstractSQL<T> {
     return sb.toString();
   }
 
-  private static class SafeAppendable {
-    private final Appendable appendable;
-    private boolean empty = true;
-
-    public SafeAppendable(Appendable a) {
-      this.appendable = a;
-    }
-
-    public SafeAppendable append(CharSequence s) {
-      try {
-        if (empty && s.length() > 0) {
-          empty = false;
-        }
-        appendable.append(s);
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-      return this;
-    }
-
-    public boolean isEmpty() {
-      return empty;
-    }
-
-  }
-
   private static class SQLStatement {
 
     public enum StatementType {
@@ -637,40 +610,6 @@ public abstract class AbstractSQL<T> {
       SELECT,
 
       UPDATE
-
-    }
-
-    private enum LimitingRowsStrategy {
-      NOP {
-        @Override
-        protected void appendClause(SafeAppendable builder, String offset, String limit) {
-          // NOP
-        }
-      },
-      ISO {
-        @Override
-        protected void appendClause(SafeAppendable builder, String offset, String limit) {
-          if (offset != null) {
-            builder.append(" OFFSET ").append(offset).append(" ROWS");
-          }
-          if (limit != null) {
-            builder.append(" FETCH FIRST ").append(limit).append(" ROWS ONLY");
-          }
-        }
-      },
-      OFFSET_LIMIT {
-        @Override
-        protected void appendClause(SafeAppendable builder, String offset, String limit) {
-          if (limit != null) {
-            builder.append(" LIMIT ").append(limit);
-          }
-          if (offset != null) {
-            builder.append(" OFFSET ").append(offset);
-          }
-        }
-      };
-
-      protected abstract void appendClause(SafeAppendable builder, String offset, String limit);
 
     }
 

--- a/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
+++ b/src/main/java/org/apache/ibatis/jdbc/AbstractSQL.java
@@ -674,7 +674,7 @@ public abstract class AbstractSQL<T> {
       sqlClause(builder, "GROUP BY", groupBy, "", "", ", ");
       sqlClause(builder, "HAVING", having, "(", ")", " AND ");
       sqlClause(builder, "ORDER BY", orderBy, "", "", ", ");
-      limitingRowsStrategy.appendClause(builder, offset, limit);
+      limitingRowsStrategy.applyLimitToSelect(builder, offset, limit);
       return builder.toString();
     }
 

--- a/src/main/java/org/apache/ibatis/jdbc/LimitingRowsStrategy.java
+++ b/src/main/java/org/apache/ibatis/jdbc/LimitingRowsStrategy.java
@@ -48,6 +48,11 @@ public enum LimitingRowsStrategy {
   };
 
   public abstract void appendClause(SafeAppendable builder, String offset, String limit);
+
+  public void applyLimitToSelect(SafeAppendable builder, String offset, String limit) {
+    this.appendClause(builder, offset, limit);
+  }
+
 }
 
 class SafeAppendable {

--- a/src/main/java/org/apache/ibatis/jdbc/LimitingRowsStrategy.java
+++ b/src/main/java/org/apache/ibatis/jdbc/LimitingRowsStrategy.java
@@ -1,0 +1,77 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.jdbc;
+
+import java.io.IOException;
+
+public enum LimitingRowsStrategy {
+  NOP {
+    @Override
+    public void appendClause(SafeAppendable builder, String offset, String limit) {
+      // NOP
+    }
+  },
+  ISO {
+    @Override
+    public void appendClause(SafeAppendable builder, String offset, String limit) {
+      if (offset != null) {
+        builder.append(" OFFSET ").append(offset).append(" ROWS");
+      }
+      if (limit != null) {
+        builder.append(" FETCH FIRST ").append(limit).append(" ROWS ONLY");
+      }
+    }
+  },
+  OFFSET_LIMIT {
+    @Override
+    public void appendClause(SafeAppendable builder, String offset, String limit) {
+      if (limit != null) {
+        builder.append(" LIMIT ").append(limit);
+      }
+      if (offset != null) {
+        builder.append(" OFFSET ").append(offset);
+      }
+    }
+  };
+
+  public abstract void appendClause(SafeAppendable builder, String offset, String limit);
+}
+
+class SafeAppendable {
+  private final Appendable appendable;
+  private boolean empty = true;
+
+  public SafeAppendable(Appendable a) {
+    this.appendable = a;
+  }
+
+  public SafeAppendable append(CharSequence s) {
+    try {
+      if (empty && s.length() > 0) {
+        empty = false;
+      }
+      appendable.append(s);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    return this;
+  }
+
+  public boolean isEmpty() {
+    return empty;
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/jdbc/SQLKeywords.java
+++ b/src/main/java/org/apache/ibatis/jdbc/SQLKeywords.java
@@ -1,0 +1,30 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.jdbc;
+
+public class SQLKeywords {
+  public static final String SELECT = "SELECT";
+  public static final String SELECT_DISTINCT = "SELECT DISTINCT";
+  public static final String FROM = "FROM";
+  public static final String WHERE = "WHERE";
+  public static final String GROUP_BY = "GROUP BY";
+  public static final String HAVING = "HAVING";
+  public static final String ORDER_BY = "ORDER BY";
+  public static final String LIMIT = "LIMIT";
+  public static final String OFFSET = "OFFSET";
+  public static final String FETCH_FIRST = "FETCH FIRST";
+  public static final String ROWS_ONLY = "ROWS ONLY";
+}


### PR DESCRIPTION
Summary:

This pull request includes a set of refactorings to improve code modularity, reduce duplication, and address implementation and design smells identified in the codebase. All changes are backward-compatible, preserve testability, and follow clean code principles.

Refactorings Applied:

Set I – Implementation Smells
- Replaced magic number '2' with a named constant 'expectedMapTypeCount'
- Renamed ambiguous variable 'resource' to 'typeSignature' for clarity
- Extracted INSERT, UPDATE, DELETE, and SELECT logic from the 'execute()' method in 'MapperMethod' to reduce cyclomatic complexity

Set II – Design Smells
- Extract Class: Moved 'LimitingRowsStrategy' enum from 'SQLStatement' inner class to its own class
- Move Method: Moved SQL LIMIT/OFFSET logic into 'LimitingRowsStrategy' using 'applyLimitToSelect()' method
- Pull-up Variable: Introduced 'SQLKeywords' constants class to eliminate repeated SQL literals like "SELECT", "FROM", etc.

Benefits:
- Improved readability and modularity
- Reduced duplication
- Easier future maintenance and extension

This is part of a structured academic refactoring assignment. I’m happy to incorporate any feedback or requested changes. Thank you for reviewing.
