### PR TITLE
Fix typo in Arg Javadoc (a object → an object)

### DIFF
--- a/src/main/java/org/apache/ibatis/annotations/Arg.java
+++ b/src/main/java/org/apache/ibatis/annotations/Arg.java
@@ -75,14 +75,14 @@ public @interface Arg {
   Class<? extends TypeHandler> typeHandler() default UnknownTypeHandler.class;
 
   /**
-   * Return the statement id for retrieving a object that map to this argument.
+   * Return the statement id for retrieving an object that map to this argument.
    *
    * @return the statement id
    */
   String select() default "";
 
   /**
-   * Returns the result map id for mapping to a object that map to this argument.
+   * Returns the result map id for mapping to an object that map to this argument.
    *
    * @return the result map id
    */


### PR DESCRIPTION
### Summary

This PR fixes a minor typo in the Javadoc of `org.apache.ibatis.annotations.Arg`.

**Before**
- `Return the statement id for retrieving a object that map to this argument.` (line 78)
- `Returns the result map id for mapping to a object that map to this argument.` (line 85)

**After**
- `Return the statement id for retrieving an object that map to this argument.`
- `Returns the result map id for mapping to an object that map to this argument.`

No behavioral changes, only Javadoc text is updated.

This is a documentation-only change.