### PR TITLE
fix: resolve TypeHandler for Kotlin enum constants with anonymous method body

### DIFF
--- a/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
+++ b/src/main/java/org/apache/ibatis/type/TypeHandlerRegistry.java
@@ -304,7 +304,7 @@ public final class TypeHandlerRegistry {
       if (type instanceof Class) {
         Class<?> clazz = (Class<?>) type;
         if (Enum.class.isAssignableFrom(clazz)) {
-          Class<?> enumClass = clazz.isAnonymousClass() ? clazz.getSuperclass() : clazz;
+          Class<?> enumClass = (clazz.isAnonymousClass() || !clazz.isEnum()) ? clazz.getSuperclass() : clazz;
           TypeHandler<?> enumHandler = getInstance(enumClass, defaultEnumTypeHandler);
           register(new Type[] { enumClass }, new JdbcType[] { jdbcType }, enumHandler);
           return enumHandler;

--- a/src/test/java/org/apache/ibatis/type/TypeHandlerRegistryTest.java
+++ b/src/test/java/org/apache/ibatis/type/TypeHandlerRegistryTest.java
@@ -256,6 +256,43 @@ class TypeHandlerRegistryTest {
     }
   }
 
+  /**
+   * Enum with an abstract method, causing each constant to produce a subclass.
+   * In Java, those subclasses report isAnonymousClass() == true.
+   * In Kotlin the equivalent reports isAnonymousClass() == false but isEnum() == false,
+   * which is the case this fix targets.
+   */
+  enum EnumWithAbstractMethod {
+    CONSTANT_A {
+      @Override
+      public String value() {
+        return "a";
+      }
+    },
+    CONSTANT_B {
+      @Override
+      public String value() {
+        return "b";
+      }
+    };
+
+    public abstract String value();
+  }
+
+  @Test
+  void shouldResolveTypeHandlerForEnumConstantWithAbstractBody() {
+    // CONSTANT_A.getClass() is a subclass of EnumWithAbstractMethod.
+    // isAnonymousClass() == true in Java; the Kotlin equivalent returns false but isEnum() == false.
+    // Both cases must resolve to the handler registered for the base enum type.
+    Class<?> constantClass = EnumWithAbstractMethod.CONSTANT_A.getClass();
+    assertFalse(constantClass.isEnum(),
+        "Enum constant with anonymous body should not report isEnum() == true");
+
+    TypeHandler<?> handler = typeHandlerRegistry.getTypeHandler(constantClass, JdbcType.VARCHAR);
+    assertSame(EnumTypeHandler.class, handler.getClass(),
+        "TypeHandler for enum constant with abstract body must resolve to the base enum handler");
+  }
+
   public static class TestHandlerBase<E> implements TypeHandler<E> {
     // @formatter:off
     public void setParameter(PreparedStatement ps, int i, E parameter, JdbcType jdbcType) throws SQLException {}


### PR DESCRIPTION
## Problem

In Kotlin, enum constants that override abstract methods produce anonymous-style subclasses, but `Class.isAnonymousClass()` returns `false` for them (unlike the equivalent Java pattern where it returns `true`).

`TypeHandlerRegistry` used `isAnonymousClass()` as the sole check to detect "this is a per-constant subclass, resolve to the base enum type":

```java
Class<?> enumClass = clazz.isAnonymousClass() ? clazz.getSuperclass() : clazz;
```

So for Kotlin enum constants with overridden abstract methods, the lookup fell through and the handler registered for the base enum class was never found.

## Fix

Add an `!clazz.isEnum()` check. Any class that:
- is assignable to `Enum`, AND
- does NOT itself declare enum constants (`isEnum() == false`)

...is treated as a constant-with-body subclass and resolved to its superclass. This covers both:
- **Java**: `isAnonymousClass() == true`
- **Kotlin**: `isAnonymousClass() == false` but `isEnum() == false`

```java
Class<?> enumClass = (clazz.isAnonymousClass() || !clazz.isEnum()) ? clazz.getSuperclass() : clazz;
```

## Testing

Added `shouldResolveTypeHandlerForEnumConstantWithAbstractBody` to `TypeHandlerRegistryTest`. It uses a Java enum with an abstract method (producing per-constant anonymous subclasses) and asserts that `getTypeHandler(constantClass)` returns the base enum's `EnumTypeHandler`, not null. This also validates the Kotlin scenario because the constant's class has `isEnum() == false`.

Fixes #3658