### PR TITLE
fix: handle Kotlin enum constant subclass (isAnonymousClass==false) in TypeHandlerRegistry

### DIFF
--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -304,7 +304,12 @@ public final class TypeHandlerRegistry {
       if (type instanceof Class) {
         Class<?> clazz = (Class<?>) type;
         if (Enum.class.isAssignableFrom(clazz)) {
-          Class<?> enumClass = clazz.isAnonymousClass() ? clazz.getSuperclass() : clazz;
+          // In Java, enum constants with a body are anonymous classes (isAnonymousClass() == true).
+          // In Kotlin, enum constants with an overridden method are NOT anonymous (isAnonymousClass() == false),
+          // but their superclass is still the enum type. Check both cases to correctly resolve the enum class.
+          Class<?> enumClass = (clazz.isAnonymousClass()
+              || (clazz.getSuperclass() != null && clazz.getSuperclass().isEnum()))
+              ? clazz.getSuperclass() : clazz;
           TypeHandler<?> enumHandler = getInstance(enumClass, defaultEnumTypeHandler);
           register(new Type[] { enumClass }, new JdbcType[] { jdbcType }, enumHandler);
           return enumHandler;
@@ -331,6 +336,10 @@ public final class TypeHandlerRegistry {
       Class<?> clazz = (Class<?>) type;
       if (!Enum.class.isAssignableFrom(clazz)) {
         jdbcHandlerMap = getJdbcHandlerMapForSuperclass(clazz);
+      } else if (clazz.getSuperclass() != null && clazz.getSuperclass().isEnum()) {
+        // Handle Kotlin-style enum constants whose body creates a subclass but isAnonymousClass() == false.
+        // Fall through to parent enum class to find the registered handler.
+        jdbcHandlerMap = typeHandlerMap.get(clazz.getSuperclass());
       }
     }
     typeHandlerMap.put(type, jdbcHandlerMap == null ? NULL_TYPE_HANDLER_MAP : jdbcHandlerMap);


### PR DESCRIPTION
## Problem

Fixes #3658

In Kotlin, when an enum constant overrides an abstract method, the Kotlin compiler generates a subclass of the enum with the constant's behavior. Unlike Java's behavior, **Class.isAnonymousClass() returns alse** for these generated subclasses in Kotlin.

This causes TypeHandlerRegistry to fail when looking up TypeHandler for such Kotlin enum constants, because the registry uses isAnonymousClass() as the sole signal to detect "this is an enum constant subclass, look at the parent":

`java
// Before (line 307) - misses Kotlin enum constant subclasses
Class<?> enumClass = clazz.isAnonymousClass() ? clazz.getSuperclass() : clazz;
`

### Reproduction (Kotlin)

`kotlin
enum class TestEnum {
    TEST1 {
        override fun test() = println("test1")
    };
    abstract fun test()
}

fun main() {
    println(TestEnum.TEST1::class.java.isAnonymousClass)   // false in Kotlin!
    println(TestEnum.TEST1.javaClass.superclass == TestEnum::class.java) // true
}
`

When MyBatis tries to resolve a TypeHandler for TestEnum.TEST1, it gets the generated subclass (not TestEnum), fails to find a handler, and the mapping breaks.

## Fix

### getSmartHandler (line 307)

Add a secondary check: if clazz.getSuperclass().isEnum() is true, the class is an enum constant's body subclass regardless of isAnonymousClass().

`java
// After - handles both Java and Kotlin
Class<?> enumClass = (clazz.isAnonymousClass()
    || (clazz.getSuperclass() != null && clazz.getSuperclass().isEnum()))
    ? clazz.getSuperclass() : clazz;
`

### getJdbcHandlerMap (line 331)

Add a branch to look up the handler map via the parent enum class when the class is a Kotlin-style enum subclass.

`java
} else if (clazz.getSuperclass() != null && clazz.getSuperclass().isEnum()) {
    jdbcHandlerMap = typeHandlerMap.get(clazz.getSuperclass());
}
`

## Notes

- The fix is backward-compatible: Java enum constants with a body still trigger isAnonymousClass() == true and are handled correctly by the original path.
- clazz.getSuperclass().isEnum() is the reliable cross-language indicator that clazz is a direct subclass of an enum (i.e., an enum constant body class).