### PR TITLE
fix: object array casting

### DIFF
--- a/src/main/java/org/apache/ibatis/type/ArrayTypeHandler.java
+++ b/src/main/java/org/apache/ibatis/type/ArrayTypeHandler.java
@@ -30,6 +30,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -89,7 +90,8 @@ public class ArrayTypeHandler extends BaseTypeHandler<Object> {
       }
       Class<?> componentType = parameter.getClass().getComponentType();
       String arrayTypeName = resolveTypeName(componentType);
-      Array array = ps.getConnection().createArrayOf(arrayTypeName, (Object[]) parameter);
+      Object[] arrayParameter = (Object[]) parameter;
+      Array array = ps.getConnection().createArrayOf(arrayTypeName, Arrays.copyOf(arrayParameter, arrayParameter.length, Object[].class));
       ps.setArray(i, array);
       array.free();
     }


### PR DESCRIPTION
The object array casting cannot change the real class of `parameter`

## Example
```java
public class Main {
    public static void main(String[] args) {
        Object parameter = new String[]{"foo"};
        Object[] arrayParameter = (Object[]) parameter;
        System.out.println(arrayParameter.getClass());
        Object[] obj = Arrays.copyOf(arrayParameter, arrayParameter.length, Object[].class);
        System.out.println(obj.getClass());
    }
}
```
## Problem
Postgresql cannot create `PgArray` in this case

```plain
org.postgresql.util.PSQLException: ERROR: insufficient data left in message
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2736)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2421)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:372)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:525)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:435)
	at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:196)
	at org.postgresql.jdbc.PgPreparedStatement.execute(PgPreparedStatement.java:182)
```
## Solution
use `Arrays.copyOf` to create a new array
```java
Array array = ps.getConnection().createArrayOf(arrayTypeName, Arrays.copyOf(arrayParameter, arrayParameter.length, Object[].class));
```