### PR TITLE
Add test to validate <choose> tag's <otherwise> fallback when parameter is null

### DIFF
--- a/src/test/java/org/apache/ibatis/plugin/PluginTest.java
+++ b/src/test/java/org/apache/ibatis/plugin/PluginTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/choosewhen/ChooseWhenMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/choosewhen/ChooseWhenMapper.java
@@ -1,0 +1,23 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.choosewhen;
+
+import java.util.List;
+import java.util.Map;
+
+public interface ChooseWhenMapper {
+  List<User> selectUser(Map<String, Object> param);
+}

--- a/src/test/java/org/apache/ibatis/submitted/choosewhen/ChooseWhenTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/choosewhen/ChooseWhenTest.java
@@ -1,0 +1,59 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.choosewhen;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ChooseWhenTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void initDatabase() throws Exception {
+    try (Reader reader = Resources.getResourceAsReader("org/apache/ibatis/submitted/choosewhen/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+      sqlSessionFactory.getConfiguration().setLazyLoadingEnabled(true);
+      sqlSessionFactory.getConfiguration().setAggressiveLazyLoading(false);
+    }
+
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+        "org/apache/ibatis/submitted/choosewhen/CreateDB.sql");
+  }
+
+  @Test
+  public void shouldApplyOtherwiseWhenNoParam() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      ChooseWhenMapper mapper = sqlSession.getMapper(ChooseWhenMapper.class);
+      Map<String, Object> param = new HashMap<>(); // name 없음
+      List<User> users = mapper.selectUser(param);
+      assertTrue(users.stream().allMatch(u -> "ACTIVE".equals(u.getStatus())));
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/choosewhen/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/choosewhen/User.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.choosewhen;
+
+public class User {
+  private String name;
+  private String status;
+
+  // getters/setters
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/optional_on_mapper_method/OptionalOnMapperMethodTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/optional_on_mapper_method/OptionalOnMapperMethodTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2025 the original author or authors.
+ *    Copyright 2009-2024 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/java/org/apache/ibatis/submitted/overwritingproperties/FooMapperTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/overwritingproperties/FooMapperTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/src/test/resources/org/apache/ibatis/submitted/choosewhen/ChooseWhenMapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/choosewhen/ChooseWhenMapper.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+       Copyright 2009-2025 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+
+<!DOCTYPE mapper
+  PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.choosewhen.ChooseWhenMapper">
+
+  <select id="selectUser" resultType="org.apache.ibatis.submitted.choosewhen.User">
+    SELECT * FROM users
+    <where>
+      <choose>
+        <when test="name != null">
+          AND name = #{name}
+        </when>
+        <otherwise>
+          AND status = 'ACTIVE'
+        </otherwise>
+      </choose>
+    </where>
+  </select>
+
+</mapper>
+

--- a/src/test/resources/org/apache/ibatis/submitted/choosewhen/CreateDB.sql
+++ b/src/test/resources/org/apache/ibatis/submitted/choosewhen/CreateDB.sql
@@ -1,0 +1,25 @@
+--
+--    Copyright 2009-2025 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       https://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100),
+    status VARCHAR(20)
+);
+
+INSERT INTO users (name, status) VALUES ('Alice', 'ACTIVE');
+INSERT INTO users (name, status) VALUES ('Bob', 'ACTIVE');
+INSERT INTO users (name, status) VALUES (null, 'ACTIVE');

--- a/src/test/resources/org/apache/ibatis/submitted/choosewhen/mybatis-config.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/choosewhen/mybatis-config.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2025 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC" />
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.h2.Driver" />
+        <property name="url" value="jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1" />
+        <property name="username" value="sa" />
+        <property name="password" value="" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <mappers>
+    <mapper resource="org/apache/ibatis/submitted/choosewhen/ChooseWhenMapper.xml"/>
+  </mappers>
+
+</configuration>


### PR DESCRIPTION
### Summary
This PR adds a unit test to ensure that `<choose>` with `<when>` conditions correctly falls back to `<otherwise>` when a parameter is missing or null.

### Motivation
While MyBatis already appears to handle OGNL evaluation with missing parameters gracefully, there wasn't an explicit test to guarantee this behavior.

By adding this test, we can be more confident that:
- When `name` is not provided, the `when` condition fails safely.
- The `otherwise` clause executes as expected, producing `AND status = 'ACTIVE'`.

### Details
- Added `ChooseWhenTest` under `submitted.choosewhen` to verify this edge case.
- Uses H2 in-memory database and `CreateDB.sql` for test setup.

### Notes
I wanted to provide a clear test case that proves `<choose>` properly falls back to `<otherwise>`.  
This improves test coverage and helps ensure future refactoring doesn't accidentally break this logic.

---

Let me know if you'd like any adjustments!
