### PR TITLE
Unknown element inside `<choose>` should throw exception

### DIFF
--- a/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
+++ b/src/main/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilder.java
@@ -247,6 +247,8 @@ public class XMLScriptBuilder extends BaseBuilder {
           handler.handleNode(child, ifSqlNodes);
         } else if (handler instanceof OtherwiseHandler) {
           handler.handleNode(child, defaultSqlNodes);
+        } else {
+          throw new BuilderException("Unknown element <" + nodeName + "> in SQL statement.");
         }
       }
     }

--- a/src/test/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilderTest.java
+++ b/src/test/java/org/apache/ibatis/scripting/xmltags/XMLScriptBuilderTest.java
@@ -17,7 +17,9 @@
 package org.apache.ibatis.scripting.xmltags;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.mapping.SqlSource;
 import org.apache.ibatis.parsing.XPathParser;
 import org.apache.ibatis.session.Configuration;
@@ -42,4 +44,19 @@ class XMLScriptBuilderTest {
         .containsPattern("(?m)^\\s*select \\* from user\\s+WHERE\\s+id = 1\\s+and id > 0\\s*$");
   }
 
+  @Test
+  void shouldThrowIfUnknownElementFound() {
+    String xml = """
+        <script>
+        select * from user
+        <choose>
+        <when test="1==1">and id = 1</when>
+        <otherwize>and id > 0</otherwize>
+        </choose>
+        </script>
+        """;
+    XMLScriptBuilder parser = new XMLScriptBuilder(new Configuration(), new XPathParser(xml).evalNode("/script"));
+    assertThatThrownBy(parser::parseScriptNode).isInstanceOf(BuilderException.class)
+        .hasMessage("Unknown element <otherwize> in SQL statement.");
+  }
 }


### PR DESCRIPTION
When using XML script in annotation (e.g. `@Select("<script>...</script>")`), the XML parser's validation is disabled.
There are other error cases (e.g. invalid attributes) which are undetectable with the current implementation, but it is not our goal to implement full-featured XML validation logic, IMHO.

Should fix #3455 