### PR TITLE
Fix ErrorContext ThreadLocal memory leak in lazy loading

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/loader/AbstractEnhancedDeserializationProxy.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/AbstractEnhancedDeserializationProxy.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.apache.ibatis.executor.ErrorContext;
 import org.apache.ibatis.executor.ExecutorException;
 import org.apache.ibatis.reflection.ExceptionUtil;
 import org.apache.ibatis.reflection.factory.ObjectFactory;
@@ -81,6 +82,7 @@ public abstract class AbstractEnhancedDeserializationProxy {
                 loadPair.load(enhanced);
               } finally {
                 reloadingProperty = false;
+                ErrorContext.instance().reset();
               }
             } else {
               /*

--- a/src/main/java/org/apache/ibatis/executor/loader/cglib/CglibProxyFactory.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/cglib/CglibProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import net.sf.cglib.proxy.Enhancer;
 import net.sf.cglib.proxy.MethodInterceptor;
 import net.sf.cglib.proxy.MethodProxy;
 
+import org.apache.ibatis.executor.ErrorContext;
 import org.apache.ibatis.executor.loader.AbstractEnhancedDeserializationProxy;
 import org.apache.ibatis.executor.loader.AbstractSerialStateHolder;
 import org.apache.ibatis.executor.loader.ProxyFactory;
@@ -171,6 +172,7 @@ public class CglibProxyFactory implements ProxyFactory {
         throw ExceptionUtil.unwrapThrowable(t);
       } finally {
         lock.unlock();
+        ErrorContext.instance().reset();
       }
     }
   }

--- a/src/main/java/org/apache/ibatis/executor/loader/javassist/JavassistProxyFactory.java
+++ b/src/main/java/org/apache/ibatis/executor/loader/javassist/JavassistProxyFactory.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import javassist.util.proxy.MethodHandler;
 import javassist.util.proxy.Proxy;
 import javassist.util.proxy.ProxyFactory;
 
+import org.apache.ibatis.executor.ErrorContext;
 import org.apache.ibatis.executor.ExecutorException;
 import org.apache.ibatis.executor.loader.AbstractEnhancedDeserializationProxy;
 import org.apache.ibatis.executor.loader.AbstractSerialStateHolder;
@@ -168,6 +169,7 @@ public class JavassistProxyFactory implements org.apache.ibatis.executor.loader.
         throw ExceptionUtil.unwrapThrowable(t);
       } finally {
         lock.unlock();
+        ErrorContext.instance().reset();
       }
     }
   }


### PR DESCRIPTION
## Summary

  Fixes a ThreadLocal memory leak in ErrorContext when lazy loading is triggered through
  proxy method interception.

  ## Problem

  When lazy loading is invoked via proxy objects (Javassist/CGLIB proxies or
  deserialization proxies), the `ErrorContext` populated during query execution was not
  being cleaned up from ThreadLocal. This caused memory leaks in thread pool environments
   like Tomcat, as reported in #1967.

  The leak occurred because:
  1. Lazy loading triggers `BaseExecutor.query()` which populates
  `ErrorContext.instance()`
  2. Proxy interceptor methods had no `ErrorContext.reset()` in their finally blocks
  3. ThreadLocal references remained in threads, preventing garbage collection

  ## Solution

  Added `ErrorContext.instance().reset()` calls in the finally blocks of:
  - `JavassistProxyFactory.EnhancedResultObjectProxyImpl.invoke()`
  - `CglibProxyFactory.EnhancedResultObjectProxyImpl.intercept()`
  - `AbstractEnhancedDeserializationProxy.invoke()`

  ## Testing

  - [x] Existing tests pass (`ErrorContextTest`)
  - [x] No regression in lazy loading functionality
  - [x] Memory leak is prevented by cleaning up ThreadLocal after lazy loading

  Closes #1967