### PR TITLE
optimize TypeParameterResolver

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
+++ b/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
@@ -231,9 +231,8 @@ public class TypeParameterResolver {
         newParentArgs[i] = parentTypeArgs[i];
       }
     }
-    return noChange
-      ? parentType
-      : new ParameterizedTypeImpl((Class<?>) parentType.getRawType(), parentType.getOwnerType(), newParentArgs);
+    return noChange ? parentType
+        : new ParameterizedTypeImpl((Class<?>) parentType.getRawType(), parentType.getOwnerType(), newParentArgs);
   }
 
   private TypeParameterResolver() {

--- a/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
+++ b/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
@@ -159,7 +159,7 @@ public class TypeParameterResolver {
       }
     } else {
       throw new IllegalArgumentException(
-          "The srcType(2nd arg) must be Class or ParameterizedType, but was: " + srcType.getClass());
+          "The 2nd arg must be Class or ParameterizedType, but was: " + srcType.getClass());
     }
 
     if (clazz == declaringClass) {

--- a/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
+++ b/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
@@ -343,11 +343,11 @@ public class TypeParameterResolver {
       if (this == obj) {
         return true;
       }
-      if (!(obj instanceof WildcardTypeImpl)) {
+      if (!(obj instanceof WildcardType)) {
         return false;
       }
-      WildcardTypeImpl other = (WildcardTypeImpl) obj;
-      return Arrays.equals(lowerBounds, other.lowerBounds) && Arrays.equals(upperBounds, other.upperBounds);
+      WildcardType other = (WildcardType) obj;
+      return Arrays.equals(lowerBounds, other.getLowerBounds()) && Arrays.equals(upperBounds, other.getUpperBounds());
     }
 
     @Override
@@ -385,11 +385,11 @@ public class TypeParameterResolver {
       if (this == obj) {
         return true;
       }
-      if (!(obj instanceof GenericArrayTypeImpl)) {
+      if (!(obj instanceof GenericArrayType)) {
         return false;
       }
-      GenericArrayTypeImpl other = (GenericArrayTypeImpl) obj;
-      return Objects.equals(genericComponentType, other.genericComponentType);
+      GenericArrayType other = (GenericArrayType) obj;
+      return Objects.equals(genericComponentType, other.getGenericComponentType());
     }
 
     @Override

--- a/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
+++ b/src/main/java/org/apache/ibatis/reflection/TypeParameterResolver.java
@@ -231,26 +231,23 @@ public class TypeParameterResolver {
         newParentArgs[i] = parentTypeArgs[i];
       }
     }
-    if (noChange && !(parentType instanceof ParameterizedTypeImpl)) noChange = false;
-    return noChange
-      ? parentType
-      : new ParameterizedTypeImpl((Class<?>) parentType.getRawType(), parentType.getOwnerType(), newParentArgs);
+    if (noChange && !(parentType instanceof ParameterizedTypeImpl))
+      noChange = false;
+    return noChange ? parentType
+        : new ParameterizedTypeImpl((Class<?>) parentType.getRawType(), parentType.getOwnerType(), newParentArgs);
   }
 
   private static Type canonicalize(Type type) {
     if (type instanceof ParameterizedType) {
       ParameterizedType p = (ParameterizedType) type;
       return new ParameterizedTypeImpl((Class<?>) p.getRawType(), p.getOwnerType(), p.getActualTypeArguments());
-    }
-    else if (type instanceof GenericArrayType) {
+    } else if (type instanceof GenericArrayType) {
       GenericArrayType g = (GenericArrayType) type;
       return new GenericArrayTypeImpl(g.getGenericComponentType());
-    }
-    else if (type instanceof WildcardType) {
+    } else if (type instanceof WildcardType) {
       WildcardType w = (WildcardType) type;
       return new WildcardTypeImpl(w.getLowerBounds(), w.getUpperBounds());
-    }
-    else {
+    } else {
       return type;
     }
   }
@@ -322,10 +319,8 @@ public class TypeParameterResolver {
         s.append(ownerType.getTypeName()).append("$");
         if (ownerType instanceof ParameterizedTypeImpl) {
           // remove prefixes that do not contain generic information
-          s.append(
-            rawType.getName().replace(((ParameterizedTypeImpl) ownerType).rawType.getName() + "$", ""));
-        }
-        else {
+          s.append(rawType.getName().replace(((ParameterizedTypeImpl) ownerType).rawType.getName() + "$", ""));
+        } else {
           s.append(rawType.getSimpleName());
         }
       } else {

--- a/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
@@ -578,6 +578,7 @@ class TypeParameterResolverTest {
   @Test
   void shouldWildcardTypeBeEqual() throws Exception {
     class WildcardTypeTester {
+      @SuppressWarnings("unused")
       public List<? extends Serializable> foo() {
         return null;
       }
@@ -600,6 +601,7 @@ class TypeParameterResolverTest {
   @Test
   void shouldGenericArrayTypeBeEqual() throws Exception {
     class GenericArrayTypeTester {
+      @SuppressWarnings("unused")
       public List<String>[] foo() {
         return null;
       }

--- a/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
@@ -606,4 +606,13 @@ class TypeParameterResolverTest {
 
     assertEquals(typeMybatis, typeJdk);
   }
+
+  @Test
+  void shouldNestedParamTypeToStringOmitCommonFqn() throws Exception {
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectMapEntry");
+    Type type = TypeParameterResolver.resolveReturnType(method, clazz);
+    assertEquals("java.util.Map<java.util.Map$Entry<java.lang.String, java.lang.Integer>, java.util.Date>",
+        type.toString());
+  }
 }

--- a/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
@@ -571,7 +571,8 @@ class TypeParameterResolverTest {
 
     assertTrue(typeJdk instanceof ParameterizedType && !(typeJdk instanceof TypeParameterResolver.ParameterizedTypeImpl));
     assertTrue(typeMybatis instanceof TypeParameterResolver.ParameterizedTypeImpl);
-    assertEquals(typeMybatis.equals(typeJdk), typeJdk.equals(typeMybatis));
+    assertTrue(typeJdk.equals(typeMybatis));
+    assertTrue(typeMybatis.equals(typeJdk));
   }
 
   @Test
@@ -592,7 +593,8 @@ class TypeParameterResolverTest {
 
     assertTrue(wildcardJdk instanceof WildcardType && !(wildcardJdk instanceof TypeParameterResolver.WildcardTypeImpl));
     assertTrue(wildcardMybatis instanceof TypeParameterResolver.WildcardTypeImpl);
-    assertEquals(wildcardMybatis.equals(wildcardJdk), wildcardJdk.equals(wildcardMybatis));
+    assertTrue(typeJdk.equals(typeMybatis));
+    assertTrue(typeMybatis.equals(typeJdk));
   }
 
   @Test
@@ -610,7 +612,8 @@ class TypeParameterResolverTest {
 
     assertTrue(typeJdk instanceof GenericArrayType && !(typeJdk instanceof TypeParameterResolver.GenericArrayTypeImpl));
     assertTrue(typeMybatis instanceof TypeParameterResolver.GenericArrayTypeImpl);
-    assertEquals(typeMybatis.equals(typeJdk), typeJdk.equals(typeMybatis));
+    assertTrue(typeJdk.equals(typeMybatis));
+    assertTrue(typeMybatis.equals(typeJdk));
   }
 
   @Test

--- a/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
@@ -28,6 +28,7 @@ import java.lang.reflect.WildcardType;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -588,4 +589,21 @@ class TypeParameterResolverTest {
     }
   }
 
+  @Test
+  void shouldParameterizedTypesWithOwnerTypeBeEqual() throws Exception {
+    class Clazz {
+      @SuppressWarnings("unused")
+      public Entry<String, Integer> entry() {
+        return null;
+      }
+    }
+
+    Type typeJdk = Clazz.class.getMethod("entry").getGenericReturnType();
+
+    Class<?> clazz = Level2Mapper.class;
+    Method method = clazz.getMethod("selectEntry");
+    Type typeMybatis = TypeParameterResolver.resolveReturnType(method, clazz);
+
+    assertEquals(typeMybatis, typeJdk);
+  }
 }

--- a/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/TypeParameterResolverTest.java
@@ -569,7 +569,8 @@ class TypeParameterResolverTest {
     Method method = clazz.getMethod("selectEntry");
     Type typeMybatis = TypeParameterResolver.resolveReturnType(method, clazz);
 
-    assertTrue(typeJdk instanceof ParameterizedType && !(typeJdk instanceof TypeParameterResolver.ParameterizedTypeImpl));
+    assertTrue(
+        typeJdk instanceof ParameterizedType && !(typeJdk instanceof TypeParameterResolver.ParameterizedTypeImpl));
     assertTrue(typeMybatis instanceof TypeParameterResolver.ParameterizedTypeImpl);
     assertTrue(typeJdk.equals(typeMybatis));
     assertTrue(typeMybatis.equals(typeJdk));
@@ -662,12 +663,11 @@ class TypeParameterResolverTest {
     Type noTypeOuterReturnType = TypeParameterResolver.resolveReturnType(noTypeOuter, innerTesterClass);
     Type stringTypeOuterReturnType = TypeParameterResolver.resolveReturnType(stringTypeOuter, innerTesterClass);
 
-    assertEquals("org.apache.ibatis.reflection.TypeParameterResolverTest$Outer<T>$Inner",
-      fooReturnType.toString());
+    assertEquals("org.apache.ibatis.reflection.TypeParameterResolverTest$Outer<T>$Inner", fooReturnType.toString());
     assertEquals("org.apache.ibatis.reflection.TypeParameterResolverTest$Outer<?>$Inner",
-      noTypeOuterReturnType.toString());
+        noTypeOuterReturnType.toString());
     assertEquals("org.apache.ibatis.reflection.TypeParameterResolverTest$Outer<java.lang.String>$Inner",
-      stringTypeOuterReturnType.toString());
+        stringTypeOuterReturnType.toString());
   }
 
 }

--- a/src/test/java/org/apache/ibatis/reflection/typeparam/Level0Mapper.java
+++ b/src/test/java/org/apache/ibatis/reflection/typeparam/Level0Mapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.apache.ibatis.reflection.typeparam;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 public interface Level0Mapper<L, M, N> {
 
@@ -45,6 +46,8 @@ public interface Level0Mapper<L, M, N> {
   List<? extends N> selectWildcardList();
 
   Map<N, M> selectMap();
+
+  Entry<N, M> selectEntry();
 
   N[] selectArray(List<N>[] param);
 

--- a/src/test/java/org/apache/ibatis/reflection/typeparam/Level0Mapper.java
+++ b/src/test/java/org/apache/ibatis/reflection/typeparam/Level0Mapper.java
@@ -49,6 +49,8 @@ public interface Level0Mapper<L, M, N> {
 
   Entry<N, M> selectEntry();
 
+  Map<Entry<N, M>, L> selectMapEntry();
+
   N[] selectArray(List<N>[] param);
 
   N[][] selectArrayOfArray();


### PR DESCRIPTION
optimize TypeParameterResolver

1. The correct ownerType has been identified
2. canonicalize type (In the original implementation, there would be a mix of JDK implementations such as sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl ...)
3. optimized toString()
4. when the specific generic is not declared, erase to the most appropriate upper bound

```java
class A<T extends Serializable> {
  public T foo(T t) {
    return t;
  }
}

class B<T extends Number> extends A<T> {}

class C<T extends Integer> extends B<T> {}

Method m = A.class.getMethod("foo", Serializable.class);

// In old code, it's Object.class. Actually, Integer
System.out.println(TypeParameterResolver.resolveReturnType(m, C.class)); 
````