### PR TITLE
fix: support byte array return type for BLOB query

### DIFF
--- a/src/main/java/org/apache/ibatis/binding/MapperMethod.java
+++ b/src/main/java/org/apache/ibatis/binding/MapperMethod.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2025 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -291,7 +291,8 @@ public class MapperMethod {
         this.returnType = method.getReturnType();
       }
       this.returnsVoid = void.class.equals(this.returnType);
-      this.returnsMany = configuration.getObjectFactory().isCollection(this.returnType) || this.returnType.isArray();
+      this.returnsMany = (configuration.getObjectFactory().isCollection(this.returnType) || this.returnType.isArray())
+          && !configuration.getTypeHandlerRegistry().hasTypeHandler(this.returnType);
       this.returnsCursor = Cursor.class.equals(this.returnType);
       this.returnsOptional = Optional.class.equals(this.returnType);
       this.mapKey = getMapKey(method);

--- a/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/annotation/MapperAnnotationBuilder.java
@@ -95,6 +95,7 @@ import org.apache.ibatis.session.ResultHandler;
 import org.apache.ibatis.session.RowBounds;
 import org.apache.ibatis.type.JdbcType;
 import org.apache.ibatis.type.TypeHandler;
+import org.apache.ibatis.type.TypeHandlerRegistry;
 import org.apache.ibatis.type.UnknownTypeHandler;
 
 /**
@@ -226,7 +227,7 @@ public class MapperAnnotationBuilder {
   }
 
   private String parseResultMap(Method method) {
-    Class<?> returnType = getReturnType(method, type);
+    Class<?> returnType = getReturnType(method, type, configuration.getTypeHandlerRegistry());
     Arg[] args = method.getAnnotationsByType(Arg.class);
     Result[] results = method.getAnnotationsByType(Result.class);
     TypeDiscriminator typeDiscriminator = method.getAnnotation(TypeDiscriminator.class);
@@ -406,7 +407,8 @@ public class MapperAnnotationBuilder {
 
       assistant.addMappedStatement(mappedStatementId, sqlSource, statementType, sqlCommandType, fetchSize, timeout,
           // ParameterMapID
-          null, parameterTypeClass, resultMapId, getReturnType(method, type), resultSetType, flushCache, useCache,
+          null, parameterTypeClass, resultMapId, getReturnType(method, type, configuration.getTypeHandlerRegistry()),
+          resultSetType, flushCache, useCache,
           // TODO gcode issue #577
           isResultOrdered, keyGenerator, keyProperty, keyColumn, statementAnnotation.getDatabaseId(), languageDriver,
           // ResultSets
@@ -441,12 +443,12 @@ public class MapperAnnotationBuilder {
     return parameterType;
   }
 
-  private static Class<?> getReturnType(Method method, Class<?> type) {
+  private static Class<?> getReturnType(Method method, Class<?> type, TypeHandlerRegistry typeHandlerRegistry) {
     Class<?> returnType = method.getReturnType();
     Type resolvedReturnType = TypeParameterResolver.resolveReturnType(method, type);
     if (resolvedReturnType instanceof Class) {
       returnType = (Class<?>) resolvedReturnType;
-      if (returnType.isArray()) {
+      if (returnType.isArray() && (typeHandlerRegistry == null || !typeHandlerRegistry.hasTypeHandler(returnType))) {
         returnType = returnType.getComponentType();
       }
       // gcode issue #508
@@ -699,7 +701,7 @@ public class MapperAnnotationBuilder {
       Class<?> mapperClass = Resources.classForName(mapperFqn);
       for (Method method : mapperClass.getMethods()) {
         if (method.getName().equals(localStatementId) && canHaveStatement(method)) {
-          return getReturnType(method, mapperClass);
+          return getReturnType(method, mapperClass, null);
         }
       }
     } catch (ClassNotFoundException e) {

--- a/src/test/java/org/apache/ibatis/submitted/blobtest/BlobMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/blobtest/BlobMapper.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,10 +17,15 @@ package org.apache.ibatis.submitted.blobtest;
 
 import java.util.List;
 
+import org.apache.ibatis.annotations.Select;
+
 public interface BlobMapper {
   int insert(BlobRecord blobRecord);
 
   List<BlobRecord> selectAll();
 
   List<BlobRecord> selectAllWithBlobObjects();
+
+  @Select("select blob from blobtest.blobs where id = #{id}")
+  byte[] selectBlobById(int id);
 }

--- a/src/test/java/org/apache/ibatis/submitted/blobtest/BlobTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/blobtest/BlobTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -85,6 +85,19 @@ class BlobTest {
       BlobRecord result = results.get(0);
       assertEquals(blobRecord.getId(), result.getId());
       assertTrue(blobsAreEqual(blobRecord.getBlob(), result.getBlob()));
+    }
+  }
+
+  @Test
+  void selectBlobByteArrayDirectly() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      BlobMapper blobMapper = sqlSession.getMapper(BlobMapper.class);
+
+      byte[] myblob = { 1, 2, 3, 4, 5 };
+      blobMapper.insert(new BlobRecord(10, myblob));
+
+      byte[] result = blobMapper.selectBlobById(10);
+      assertTrue(blobsAreEqual(myblob, result));
     }
   }
 


### PR DESCRIPTION
byte[] has a registered `TypeHandler` (`ByteArrayTypeHandler`) and represents a single binary value (VARBINARY/BLOB), but was incorrectly treated as a multi-row collection `because byte[].isArray() == true`.

  Two fixes:
  - `MapperMethod`: exclude array types with a registered `TypeHandler` from `returnsMany`, so `byte[]` routes through `selectOne`
  - `MapperAnnotationBuilder`: preserve `byte[]` as the ResultMap type instead of stripping to `byte`, so `ByteArrayTypeHandler` is selected correctly

  Added regression test in `BlobTest`.
  
  #3670 