### PR TITLE
Fix connection cleanup when rollback fails in PooledDataSource

### DIFF
--- a/src/main/java/org/apache/ibatis/datasource/pooled/PooledDataSource.java
+++ b/src/main/java/org/apache/ibatis/datasource/pooled/PooledDataSource.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -397,8 +397,18 @@ public class PooledDataSource implements DataSource {
         if (state.idleConnections.size() < poolMaximumIdleConnections
             && conn.getConnectionTypeCode() == expectedConnectionTypeCode) {
           state.accumulatedCheckoutTime += conn.getCheckoutTime();
-          if (!conn.getRealConnection().getAutoCommit()) {
-            conn.getRealConnection().rollback();
+          try {
+            if (!conn.getRealConnection().getAutoCommit()) {
+              conn.getRealConnection().rollback();
+            }
+          } catch (SQLException e) {
+            try {
+              conn.getRealConnection().close();
+            } catch (SQLException e2) {
+              // ignore
+            }
+            conn.invalidate();
+            throw e;
           }
           PooledConnection newConn = new PooledConnection(conn.getRealConnection(), this);
           state.idleConnections.add(newConn);
@@ -411,14 +421,23 @@ public class PooledDataSource implements DataSource {
           condition.signal();
         } else {
           state.accumulatedCheckoutTime += conn.getCheckoutTime();
-          if (!conn.getRealConnection().getAutoCommit()) {
-            conn.getRealConnection().rollback();
+          try {
+            if (!conn.getRealConnection().getAutoCommit()) {
+              conn.getRealConnection().rollback();
+            }
+          } catch (SQLException e) {
+            // ignore rollback exception, we are closing the connection anyway
+          } finally {
+            try {
+              conn.getRealConnection().close();
+            } catch (SQLException e) {
+              // ignore
+            }
+            conn.invalidate();
           }
-          conn.getRealConnection().close();
           if (log.isDebugEnabled()) {
             log.debug("Closed connection " + conn.getRealHashCode() + ".");
           }
-          conn.invalidate();
         }
       } else {
         if (log.isDebugEnabled()) {
@@ -508,8 +527,18 @@ public class PooledDataSource implements DataSource {
         if (conn != null) {
           // ping to server and check the connection is valid or not
           if (conn.isValid()) {
-            if (!conn.getRealConnection().getAutoCommit()) {
-              conn.getRealConnection().rollback();
+            try {
+              if (!conn.getRealConnection().getAutoCommit()) {
+                conn.getRealConnection().rollback();
+              }
+            } catch (SQLException e) {
+              try {
+                conn.getRealConnection().close();
+              } catch (SQLException e2) {
+                // ignore
+              }
+              conn.invalidate();
+              throw e;
             }
             conn.setConnectionTypeCode(assembleConnectionTypeCode(dataSource.getUrl(), username, password));
             conn.setCheckoutTimestamp(System.currentTimeMillis());

--- a/src/test/java/org/apache/ibatis/datasource/pooled/PooledDataSourceTest.java
+++ b/src/test/java/org/apache/ibatis/datasource/pooled/PooledDataSourceTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.ibatis.datasource.unpooled.UnpooledDataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -157,5 +158,112 @@ class PooledDataSourceTest {
 
     assertEquals(0, poolState.getActiveConnectionCount());
     assertEquals(0, poolState.getIdleConnectionCount());
+  }
+
+  @Test
+  void shouldCloseConnectionOnRollbackFailureWhenPopping() throws Exception {
+    java.util.concurrent.atomic.AtomicBoolean closed = new java.util.concurrent.atomic.AtomicBoolean(false);
+    Connection mockConnection = (Connection) java.lang.reflect.Proxy.newProxyInstance(
+        PooledDataSourceTest.class.getClassLoader(), new Class<?>[] { Connection.class }, (proxy, method, args) -> {
+          if ("getAutoCommit".equals(method.getName())) {
+            return false;
+          }
+          if ("rollback".equals(method.getName())) {
+            throw new SQLException("Simulated rollback failure");
+          }
+          if ("close".equals(method.getName())) {
+            closed.set(true);
+            return null;
+          }
+          if ("isClosed".equals(method.getName())) {
+            return closed.get();
+          }
+          if ("hashCode".equals(method.getName())) {
+            return 12345;
+          }
+          if ("equals".equals(method.getName())) {
+            return proxy == args[0];
+          }
+          return null;
+        });
+
+    UnpooledDataSource uds = new UnpooledDataSource() {
+      @Override
+      public Connection getConnection() throws SQLException {
+        return mockConnection;
+      }
+
+      @Override
+      public Connection getConnection(String username, String password) throws SQLException {
+        return mockConnection;
+      }
+    };
+
+    PooledDataSource pds = new PooledDataSource(uds);
+    pds.setPoolMaximumActiveConnections(1);
+
+    try {
+      pds.getConnection();
+    } catch (SQLException e) {
+      // Expected
+    }
+
+    assertTrue(closed.get(), "Connection should have been closed after rollback failure");
+  }
+
+  @Test
+  void shouldCloseConnectionOnRollbackFailureWhenPushing() throws Exception {
+    java.util.concurrent.atomic.AtomicBoolean closed = new java.util.concurrent.atomic.AtomicBoolean(false);
+    java.util.concurrent.atomic.AtomicInteger rollbackCount = new java.util.concurrent.atomic.AtomicInteger(0);
+    Connection mockConnection = (Connection) java.lang.reflect.Proxy.newProxyInstance(
+        PooledDataSourceTest.class.getClassLoader(), new Class<?>[] { Connection.class }, (proxy, method, args) -> {
+          if ("getAutoCommit".equals(method.getName())) {
+            return false;
+          }
+          if ("rollback".equals(method.getName())) {
+            if (rollbackCount.incrementAndGet() > 1) {
+              throw new SQLException("Simulated rollback failure");
+            }
+            return null;
+          }
+          if ("close".equals(method.getName())) {
+            closed.set(true);
+            return null;
+          }
+          if ("isClosed".equals(method.getName())) {
+            return closed.get();
+          }
+          if ("hashCode".equals(method.getName())) {
+            return 12345;
+          }
+          if ("equals".equals(method.getName())) {
+            return proxy == args[0];
+          }
+          return null;
+        });
+
+    UnpooledDataSource uds = new UnpooledDataSource() {
+      @Override
+      public Connection getConnection() throws SQLException {
+        return mockConnection;
+      }
+
+      @Override
+      public Connection getConnection(String username, String password) throws SQLException {
+        return mockConnection;
+      }
+    };
+
+    PooledDataSource pds = new PooledDataSource(uds);
+    pds.setPoolMaximumActiveConnections(1);
+
+    Connection conn = pds.getConnection();
+    try {
+      conn.close();
+    } catch (SQLException e) {
+      // Expected
+    }
+
+    assertTrue(closed.get(), "Connection should have been closed after rollback failure on close/push");
   }
 }


### PR DESCRIPTION
## Summary

When `rollback()` throws `SQLException` during connection checkout or return-to-pool, cleanup logic is bypassed and the underlying connection is not properly cleaned up.

This patch ensures connections encountering rollback failures are closed and invalidated before propagating the exception.

## Changes

* Handle rollback failures during connection checkout (`popConnection`)
* Handle rollback failures during connection return (`pushConnection`)
* Ensure affected connections are closed and invalidated
* Add regression tests covering both failure paths

## Verification

Before this change:

* Regression tests fail
* Connections are not cleaned up after rollback failures

After this change:

* Regression tests pass
* Connections are properly cleaned up and invalidated

## Backward Compatibility

This change only affects error handling when `rollback()` throws `SQLException`.
Normal connection lifecycle behavior is unchanged.
