### PR TITLE
typo

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/CacheNamespace.java
+++ b/src/main/java/org/apache/ibatis/annotations/CacheNamespace.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -32,8 +32,9 @@ import org.apache.ibatis.cache.impl.PerpetualCache;
  *
  * <pre>{@code
  * @CacheNamespace(implementation = CustomCache.class, properties = {
- *     &#064;Property(name = "host", value = "${mybatis.cache.host}"),
- *     &#064;Property(name = "port", value = "${mybatis.cache.port}"), &#064;Property(name = "name", value = "usersCache") })
+ *   @Property(name = "host", value = "${mybatis.cache.host}"),
+ *   @Property(name = "port", value = "${mybatis.cache.port}"),
+ *   @Property(name = "name", value = "usersCache") })
  * public interface UserMapper {
  *   // ...
  * }

--- a/src/main/java/org/apache/ibatis/annotations/ConstructorArgs.java
+++ b/src/main/java/org/apache/ibatis/annotations/ConstructorArgs.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -28,10 +28,10 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * public interface UserMapper {
- *   @ConstructorArgs({ &#064;Arg(column = "id", javaType = int.class, id = true),
- *       &#064;Arg(column = "name", javaType = String.class),
- *       &#064;Arg(javaType = UserEmail.class, select = "selectUserEmailById", column = "id") })
- *   &#064;Select("SELECT id, name FROM users WHERE id = #{id}")
+ *   @ConstructorArgs(value = { @Arg(column = "id", javaType = int.class, id = true),
+ *       @Arg(column = "name", javaType = String.class),
+ *       @Arg(javaType = UserEmail.class, select = "selectUserEmailById", column = "id") })
+ *   @Select("SELECT id, name FROM users WHERE id = #{id}")
  *   User selectById(int id);
  * }
  * }</pre>

--- a/src/main/java/org/apache/ibatis/annotations/Select.java
+++ b/src/main/java/org/apache/ibatis/annotations/Select.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ import java.lang.annotation.Target;
  *
  * <pre>{@code
  * public interface UserMapper {
- *   @Select({ "<script>", "select * from users", "where name = #{name}",
+ *   @Select(value = { "<script>", "select * from users", "where name = #{name}",
  *       "<if test=\"age != null\"> age = #{age} </if>", "</script>" })
  *   User select(@NotNull String name, @Nullable Integer age);
  * }

--- a/src/main/java/org/apache/ibatis/annotations/TypeDiscriminator.java
+++ b/src/main/java/org/apache/ibatis/annotations/TypeDiscriminator.java
@@ -32,11 +32,11 @@ import org.apache.ibatis.type.UnknownTypeHandler;
  *
  * <pre>{@code
  * public interface UserMapper {
- *   &#064;Select("SELECT id, name, type FROM users ORDER BY id")
- *   &#064;TypeDiscriminator(column = "type", javaType = String.class, cases = {
- *       &#064;Case(value = "1", type = PremiumUser.class), &#064;Case(value = "2", type = GeneralUser.class),
- *       &#064;Case(value = "3", type = TemporaryUser.class) })
- *   List&lt;User&gt; selectAll();
+ *   @Select("SELECT id, name, type FROM users ORDER BY id")
+ *   @TypeDiscriminator(column = "type", javaType = String.class, cases = {
+ *     @Case(value = "1", type = PremiumUser.class), @Case(value = "2", type = GeneralUser.class),
+ *     @Case(value = "3", type = TemporaryUser.class) })
+ *   List<User> selectAll();
  * }
  * }</pre>
  *

--- a/src/main/java/org/apache/ibatis/plugin/Intercepts.java
+++ b/src/main/java/org/apache/ibatis/plugin/Intercepts.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,9 +27,9 @@ import java.lang.annotation.Target;
  * <b>How to use:</b>
  *
  * <pre>{@code
- * @Intercepts({ &#064;Signature(type = Executor.class, method = "update", args = { MappedStatement.class, Object.class }) })
+ * @Intercepts(value = { @Signature(type = Executor.class, method = "update", args = { MappedStatement.class, Object.class }) })
  * public class ExamplePlugin implements Interceptor {
- *   &#064;Override
+ *   @Override
  *   public Object intercept(Invocation invocation) throws Throwable {
  *     // implement pre-processing if needed
  *     Object returnObject = invocation.proceed();

--- a/src/main/java/org/apache/ibatis/type/SimpleTypeRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/SimpleTypeRegistry.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class SimpleTypeRegistry {
     // Prevent Instantiation
   }
 
-  /*
+  /**
    * Tells us if the class passed in is a known common type
    * @param clazz The class to check
    * @return True if the class is known

--- a/src/test/java/org/apache/ibatis/io/ExternalResourcesTest.java
+++ b/src/test/java/org/apache/ibatis/io/ExternalResourcesTest.java
@@ -39,7 +39,7 @@ class ExternalResourcesTest {
   private File badFile;
   private File tempFile;
 
-  /*
+  /**
    * @throws java.lang.Exception
    */
   @BeforeEach

--- a/src/test/java/org/apache/ibatis/submitted/dynsql/Parameter.java
+++ b/src/test/java/org/apache/ibatis/submitted/dynsql/Parameter.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.apache.ibatis.submitted.dynsql;
 
 import java.util.List;
 
-/*
+/**
  * @author Jeff Butler
  */
 public class Parameter {

--- a/src/test/java/org/apache/ibatis/submitted/dynsql2/Parameter.java
+++ b/src/test/java/org/apache/ibatis/submitted/dynsql2/Parameter.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.apache.ibatis.submitted.dynsql2;
 
 import java.util.List;
 
-/*
+/**
  * @author Jeff Butler
  */
 public class Parameter {

--- a/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/NpeExtendsTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/extends_with_constructor/NpeExtendsTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -33,7 +33,7 @@ import org.apache.ibatis.transaction.jdbc.JdbcTransactionFactory;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * Test for NPE when using extends.
  *
  * @author poitrac

--- a/src/test/java/org/apache/ibatis/submitted/overwritingproperties/FooMapperTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/overwritingproperties/FooMapperTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-/*
+/**
  * @author jjensen
  */
 class FooMapperTest {


### PR DESCRIPTION
HTML entities will not render properly in ` {@ code}`
<img width="690" height="352" alt="image" src="https://github.com/user-attachments/assets/e03ab5e0-9886-49a9-95d4-5833b2f7a87f" />
A single line starting with `* @Annotation({...` will result in abnormal macthing of the end flag of `{@code`
To avoid this situation, I used the form `* @Annotation(value = {...` (Although this is a bit redundant, it is also in line with Java syntax)
<img width="620" height="350" alt="image" src="https://github.com/user-attachments/assets/05868475-3939-4ae4-9e85-d45392798443" />
After modification
<img width="619" height="351" alt="image" src="https://github.com/user-attachments/assets/c7b1f700-3ef1-4be7-881a-f62c37c0d900" />
