### PR TITLE
Handle non-anonymous enum subclasses in TypeHandlerRegistry

### DIFF
--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -265,7 +265,7 @@ public final class TypeHandlerRegistry {
     if (type instanceof Class) {
       Class<?> clazz = (Class<?>) type;
       if (Enum.class.isAssignableFrom(clazz)) {
-        if (clazz.isAnonymousClass()) {
+        if (isEnumSubclass(clazz)) {
           return getJdbcHandlerMap(clazz.getSuperclass());
         }
         jdbcHandlerMap = getJdbcHandlerMapForEnumInterfaces(clazz, clazz);
@@ -279,6 +279,11 @@ public final class TypeHandlerRegistry {
     }
     typeHandlerMap.put(type, jdbcHandlerMap == null ? NULL_TYPE_HANDLER_MAP : jdbcHandlerMap);
     return jdbcHandlerMap;
+  }
+
+  private boolean isEnumSubclass(Class<?> clazz) {
+    Class<?> superclass = clazz.getSuperclass();
+    return superclass != null && superclass != Enum.class && Enum.class.isAssignableFrom(superclass);
   }
 
   private Map<JdbcType, TypeHandler<?>> getJdbcHandlerMapForEnumInterfaces(Class<?> clazz, Class<?> enumClazz) {

--- a/src/test/java/org/apache/ibatis/type/TypeHandlerRegistryTest.java
+++ b/src/test/java/org/apache/ibatis/type/TypeHandlerRegistryTest.java
@@ -34,6 +34,9 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+
 import org.apache.ibatis.domain.misc.RichType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -249,5 +252,21 @@ class TypeHandlerRegistryTest {
     } finally {
       executorService.shutdownNow();
     }
+  }
+
+  @Test
+  void shouldUseEnumHandlerForNonAnonymousEnumSubclass() {
+    typeHandlerRegistry.register(SomeInterfaceTypeHandler.class);
+
+    Class<?> enumBaseClass = new ByteBuddy().subclass(Enum.class).implement(SomeInterface.class)
+        .name(TypeHandlerRegistryTest.class.getName() + "$KotlinLikeEnumBase").make()
+        .load(TypeHandlerRegistryTest.class.getClassLoader(), ClassLoadingStrategy.Default.INJECTION).getLoaded();
+    Class<?> kotlinLikeEnumSubclass = new ByteBuddy().subclass(enumBaseClass)
+        .name(enumBaseClass.getName() + "$Subclass").make()
+        .load(TypeHandlerRegistryTest.class.getClassLoader(), ClassLoadingStrategy.Default.INJECTION).getLoaded();
+
+    assertFalse(kotlinLikeEnumSubclass.isAnonymousClass());
+    assertSame(enumBaseClass, kotlinLikeEnumSubclass.getSuperclass());
+    assertSame(SomeInterfaceTypeHandler.class, typeHandlerRegistry.getTypeHandler(kotlinLikeEnumSubclass).getClass());
   }
 }


### PR DESCRIPTION
### Summary
- treat enum subclasses by their enum superclass when resolving type handlers
- cover the Kotlin-like runtime shape where the subclass is not anonymous
- add a regression test using Byte Buddy to exercise the non-anonymous enum subclass path

### Testing
- `JAVA_HOME=C:\Users\wangliang\.jdks\ms-21.0.8 .\mvnw.cmd -Dtest=TypeHandlerRegistryTest test`

Fixes #3658
