### PR TITLE
Fix cross-file statement conflict when using databaseId

### DIFF
--- a/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
+++ b/src/main/java/org/apache/ibatis/builder/xml/XMLStatementBuilder.java
@@ -75,6 +75,13 @@ public class XMLStatementBuilder extends BaseBuilder {
     if (!databaseIdMatchesCurrent(id, databaseId, this.requiredDatabaseId)) {
       return;
     }
+    if (requiredDatabaseId != null && databaseId != null) {
+      String fullId = builderAssistant.applyCurrentNamespace(id, false);
+      if (configuration.hasStatement(fullId, false)
+          && configuration.getMappedStatement(fullId, false).getDatabaseId() == null) {
+        configuration.removeMappedStatement(fullId);
+      }
+    }
 
     String nodeName = context.getNode().getNodeName();
     SqlCommandType sqlCommandType = SqlCommandType.valueOf(nodeName.toUpperCase(Locale.ENGLISH));

--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2025 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -832,6 +832,10 @@ public class Configuration {
 
   public void addMappedStatement(MappedStatement ms) {
     mappedStatements.put(ms.getId(), ms);
+  }
+
+  public void removeMappedStatement(String id) {
+    mappedStatements.remove(id);
   }
 
   public Collection<String> getMappedStatementNames() {

--- a/src/test/java/org/apache/ibatis/submitted/multidb_crossfile/CrossFileDbTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/multidb_crossfile/CrossFileDbTest.java
@@ -1,0 +1,58 @@
+/*
+ *    Copyright 2009-2026 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.multidb_crossfile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.Reader;
+
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.session.SqlSession;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.SqlSessionFactoryBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class CrossFileDbTest {
+
+  protected static SqlSessionFactory sqlSessionFactory;
+
+  @BeforeAll
+  static void setUp() throws Exception {
+    try (Reader reader = Resources
+        .getResourceAsReader("org/apache/ibatis/submitted/multidb_crossfile/CrossFileDbConfig.xml")) {
+      sqlSessionFactory = new SqlSessionFactoryBuilder().build(reader);
+    }
+  }
+
+  @Test
+  void shouldNotThrowExceptionWhenLoadingCrossFileStatements() {
+    // The bug was that loading two mapper XML files with the same statement id
+    // (one default, one with databaseId) would throw a conflict exception.
+    // If we reach here without exception, the bug is fixed.
+  }
+
+  @Test
+  void shouldUseDatabaseSpecificStatement() {
+    try (SqlSession sqlSession = sqlSessionFactory.openSession()) {
+      CrossFileMapper mapper = sqlSession.getMapper(CrossFileMapper.class);
+      String result = mapper.selectTest();
+      // current databaseId is "oracle", so Oracle version should be used
+      assertEquals("oracle", result);
+    }
+  }
+
+}

--- a/src/test/java/org/apache/ibatis/submitted/multidb_crossfile/CrossFileMapper.java
+++ b/src/test/java/org/apache/ibatis/submitted/multidb_crossfile/CrossFileMapper.java
@@ -1,0 +1,22 @@
+/*
+ *    Copyright 2009-2026 the original author or authors.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *       https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.apache.ibatis.submitted.multidb_crossfile;
+
+public interface CrossFileMapper {
+
+  String selectTest();
+
+}

--- a/src/test/resources/org/apache/ibatis/submitted/multidb_crossfile/CrossFileDbConfig.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/multidb_crossfile/CrossFileDbConfig.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+       Copyright 2009-2026 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE configuration
+    PUBLIC "-//mybatis.org//DTD Config 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-config.dtd">
+
+<configuration>
+
+  <environments default="development">
+    <environment id="development">
+      <transactionManager type="JDBC">
+        <property name="" value="" />
+      </transactionManager>
+      <dataSource type="UNPOOLED">
+        <property name="driver" value="org.hsqldb.jdbcDriver" />
+        <property name="url" value="jdbc:hsqldb:mem:multidb_crossfile" />
+        <property name="username" value="sa" />
+      </dataSource>
+    </environment>
+  </environments>
+
+  <databaseIdProvider type="org.apache.ibatis.submitted.multidb.DummyDatabaseIdProvider">
+    <property name="name" value="oracle" />
+  </databaseIdProvider>
+
+  <mappers>
+    <mapper resource="org/apache/ibatis/submitted/multidb_crossfile/DefaultMapper.xml" />
+    <mapper resource="org/apache/ibatis/submitted/multidb_crossfile/OracleMapper.xml" />
+  </mappers>
+
+</configuration>

--- a/src/test/resources/org/apache/ibatis/submitted/multidb_crossfile/DefaultMapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/multidb_crossfile/DefaultMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2026 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.multidb_crossfile.CrossFileMapper">
+
+  <select id="selectTest" resultType="string">
+    SELECT 'default' FROM (VALUES(1))
+  </select>
+
+</mapper>

--- a/src/test/resources/org/apache/ibatis/submitted/multidb_crossfile/OracleMapper.xml
+++ b/src/test/resources/org/apache/ibatis/submitted/multidb_crossfile/OracleMapper.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+       Copyright 2009-2026 the original author or authors.
+
+       Licensed under the Apache License, Version 2.0 (the "License");
+       you may not use this file except in compliance with the License.
+       You may obtain a copy of the License at
+
+          https://www.apache.org/licenses/LICENSE-2.0
+
+       Unless required by applicable law or agreed to in writing, software
+       distributed under the License is distributed on an "AS IS" BASIS,
+       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+       See the License for the specific language governing permissions and
+       limitations under the License.
+
+-->
+<!DOCTYPE mapper
+    PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+    "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.apache.ibatis.submitted.multidb_crossfile.CrossFileMapper">
+
+  <select id="selectTest" databaseId="oracle" resultType="string">
+    SELECT 'oracle' FROM (VALUES(1))
+  </select>
+
+</mapper>


### PR DESCRIPTION
When multiple mapper XML files contain statements with the same id but different databaseId, the database-specific version should replace the default version without throwing a conflict exception.

The bug was in XMLStatementBuilder: during the first pass (with requiredDatabaseId), databaseIdMatchesCurrent returned true without checking if a default statement already existed in the statement map, causing StrictMap to throw a duplicate key exception.

Fix: remove the existing default statement before adding the database-specific one. Added removeMappedStatement() to Configuration to support this.

Closes #3550