### PR TITLE
Ensure consistency between the cache state and cached data in DefaultReflectorFactory.

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/DefaultReflectorFactory.java
+++ b/src/main/java/org/apache/ibatis/reflection/DefaultReflectorFactory.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 public class DefaultReflectorFactory implements ReflectorFactory {
-  private boolean classCacheEnabled = true;
+  private volatile boolean classCacheEnabled = true;
   private final ConcurrentMap<Type, Reflector> reflectorMap = new ConcurrentHashMap<>();
 
   public DefaultReflectorFactory() {
@@ -33,6 +33,10 @@ public class DefaultReflectorFactory implements ReflectorFactory {
 
   @Override
   public void setClassCacheEnabled(boolean classCacheEnabled) {
+    boolean previous = this.classCacheEnabled;
+    if (previous != classCacheEnabled) {
+      reflectorMap.clear();
+    }
     this.classCacheEnabled = classCacheEnabled;
   }
 


### PR DESCRIPTION
1. When disabling the cache, an attempt is made to clear all cached Reflector instances. However, complete clearance cannot be strictly guaranteed due to potential concurrent writes.

2. To ensure that stale data does not affect new cache entries, the cache is proactively cleared again when re-enabling caching.

This change guarantees that once caching is turned back on, it always starts with a clean state, preventing any residual data from the previous caching cycle from being reused.