### PR TITLE
Fix for newer Apache Tomcat versions throwing an IllegalArgumentException for invalid paths (#3689)

### DIFF
--- a/src/main/java/org/apache/ibatis/io/DefaultVFS.java
+++ b/src/main/java/org/apache/ibatis/io/DefaultVFS.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2025 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
-import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -113,8 +112,8 @@ public class DefaultVFS extends VFS {
                   break;
                 }
               }
-            } catch (InvalidPathException | FileSystemException e) {
-              // #1974 #2598
+            } catch (IllegalArgumentException | FileSystemException e) {
+              // #1974 #2598 #3689
               lines.clear();
             }
             if (!lines.isEmpty()) {


### PR DESCRIPTION
Minimal fix for: Tomcat 9.0.118 / 10.1.55 introduced a change which causes an IllegalArgumentException to be thrown in getResources for invalid paths (#3689)