### PR TITLE
feat: add strictResultMapCollectionTypeCheck for ResultMap collection ofType validation

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLConfigBuilder.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2024 the original author or authors.
+ *    Copyright 2009-2025 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -292,6 +292,8 @@ public class XMLConfigBuilder extends BaseBuilder {
         booleanValueOf(props.getProperty("argNameBasedConstructorAutoMapping"), false));
     configuration.setDefaultSqlProviderType(resolveClass(props.getProperty("defaultSqlProviderType")));
     configuration.setNullableOnForEach(booleanValueOf(props.getProperty("nullableOnForEach"), false));
+    configuration.setStrictResultMapCollectionTypeCheck(
+        booleanValueOf(props.getProperty("strictResultMapCollectionTypeCheck"), false));
   }
 
   private void environmentsElement(XNode context) throws Exception {

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -15,6 +15,8 @@
  */
 package org.apache.ibatis.session;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -30,6 +32,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
 
 import org.apache.ibatis.binding.MapperRegistry;
+import org.apache.ibatis.builder.BuilderException;
 import org.apache.ibatis.builder.CacheRefResolver;
 import org.apache.ibatis.builder.IncompleteElementException;
 import org.apache.ibatis.builder.ResultMapResolver;
@@ -73,12 +76,14 @@ import org.apache.ibatis.mapping.Environment;
 import org.apache.ibatis.mapping.MappedStatement;
 import org.apache.ibatis.mapping.ParameterMap;
 import org.apache.ibatis.mapping.ResultMap;
+import org.apache.ibatis.mapping.ResultMapping;
 import org.apache.ibatis.mapping.ResultSetType;
 import org.apache.ibatis.mapping.VendorDatabaseIdProvider;
 import org.apache.ibatis.parsing.XNode;
 import org.apache.ibatis.plugin.Interceptor;
 import org.apache.ibatis.plugin.InterceptorChain;
 import org.apache.ibatis.reflection.DefaultReflectorFactory;
+import org.apache.ibatis.reflection.MetaClass;
 import org.apache.ibatis.reflection.MetaObject;
 import org.apache.ibatis.reflection.ReflectorFactory;
 import org.apache.ibatis.reflection.factory.DefaultObjectFactory;
@@ -117,6 +122,7 @@ public class Configuration {
   protected boolean shrinkWhitespacesInSql;
   protected boolean nullableOnForEach;
   protected boolean argNameBasedConstructorAutoMapping;
+  protected boolean strictResultMapCollectionTypeCheck;
 
   protected String logPrefix;
   protected Class<? extends Log> logImpl;
@@ -339,6 +345,34 @@ public class Configuration {
 
   public void setArgNameBasedConstructorAutoMapping(boolean argNameBasedConstructorAutoMapping) {
     this.argNameBasedConstructorAutoMapping = argNameBasedConstructorAutoMapping;
+  }
+
+  /**
+   * Whether to enable strict type checking for {@code <collection>} elements in ResultMap.
+   * <p>
+   * When enabled, the {@code ofType} attribute of each {@code <collection>} element is validated against the generic
+   * element type of the corresponding collection field in the entity class. A {@link BuilderException} is thrown if the
+   * declared type is not assignable to the expected type. Default is false.
+   * </p>
+   *
+   * @return true if strict collection type checking is enabled
+   *
+   * @since 3.6.0
+   */
+  public boolean isStrictResultMapCollectionTypeCheck() {
+    return strictResultMapCollectionTypeCheck;
+  }
+
+  /**
+   * Enables or disables strict type checking for {@code <collection>} elements in ResultMap.
+   *
+   * @param strictResultMapCollectionTypeCheck
+   *          true to enable strict collection type checking
+   *
+   * @since 3.6.0
+   */
+  public void setStrictResultMapCollectionTypeCheck(boolean strictResultMapCollectionTypeCheck) {
+    this.strictResultMapCollectionTypeCheck = strictResultMapCollectionTypeCheck;
   }
 
   public String getDatabaseId() {
@@ -792,6 +826,119 @@ public class Configuration {
     resultMaps.put(rm.getId(), rm);
     checkLocallyForDiscriminatedNestedResultMaps(rm);
     checkGloballyForDiscriminatedNestedResultMaps(rm);
+    if (strictResultMapCollectionTypeCheck) {
+      validateCollectionResultMapTypes(rm);
+    }
+  }
+
+  /**
+   * Validates that the element type declared via {@code ofType} on each {@code <collection>} element is compatible with
+   * the generic element type of the corresponding collection field in the entity class.
+   * <p>
+   * For each {@link ResultMapping} that maps to a collection property, the expected element type is resolved from the
+   * entity field's generic signature via {@link MetaClass}, and the declared element type is resolved from the XML
+   * mapping. A {@link BuilderException} is thrown if the declared type is not assignable to the expected type.
+   * </p>
+   *
+   * @param rm
+   *          the ResultMap to validate
+   *
+   * @since 3.6.0
+   */
+  private void validateCollectionResultMapTypes(ResultMap rm) {
+    Class<?> entityType = rm.getType();
+    MetaClass metaClass = MetaClass.forClass(entityType, reflectorFactory);
+    for (ResultMapping mapping : rm.getResultMappings()) {
+      if (mapping.getProperty() == null) {
+        continue;
+      }
+      Class<?> expectedElementType = resolveExpectedCollectionElementType(metaClass, mapping.getProperty());
+      if (expectedElementType == null) {
+        continue;
+      }
+      Class<?> declaredElementType = resolveDeclaredElementType(mapping);
+      if (declaredElementType == null) {
+        continue;
+      }
+      if (!expectedElementType.isAssignableFrom(declaredElementType)) {
+        throw new BuilderException("ResultMap '" + rm.getId() + "': " + "Collection property '" + mapping.getProperty()
+            + "' " + "expects elements of type '" + expectedElementType.getName() + "' " + "but XML declares '"
+            + declaredElementType.getName() + "'. "
+            + "Please check the 'ofType' attribute on your <collection> element.");
+      }
+    }
+  }
+
+  /**
+   * Resolves the expected element type of a collection property on the given entity class.
+   * <p>
+   * Uses {@link MetaClass#getGenericSetterType(String)} to obtain the generic type of the setter parameter (or field
+   * type if no setter exists). If the raw type is a {@link Collection} and the generic type is parameterized with a
+   * single {@link Class} argument, that argument is returned.
+   * </p>
+   *
+   * @param metaClass
+   *          the MetaClass for the entity type
+   * @param property
+   *          the collection property name
+   *
+   * @return the expected element type, or {@code null} if the property is not a parameterized collection
+   *
+   * @since 3.6.0
+   */
+  private Class<?> resolveExpectedCollectionElementType(MetaClass metaClass, String property) {
+    if (!metaClass.hasSetter(property)) {
+      return null;
+    }
+    Map.Entry<Type, Class<?>> setterType = metaClass.getGenericSetterType(property);
+    Class<?> rawType = setterType.getValue();
+    if (rawType == null || !Collection.class.isAssignableFrom(rawType)) {
+      return null;
+    }
+    Type genericType = setterType.getKey();
+    if (genericType instanceof ParameterizedType) {
+      Type[] typeArgs = ((ParameterizedType) genericType).getActualTypeArguments();
+      if (typeArgs.length == 1 && typeArgs[0] instanceof Class) {
+        return (Class<?>) typeArgs[0];
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Resolves the element type declared in the XML mapping for a {@code <collection>} element.
+   * <p>
+   * The resolution strategy, in order of priority:
+   * <ol>
+   * <li>The {@code type} of the nested {@link ResultMap} referenced via {@code ofType} or {@code resultMap}
+   * attribute</li>
+   * <li>The {@code javaType} attribute value, only if it is not itself a collection type</li>
+   * </ol>
+   * Returns {@code null} if the declared element type cannot be determined, in which case the type check for this
+   * mapping is skipped.
+   * </p>
+   *
+   * @param mapping
+   *          the ResultMapping to inspect
+   *
+   * @return the declared element type, or {@code null} if it cannot be determined
+   *
+   * @since 3.6.0
+   */
+  private Class<?> resolveDeclaredElementType(ResultMapping mapping) {
+    String nestedResultMapId = mapping.getNestedResultMapId();
+    if (nestedResultMapId != null) {
+      ResultMap nestedResultMap = getResultMap(nestedResultMapId);
+      if (nestedResultMap != null) {
+        return nestedResultMap.getType();
+      }
+      return null;
+    }
+    Class<?> javaType = mapping.getJavaType();
+    if (javaType != null && !Collection.class.isAssignableFrom(javaType)) {
+      return javaType;
+    }
+    return null;
   }
 
   public Collection<String> getResultMapNames() {

--- a/src/test/java/org/apache/ibatis/submitted/strict_collection/Group.java
+++ b/src/test/java/org/apache/ibatis/submitted/strict_collection/Group.java
@@ -1,0 +1,49 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.strict_collection;
+
+import java.util.List;
+
+public class Group {
+
+  private Integer id;
+  private String name;
+  private List<User> users;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public List<User> getUsers() {
+    return users;
+  }
+
+  public void setUsers(List<User> users) {
+    this.users = users;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/strict_collection/StrictCollectionMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/strict_collection/StrictCollectionMapper.java
@@ -1,0 +1,23 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.strict_collection;
+
+import java.util.List;
+
+public interface StrictCollectionMapper {
+
+  List<Group> getGroups();
+}

--- a/src/test/java/org/apache/ibatis/submitted/strict_collection/StrictCollectionTypeCheckTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/strict_collection/StrictCollectionTypeCheckTest.java
@@ -1,0 +1,99 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.strict_collection;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.Reader;
+import java.util.List;
+
+import org.apache.ibatis.BaseDataTest;
+import org.apache.ibatis.builder.BuilderException;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class StrictCollectionTypeCheckTest {
+
+  private static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    // create an SqlSessionFactory
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/strict_collection/mybatis-config.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+
+    // populate in-memory database
+    BaseDataTest.runScript(sqlSessionFactory.getConfiguration().getEnvironment().getDataSource(),
+        "org/apache/ibatis/submitted/strict_collection/CreateDB.sql");
+  }
+
+  @Test
+  void correctOfTypePassesWhenStrictCheckEnabled() throws Exception {
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/strict_collection/mybatis-config.xml")) {
+      SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader);
+      factory.getConfiguration().setStrictResultMapCollectionTypeCheck(true);
+      factory.getConfiguration().addMapper(StrictCollectionMapper.class);
+
+      try (SqlSession sqlSession = factory.openSession()) {
+        StrictCollectionMapper mapper = sqlSession.getMapper(StrictCollectionMapper.class);
+        List<Group> groups = mapper.getGroups();
+        assertEquals(2, groups.size());
+        assertEquals(2, groups.get(0).getUsers().size());
+        assertEquals("User 1", groups.get(0).getUsers().get(0).getName());
+        assertEquals(1, groups.get(1).getUsers().size());
+      }
+    }
+  }
+
+  @Test
+  void wrongOfTypeThrowsBuilderExceptionWhenStrictCheckEnabled() throws Exception {
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/strict_collection/mybatis-config.xml")) {
+      SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader);
+      factory.getConfiguration().setStrictResultMapCollectionTypeCheck(true);
+
+      BuilderException ex = assertThrows(BuilderException.class,
+          () -> factory.getConfiguration().addMapper(StrictCollectionWrongMapper.class));
+      assertTrue(ex.getMessage().contains("Collection property 'users'"));
+      assertTrue(ex.getMessage().contains("ofType"));
+    }
+  }
+
+  @Test
+  void wrongOfTypePassesWhenStrictCheckDisabled() throws Exception {
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/strict_collection/mybatis-config.xml")) {
+      SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader);
+      // strict check is disabled by default
+      factory.getConfiguration().addMapper(StrictCollectionWrongMapper.class);
+
+      try (SqlSession sqlSession = factory.openSession()) {
+        StrictCollectionWrongMapper mapper = sqlSession.getMapper(StrictCollectionWrongMapper.class);
+        List<Group> groups = mapper.getGroups();
+        assertEquals(2, groups.size());
+      }
+    }
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/strict_collection/StrictCollectionWrongMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/strict_collection/StrictCollectionWrongMapper.java
@@ -1,0 +1,23 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.strict_collection;
+
+import java.util.List;
+
+public interface StrictCollectionWrongMapper {
+
+  List<Group> getGroups();
+}

--- a/src/test/java/org/apache/ibatis/submitted/strict_collection/User.java
+++ b/src/test/java/org/apache/ibatis/submitted/strict_collection/User.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.strict_collection;
+
+public class User {
+
+  private Integer id;
+  private String name;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/java/org/apache/ibatis/submitted/strict_collection/WrongUser.java
+++ b/src/test/java/org/apache/ibatis/submitted/strict_collection/WrongUser.java
@@ -1,0 +1,38 @@
+/*
+ *    Copyright 2009-2025 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.strict_collection;
+
+public class WrongUser {
+
+  private Integer id;
+  private String name;
+
+  public Integer getId() {
+    return id;
+  }
+
+  public void setId(Integer id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/resources/org/apache/ibatis/submitted/strict_collection/CreateDB.sql
+++ b/src/test/resources/org/apache/ibatis/submitted/strict_collection/CreateDB.sql
@@ -1,0 +1,33 @@
+--
+--    Copyright 2009-2025 the original author or authors.
+--
+--    Licensed under the Apache License, Version 2.0 (the "License");
+--    you may not use this file except in compliance with the License.
+--    You may obtain a copy of the License at
+--
+--       https://www.apache.org/licenses/LICENSE-2.0
+--
+--    Unless required by applicable law or agreed to in writing, software
+--    distributed under the License is distributed on an "AS IS" BASIS,
+--    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--    See the License for the specific language governing permissions and
+--    limitations under the License.
+--
+
+CREATE TABLE groups (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(50)
+);
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  name VARCHAR(50),
+  group_id INTEGER
+);
+
+INSERT INTO groups (id, name) VALUES (1, 'Group 1');
+INSERT INTO groups (id, name) VALUES (2, 'Group 2');
+
+INSERT INTO users (id, name, group_id) VALUES (1, 'User 1', 1);
+INSERT INTO users (id, name, group_id) VALUES (2, 'User 2', 1);
+INSERT INTO users (id, name, group_id) VALUES (3, 'User 3', 2);

--- a/src/test/resources/org/apache/ibatis/submitted/strict_collection/StrictCollectionMapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/strict_collection/StrictCollectionMapper.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2025 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper
+  namespace="org.apache.ibatis.submitted.strict_collection.StrictCollectionMapper">
+
+  <resultMap id="groupResultMap"
+    type="org.apache.ibatis.submitted.strict_collection.Group">
+    <id property="id" column="group_id" />
+    <result property="name" column="group_name" />
+    <collection property="users"
+      ofType="org.apache.ibatis.submitted.strict_collection.User">
+      <id property="id" column="user_id" />
+      <result property="name" column="user_name" />
+    </collection>
+  </resultMap>
+
+  <select id="getGroups" resultMap="groupResultMap">
+    SELECT g.id AS group_id, g.name AS group_name,
+           u.id AS user_id, u.name AS user_name
+    FROM groups g
+    LEFT JOIN users u ON g.id = u.group_id
+    ORDER BY g.id, u.id
+  </select>
+
+</mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/strict_collection/StrictCollectionWrongMapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/strict_collection/StrictCollectionWrongMapper.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2025 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper
+  namespace="org.apache.ibatis.submitted.strict_collection.StrictCollectionWrongMapper">
+
+  <resultMap id="groupResultMap"
+    type="org.apache.ibatis.submitted.strict_collection.Group">
+    <id property="id" column="group_id" />
+    <result property="name" column="group_name" />
+    <collection property="users"
+      ofType="org.apache.ibatis.submitted.strict_collection.WrongUser">
+      <id property="id" column="user_id" />
+      <result property="name" column="user_name" />
+    </collection>
+  </resultMap>
+
+  <select id="getGroups" resultMap="groupResultMap">
+    SELECT g.id AS group_id, g.name AS group_name,
+           u.id AS user_id, u.name AS user_name
+    FROM groups g
+    LEFT JOIN users u ON g.id = u.group_id
+    ORDER BY g.id, u.id
+  </select>
+
+</mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/strict_collection/mybatis-config.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/strict_collection/mybatis-config.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2025 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC" />
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.h2.Driver" />
+        <property name="url" value="jdbc:h2:mem:strictcollection;DB_CLOSE_DELAY=-1" />
+        <property name="username" value="sa" />
+        <property name="password" value="" />
+      </dataSource>
+    </environment>
+  </environments>
+
+</configuration>


### PR DESCRIPTION

## Motivation

When using `<collection>` in XML ResultMap mappings, MyBatis relies on Java type erasure and silently accepts mismatched `ofType` declarations at runtime. For example, if an entity defines `List<User> users` but the XML declares `ofType="WrongType"`, no error is reported during parsing — the mismatch only surfaces as obscure `ClassCastException`s at runtime, often far from the root cause.

This makes it difficult to catch configuration errors early, especially in large codebases with complex ResultMap mappings.

## Changes

This PR introduces an opt-in strict validation mode that checks `ofType` declarations against the entity field's generic element type at ResultMap registration time.

**Modified files:**

- **`Configuration.java`** (`org.apache.ibatis.session`)
  - Added `strictResultMapCollectionTypeCheck` field (default: `false`)
  - Added `validateCollectionResultMapTypes()` — iterates ResultMappings, resolves expected vs. declared element types, throws `BuilderException` on mismatch
  - Added `resolveExpectedCollectionElementType()` — resolves the expected element type via `MetaClass.getGenericSetterType()`, leveraging MyBatis's existing reflection infrastructure
  - Added `resolveDeclaredElementType()` — resolves the declared element type from nested ResultMap (`ofType`/`resultMap` attribute) or `javaType`
  - Validation hook added to `addResultMap()`
- **`XMLConfigBuilder.java`** (`org.apache.ibatis.builder.xml`)
  - Added `strictResultMapCollectionTypeCheck` setting mapping in `settingsElement()` to support XML `<settings>` configuration

**New test files:**

- `StrictCollectionTypeCheckTest.java` — 3 test cases covering enabled/disabled scenarios
- `Group.java`, `User.java`, `WrongUser.java` — test entities
- `StrictCollectionMapper.java`, `StrictCollectionWrongMapper.java` — mapper interfaces
- `StrictCollectionMapper.xml`, `StrictCollectionWrongMapper.xml` — XML mappings
- `CreateDB.sql`, `mybatis-config.xml` — test database setup

## Usage

Enable via `mybatis-config.xml`:

```xml
<settings>
    <setting name="strictResultMapCollectionTypeCheck" value="true"/>
</settings>
```

Or programmatically:

```java
Configuration configuration = new Configuration();
configuration.setStrictResultMapCollectionTypeCheck(true);
```

When enabled and a mismatch is detected, the following exception is thrown at parse time:

```
BuilderException: ResultMap 'org.example.Mapper.groupResultMap':
Collection property 'users' expects elements of type 'org.example.User'
but XML declares 'org.example.WrongUser'.
Please check the 'ofType' attribute on your <collection> element.
```

## Design Decisions

- **Opt-in by default**: `false` by default to preserve full backward compatibility. Existing projects are unaffected.
- **Uses existing MetaClass**: Leverages `MetaClass.getGenericSetterType()` to resolve the generic element type, which handles both setter methods and direct field access via `Reflector`. No new reflection utility classes needed.
- **Assignability check**: Uses `Class.isAssignableFrom()` instead of strict equality, so inheritance hierarchies (e.g., `ofType="Dog"` for `List<Animal>`) are correctly accepted.
- **Graceful skipping**: Fields that are not parameterized collections, nested ResultMaps not yet registered, or `select`-based collections are silently skipped — no false positives.
- **Type resolution priority**: Nested ResultMap `type` → `javaType` attribute (if not a collection type itself).

## Testing

3 unit tests using H2 in-memory database:

| Test | Scenario | Expected Result | Status |
|------|----------|----------------|--------|
| `correctOfTypePassesWhenStrictCheckEnabled` | Correct `ofType` with strict check ON | Query succeeds, returns expected data | ✅ Pass |
| `wrongOfTypeThrowsBuilderExceptionWhenStrictCheckEnabled` | Wrong `ofType` with strict check ON | `BuilderException` thrown at parse time | ✅ Pass |
| `wrongOfTypePassesWhenStrictCheckDisabled` | Wrong `ofType` with strict check OFF | Silently accepted (backward compatible) | ✅ Pass |

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
