### PR TITLE
Method Field Invoker reflection performance optimization, Supports JD…

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/ReflectionUtil.java
+++ b/src/main/java/org/apache/ibatis/reflection/ReflectionUtil.java
@@ -1,0 +1,61 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.reflection;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+
+/**
+ * @author hubin
+ */
+public class ReflectionUtil {
+
+  public static boolean jdk8Class(Class<?> clazz) {
+    // JDK inner class or JDK 8
+    return clazz.getModule().isNamed() && clazz.getModule().getName().startsWith("java.");
+  }
+
+  public static MethodHandle getMethodHandle(Method method) {
+    try {
+      MethodHandles.Lookup lookup = MethodHandles.lookup();
+      return lookup.unreflect(method);
+    } catch (IllegalAccessException ignored) {
+      // ignored
+    }
+    return null;
+  }
+
+  public static MethodHandles.Lookup getMethodHandlesLookup(Class<?> targetClass) throws IllegalAccessException {
+    MethodHandles.Lookup lookup = MethodHandles.lookup();
+    return MethodHandles.privateLookupIn(targetClass, lookup);
+  }
+
+  public static Object invoke(MethodHandle methodHandle, Object target, Object[] args) throws Throwable {
+    if (args == null || args.length == 0) {
+      return methodHandle.invoke(target);
+    } else if (args.length == 1) {
+      return methodHandle.invoke(target, args[0]);
+    }
+
+    // Execute multiple parameters
+    Object[] fullArgs = new Object[args.length + 1];
+    fullArgs[0] = target;
+    System.arraycopy(args, 0, fullArgs, 1, args.length);
+    return methodHandle.invokeWithArguments(fullArgs);
+  }
+
+}

--- a/src/main/java/org/apache/ibatis/reflection/invoker/Invoker.java
+++ b/src/main/java/org/apache/ibatis/reflection/invoker/Invoker.java
@@ -15,13 +15,13 @@
  */
 package org.apache.ibatis.reflection.invoker;
 
-import java.lang.reflect.InvocationTargetException;
-
 /**
  * @author Clinton Begin
  */
 public interface Invoker {
-  Object invoke(Object target, Object[] args) throws IllegalAccessException, InvocationTargetException;
+
+  Object invoke(Object target, Object[] args) throws Throwable;
 
   Class<?> getType();
+
 }


### PR DESCRIPTION
Added reflection performance optimization for MethodInvoker.java, modified to use MethodHandles instead of Reflection.

1，Invocation.java  list targetClasses change set. Gain higher performance

2，Compatible with JDK 8 reflection

Reflection vs MethodHandles API in Java: Performance, Use Cases, and Best Practices
https://prgrmmng.com/reflection-vs-methodhandles-api-java


--------------
| Method | time |
| -- | -- |
| directCall | ~1 ns |
|methodHandleExact | ~2–4 ns |
| methodHandleInvoke | ~4–8 ns |
| reflectionCall | ~15–30 ns |
Resolve reflective metadata at startup, convert it to MethodHandles, and eliminate reflection from the hot path.

| Approach | Relative Cost | Notes
| -- | -- | -- |
| Direct field access | 1× | Baseline |
| MethodHandle getter | 1.2× | JIT inlineable |
| Method call via reflection | 6–10× | Access checks + JNI |
| Field.get() | 8–15× | Worst case |
