### PR TITLE
Support custom injection of MapperRegistry extension, optimize thread safety

### DIFF
--- a/src/main/java/org/apache/ibatis/binding/MapperRegistry.java
+++ b/src/main/java/org/apache/ibatis/binding/MapperRegistry.java
@@ -64,7 +64,7 @@ public class MapperRegistry {
       }
       boolean loadCompleted = false;
       try {
-        knownMappers.put(type, new MapperProxyFactory<>(type));
+        knownMappers.put(type, createMapperProxyFactory(type));
         // It's important that the type is added before the parser is run
         // otherwise the binding may automatically be attempted by the
         // mapper parser. If the type is already known, it won't try.
@@ -77,6 +77,10 @@ public class MapperRegistry {
         }
       }
     }
+  }
+
+  protected <T> MapperProxyFactory<T> createMapperProxyFactory(Class<T> type) {
+    return new MapperProxyFactory<>(type);
   }
 
   /**

--- a/src/main/java/org/apache/ibatis/cache/impl/PerpetualCache.java
+++ b/src/main/java/org/apache/ibatis/cache/impl/PerpetualCache.java
@@ -17,6 +17,7 @@ package org.apache.ibatis.cache.impl;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.ibatis.cache.Cache;
 import org.apache.ibatis.cache.CacheException;
@@ -28,7 +29,7 @@ public class PerpetualCache implements Cache {
 
   private final String id;
 
-  private final Map<Object, Object> cache = new HashMap<>();
+  private final Map<Object, Object> cache = new ConcurrentHashMap<>();
 
   public PerpetualCache(String id) {
     this.id = id;

--- a/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
+++ b/src/main/java/org/apache/ibatis/executor/BaseExecutor.java
@@ -388,7 +388,8 @@ public abstract class BaseExecutor implements Executor {
     }
 
     public boolean canLoad() {
-      return localCache.getObject(key) != null && localCache.getObject(key) != EXECUTION_PLACEHOLDER;
+      Object cached = localCache.getObject(key);
+      return cached != null && cached != EXECUTION_PLACEHOLDER;
     }
 
     public void load() {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -149,7 +149,7 @@ public class Configuration {
    */
   protected Class<?> configurationFactory;
 
-  protected final MapperRegistry mapperRegistry = new MapperRegistry(this);
+  protected MapperRegistry mapperRegistry = new MapperRegistry(this);
   protected final InterceptorChain interceptorChain = new InterceptorChain();
   protected final TypeHandlerRegistry typeHandlerRegistry = new TypeHandlerRegistry(this);
   protected final TypeAliasRegistry typeAliasRegistry = new TypeAliasRegistry();
@@ -164,7 +164,7 @@ public class Configuration {
   protected final Map<String, ParameterMap> parameterMaps = new StrictMap<>("Parameter Maps collection");
   protected final Map<String, KeyGenerator> keyGenerators = new StrictMap<>("Key Generators collection");
 
-  protected final Set<String> loadedResources = new HashSet<>();
+  protected final Set<String> loadedResources = ConcurrentHashMap.newKeySet();
   protected final Map<String, XNode> sqlFragments = new StrictMap<>("XML fragments parsed from previous mappers");
   protected final Collection<XMLStatementBuilder> incompleteStatements = new LinkedList<>();
   protected final Collection<CacheRefResolver> incompleteCacheRefs = new LinkedList<>();
@@ -621,6 +621,22 @@ public class Configuration {
    */
   public MapperRegistry getMapperRegistry() {
     return mapperRegistry;
+  }
+
+  /**
+   * Sets a custom mapper registry.
+   * <p>
+   * This allows injecting a custom {@link MapperRegistry} implementation at runtime.
+   *
+   * @param mapperRegistry
+   *          the custom mapper registry to use
+   *
+   * @since 3.6.0
+   */
+  public void setMapperRegistry(MapperRegistry mapperRegistry) {
+    if (null != mapperRegistry) {
+      this.mapperRegistry = mapperRegistry;
+    }
   }
 
   public ReflectorFactory getReflectorFactory() {


### PR DESCRIPTION
optimization points

1, Support custom injection of MapperRegistry extension

2, MapperRegistry Extract the createMapperProxyFactory method

3，eldestKey supports high concurrency and prevents exceptions

5，canLoad() Avoid multiple reads

5，HashMap to ConcurrentHashMap Support concurrent scenarios

