### PR TITLE
Fix NPE in Jdbc3KeyGenerator when getGeneratedKeys() returns null

### DIFF
--- a/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
+++ b/src/main/java/org/apache/ibatis/executor/keygen/Jdbc3KeyGenerator.java
@@ -77,6 +77,9 @@ public class Jdbc3KeyGenerator implements KeyGenerator {
       return;
     }
     try (ResultSet rs = stmt.getGeneratedKeys()) {
+      if (rs == null) {
+        return;
+      }
       final ResultSetMetaData rsmd = rs.getMetaData();
       final Configuration configuration = ms.getConfiguration();
       if (rsmd.getColumnCount() < keyProperties.length) {


### PR DESCRIPTION
## Problem

`Jdbc3KeyGenerator.processBatch()` throws NPE when `Statement.getGeneratedKeys()` returns `null`. This happens with DB2 JDBC driver during batch insert operations with auto-increment keys.

The NPE occurs at `rs.getMetaData()` (line 80) because `rs` is null:
```java
try (ResultSet rs = stmt.getGeneratedKeys()) {
    final ResultSetMetaData rsmd = rs.getMetaData(); // NPE here
```

Reported in: baomidou/mybatis-plus#5928

## Fix

Added a null check on the `ResultSet` returned by `getGeneratedKeys()`. When null, the method returns early (same behavior as when `keyProperties` is empty).

## Notes

- Some JDBC drivers (e.g. DB2) return null from `getGeneratedKeys()` for batch operations
- Per JDBC spec, `getGeneratedKeys()` should return a ResultSet, but null is a practical edge case
- The fix is safe: if no generated keys are available, we simply skip key assignment (the entity just won't have the key populated, same as `NoKeyGenerator` behavior)
- The insert itself still succeeds; only the key writeback is skipped