### PR TITLE
Fix DefaultVFS listing .class files as resources

### DIFF
--- a/src/main/java/org/apache/ibatis/io/DefaultVFS.java
+++ b/src/main/java/org/apache/ibatis/io/DefaultVFS.java
@@ -56,6 +56,11 @@ public class DefaultVFS extends VFS {
 
   @Override
   public List<String> list(URL url, String path) throws IOException {
+    // #3689 - .class files are not directories, skip them to avoid exceptions
+    // in Tomcat 9.0.118+ / 10.1.55+ which validates resource paths more strictly
+    if (url.getPath().endsWith(".class")) {
+      return new ArrayList<>();
+    }
     InputStream is = null;
     try {
       List<String> resources = new ArrayList<>();

--- a/src/test/java/org/apache/ibatis/io/VFSTest.java
+++ b/src/test/java/org/apache/ibatis/io/VFSTest.java
@@ -17,6 +17,8 @@ package org.apache.ibatis.io;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -95,6 +97,16 @@ class VFSTest {
       VFS.invoke(Integer.class.getMethod("valueOf", String.class), Resources.class, "InvalidIntegerNumber");
     });
 
+  }
+
+  @Test
+  void listShouldSkipClassFiles() throws Exception {
+    // #3689 - DefaultVFS should not attempt to list .class file contents as resources
+    DefaultVFS vfs = new DefaultVFS();
+    URL classUrl = new URL("file:/tmp/com/example/MyClass.class");
+    List<String> result = vfs.list(classUrl, "com/example/MyClass.class");
+    Assertions.assertNotNull(result);
+    Assertions.assertTrue(result.isEmpty(), ".class files should return empty list");
   }
 
   private static class InstanceGetterProcedure implements Runnable {


### PR DESCRIPTION
Fixes #3689

## Problem

`DefaultVFS.list()` recursively processes `.class` files as resources, which causes `IllegalArgumentException` in Tomcat 9.0.118+ / 10.1.55+ due to improved resource path validation in `StandardRoot.validate`.

## Fix

Added an early-return check at the beginning of `DefaultVFS.list()` to skip `.class` files, since they are not directories and cannot contain child resources.

## Test

Added a unit test `listShouldSkipClassFiles` that verifies `.class` file URLs return an empty list.