### PR TITLE
Throw a clear BuilderException for malformed inline parameters

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/ParameterExpression.java
+++ b/src/main/java/org/apache/ibatis/builder/ParameterExpression.java
@@ -66,6 +66,9 @@ public class ParameterExpression extends HashMap<String, String> {
   private void property(String expression, int left) {
     if (left < expression.length()) {
       int right = skipUntil(expression, left, ",:");
+      if (right <= left) {
+        throw new BuilderException("Parsing error in {" + expression + "} in position " + left);
+      }
       put("property", trimmedStr(expression, left, right));
       jdbcTypeOpt(expression, right);
     }
@@ -117,6 +120,9 @@ public class ParameterExpression extends HashMap<String, String> {
     int left = skipWS(expression, p);
     if (left < expression.length()) {
       int right = skipUntil(expression, left, "=");
+      if (right == expression.length()) {
+        throw new BuilderException("Parsing error in {" + expression + "} in position " + left);
+      }
       String name = trimmedStr(expression, left, right);
       left = right + 1;
       right = skipUntil(expression, left, ",");

--- a/src/test/java/org/apache/ibatis/builder/ParameterExpressionTest.java
+++ b/src/test/java/org/apache/ibatis/builder/ParameterExpressionTest.java
@@ -146,4 +146,24 @@ class ParameterExpressionTest {
     }
   }
 
+  @Test
+  void shouldThrowForAttributeWithoutValue() {
+    try {
+      new ParameterExpression("id,name");
+      Assertions.fail();
+    } catch (BuilderException e) {
+      Assertions.assertTrue(e.getMessage().contains("Parsing error in {id,name} in position 3"));
+    }
+  }
+
+  @Test
+  void shouldThrowForEmptyPropertyName() {
+    try {
+      new ParameterExpression(",foo=bar");
+      Assertions.fail();
+    } catch (BuilderException e) {
+      Assertions.assertTrue(e.getMessage().contains("Parsing error in {,foo=bar} in position 0"));
+    }
+  }
+
 }


### PR DESCRIPTION
## What is wrong

`ParameterExpression` throws a raw `StringIndexOutOfBoundsException` (instead of a clear `BuilderException`) for two kinds of malformed inline parameter expressions.

## Where

`src/main/java/org/apache/ibatis/builder/ParameterExpression.java`

- **`option()`** — an attribute with no `=`, e.g. `#{id,name}`
- **`property()`** — an empty property name, e.g. `#{,foo=bar}`

## How it fails

- `option()`: with no `=`, `skipUntil(..., "=")` returns `expression.length()`, so `left` becomes `length + 1` and `trimmedStr(expression, length + 1, length)` calls `str.charAt(length + 1)`.
- `property()`: with an empty name (a leading delimiter), `skipUntil(..., ",:")` returns `left`, so `trimmedStr(expression, left, left)` calls `str.charAt(left - 1)`, which for a leading `,` is `charAt(-1)`.

Both surface during mapper parsing as an opaque `StringIndexOutOfBoundsException` instead of a clear parse error pointing at the bad expression.

## Test

Two cases added to `ParameterExpressionTest`. Against the unfixed parser they fail with the raw exception:

```
shouldThrowForAttributeWithoutValue -> StringIndexOutOfBoundsException: Index 8 out of bounds for length 7
shouldThrowForEmptyPropertyName     -> StringIndexOutOfBoundsException: Index -1 out of bounds for length 8
```

## Fix

Guard both methods to throw `BuilderException("Parsing error in {...} in position ...")`, mirroring the guard `jdbcType()` already carries for the same `right <= left` situation:

```java
// option(): attribute without a value
int right = skipUntil(expression, left, "=");
if (right == expression.length()) {
  throw new BuilderException("Parsing error in {" + expression + "} in position " + left);
}

// property(): empty property name
int right = skipUntil(expression, left, ",:");
if (right <= left) {
  throw new BuilderException("Parsing error in {" + expression + "} in position " + left);
}
```

## Verification

The two new tests fail (raw `StringIndexOutOfBoundsException`) before the change and pass after; the full `ParameterExpressionTest` is green (16/16) on JDK 21.

## AI assistance disclosure

This contribution was produced with the help of an AI pipeline. The pipeline processed a large amount of source code to surface suspected bugs, reproduced a subset of them with failing unit tests and generated candidate fixes, and prepared pull requests from the ones that held up. Each PR was then reviewed and verified by a human before being opened: the fix and test were checked by hand and the test was confirmed to fail before the change and pass after.
