### PR TITLE
Fix SQL Array parameter logging

### DIFF
--- a/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
+++ b/src/main/java/org/apache/ibatis/logging/jdbc/BaseJdbcLogger.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -46,7 +46,7 @@ public abstract class BaseJdbcLogger {
   private final Map<Object, Object> columnMap = new HashMap<>();
 
   private final List<Object> columnNames = new ArrayList<>();
-  private final List<Object> columnValues = new ArrayList<>();
+  private final List<String> columnValues = new ArrayList<>();
 
   protected final Log statementLog;
   protected final int queryStack;
@@ -77,7 +77,7 @@ public abstract class BaseJdbcLogger {
   protected void setColumn(Object key, Object value) {
     columnMap.put(key, value);
     columnNames.add(key);
-    columnValues.add(value);
+    columnValues.add(parameterValueString(value));
   }
 
   protected Object getColumn(Object key) {
@@ -85,16 +85,15 @@ public abstract class BaseJdbcLogger {
   }
 
   protected String getParameterValueString() {
-    List<Object> typeList = new ArrayList<>(columnValues.size());
-    for (Object value : columnValues) {
-      if (value == null) {
-        typeList.add("null");
-      } else {
-        typeList.add(objectValueString(value) + "(" + value.getClass().getSimpleName() + ")");
-      }
-    }
-    final String parameters = typeList.toString();
+    final String parameters = columnValues.toString();
     return parameters.substring(1, parameters.length() - 1);
+  }
+
+  private String parameterValueString(Object value) {
+    if (value == null) {
+      return "null";
+    }
+    return objectValueString(value) + "(" + value.getClass().getSimpleName() + ")";
   }
 
   protected String objectValueString(Object value) {

--- a/src/test/java/org/apache/ibatis/logging/jdbc/BaseJdbcLoggerTest.java
+++ b/src/test/java/org/apache/ibatis/logging/jdbc/BaseJdbcLoggerTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2022 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,9 +16,12 @@
 package org.apache.ibatis.logging.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.when;
 
 import java.sql.Array;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.ibatis.logging.Log;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,15 +47,33 @@ class BaseJdbcLoggerTest {
 
   @Test
   void shouldDescribePrimitiveArrayParameter() throws Exception {
-    logger.setColumn("1", array);
     when(array.getArray()).thenReturn(new int[] { 1, 2, 3 });
+    logger.setColumn("1", array);
     assertThat(logger.getParameterValueString()).startsWith("[1, 2, 3]");
   }
 
   @Test
   void shouldDescribeObjectArrayParameter() throws Exception {
-    logger.setColumn("1", array);
     when(array.getArray()).thenReturn(new String[] { "one", "two", "three" });
+    logger.setColumn("1", array);
+    assertThat(logger.getParameterValueString()).startsWith("[one, two, three]");
+  }
+
+  @Test
+  void shouldDescribeArrayParameterAfterArrayIsFreed() throws Exception {
+    AtomicBoolean freed = new AtomicBoolean();
+    when(array.getArray()).thenAnswer(invocation -> {
+      if (freed.get()) {
+        throw new SQLException("Array has been freed.");
+      }
+      return new String[] { "one", "two", "three" };
+    });
+    doAnswer(invocation -> {
+      freed.set(true);
+      return null;
+    }).when(array).free();
+    logger.setColumn("1", array);
+    array.free();
     assertThat(logger.getParameterValueString()).startsWith("[one, two, three]");
   }
 }


### PR DESCRIPTION
## Summary

- Format JDBC parameter values when `setColumn()` records them, before a driver can release mutable resources such as `java.sql.Array`.
- Keep the original value in `columnMap`, preserving `getColumn()` behavior.
- Add one regression test that frees an SQL Array before the parameter log is rendered.

Fixes #3162.

## Tests

- `./mvnw --no-transfer-progress -Dtest=BaseJdbcLoggerTest,PreparedStatementLoggerTest test`
- `./mvnw --no-transfer-progress --quiet test` (2,010 tests, 0 failures/errors)
- `git diff --check`
