### PR TITLE
fix: allow database-specific statement to override default across mapper files

### DIFF
--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2025 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -831,6 +831,13 @@ public class Configuration {
   }
 
   public void addMappedStatement(MappedStatement ms) {
+    // Let a database-specific statement override a default (no databaseId) one with the same id, even when they live in
+    // different mapper files. Real duplicates still fall through to StrictMap.put and are rejected.
+    if (ms.getDatabaseId() != null && mappedStatements.containsKey(ms.getId())
+        && mappedStatements.get(ms.getId()).getDatabaseId() == null) {
+      ((StrictMap<MappedStatement>) mappedStatements).replaceValue(ms.getId(), ms);
+      return;
+    }
     mappedStatements.put(ms.getId(), ms);
   }
 
@@ -1167,6 +1174,28 @@ public class Configuration {
         }
       }
       return super.put(key, value);
+    }
+
+    /**
+     * Replaces the value of an existing full key, keeping the short-name index in sync. The short-name entry is updated
+     * only when it still points at the old value; an ambiguous entry is left untouched.
+     *
+     * @param key
+     *          the full key (including namespace) whose value should be replaced
+     * @param value
+     *          the new value
+     *
+     * @return the previous value associated with the key
+     */
+    public V replaceValue(String key, V value) {
+      V previous = super.put(key, value);
+      if (key.contains(".")) {
+        final String shortKey = getShortName(key);
+        if (super.get(shortKey) != AMBIGUITY_INSTANCE) {
+          super.put(shortKey, value);
+        }
+      }
+      return previous;
     }
 
     @Override

--- a/src/test/java/org/apache/ibatis/submitted/databaseid_split/DatabaseIdSplitMapperTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/databaseid_split/DatabaseIdSplitMapperTest.java
@@ -1,0 +1,144 @@
+/*
+ *    Copyright 2009-2026 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.databaseid_split;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.Reader;
+
+import org.apache.ibatis.builder.BuilderException;
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.MappedStatement;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that a {@code databaseId}-specific statement overrides the default statement with the same id even when the
+ * two are declared in separate mapper files (a common pattern when default and vendor-specific SQL are kept in
+ * different XML files). Before the fix, parsing the default file first and the vendor-specific file afterwards threw an
+ * {@link IllegalArgumentException} for a duplicate statement id.
+ */
+class DatabaseIdSplitMapperTest {
+
+  private static final String STATEMENT_ID = "org.apache.ibatis.submitted.databaseid_split.TestMapper.selectTest";
+  private static final String BASE = "org/apache/ibatis/submitted/databaseid_split/";
+
+  @Test
+  void databaseSpecificStatementOverridesDefaultWhenDefaultParsedFirst() {
+    Configuration configuration = new Configuration();
+    configuration.setDatabaseId("oracle");
+
+    parseMapper(configuration, BASE + "DefaultMapper.xml");
+    parseMapper(configuration, BASE + "PostgresMapper.xml");
+    parseMapper(configuration, BASE + "OracleMapper.xml");
+
+    MappedStatement ms = configuration.getMappedStatement(STATEMENT_ID);
+    assertEquals("oracle", ms.getDatabaseId());
+    assertEquals("select 1 from dual", boundSql(ms));
+  }
+
+  @Test
+  void resolutionIsOrderIndependentWhenDatabaseSpecificParsedFirst() {
+    Configuration configuration = new Configuration();
+    configuration.setDatabaseId("oracle");
+
+    parseMapper(configuration, BASE + "OracleMapper.xml");
+    parseMapper(configuration, BASE + "PostgresMapper.xml");
+    parseMapper(configuration, BASE + "DefaultMapper.xml");
+
+    MappedStatement ms = configuration.getMappedStatement(STATEMENT_ID);
+    assertEquals("oracle", ms.getDatabaseId());
+    assertEquals("select 1 from dual", boundSql(ms));
+  }
+
+  @Test
+  void defaultStatementIsUsedWhenNoDatabaseSpecificMatchExists() {
+    Configuration configuration = new Configuration();
+    configuration.setDatabaseId("oracle");
+
+    parseMapper(configuration, BASE + "DefaultMapper.xml");
+    parseMapper(configuration, BASE + "PostgresMapper.xml");
+
+    MappedStatement ms = configuration.getMappedStatement(STATEMENT_ID);
+    assertNull(ms.getDatabaseId());
+    assertEquals("select 1", boundSql(ms));
+  }
+
+  @Test
+  void databaseSpecificStatementsAreIgnoredWhenNoDatabaseIdConfigured() {
+    Configuration configuration = new Configuration();
+    // no databaseId configured
+
+    parseMapper(configuration, BASE + "DefaultMapper.xml");
+    parseMapper(configuration, BASE + "OracleMapper.xml");
+
+    MappedStatement ms = configuration.getMappedStatement(STATEMENT_ID);
+    assertNull(ms.getDatabaseId());
+    assertEquals("select 1", boundSql(ms));
+  }
+
+  @Test
+  void duplicateStatementsWithSameDatabaseIdStillFail() {
+    Configuration configuration = new Configuration();
+    configuration.setDatabaseId("oracle");
+
+    parseMapper(configuration, BASE + "OracleMapper.xml");
+
+    // A second statement carrying the same databaseId is a genuine duplicate and must still be rejected.
+    BuilderException e = assertThrows(BuilderException.class,
+        () -> parseMapper(configuration, BASE + "OracleMapper2.xml"));
+    assertEquals(IllegalArgumentException.class, rootCause(e).getClass());
+  }
+
+  @Test
+  void databaseSpecificStatementOverridesDefaultWithinSameFile() {
+    Configuration configuration = new Configuration();
+    configuration.setDatabaseId("oracle");
+
+    parseMapper(configuration, BASE + "CombinedMapper.xml");
+
+    MappedStatement ms = configuration
+        .getMappedStatement("org.apache.ibatis.submitted.databaseid_split.CombinedMapper.selectTest");
+    assertEquals("oracle", ms.getDatabaseId());
+    assertEquals("select 1 from dual", boundSql(ms));
+  }
+
+  private static String boundSql(MappedStatement ms) {
+    return ms.getBoundSql(null).getSql().trim();
+  }
+
+  private static Throwable rootCause(Throwable t) {
+    Throwable cause = t;
+    while (cause.getCause() != null && cause.getCause() != cause) {
+      cause = cause.getCause();
+    }
+    return cause;
+  }
+
+  private static void parseMapper(Configuration configuration, String resource) {
+    try (Reader reader = Resources.getResourceAsReader(resource)) {
+      XMLMapperBuilder mapperParser = new XMLMapperBuilder(reader, configuration, resource,
+          configuration.getSqlFragments());
+      mapperParser.parse();
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/src/test/resources/org/apache/ibatis/submitted/databaseid_split/CombinedMapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/databaseid_split/CombinedMapper.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2026 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.submitted.databaseid_split.CombinedMapper">
+    <select id="selectTest" databaseId="oracle" resultType="int">
+        select 1 from dual
+    </select>
+
+    <select id="selectTest" resultType="int">
+        select 1
+    </select>
+</mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/databaseid_split/DefaultMapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/databaseid_split/DefaultMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2026 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.submitted.databaseid_split.TestMapper">
+    <select id="selectTest" resultType="int">
+        select 1
+    </select>
+</mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/databaseid_split/OracleMapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/databaseid_split/OracleMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2026 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.submitted.databaseid_split.TestMapper">
+    <select id="selectTest" databaseId="oracle" resultType="int">
+        select 1 from dual
+    </select>
+</mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/databaseid_split/OracleMapper2.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/databaseid_split/OracleMapper2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2026 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.submitted.databaseid_split.TestMapper">
+    <select id="selectTest" databaseId="oracle" resultType="int">
+        select 2 from dual
+    </select>
+</mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/databaseid_split/PostgresMapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/databaseid_split/PostgresMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2026 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.apache.ibatis.submitted.databaseid_split.TestMapper">
+    <select id="selectTest" databaseId="postgres" resultType="int">
+        select 2
+    </select>
+</mapper>


### PR DESCRIPTION
Fixes #3550 

## Problem

When a statement id is split across mapper files — a default (no `databaseId`) in one file and a vendor-specific one in another - parsing the default file first throws `IllegalArgumentException: Mapped Statements collection already contains key ...`. The override only works when both are in the same file.

## Cause
 
The override relies on the database-specific pass running before the default pass, which only holds within a single file. Across files the default is already registered, so `StrictMap.put` hits a duplicate key.


## Fix
In `Configuration.addMappedStatement`, let a statement with a `databaseId` override an existing default one with the same id (new `StrictMap.replaceValue` keeps the short-name index consistent). Genuine duplicates (same id + same `databaseId`, or two defaults) are still rejected.

## Tests

Added `DatabaseIdSplitMapperTest`, covering:
  
1. Default parsed first, then database-specific → override succeeds (the bug)
2. Database-specific parsed first → resolution is order-independent
3. No database-specific match → default is used
4. No `databaseId` configured → database-specific statements ignored
5. Duplicate statements with the same `databaseId` → still rejected
6. In-file override → unchanged (regression guard)