### PR TITLE
docs: add SqlSessionManager documentation

### DIFF
--- a/src/site/markdown/java-api.md
+++ b/src/site/markdown/java-api.md
@@ -213,7 +213,7 @@ boolean isStarted = manager.isManagedSessionStarted();
 
 ##### Using the SqlSessionManager
 
-When a managed session is started, calling `commit()`, `rollback()`, `close()`, or any data access method (`selectOne`, `selectList`, `insert`, `update`, `delete`, etc.) will operate on the thread-local session. You must ensure to call `close()` when you are done with the session to clean up the thread-local storage:
+When a managed session is started, calling `commit()`, `rollback()`, `close()`, or any data access method (`selectOne`, `selectList`, `insert`, `update`, `delete`, etc.) will operate on the thread-local session. You must ensure to call `close()` when you are done with the session to clean up the thread-local storage,  Because it uses a ThreadLocal, failing to call `close()` in a pooled web server environment (like Tomcat or Jetty) will leak the SQL session onto the thread, causing unpredictable transaction behavior or connection leaks when that thread is reused for a different HTTP request.:
 
 ```java
 try {
@@ -225,7 +225,7 @@ try {
 }
 ```
 
-If no managed session has been started, calling any `SqlSession` method on the `SqlSessionManager` will automatically open a new session, execute the method, commit (or rollback on failure), and close the session. This provides an automatic session management mode similar to using the `openSession()` approach but with automatic commit and close.
+If no managed session has been started, calling any SqlSession method on the SqlSessionManager will automatically open a short-lived session, execute that single method, and immediately close it. Note that it will not explicitly commit write operations, making this mode ideal primarily for single read queries.
 
 ##### Difference from DefaultSqlSessionFactory
 
@@ -233,8 +233,8 @@ If no managed session has been started, calling any `SqlSession` method on the `
 |---------|-------------------------|-------------------|
 | Session creation | Creates new session per `openSession()` call | Can manage thread-local sessions via `startManagedSession()` |
 | Thread safety | Requires external management | Built-in thread-local session management |
-| Automatic session lifecycle | No | Yes, when no managed session is started |
-| DI framework integration | Manual | Can replace `SqlSessionFactory` and `SqlSession` in non-DI environments |
+| Automatic session lifecycle | No (Requires manual close) | Yes, when no managed session is started |
+| DI framework integration | Requires DI-specific integrations (e.g., `SqlSessionTemplate` in Spring) | Can replace `SqlSessionFactory` and `SqlSession` in non-DI environments |
 
 `SqlSessionManager` is particularly useful in environments where you don't use a dependency injection framework but still need proper session management per thread. If you are using Spring or Guice, you should continue to use `MyBatis-Spring` or `MyBatis-Guice` for session management.
 

--- a/src/site/markdown/java-api.md
+++ b/src/site/markdown/java-api.md
@@ -152,6 +152,92 @@ SqlSessionFactory factory = builder.build(configuration);
 
 Now you have a SqlSessionFactory that can be used to create SqlSession instances.
 
+#### SqlSessionManager
+
+As of version 3.4.0+, MyBatis provides `SqlSessionManager` which implements both `SqlSessionFactory` and `SqlSession` interfaces. Unlike `DefaultSqlSessionFactory` which creates a new `SqlSession` for each call to `openSession()`, `SqlSessionManager` uses a `ThreadLocal` to manage sessions for each thread. This provides a convenient way to manage `SqlSession` lifecycle in multithreaded environments without requiring an external dependency injection framework.
+
+##### Creating a SqlSessionManager
+
+You can create a `SqlSessionManager` in two ways:
+
+1. Using one of the static `newInstance()` methods that accept a MyBatis XML configuration file:
+
+```java
+SqlSessionManager manager = SqlSessionManager.newInstance(inputStream);
+```
+
+Or with an environment and/or properties:
+
+```java
+SqlSessionManager manager = SqlSessionManager.newInstance(inputStream, environment, properties);
+```
+
+2. Wrapping an existing `SqlSessionFactory` instance:
+
+```java
+SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(inputStream);
+SqlSessionManager manager = SqlSessionManager.newInstance(factory);
+```
+
+##### Managed Sessions
+
+The key feature of `SqlSessionManager` is its ability to manage sessions per thread. Once a managed session is started, all calls to `SqlSession` methods through the `SqlSessionManager` proxy will use the thread-local session.
+
+To start a managed session:
+
+```java
+manager.startManagedSession();
+```
+
+Or with specific options:
+
+```java
+// With auto-commit
+manager.startManagedSession(true);
+
+// With a specific executor type
+manager.startManagedSession(ExecutorType.BATCH);
+
+// With a specific isolation level
+manager.startManagedSession(TransactionIsolationLevel.READ_COMMITTED);
+
+// With a specific connection
+manager.startManagedSession(connection);
+```
+
+To check if a managed session has been started for the current thread:
+
+```java
+boolean isStarted = manager.isManagedSessionStarted();
+```
+
+##### Using the SqlSessionManager
+
+When a managed session is started, calling `commit()`, `rollback()`, `close()`, or any data access method (`selectOne`, `selectList`, `insert`, `update`, `delete`, etc.) will operate on the thread-local session. You must ensure to call `close()` when you are done with the session to clean up the thread-local storage:
+
+```java
+try {
+    manager.startManagedSession();
+    // ... use the session ...
+    manager.commit();
+} finally {
+    manager.close();
+}
+```
+
+If no managed session has been started, calling any `SqlSession` method on the `SqlSessionManager` will automatically open a new session, execute the method, commit (or rollback on failure), and close the session. This provides an automatic session management mode similar to using the `openSession()` approach but with automatic commit and close.
+
+##### Difference from DefaultSqlSessionFactory
+
+| Feature | DefaultSqlSessionFactory | SqlSessionManager |
+|---------|-------------------------|-------------------|
+| Session creation | Creates new session per `openSession()` call | Can manage thread-local sessions via `startManagedSession()` |
+| Thread safety | Requires external management | Built-in thread-local session management |
+| Automatic session lifecycle | No | Yes, when no managed session is started |
+| DI framework integration | Manual | Can replace `SqlSessionFactory` and `SqlSession` in non-DI environments |
+
+`SqlSessionManager` is particularly useful in environments where you don't use a dependency injection framework but still need proper session management per thread. If you are using Spring or Guice, you should continue to use `MyBatis-Spring` or `MyBatis-Guice` for session management.
+
 #### SqlSessionFactory
 
 SqlSessionFactory has six methods that are used to create SqlSession instances. In general, the decisions you'll be making when selecting one of these methods are:

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -46,6 +46,7 @@
       <item name="Java API" href="java-api.html" collapse="true">
         <item name="Directory Structure" href="java-api.html#directory-structure" />
         <item name="SqlSessions" href="java-api.html#sqlsessions" />
+        <item name="SqlSessionManager" href="java-api.html#sqlsessionmanager" />
       </item>
       <item name="SQL Builder Class" href="statement-builders.html" collapse="true"/>
       <item name="Logging" href="logging.html"/>


### PR DESCRIPTION
Fixes #1532

Add documentation for SqlSessionManager, which provides thread-safe SqlSession management.

Changes:
- Added new **SqlSessionManager** section to the Java API documentation (java-api.md)
  - Explanation of what SqlSessionManager is and its dual-role implementation (SqlSessionFactory + SqlSession)
  - Two ways to create an instance: via `newInstance()` static methods or wrapping an existing `SqlSessionFactory`
  - Managed sessions using ThreadLocal (`startManagedSession()`) with all overload variants
  - Usage pattern with `commit()`, `rollback()`, and `close()` for proper session lifecycle
  - Automatic session management behavior when no managed session is started
  - Comparison table between `DefaultSqlSessionFactory` and `SqlSessionManager`
- Added SqlSessionManager entry to the site navigation menu (site.xml)

cc @kazuki43zoo