### PR TITLE
Throw ReflectionException instead of NullPointerException from Reflector.getSetterType

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/Reflector.java
+++ b/src/main/java/org/apache/ibatis/reflection/Reflector.java
@@ -400,7 +400,7 @@ public class Reflector {
    * @return The Class of the property setter
    */
   public Class<?> getSetterType(String propertyName) {
-    Class<?> clazz = setTypes.get(propertyName).getValue();
+    Class<?> clazz = setTypes.getOrDefault(propertyName, nullEntry).getValue();
     if (clazz == null) {
       throw new ReflectionException("There is no setter for property named '" + propertyName + "' in '" + clazz + "'");
     }

--- a/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/ReflectorTest.java
@@ -45,6 +45,15 @@ class ReflectorTest {
   }
 
   @Test
+  void getSetterTypeThrowsReflectionExceptionForPropertyWithoutSetter() {
+    ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
+    Reflector reflector = reflectorFactory.findForClass(Section.class);
+    // a property with no setter (here: an unknown one) must report a ReflectionException,
+    // consistent with getGetterType(); it previously threw a raw NullPointerException.
+    Assertions.assertThrows(ReflectionException.class, () -> reflector.getSetterType("nonexistentProperty"));
+  }
+
+  @Test
   void getGetterType() {
     ReflectorFactory reflectorFactory = new DefaultReflectorFactory();
     Reflector reflector = reflectorFactory.findForClass(Section.class);


### PR DESCRIPTION
`Reflector.getSetterType(String)` calls `setTypes.get(propertyName).getValue()` directly. When the property has no setter (for example a read-only property, or an unknown name), `setTypes.get(...)` returns `null`, so `.getValue()` throws a raw `NullPointerException` — before the `if (clazz == null)` check that is meant to raise the documented `ReflectionException`.

The sibling `getGetterType(String)` already guards this with `getTypes.getOrDefault(propertyName, nullEntry)`. This applies the same pattern to `getSetterType`, so a property with no setter consistently reports `ReflectionException`. Includes a regression test.
