### PR TITLE
docs(ko): fix broken markup, mistranslations and typos in the Korean docs

### DIFF
--- a/src/site/ko/markdown/getting-started.md
+++ b/src/site/ko/markdown/getting-started.md
@@ -19,9 +19,9 @@ author: Clinton Begin, 이동국(한국어 번역)
 
 ## XML에서 SqlSessionFactory 빌드하기
 
-모든 마이바티스 애플리케이션은 SqlSessionFactory 인스턴스를 사용한다. SqlSessionFactory인스턴스는 SqlSessionFactoryBuilder를 사용하여 만들수 있다. SqlSessionFactoryBuilder는 XML설정파일에서 SqlSessionFactory인스턴스를 빌드할 수 있다.
+모든 마이바티스 애플리케이션은 SqlSessionFactory 인스턴스를 사용한다. SqlSessionFactory인스턴스는 SqlSessionFactoryBuilder를 사용하여 만들 수 있다. SqlSessionFactoryBuilder는 XML설정파일에서 SqlSessionFactory인스턴스를 빌드할 수 있다.
 
-XML파일에서 SqlSessionFactory인스턴스를 빌드하는 것은 매우 간단한다. 설정을 위해 클래스패스 자원을 사용하는 것을 추천하나 파일 경로나 `file://` URL로부터 만들어진 InputStream인스턴스를 사용할 수도 있다. 마이바티스는 클래스패스와 다른 위치에서 자원을 로드하는 것으로 좀더 쉽게 해주는 Resources 라는 유틸성 클래스를 가지고 있다.
+XML파일에서 SqlSessionFactory인스턴스를 빌드하는 것은 매우 간단하다. 설정을 위해 클래스패스 자원을 사용하는 것을 추천하나 파일 경로나 `file://` URL로부터 만들어진 InputStream인스턴스를 사용할 수도 있다. 마이바티스는 클래스패스와 다른 위치에서 자원을 로드하는 것으로 좀더 쉽게 해주는 Resources 라는 유틸성 클래스를 가지고 있다.
 
 ```java
 String resource = "org/mybatis/example/mybatis-config.xml";
@@ -29,7 +29,7 @@ InputStream inputStream = Resources.getResourceAsStream(resource);
 SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(inputStream);
 ```
 
-XML설정파일에서 지정하는 마이바티스의 핵심이 되는 설정은 트랜잭션을 제어하기 위한 TransactionManager과 함께 데이터베이스 Connection인스턴스를 가져오기 위한 DataSource 를 포함한다. 세부적인 설정은 조금 뒤에 보고 간단한 예제를 먼저보자.
+XML설정파일에서 지정하는 마이바티스의 핵심이 되는 설정은 트랜잭션을 제어하기 위한 TransactionManager와 함께 데이터베이스 Connection인스턴스를 가져오기 위한 DataSource 를 포함한다. 세부적인 설정은 조금 뒤에 보고 간단한 예제를 먼저보자.
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -73,7 +73,7 @@ SqlSessionFactory sqlSessionFactory = new SqlSessionFactoryBuilder().build(confi
 
 ## SqlSessionFactory 에서 SqlSession 만들기
 
-SqlSessionFactory 이름에서 보듯이 SqlSession 인스턴스를 만들수 있다. SqlSession 은 데이터베이스에 대해 SQL명령어를 실행하기 위해 필요한 모든 메소드를 가지고 있다. 그래서 SqlSession 인스턴스를 통해 직접 SQL 구문을 실행할 수 있다. 예를 들면 :
+SqlSessionFactory 이름에서 보듯이 SqlSession 인스턴스를 만들 수 있다. SqlSession 은 데이터베이스에 대해 SQL명령어를 실행하기 위해 필요한 모든 메소드를 가지고 있다. 그래서 SqlSession 인스턴스를 통해 직접 SQL 구문을 실행할 수 있다. 예를 들면 :
 
 ```java
 try (SqlSession session = sqlSessionFactory.openSession()) {
@@ -118,7 +118,7 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
 Blog blog = (Blog) session.selectOne("org.mybatis.example.BlogMapper.selectBlog", 101);
 ```
 
-이건 마치 패키지를 포함한 전체 경로의 클래스내 메소드를 호출하는 것과 비슷한 형태이다. 이 이름은 매핑된 select구문의 이름과 파라미터 그리고 리턴타입을 가진 네임스페이스과 같은 이름의 Mapper 클래스와 직접 매핑될 수 있다. 이건 위에서 본것과 같은 Mapper 인터페이스의 메소드를 간단히 호출하도록 허용한다. 위 예제에 대응되는 형태는 아래와 같다.
+이건 마치 패키지를 포함한 전체 경로의 클래스내 메소드를 호출하는 것과 비슷한 형태이다. 이 이름은 매핑된 select구문의 이름과 파라미터 그리고 리턴타입을 가진 네임스페이스와 같은 이름의 Mapper 클래스와 직접 매핑될 수 있다. 이건 위에서 본것과 같은 Mapper 인터페이스의 메소드를 간단히 호출하도록 허용한다. 위 예제에 대응되는 형태는 아래와 같다.
 
 ```java
 BlogMapper mapper = session.getMapper(BlogMapper.class);
@@ -133,12 +133,12 @@ Blog blog = mapper.selectBlog(101);
 
 **네임스페이스(Namespaces)** 가 이전버전에서는 사실 선택사항이었다. 하지만 이제는 패키지경로를 포함한 전체 이름을 가진 구문을 구분하기 위해 필수로 사용해야 한다.
 
-네임스페이스은 인터페이스 바인딩을 가능하게 한다. 네임스페이스을 사용하고 자바 패키지의 네임스페이스을 두면 코드가 깔끔해지고 마이바티스의 사용성이 크게 향상될 것이다.
+네임스페이스는 인터페이스 바인딩을 가능하게 한다. 네임스페이스를 사용하고 자바 패키지의 네임스페이스를 두면 코드가 깔끔해지고 마이바티스의 사용성이 크게 향상될 것이다.
 
 **이름 분석(Name Resolution):** 타이핑을 줄이기 위해 마이바티스는 구문과 결과매핑, 캐시등의 모든 설정엘리먼트를 위한 이름 분석 규칙을 사용한다.
 
 - “com.mypackage.MyMapper.selectAllThings”과 같은 패키지를 포함한 전체 경로명(Fully qualified names)은 같은 형태의 경로가 있다면 그 경로내에서 직접 찾는다.
-- “selectAllThings”과 같은 짧은 형태의 이름은 모호하지 않은 엔트리를 참고하기 위해 사용될 수 있다. 그래서 짧은 이름은 모호해서 에러를 자주 보게 되니 되도록 이면 전체 경로를 사용해야 할 것이다.
+- “selectAllThings”과 같은 짧은 형태의 이름은 모호하지 않은 엔트리를 참고하기 위해 사용될 수 있다. 그래서 짧은 이름은 모호해서 에러를 자주 보게 되니 되도록이면 전체 경로를 사용해야 할 것이다.
 
 ---
 
@@ -170,7 +170,7 @@ public interface BlogMapper {
 
 #### SqlSessionFactoryBuilder
 
-이 클래스는 인스턴스화되어 사용되고 던져질 수 있다. SqlSessionFactory 를 생성한 후 유지할 필요는 없다. 그러므로 SqlSessionFactoryBuilder 인스턴스의 가장 좋은 스코프는 메소드 스코프(예를들면 메소드 지역변수)이다. 여러개의 SqlSessionFactory 인스턴스를 빌드하기 위해 SqlSessionFactoryBuilder를 재사용할 수도 있지만 유지하지 않는 것이 가장 좋다.
+이 클래스는 인스턴스화해서 사용한 뒤 버리면 된다. SqlSessionFactory 를 생성한 후 유지할 필요는 없다. 그러므로 SqlSessionFactoryBuilder 인스턴스의 가장 좋은 스코프는 메소드 스코프(예를들면 메소드 지역변수)이다. 여러개의 SqlSessionFactory 인스턴스를 빌드하기 위해 SqlSessionFactoryBuilder를 재사용할 수도 있지만 유지하지 않는 것이 가장 좋다.
 
 #### SqlSessionFactory
 
@@ -190,7 +190,7 @@ try (SqlSession session = sqlSessionFactory.openSession()) {
 
 #### Mapper 인스턴스
 
-Mapper는 매핑된 구문을 바인딩 하기 위해 만들어야 할 인터페이스이다. mapper 인터페이스의 인스턴스는 SqlSession 에서 생성한다. 그래서 mapper 인스턴스의 가장 좋은 스코프는 SqlSession 과 동일하다. 어쨌든 mapper 인스턴스의 가장 좋은 스코프는 메소드 스코프이다. 사용할 메소드가 호출되면 생성되고 끝난다. 명시적으로 닫을 필요는 없다.
+Mapper는 매핑된 구문을 바인딩 하기 위해 만들어야 할 인터페이스이다. mapper 인터페이스의 인스턴스는 SqlSession 에서 생성한다. 그래서 엄밀히 말하면 mapper 인스턴스의 가장 넓은 스코프는 그것을 얻어온 SqlSession 과 동일하다. 어쨌든 mapper 인스턴스의 가장 좋은 스코프는 메소드 스코프이다. 사용할 메소드가 호출되면 생성되고 끝난다. 명시적으로 닫을 필요는 없다.
 
 ```java
 try (SqlSession session = sqlSessionFactory.openSession()) {

--- a/src/site/ko/markdown/index.md
+++ b/src/site/ko/markdown/index.md
@@ -29,7 +29,7 @@ author: Clinton Begin, 이동국(한국어 번역)
 <!--      <li class="fr"><a href="../fr/index.html">Français</a></li> -->
           <li class="ja"><a href="../ja/index.html">日本語</a></li>
           <li class="ko"><a href="../ko/index.html">한국어</a></li>
-          <li class="zh"><a href="../zh/index.html">简体中文</a></li>
+          <li class="zh"><a href="../zh_CN/index.html">简体中文</a></li>
 </ul>
 
 당신의 모국어로 작성된 마이바티스 문서를 읽고 싶은가? 그렇다면 모국어로 작성된 문서를 패치로 첨부한 이슈를 등록해달라!

--- a/src/site/ko/markdown/logging.md
+++ b/src/site/ko/markdown/logging.md
@@ -26,9 +26,9 @@ org.apache.ibatis.logging.LogFactory.useCommonsLogging();
 org.apache.ibatis.logging.LogFactory.useStdOutLogging();
 ```
 
-마이바티스가 메소드를 호출하기 전에 위 메소드 중 하나를 호출해야 한다. 이 메소드들은 런타임 클래스패스에 구현체가 존재하면 그 로그 구현체를 사용하게 한다. 예를들어 Log4J2 로깅을 선택했지만 런타임에 Log4J2 구현체가 클래스패스에 없다면 마이바티스는 Log4J2 구현체의 사용을 무시하고 로깅 구현체를 찾아 다시 사용할 것이다.
+이 메소드들 중 하나를 호출하기로 했다면 다른 마이바티스 메소드를 호출하기 전에 호출해야 한다. 이 메소드들은 런타임 클래스패스에 구현체가 존재하면 그 로그 구현체를 사용하게 한다. 예를들어 Log4J2 로깅을 선택했지만 런타임에 Log4J2 구현체가 클래스패스에 없다면 마이바티스는 Log4J2 구현체의 사용을 무시하고 로깅 구현체를 찾아 다시 사용할 것이다.
 
-SLF4J, Jakarta Commons 로깅, Log4J 그리고 JDK 로깅 API 에 대한 설명은 이 문서의 범위를 벗어난다. 이러한 로깅 관련 프레임워크에 대해 좀더 알고 싶다면 개별 위치에서 좀더 많은 정보를 얻을 수 있을 것이다.
+SLF4J, Apache Commons Logging, Apache Log4J 그리고 JDK 로깅 API 에 대한 설명은 이 문서의 범위를 벗어난다. 이러한 로깅 관련 프레임워크에 대해 좀더 알고 싶다면 개별 위치에서 좀더 많은 정보를 얻을 수 있을 것이다.
 
 - [SLF4J](https://www.slf4j.org/)
 - [Apache Commons Logging](https://commons.apache.org/proper/commons-logging/)
@@ -47,7 +47,7 @@ SLF4J(Logback)를 사용하기 때문에 애플리케이션에 JAR 파일이 있
 
 웹이나 기업용 애플리케이션에서는 `WEB-INF/lib` 디렉터리에 `logback-classic.jar` ,`logback-core.jar` and `slf4j-api.jar` 파일을 추가할 수 있다. 단독으로 실행되는 애플리케이션에서는 JVM의 `-classpath` 시작 파라미터에서 간단히 추가할 수 있다.
 
-If you use the maven, you can download jar files by adding following settings on your `pom.xml`.
+메이븐을 사용한다면 `pom.xml` 에 다음 설정을 추가해서 jar 파일을 내려받을 수 있다.
 
 ```xml
 <dependency>
@@ -118,7 +118,7 @@ finer레벨로 로깅을 하고자 한다면 전체 매퍼 파일대신 특정 �
 </logger>
 ```
 
-다음처럼 매퍼 인터페이스가 아닌 매퍼 XML을 사용하다면 어떻게 해야 할까?
+다음처럼 매퍼 인터페이스가 아닌 매퍼 XML을 사용한다면 어떻게 해야 할까?
 
 ```xml
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -164,8 +164,8 @@ finer레벨로 로깅을 하고자 한다면 전체 매퍼 파일대신 특정 �
 ```
 
 ```xml
-<!-- log4j2.xml -->
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- log4j2.xml -->
 <Configuration xmlns="http://logging.apache.org/log4j/2.0/config">
 
   <Appenders>
@@ -213,7 +213,7 @@ log4j.appender.stdout.layout.ConversionPattern=%5p [%t] - %m%n
 handlers=java.util.logging.ConsoleHandler
 .level=SEVERE
 
-org.mybatis.example.BlogMapper=FINER
+org.mybatis.example.BlogMapper.level=FINER
 
 java.util.logging.ConsoleHandler.level=ALL
 java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter

--- a/src/site/ko/xdoc/configuration.xml
+++ b/src/site/ko/xdoc/configuration.xml
@@ -174,7 +174,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 true | false
               </td>
               <td>
-                false (3.4.1 부터 true)
+                false (3.4.1 이하에서는 true)
               </td>
             </tr>
             <tr>
@@ -291,21 +291,6 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
                 설정하지 않음(null)
-              </td>
-            </tr>
-            <tr>
-              <td>
-                defaultFetchSize
-              </td>
-              <td>
-                결과를 가져오는 크기를 제어하는 힌트처럼 드라이버에 설정한다.
-        이 파라미터는 쿼리설정으로 변경할 수 있다.
-              </td>
-              <td>
-                양수
-              </td>
-              <td>
-                셋팅되지 않음(null)
               </td>
             </tr>
             <tr>
@@ -460,7 +445,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 returnInstanceForEmptyRow
               </td>
               <td>
-                MyBatis 는 기본적으로 모든 열들의 행이 NULL 이 반환되었을 때 <code>null</code>을 반환한다.
+                MyBatis 는 기본적으로 반환된 행의 모든 칼럼이 NULL 일 때 <code>null</code>을 반환한다.
                 이 설정을 사용하면 MyBatis가 대신 empty 인스턴스를 반환한다.
                 nested results(collection 또는 association) 에도 적용된다. 3.4.2 부터
               </td>
@@ -511,7 +496,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
                 CGLIB (deprecated since 3.5.10) | JAVASSIST
               </td>
               <td>
-                JAVASSIST (마이바티스 3.3과 이상의 버전)
+                JAVASSIST (마이바티스 3.3 이상의 버전)
               </td>
             </tr>
             <tr>
@@ -523,6 +508,9 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader, environ
               </td>
               <td>
                 콤마를 사용해서 VFS구현체의 패키지를 포함한 전체 클래스명
+              </td>
+              <td>
+                설정하지 않음
               </td>
             </tr>
             <tr>
@@ -1454,7 +1442,7 @@ public class ExampleTypeHandler extends BaseTypeHandler<String> {
         </ul>
 
         <p>
-          <code>ResultMap</code>에서 타입핸들러를 사용한다고 결정하면 마이바티스가 자바타입은 잘 처리하지만 JDBC타입은 잘 처리하지 못할 수 있다.
+          <code>ResultMap</code>에서 사용할 타입핸들러를 결정할 때 자바타입은 (결과 타입으로부터) 알 수 있지만 JDBC타입은 알 수 없다.
       그래서 마이바티스는 타입핸들러를 선택하기 위해 <code>javaType=[TheJavaType], jdbcType=null</code>조합을 사용한다.
       <code>@MappedJdbcTypes</code> 애노테이션의 사용은 타입핸들러의  범위를 <i>제한</i>하고 명시적으로 설정하지 않는한 <code>결과매핑</code>을 사용하지 못하도록 만든다.
       <code>결과매핑</code>에서 타입핸들러를 사용할수 있도록 하려면 <code>@MappedJdbcTypes</code>애노테이션에 <code>includeNullJdbcType=true</code>를 설정하자.
@@ -1471,7 +1459,7 @@ public class ExampleTypeHandler extends BaseTypeHandler<String> {
 
         <p>JDBC타입에 대한 자동검색 기능은 애노테이션을 명시한 경우에만 가능하다는 것을 알아둘 필요가 있다. </p>
         <p>
-          한 개 이상의 클래스를 다루는 제네릭 TypeHandler를 만들수 있다.
+          한 개 이상의 클래스를 다루는 제네릭 TypeHandler를 만들 수 있다.
           파라미터로 클래스를 가져오는 생성자를 추가하고 마이바티스는 TypeHandler를 만들때 실제 클래스를 전달할 것이다.
         </p>
 
@@ -1498,7 +1486,7 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
         <code>Enum</code>을 매핑하고자 한다면 <code>EnumTypeHandler</code> 나 <code>EnumOrdinalTypeHandler</code> 를 사용할 필요가 있을 것이다.
         </p>
 
-        <p>예를들어 순환 방식으로 몇개의 숫자를 사용하는 순환모드를 저장할 필요가 있다고 해보자.
+        <p>예를들어 어떤 숫자를 반올림할 때 사용할 반올림 모드(rounding mode)를 저장해야 한다고 해보자.
         기본적으로 마이바티스는 <code>Enum</code> 값을 각각의 이름으로 변환하기 위해 <code>EnumTypeHandler</code> 를 사용한다.
         </p>
 
@@ -1508,7 +1496,7 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
         <p>아무리 이름을 저장하려해도 DBA는 숫자코드를 고집할수 있다.
     이름 대신 숫자코드를 저장하는 방법은 쉽다.
         설정파일의 <code>typeHandlers</code>에 <code>EnumOrdinalTypeHandler</code> 를 추가하자.
-        그러면 각각의 <code>RoundingMode</code>는 순서값을 사용해서 숫자를 매핑할 것이다.
+        그러면 각각의 <code>RoundingMode</code>는 순서값을 사용해서 숫자로 매핑될 것이다.
         </p>
        <source><![CDATA[<!-- mybatis-config.xml -->
 <typeHandlers>
@@ -1520,11 +1508,11 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
     </p>
         <p>
           자동매퍼는 <code>EnumOrdinalTypeHandler</code> 를 자동으로 사용할 것이다.
-          그래서 평범한 순서를 나타내는 <code>EnumTypeHandler</code> 를 사용하고자 한다면 SQL구문에 사용할 타입핸들러를 명시적으로 설정한다.
+          그래서 원래의 평범한 <code>EnumTypeHandler</code> 를 다시 사용하고자 한다면 SQL구문에 사용할 타입핸들러를 명시적으로 설정한다.
         </p>
         <p>
           (매퍼 파일은 다음 절까지는 다루지 않는다.
-          그래서 문서를 보면서 처음 봤다면 일단 이 부분은 건너띄고 다음에 다시 볼수도 있다. )
+          그래서 문서를 보면서 처음 봤다면 일단 이 부분은 건너뛰고 다음에 다시 볼수도 있다. )
         </p>
         <source><![CDATA[<!DOCTYPE mapper
     PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
@@ -1571,7 +1559,7 @@ public class GenericTypeHandler<E extends MyObject> extends BaseTypeHandler<E> {
 
       <subsection name="objectFactory">
         <p>매번 마이바티스는 결과 객체의 인스턴스를 만들기 위해 ObjectFactory를 사용한다.
-    디폴트 ObjectFactory 는 디폴트 생성자를 가진 대상 클래스를 인스턴스화하는 것보다 조금 더 많은 작업을 한다.
+    디폴트 ObjectFactory 는 대상 클래스를 디폴트 생성자로(파라미터 매핑이 있으면 파라미터를 받는 생성자로) 인스턴스화하는 것 외에는 거의 하는 일이 없다.
     ObjectFactory 의 디폴트 행위를 오버라이드하고자 한다면 만들 수 있다.
     예를들면:</p>
         <source><![CDATA[// ExampleObjectFactory.java
@@ -1601,7 +1589,7 @@ public class ExampleObjectFactory extends DefaultObjectFactory {
 <objectFactory type="org.mybatis.example.ExampleObjectFactory">
   <property name="someProperty" value="100"/>
 </objectFactory>]]></source>
-        <p>ObjectFactory인터페이스는 매우 간단한다.
+        <p>ObjectFactory인터페이스는 매우 간단하다.
     두 개의 create메소드를 가지고 있으며 하나는 디폴트 생성자를 처리하고 다른 하나는 파라미터를 가진 생성자를 처리한다.
     마지막으로 setProperties 메소드는 ObjectFactory를 설정하기 위해 사용될 수 있다.
     objectFactory엘리먼트에 정의된 프로퍼티는 ObjectFactory인스턴스가 초기화된 후 setProperties에 전달될 것이다.</p>
@@ -1737,7 +1725,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
           <li>MANAGED - 이 설정은 어떤것도 하지 않는다.
       결코 커밋이나 롤백을 하지 않는다.
       대신 컨테이너가 트랜잭션의 모든 생명주기를 관리한다.
-      디플트로 커넥션을 닫긴 한다.
+      디폴트로 커넥션을 닫긴 한다.
       하지만 몇몇 컨테이너는 커넥션을 닫는 것 또한 기대하지 않기 때문에 커넥션 닫는 것으로 멈추고자 한다면 “closeConnection”프로퍼티를 false로 설정하라.
       예를 들면:
             <source><![CDATA[<transactionManager type="MANAGED">
@@ -1781,7 +1769,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
       조금 늦긴 하지만 성능을 크게 필요로 하지 않는 간단한 애플리케이션을 위해서는 괜찮은 선택이다.
       UNPOOLED DataSource에는 다음과 같은 속성이 있습니다.</p>
         <ul>
-          <li><code>driver</code> - JDBC드라이버의 패키지 경로를 포함한 결제 자바 클래스명</li>
+          <li><code>driver</code> - JDBC드라이버의 패키지 경로를 포함한 전체 자바 클래스명</li>
           <li><code>url</code> - 데이터베이스 인스턴스에 대한 JDBC URL</li>
           <li><code>username</code> - 데이터베이스에 로그인 할 때 사용할 사용자명</li>
           <li><code>password</code> - 데이터베이스에 로그인 할 때 사용할 패스워드</li>
@@ -1807,11 +1795,11 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
           <li><code>poolMaximumIdleConnections</code> - 주어진 시간에 존재할 수 있는 유휴 커넥션의 수</li>
           <li><code>poolMaximumCheckoutTime</code> - 강제로 리턴되기 전에 풀에서 “체크아웃” 될 수 있는 커넥션의 시간.
       디폴트는 20000ms(20 초)</li>
-          <li><code>poolTimeToWait</code> - 풀이 로그 상태를 출력하고 비정상적으로 긴 경우 커넥션을 다시 얻을려고 시도하는 로우 레벨 설정.
+          <li><code>poolTimeToWait</code> - 풀이 로그 상태를 출력하고 비정상적으로 긴 경우 커넥션을 다시 얻으려고 시도하는 로우 레벨 설정.
       디폴트는 20000ms(20 초)</li>
           <li><code>poolMaximumLocalBadConnectionTolerance</code> – 이것은 모든 쓰레드에 대해 bad Connection이 허용되는 정도에 대한 낮은 수준의 설정입니다.
             만약 쓰레드가 bad connection 을 얻게 되어도 유효한 또 다른 connection 을 다시 받을 수 있습니다.
-            하지만 재시도 횟수는 <code>poolMaximumIdleConnections</code> 과 <code>poolMaximumLocalBadConnectionTolerance</code> 의 합보다 많아야 합니다.
+            하지만 재시도 횟수는 <code>poolMaximumIdleConnections</code> 와 <code>poolMaximumLocalBadConnectionTolerance</code> 의 합을 넘지 않습니다.
             디폴트는 3이다. (3.4.5 부터)
           </li>
           <li><code>poolPingQuery</code> - 커넥션이 작업하기 좋은 상태이고 요청을 받아서 처리할 준비가 되었는지 체크하기 위해 데이터베이스에 던지는 핑쿼리(Ping Query).
@@ -1831,7 +1819,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
         <ul>
           <li><code>initial_context</code> - 이 프로퍼티는 InitialContext 에서 컨텍스트를 찾기(예를 들어 initialContext.lookup(initial_context))위해 사용된다.
       이 프로퍼티는 선택적인 값이다.
-      이 설정을 생략하면 data_source프로퍼티가 InitialContext에서 직접 찾을 것이다.</li>
+      이 설정을 생략하면 data_source 프로퍼티를 InitialContext에서 직접 찾을 것이다.</li>
           <li><code>data_source</code> - DataSource인스턴스의 참조를 찾을 수 있는 컨텍스트 경로이다.
       initial_context 룩업을 통해 리턴된 컨텍스트에서 찾을 것이다.
       initial_context 가 지원되지 않는다면 InitialContext 에서 직접 찾을 것이다.</li>
@@ -1843,7 +1831,7 @@ SqlSessionFactory factory = new SqlSessionFactoryBuilder().build(reader,properti
         <p>이 설정은 인스턴스화할 때 InitialContext생성자에 “encoding”프로퍼티를 “UTF8”로 전달한다.</p>
 
     <p>
-      <code>org.apache.ibatis.datasource.DataSourceFactory</code> 인터페이스를 구현해서 또다른 DataSource구현체를 만들수 있다.
+      <code>org.apache.ibatis.datasource.DataSourceFactory</code> 인터페이스를 구현해서 또다른 DataSource구현체를 만들 수 있다.
     </p>
 
         <source><![CDATA[public interface DataSourceFactory {
@@ -1882,7 +1870,7 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
       <subsection name="databaseIdProvider">
         <p>마이바티스는 데이터베이스 제품마다 다른 구문을 실행할 수 있다.
     여러 개의 데이터베이스 제품을 가진 업체 제품은 <code>databaseId</code> 속성을 사용한 매핑된 구문을 기반으로 지원한다.
-        마이바티스는 <code>databaseId</code>속성이 없거나 <code>databaseId</code>속성을 가진 모든 구문을 로드한다.
+        마이바티스는 <code>databaseId</code>속성이 없거나 현재 <code>databaseId</code>와 일치하는 <code>databaseId</code>속성을 가진 모든 구문을 로드한다.
         같은 구문인데 하나는 <code>databaseId</code>속성이 있고 하나는 <code>databaseId</code>속성이 없을때 뒤에 나온 것이 무시된다.
         다중 지원을 사용하기 위해서는 mybatis-config.xml파일에 다음처럼 <code>databaseIdProvider</code>를 추가하라:
         </p>
@@ -1900,7 +1888,7 @@ public class C3P0DataSourceFactory extends UnpooledDataSourceFactory {
   <property name="Oracle" value="oracle" />
 </databaseIdProvider>]]></source>
 
-    <p>프로퍼터가 제공되면 DB_VENDOR databaseIdProvider는 리턴된 데이터베이스 제품명에서 찾은 첫번째 프로퍼티값이나 일치하는 프로퍼티가 없다면 "null" 을 찾을 것이다.
+    <p>프로퍼티가 제공되면 DB_VENDOR databaseIdProvider는 리턴된 데이터베이스 제품명에서 찾은 첫번째 프로퍼티값이나 일치하는 프로퍼티가 없다면 "null" 을 찾을 것이다.
     이 경우 <code>getDatabaseProductName()</code>가 "Oracle (DataDirect)"를 리턴한다면 databaseId는 "oracle"로 설정될 것이다. </p>
 
     <p><code>org.apache.ibatis.mapping.DatabaseIdProvider</code> 인터페이스를 구현해서 자신만의 DatabaseIdProvider를 빌드하고 mybatis-config.xml파일에 등록할 수 있다:

--- a/src/site/ko/xdoc/dynamic-sql.xml
+++ b/src/site/ko/xdoc/dynamic-sql.xml
@@ -49,7 +49,7 @@
         <source><![CDATA[<select id="findActiveBlogWithTitleLike"
      resultType="Blog">
   SELECT * FROM BLOG
-  WHERE state = ‘ACTIVE’
+  WHERE state = 'ACTIVE'
   <if test="title != null">
     AND title like #{title}
   </if>
@@ -62,7 +62,7 @@
     그리고 다른 조건을 추가한다.</p>
         <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG WHERE state = ‘ACTIVE’
+  SELECT * FROM BLOG WHERE state = 'ACTIVE'
   <if test="title != null">
     AND title like #{title}
   </if>
@@ -79,7 +79,7 @@
     둘다 제공하지 않는다면 featured 상태의 blog가 리턴된다.</p>
         <source><![CDATA[<select id="findActiveBlogLike"
      resultType="Blog">
-  SELECT * FROM BLOG WHERE state = ‘ACTIVE’
+  SELECT * FROM BLOG WHERE state = 'ACTIVE'
   <choose>
     <when test="title != null">
       AND title like #{title}
@@ -119,7 +119,7 @@ WHERE]]></source>
     아마도 다음과 같은 SQL이 만들어질 것이다.</p>
         <source><![CDATA[SELECT * FROM BLOG
 WHERE
-AND title like ‘someTitle’]]></source>
+AND title like 'someTitle']]></source>
         <p>이것도 아마 실패할 것이다.
     이 문제는 조건만 가지고는 해결되지 않았다.
     이렇게 작성했다면 다시는 이렇게 작성하지 않게 될 것이다.</p>
@@ -147,8 +147,8 @@ AND title like ‘someTitle’]]></source>
         <source><![CDATA[<trim prefix="WHERE" prefixOverrides="AND |OR ">
   ...
 </trim>]]></source>
-        <p>override 속성은 오버라이드하는 텍스트의 목록을 제한한다.
-    결과는 override 속성에 명시된 것들을 지우고 with 속성에 명시된 것을 추가한다.</p>
+        <p><em>prefixOverrides</em> 속성은 오버라이드할 텍스트의 목록을 파이프(|)로 구분해서 받으며 이때 공백도 의미가 있다.
+    결과적으로 <em>prefixOverrides</em> 속성에 명시된 것들은 지워지고 <em>prefix</em> 속성에 명시된 것이 추가된다.</p>
         <p>다음 예제는 동적인 update 구문의 유사한 경우이다.
     set 엘리먼트는 update 하고자 하는 칼럼을 동적으로 포함시키기 위해 사용될 수 있다.
     예를 들어:</p>
@@ -162,7 +162,7 @@ AND title like ‘someTitle’]]></source>
     </set>
   where id=#{id}
 </update>]]></source>
-        <p>여기서 set 엘리먼트는 동적으로 SET 키워드를 붙히고 필요없는 콤마를 제거한다.</p>
+        <p>여기서 set 엘리먼트는 동적으로 SET 키워드를 붙이고 필요없는 콤마를 제거한다.</p>
         <p>아마도 trim 엘리먼트로 처리한다면 아래와 같을 것이다.</p>
         <source><![CDATA[<trim prefix="SET" suffixOverrides=",">
   ...
@@ -215,7 +215,7 @@ AND title like ‘someTitle’]]></source>
 </select>]]></source>
   </subsection>
       <subsection name="Multi-db vendor support">
-        <p>"_databaseId" 변수로 설정된 databaseIdProvider가 동적인 코드에도 사용가능하다면 데이터베이스 제품별로 서로다른 구문을 사용할 수 있다.
+        <p>databaseIdProvider가 설정되어 있다면 동적인 코드에서 "_databaseId" 변수를 사용할 수 있고, 이를 통해 데이터베이스 제품별로 서로 다른 구문을 사용할 수 있다.
     다음의 예제를 보라:</p>
         <source><![CDATA[<insert id="insert">
   <selectKey keyProperty="id" resultType="int" order="BEFORE">
@@ -223,7 +223,7 @@ AND title like ‘someTitle’]]></source>
       select seq_users.nextval from dual
     </if>
     <if test="_databaseId == 'db2'">
-      select nextval for seq_users from sysibm.sysdummy1"
+      select nextval for seq_users from sysibm.sysdummy1
     </if>
   </selectKey>
   insert into users values (#{id}, #{name})

--- a/src/site/ko/xdoc/java-api.xml
+++ b/src/site/ko/xdoc/java-api.xml
@@ -84,7 +84,7 @@
   추가적인 정보는 MyBatis-Spring이나 MyBatis-Guice를 참고하길 바란다. </p>
   <h4>SqlSessionFactoryBuilder</h4>
   <p>SqlSessionFactoryBuilder는 5개의 build() 메소드를 가진다.
-  각각은 서로 다른 소스에서 SqlSessionFactory을 빌드한다.</p>
+  각각은 서로 다른 소스에서 SqlSessionFactory를 빌드한다.</p>
   <source>SqlSessionFactory build(InputStream inputStream)
 SqlSessionFactory build(InputStream inputStream, String environment)
 SqlSessionFactory build(InputStream inputStream, Properties properties)
@@ -125,8 +125,8 @@ SqlSessionFactory build(Configuration config)</source>
   <p>프로퍼티가 한개 이상 존재한다면 마이바티스는 일정한 순서로 로드한다.</p>
   <ul>
   <li>properties엘리먼트에 명시된 속성을 가장 먼저 읽는다.</li>
-  <li>properties엘리먼트의 클래스패스 자원이나 url 속성으로 부터 로드된 속성을 두번재로 읽는다.
-  그래서 이미 읽은 값이 있다면 덮어쓴다.,</li>
+  <li>properties엘리먼트의 클래스패스 자원이나 url 속성으로 부터 로드된 속성을 두번째로 읽는다.
+  그래서 이미 읽은 값이 있다면 덮어쓴다.</li>
   <li>마지막으로 메소드 파라미터로 전달된 속성을 읽는다.
   앞서 로드된 값을 덮어쓴다</li>
   </ul>
@@ -163,7 +163,7 @@ Properties getUrlAsProperties(String urlString)
 Class classForName(String className)</source>
 
   <p>마지막 build메소드는 Configuration의 인스턴스를 가진다.
-  Configuration클래스는 SqlSessionFactory 인스턴스에 대해 알 필요가 있는 모든 것으로 가지고 있다.
+  Configuration클래스는 SqlSessionFactory 인스턴스에 대해 알 필요가 있는 모든 것을 가지고 있다.
   Configuration클래스는 SQL Map을 찾거나 관리하는 것을 포함하여 설정을 살펴보기 위해 유용하다.
   Configuration클래스는 앞서 봤던 모든 설정을 처리할 수 있으며 자바 API 로 나타낼 수 있다.
   SqlSessionFactory를 생성하기 위해 Configuration인스턴스를 build()메소드에 전달하는 예제이다.</p>
@@ -174,7 +174,6 @@ Environment environment = new Environment("development", transactionFactory, dat
 
 Configuration configuration = new Configuration(environment);
 configuration.setLazyLoadingEnabled(true);
-configuration.setEnhancementEnabled(true);
 configuration.getTypeAliasRegistry().registerAlias(Blog.class);
 configuration.getTypeAliasRegistry().registerAlias(Post.class);
 configuration.getTypeAliasRegistry().registerAlias(Author.class);
@@ -192,7 +191,7 @@ SqlSessionFactory factory = builder.build(configuration);</source>
   6개의 메소드가 선택해서 사용하는 것들을 보자.</p>
   <ul>
     <li><strong>Transaction</strong>: 세션에서 트랜잭션 스코프 또는 자동 커밋을 사용하고 싶은가?</li>
-    <li><strong>Connection</strong>: 설정된 DataSource에서 Connection 을 회득하고 싶은가?</li>
+    <li><strong>Connection</strong>: 설정된 DataSource에서 Connection 을 획득하고 싶은가?</li>
     <li><strong>Execution</strong>: PreparedStatements그리고/또는 배치(insert, delete를 포함해서) 업데이트를 재사용하고 싶은가?</li>
   </ul>
   <p>오버로드된 메소드인 openSession() 이 3가지를 적절히 혼합해서 사용할 수 있다.</p>
@@ -209,7 +208,7 @@ Configuration getConfiguration();</source>
   <p>파라미터를 가지지 않는 디폴트 openSession()메소드는 다음과 같은 성격을 가진 SqlSession을 만들것이다.</p>
   <ul>
     <li>트랜잭션 스코프는 시작될 것이다.</li>
-    <li>Connection 객체는 활성화된 환경에 의해 설정된 DataSource인스턴스를 획득할 것이다.</li>
+    <li>Connection 객체는 활성화된 환경에 설정된 DataSource 인스턴스로부터 획득될 것이다.</li>
     <li>트랜잭션 격리 레벨은 드라이버나 데이터소스가 디폴트로 제공하는 옵션을 사용할 것이다.</li>
     <li>PreparedStatements는 재사용되지 않을 것이다.
   그리고 update또한 배치처리되지 않을 것이다.</li>
@@ -220,11 +219,11 @@ Configuration getConfiguration();</source>
   <p>Connection 과 autoCommit 둘다 설정하는 것을 오버라이드하지 않는다.
   왜냐하면 마이바티스는 제공된 connection 객체를 설정할때마다 현재 사용중인 것을 사용한다.
   마이바티스는 TransactionIsolationLevel라고 불리는 트랜잭션 격리 레벨을 위한 자바 enum 래퍼를 사용한다.
-  JDBC를 5가지를 지원한다(NONE, READ_UNCOMMITTED, READ_COMMITTED, REPEATABLE_READ, SERIALIZABLE).</p>
+  JDBC가 지원하는 5가지 레벨을 그대로 제공한다(NONE, READ_UNCOMMITTED, READ_COMMITTED, REPEATABLE_READ, SERIALIZABLE).</p>
   <p>새롭게 보일수 있는 하나의 파라미터는 ExecutorType이다.
   enum으로는 3개의 값을 정의한다.</p>
   <ul>
-    <li><code>ExecutorType.SIMPLE</code>: 이 타입의 실행자는 아무것도 하지 않는다.
+    <li><code>ExecutorType.SIMPLE</code>: 이 타입의 실행자는 특별한 처리를 하지 않는다.
   구문 실행마다 새로운 PreparedStatement를 생성한다.</li>
     <li><code>ExecutorType.REUSE</code>: 이 타입의 실행자는 PreparedStatements를 재사용할 것이다.</li>
     <li><code>ExecutorType.BATCH</code>: 이 실행자는 모든 update구문을 배치처리하고 중간에 select 가 실행될 경우 필요하다면 경계를 표시한다.
@@ -254,8 +253,8 @@ Configuration getConfiguration();</source>
 int insert(String statement, Object parameter)
 int update(String statement, Object parameter)
 int delete(String statement, Object parameter)]]></source>
-  <p>selectOne과 selectList의 차이점은 selectOne메소드는 오직 하나의 객체만을 리턴해야 한다는 것이다.
-  한개 이상을 리턴하거나 null 이 리턴된다면 예외가 발생할 것이다.
+  <p>selectOne과 selectList의 차이점은 selectOne메소드는 정확히 한개의 객체 또는 null(결과 없음)을 리턴해야 한다는 것이다.
+  두개 이상이 리턴되면 예외가 발생할 것이다.
   얼마나 많은 객체가 리턴될지 모른다면 selectList를 사용하라.
   객체의 존재여부를 체크하고 싶다면 개수를 리턴하는 방법이 더 좋다.
   selectMap은 결과 목록을 Map으로 변환하기 위해 디자인된 특별한 경우이다.
@@ -285,7 +284,7 @@ int delete(String statement)]]></source>
 void select (String statement, Object parameter, ResultHandler<T> handler)
 void select (String statement, Object parameter, RowBounds rowBounds, ResultHandler<T> handler)]]></source>
 
-  <p>RowBounds 파라미터는 마이바티스로 하여금 특정 개수 만큼의 레코드를 건너띄게 한다.
+  <p>RowBounds 파라미터는 마이바티스로 하여금 특정 개수 만큼의 레코드를 건너뛰게 한다.
   RowBounds클래스는 offset과 limit 둘다 가지는 생성자가 있다.</p>
 
   <source>int offset = 100;
@@ -303,13 +302,13 @@ public interface ResultHandler<T> {
   void handleResult(ResultContext<? extends T> context);
 }]]></source>
 
-  <p>ResultContext파라미터는 결과 객체에 접근할 수 있도록 해준다.</p>
+  <p>ResultContext파라미터는 결과 객체 자체와 지금까지 생성된 결과 객체의 개수에 접근할 수 있게 해주고, 더 이상 결과를 로딩하지 않도록 중단시키는 stop() 메소드를 제공한다.</p>
 
   <p>ResultHandler를 사용할 때 유의해야 할 제약사항이 2개 있다:</p>
 
   <ul>
     <li>ResultHandler를 사용하여 호출된 메소드의 데이터는 캐싱 되지 않는다.</li>
-    <li>고급 resualtMap을 사용할 경우, 마이바티스는 객체를 완성하기 위해 여러 줄의 코드를 필요로 할 수 있다. ResultHandler를 사용할 때 받는 객체는 associations나 collections가 완전히 채워지지 않은 상태일 수도 있다.</li>
+    <li>고급 resultMap을 사용할 경우, 마이바티스는 객체를 완성하기 위해 여러 줄의 코드를 필요로 할 수 있다. ResultHandler를 사용할 때 받는 객체는 associations나 collections가 완전히 채워지지 않은 상태일 수도 있다.</li>
   </ul>
 
   <h5>배치 수정시 flush메소드</h5>
@@ -317,7 +316,7 @@ public interface ResultHandler<T> {
   이 방법은 <code>ExecutorType</code>을 <code>ExecutorType.BATCH</code>로 설정한 경우 사용가능하다. </p>
   <source><![CDATA[List<BatchResult> flushStatements()]]></source>
 
-  <h5 id="transaction-control-methods">트랙잭션 제어 메소드</h5>
+  <h5 id="transaction-control-methods">트랜잭션 제어 메소드</h5>
   <p>트랜잭션을 제어하기 위해 4개의 메소드가 있다.
   물론 자동커밋을 선택하였거나 외부 트랜잭션 관리자를 사용하면 영향이 없다.
   어쨌든 Connection인스턴스에 의해 관리되고 JDBC 트랜잭션 관리자를 사용하면 이 4개의 메소드를 사용할 수 있다.</p>
@@ -325,15 +324,15 @@ public interface ResultHandler<T> {
 void commit(boolean force)
 void rollback()
 void rollback(boolean force)</source>
-  <p>기본적으로 마이바티스는 insert, update, delete 또는 <code>affectData</code>가 활성화된select 를 호출하여 데이터베이스가 변경된 것으로 감지하지 않는 한 실제로 커밋하지 않는다.
+  <p>기본적으로 마이바티스는 insert, update, delete 또는 <code>affectData</code>가 활성화된 select 를 호출하여 데이터베이스가 변경된 것으로 감지하지 않는 한 실제로 커밋하지 않는다.
   이러한 메소드 호출없이 변경되면 커밋된 것으로 보장하기 위해 commit 와 rollback 메소드에 true 값을 전달한다.</p>
   <p><span class="label important">참고</span> MyBatis-Spring 과 MyBatis-Guice는 선언적인 트랜잭션 관리기법을 제공한다.
   그래서 스프링이나 쥬스와 함께 마이바티스를 사용한다면 해당되는 메뉴얼을 꼭 참고하길 바란다. </p>
 
   <h5>세션 레벨의 캐시를 지우기</h5>
   <source>void clearCache()</source>
-  <p>SqlSession인스턴스는 update, commit, rollback 또는 close 할때마다 지워지는 로컬 캐시이다.
-  명시적으로 닫기 위해서는 clearCache()메소드를 호출할 수 있다.</p>
+  <p>SqlSession인스턴스는 update, commit, rollback 또는 close 할때마다 지워지는 로컬 캐시를 가진다.
+  명시적으로 지우고 싶다면 위의 clearCache() 메소드를 호출하면 된다.</p>
 
   <h5>SqlSession 을 반드시 닫도록 한다.</h5>
   <source>void close()</source>
@@ -360,7 +359,7 @@ void rollback(boolean force)</source>
   <source><![CDATA[public interface AuthorMapper {
   // (Author) selectOne("selectAuthor",5);
   Author selectAuthor(int id);
-  // (List<Author>) selectList(“selectAuthors”)
+  // (List<Author>) selectList("selectAuthors")
   List<Author> selectAuthors();
 
   // (Map<Integer,Author>) selectMap("selectAuthors", "id")
@@ -602,7 +601,7 @@ void rollback(boolean force)</source>
             <li><code>&lt;select&gt;</code></li>
           </ul>
         </td>
-        <td>실행시 SQL 을 리턴할 클래스 과 메소드명을 명시하도록 해주는 대체수단의 애노테이션이다 (Since 3.4.6, you can specify the <code>CharSequence</code> instead of <code>String</code> as a method return type).
+        <td>실행시 SQL 을 리턴할 클래스와 메소드명을 명시하도록 해주는 대체수단의 애노테이션이다 (Since 3.4.6, you can specify the <code>CharSequence</code> instead of <code>String</code> as a method return type).
     매핑된 구문을 실행할 때 마이바티스는 클래스의 인스턴스를 만들고 메소드를 실행한다.
     Mapper 메서드의 인수인 "Mapper interface type" and "Database ID" 과 <code>ProviderContext</code>(Mybatis 3.4.5 부터) 를 이용한 "Mapper method" 로 전달 된 객체를 메서드 매개변수로 전달할 수 있다.(마이바티스 3.4이상에서는 복수 파라미터를 허용한다.)
     사용가능한 속성들 : value, type, method.

--- a/src/site/ko/xdoc/sqlmap-xml.xml
+++ b/src/site/ko/xdoc/sqlmap-xml.xml
@@ -35,7 +35,7 @@
       <p>SQL Map XML파일은 첫번째(first class)엘리먼트만을 가진다.</p>
       <ul>
         <li>
-          <code>cache</code> - 해당 네임스페이스을 위한 캐시 설정
+          <code>cache</code> - 해당 네임스페이스를 위한 캐시 설정
         </li>
         <li>
           <code>cache-ref</code> - 다른 네임스페이스의 캐시 설정에 대한 참조</li>
@@ -171,7 +171,7 @@ ps.setInt(1,id);]]></source>
             <tr>
               <td><code>resultSetType</code></td>
               <td>FORWARD_ONLY|SCROLL_SENSITIVE|SCROLL_INSENSITIVE|DEFAULT(same as unset)중 하나를 선택할 수 있다.
-        디폴트는 셋팅하지 않는 것이고 드라이버에 다라 다소 지원되지 않을 수 있다.</td>
+        디폴트는 셋팅하지 않는 것이고 드라이버에 따라 다소 지원되지 않을 수 있다.</td>
             </tr>
             <tr>
               <td><code>databaseId</code></td>
@@ -258,8 +258,8 @@ ps.setInt(1,id);]]></source>
             </tr>
             <tr>
               <td><code>flushCache</code></td>
-              <td>이 값을 true 로 셋팅하면 구문이 호출될때마다 캐시가 지원질것이다(flush).
-        디폴트는 false 이다.</td>
+              <td>이 값을 true 로 셋팅하면 구문이 호출될때마다 2nd 레벨 캐시와 로컬 캐시가 지워질것이다(flush).
+        insert, update, delete 구문의 디폴트는 true 이다.</td>
             </tr>
             <tr>
               <td><code>timeout</code></td>
@@ -275,7 +275,7 @@ ps.setInt(1,id);]]></source>
             <tr>
               <td><code>useGeneratedKeys</code></td>
               <td>(입력(insert, update)에만 적용) 데이터베이스에서 내부적으로 생성한 키
-        (예를들어 MySQL또는 SQL Server와 같은 RDBMS의 자동 증가 필드)를 받는 JDBC getGeneratedKeys메소드를 사용하도록 설정하다.
+        (예를들어 MySQL또는 SQL Server와 같은 RDBMS의 자동 증가 필드)를 받는 JDBC getGeneratedKeys메소드를 사용하도록 설정한다.
         디폴트는 false 이다.</td>
             </tr>
             <tr>
@@ -287,7 +287,7 @@ ps.setInt(1,id);]]></source>
             <tr>
               <td><code>keyColumn</code></td>
               <td>(입력(insert, update)에만 적용) 생성키를 가진 테이블의 칼럼명을 셋팅.
-        키 칼럼이 테이블이 첫번째 칼럼이 아닌 데이터베이스(PostgreSQL 처럼)에서만 필요하다.
+        키 칼럼이 테이블의 첫번째 칼럼이 아닌 데이터베이스(PostgreSQL 처럼)에서만 필요하다.
         여러개의 칼럼을 사용한다면 프로퍼티명에 콤마를 구분자로 나열할수 있다. </td>
             </tr>
             <tr>
@@ -386,7 +386,7 @@ ps.setInt(1,id);]]></source>
             <tr>
               <td><code>resultType</code></td>
               <td>결과의 타입.
-        마이바티스는 이 기능을 제거할 수 있지만 추가하는게 문제가 되지는 않을것이다.
+        마이바티스는 대개 이 타입을 알아낼 수 있지만 확실히 하기 위해 명시해도 문제가 되지는 않는다.
         마이바티스는 String을 포함하여 키로 사용될 수 있는 간단한 타입을 허용한다.</td>
             </tr>
             <tr>
@@ -399,7 +399,7 @@ ps.setInt(1,id);]]></source>
             <tr>
               <td><code>statementType</code></td>
               <td>위 내용과 같다.
-        마이바티스는 Statement, PreparedStatement 그리고 CallableStatement을 매핑하기 위해 STATEMENT, PREPARED 그리고 CALLABLE 구문타입을 지원한다.</td>
+        마이바티스는 Statement, PreparedStatement 그리고 CallableStatement를 매핑하기 위해 STATEMENT, PREPARED 그리고 CALLABLE 구문타입을 지원한다.</td>
             </tr>
           </tbody>
         </table>
@@ -468,7 +468,7 @@ ps.setInt(1,id);]]></source>
 
         <p>위 예제는 매우 간단한 명명된 파라미터 매핑을 보여준다.
     parameterType은 “int”로 설정되어 있다.
-    Integer과 String과 같은 원시타입 이나 간단한 데이터 타입은 프로퍼티를 가지지 않는다.
+    Integer와 String 같은 원시타입이나 간단한 데이터 타입은 프로퍼티를 가지지 않는다.
     그래서 파라미터 전체가 값을 대체하게 된다.
     하지만 복잡한 객체를 전달하고자 한다면 다음의 예제처럼 상황은 조금 다르게 된다.</p>
 
@@ -500,13 +500,13 @@ ps.setInt(1,id);]]></source>
     다소 설정이 장황하게 보일수 있지만 실제로 이렇게 설정할일은 거의 없다.
     </p>
 
-        <p>숫자 타입을 위해서 크기를 판단하기 위한 numericScale속성도 있다.</p>
+        <p>숫자 타입을 위해서 소수점 이하 몇 자리까지 유효한지 지정하는 numericScale속성도 있다.</p>
 
         <source><![CDATA[#{height,javaType=double,jdbcType=NUMERIC,numericScale=2}]]></source>
 
         <p>마지막으로 mode속성은 IN, OUT 또는 INOUT 파라미터를 명시하기 위해 사용한다.
     파라미터가 OUT 또는 INOUT 이라면 파라미터의 실제 값은 변경될 것이다.
-    mode=OUT(또는 INOUT) 이고 jdbcType=CURSOR(예를들어 오라클 REFCURSOR)라면 파라미터의 타입에 ResultSet 를 매핑하기 위해 resultMap을 명시해야만 한다.</p>
+    mode=OUT(또는 INOUT) 이고 jdbcType=CURSOR(예를들어 오라클 REFCURSOR)라면 파라미터의 타입에 ResultSet 을 매핑하기 위해 resultMap을 명시해야만 한다.</p>
 
         <source><![CDATA[#{department, mode=OUT, jdbcType=CURSOR, javaType=ResultSet, resultMap=departmentResultMap}]]></source>
 
@@ -815,7 +815,7 @@ public class User {
             </tr>
             <tr>
               <td><code>type</code></td>
-              <td>패키지를 포함한 자바 클래스명이나 타입별칭(내장된 타입별칭이 목록은 위 표를 보자).
+              <td>패키지를 포함한 자바 클래스명이나 타입별칭(내장된 타입별칭의 목록은 위 표를 보자).
               </td>
             </tr>
             <tr>
@@ -865,7 +865,7 @@ public class User {
               <td><code>property</code></td>
               <td>결과 칼럼에 매핑하기 위한 필드나 프로퍼티.
         자바빈 프로퍼티가 해당 이름과 일치한다면 그 프로퍼티가 사용될 것이다.
-        반면에 마이바티스는 해당 이름이 필드를 찾을 것이다.
+        반면에 마이바티스는 해당 이름의 필드를 찾을 것이다.
         점 표기를 사용하여 복잡한 프로퍼티 검색을 사용할 수 있다.
         예를들어 “username”과 같이 간단하게 매핑될 수 있거나 “address.street.number” 처럼 복잡하게 매핑될수도 있다.</td>
             </tr>
@@ -964,7 +964,7 @@ public class User {
 
         <p>
           결과를 생성자에 주입하려면 MyBatis 가 어떻게든 생성자를 식별해야 한다.
-          다음 예제에서 MyBatis는 <code>java.lang.Integer</code>, <code>java.lang.String</code> and <code>int</code> 의 순서로 세 개의 매개 변수로 선언 된 생성자를 검색한다.
+          다음 예제에서 MyBatis는 <code>java.lang.Integer</code>, <code>java.lang.String</code> and <code>int</code> 의 순서로 세 개의 매개 변수로 선언된 생성자를 검색한다.
         </p>
 
         <source><![CDATA[<constructor>
@@ -986,7 +986,7 @@ public class User {
 </constructor>]]></source>
 
         <p>
-          같은 이름과 형태의 쓰기 가능한 property 가 있는 경우는 <code>javaType</code> 를 생략 할 수 있다.
+          같은 이름과 형태의 쓰기 가능한 property 가 있는 경우는 <code>javaType</code> 을 생략할 수 있다.
         </p>
 
         <p>나머지 속성과 규칙은 id와 result엘리먼트와 동일하다.</p>
@@ -1096,7 +1096,7 @@ public class UserRole {
       u.id,
       u.username,
       r.id as role_id,
-      r.role as role_role,
+      r.role as role_role
     from user u
       left join user_role ur on u.id = ur.user_id
       inner join role r on r.id = ur.role_id
@@ -1199,7 +1199,7 @@ When using this functionality, it is preferable for the entire mapping hierarchy
               <td><code>property</code></td>
               <td>결과 칼럼에 매핑하기 위한 필드나 프로퍼티.
         자바빈 프로퍼티가 해당 이름과 일치한다면 그 프로퍼티가 사용될 것이다.
-        반면에 마이바티스는 해당 이름이 필드를 찾을 것이다.
+        반면에 마이바티스는 해당 이름의 필드를 찾을 것이다.
         점 표기를 사용하여 복잡한 프로퍼티 검색을 사용할 수 있다.
         예를들어 “username”과 같이 간단하게 매핑될 수 있거나 “address.street.number” 처럼 복잡하게 매핑될수도 있다.</td>
             </tr>
@@ -1280,7 +1280,7 @@ When using this functionality, it is preferable for the entire mapping hierarchy
         <p>다른 프로퍼티들은 칼럼과 프로퍼티명에 일치하는 것들로 자동으로 로드 될 것이다.</p>
 
         <p>이 방법은 간단한 반면에 큰 데이터나 목록에는 제대로 작동하지 않을 것이다.
-    이 방법은 “N+1 Selects 문제” 으로 알려진 문제점을 가진다.
+    이 방법은 “N+1 Selects 문제”로 알려진 문제점을 가진다.
     N+1 조회 문제는 처리과정의 특이성으로 인해 야기된다.</p>
 
         <ul>
@@ -1320,7 +1320,7 @@ When using this functionality, it is preferable for the entire mapping hierarchy
               <td>
                 여러개의 테이블을 조인할때 ResultSet에서 칼럼명의 중복을 피하기 위해 칼럼별칭을 사용할 수 있다.
                 칼럼을 외부 결과매핑에 매핑하기 위해 columnPrefix를 명시하자.
-        이 절의 뒤에 나오는 에제를 보자.
+        이 절의 뒤에 나오는 예제를 보자.
               </td>
             </tr>
             <tr>
@@ -1563,7 +1563,7 @@ SELECT * FROM AUTHOR WHERE ID = #{id}]]></source>
   <result property="body" column="post_body"/>
 </collection>]]></source>
 
-        <p>collection 엘리먼트는 관계를 파악하기 위해 작동한다.
+        <p>collection 엘리먼트는 association 과 거의 동일하게 작동한다.
     사실 이 내용이 중복되는 내용으로 차이점에 대해서만 주로 살펴보자.</p>
 
         <p>위 예제를 계속 진행하기 위해 Blog는 오직 하나의 Author를 가진다.
@@ -1573,7 +1573,7 @@ SELECT * FROM AUTHOR WHERE ID = #{id}]]></source>
         <source><![CDATA[private List<Post> posts;]]></source>
 
         <p>List에 내포된 결과를 매핑하기 위해 collection엘리먼트를 사용한다.
-    association 엘리먼트와는 달리 조인에서 내포된 select나 내포된 결과를 사용할 수 있다.</p>
+    association 엘리먼트와 마찬가지로 내포된 select나 조인의 내포된 결과를 사용할 수 있다.</p>
 
         <h4>Collection 을 위한 내포된(Nested) Select</h4>
 
@@ -1603,7 +1603,7 @@ SELECT * FROM AUTHOR WHERE ID = #{id}]]></source>
         </p>
 
         <p>javaType 속성은 그다지 필요하지 않다.
-    마이바티스는 대부분의 경우 이 속성을 사용하지 않을 것이다.
+    마이바티스가 대부분의 경우 타입을 알아서 판단하기 때문이다.
     그래서 간단하게 설정할 수 있다.</p>
 
         <source><![CDATA[<collection property="posts" column="id" ofType="Post" select="selectPostsForBlog"/>]]></source>
@@ -1611,7 +1611,7 @@ SELECT * FROM AUTHOR WHERE ID = #{id}]]></source>
         <h4>Collection을 위한 내포된(Nested) Results</h4>
 
         <p>이 시점에 collection 을 위한 내포된 결과가 어떻게 작동하는지 짐작할 수 있을 것이다.
-    왜냐하면 association와 정확히 일치하기 때문이다.
+    왜냐하면 association 과 정확히 일치하기 때문이다.
     하지만 “ofType” 속성이 추가로 적용되었다.</p>
 
         <p>먼저 SQL을 보자.</p>
@@ -1623,7 +1623,7 @@ SELECT * FROM AUTHOR WHERE ID = #{id}]]></source>
   B.author_id as blog_author_id,
   P.id as post_id,
   P.subject as post_subject,
-  P.body as post_body,
+  P.body as post_body
   from Blog B
   left outer join Post P on B.id = P.blog_id
   where B.id = #{id}
@@ -1732,8 +1732,8 @@ SELECT * FROM POST WHERE BLOG_ID = #{id}]]></source>
     discriminator엘리먼트는 클래스 상속 관계를 포함하여 이러한 상황을 위해 고안되었다.
     discriminator는 자바의 switch와 같이 작동하기 때문에 이해하기 쉽다.</p>
 
-        <p>discriminator정의는 colume과 javaType속성을 명시한다.
-    colume은 마이바티스로 하여금 비교할 값을 찾을 것이다.
+        <p>discriminator정의는 column과 javaType속성을 명시한다.
+    column은 마이바티스가 비교할 값을 찾는 대상이다.
     javaType은 동일성 테스트와 같은 것을 실행하기 위해 필요하다.
     예를들어</p>
 
@@ -1831,7 +1831,7 @@ SELECT * FROM POST WHERE BLOG_ID = #{id}]]></source>
 
         <p>
           자동매핑은 결과매핑을 선언한 경우에도 동작한다.
-          이런 경우 각각의 결과매핑에서 ResultSet의 모든 칼럼은 자동매핑이 아니라 수동매핑으로 처리한다.
+          이런 경우 각각의 결과매핑마다 ResultSet에 존재하지만 수동으로 매핑하지 않은 모든 칼럼이 자동매핑되고, 그 다음에 수동매핑이 처리된다.
           다음 샘플에서 <i>id</i> 와 <i>userName</i> 칼럼은 자동매핑되고 <i>hashed_password</i> 칼럼은 수동으로 매핑한다. </p>
 
         <source><![CDATA[<select id="selectUsers" resultMap="userResultMap">
@@ -1874,7 +1874,7 @@ SELECT * FROM POST WHERE BLOG_ID = #{id}]]></source>
   select
     B.id,
     B.title,
-    A.username,
+    A.username
   from Blog B left outer join Author A on B.author_id = A.id
   where B.id = #{id}
 </select>]]></source>
@@ -1890,7 +1890,7 @@ SELECT * FROM POST WHERE BLOG_ID = #{id}]]></source>
         <p>
           <i>Blog</i> 와 <i>Author</i> 는 자동매핑으로 처리하지만 <i>Author</i>는 <i>id</i> 프로퍼티를 가지고 ResultSet은 <i>id</i> 칼럼을 가진다.
           그래서 기대한 것과는 달리 저자(Author)의 id는 블로그(Blog)의 id로 채워질것이다.
-          <code>FULL</code> 는 이런 위험을 가진다.
+          <code>FULL</code> 은 이런 위험이 있으니 주의해서 사용하자.
         </p>
 
 
@@ -1948,7 +1948,7 @@ SELECT * FROM POST WHERE BLOG_ID = #{id}]]></source>
           <li><code>LRU</code> – Least Recently Used: 가장 오랜시간 사용하지 않는 객체를 제거</li>
           <li><code>FIFO</code> – First In First Out: 캐시에 들어온 순서대로 객체를 제거</li>
           <li><code>SOFT</code> – Soft Reference: 가비지 컬렉터의 상태와 강하지 않은 참조(Soft References )의 규칙에 기초하여 객체를 제거</li>
-          <li><code>WEAK</code> – Weak Reference: 가비지 컬렉터의 상태와 약한 참조(Weak References)의 규칙에 기초하여 점진적으로 객체 제거</li>
+          <li><code>WEAK</code> – Weak Reference: 가비지 컬렉터의 상태와 약한 참조(Weak References)의 규칙에 기초하여 더 적극적으로 객체 제거</li>
         </ul>
 
         <p>디폴트 값은 LRU 이다.</p>
@@ -1974,7 +1974,7 @@ SELECT * FROM POST WHERE BLOG_ID = #{id}]]></source>
         <source><![CDATA[<cache type="com.domain.something.MyCustomCache"/>]]></source>
 
         <p>이 예제는 사용자 지정 캐시 구현체를 사용하는 방법을 보여준다.
-    type속성에 명시된 클래스는 org.apache.ibatis.cache.Cache인터페이스를 반드시 구현해야 한다.
+    type속성에 명시된 클래스는 org.apache.ibatis.cache.Cache인터페이스를 반드시 구현하고 String 타입의 id를 인자로 받는 생성자를 제공해야 한다.
     이 인터페이스는 마이바티스 프레임워크의 가장 복잡한 구성엘리먼트 중 하나이다.
     하지만 하는 일은 간단하다.</p>
 
@@ -1983,13 +1983,12 @@ SELECT * FROM POST WHERE BLOG_ID = #{id}]]></source>
   int getSize();
   void putObject(Object key, Object value);
   Object getObject(Object key);
-  boolean hasKey(Object key);
   Object removeObject(Object key);
   void clear();
 }]]></source>
 
         <p>캐시를 설정하기 위해 캐시 구현체에 public 자바빈 프로퍼티를 추가하고 cache 엘리먼트를 통해 프로퍼티를 전달한다.
-    예를들어 다음 예제는 캐시 구현체에서 “setCacheFile(String file)” 를 호출하여 메소드를 호출할 것이다.</p>
+    예를들어 다음 예제는 캐시 구현체의 “setCacheFile(String file)” 메소드를 호출할 것이다.</p>
 
         <source><![CDATA[<cache type="com.domain.something.MyCustomCache">
   <property name="cacheFile" value="/tmp/my-custom-cache.tmp"/>
@@ -2019,13 +2018,13 @@ SELECT * FROM POST WHERE BLOG_ID = #{id}]]></source>
 <update ... flushCache="true"/>
 <delete ... flushCache="true"/>]]></source>
 
-        <p>이러한 방법으로 구문을 설정하는 하는 방법은 굉장히 좋지 않다.
+        <p>이러한 방법으로 구문을 명시적으로 설정하는 것은 좋지 않다.
     대신 디폴트 행위를 변경해야 할 경우에만 flushCache와 useCache 속성을 변경하는 것이 좋다.
     예를들어 캐시에서 특정 select 구문의 결과를 제외하고 싶거나 캐시를 지우기 위한 select 구문을 원할 것이다.
     유사하게 실행할때마다 캐시를 지울 필요가 없는 update구문도 있을 것이다.</p>
 
         <h4>cache-ref</h4>
-        <p>이전 섹션 내용을 돌이켜보면서 특정 네임스페이스을 위한 캐시는 오직 하나만 사용되거나 같은 네임스페이스내에서는 구문마다 캐시를 지울수 있다.
+        <p>이전 섹션 내용을 돌이켜보면서 특정 네임스페이스를 위한 캐시는 오직 하나만 사용되거나 같은 네임스페이스내에서는 구문마다 캐시를 지울수 있다.
     네임스페이스간의 캐시 설정과 인스턴스를 공유하고자 할때가 있을 것이다.
     이 경우 cache-ref 엘리먼트를 사용해서 다른 캐시를 참조할 수 있다.</p>
 

--- a/src/site/ko/xdoc/statement-builders.xml
+++ b/src/site/ko/xdoc/statement-builders.xml
@@ -20,7 +20,7 @@
           xsi:schemaLocation="http://maven.apache.org/XDOC/2.0 https://maven.apache.org/xsd/xdoc-2.0.xsd">
 
   <properties>
-    <title>마이바티스 3 | SQL BUilder 클래스</title>
+    <title>마이바티스 3 | SQL Builder 클래스</title>
     <author email="clinton.begin@gmail.com">Clinton Begin</author>
   <author email="fromm0@gmail.com">이동국(한국어 번역)</author>
   </properties>
@@ -105,8 +105,8 @@ public String deletePersonSql() {
 // 빌더 / 깔끔한 형태
 public String insertPersonSql() {
   String sql = new SQL()
-    .INSERT_INTO("PERSON");
-    .VALUES("ID, FIRST_NAME", "#{id}, #{firstName}");
+    .INSERT_INTO("PERSON")
+    .VALUES("ID, FIRST_NAME", "#{id}, #{firstName}")
     .VALUES("LAST_NAME", "#{lastName}")
     .toString();
   return sql;
@@ -127,21 +127,6 @@ public String selectPersonLike(final String id, final String firstName, final St
       WHERE("P.LAST_NAME like #{lastName}");
     }
     ORDER_BY("P.LAST_NAME");
-  }}.toString();
-}
-
-public String deletePersonSql() {
-  return new SQL() {{
-    DELETE_FROM("PERSON");
-    WHERE("ID = #{id}");
-  }}.toString();
-}
-
-public String insertPersonSql() {
-  return new SQL() {{
-    INSERT_INTO("PERSON");
-    VALUES("ID, FIRST_NAME", "#{id}, #{firstName}");
-    VALUES("LAST_NAME", "#{lastName}");
   }}.toString();
 }
 
@@ -266,7 +251,7 @@ public String updatePersonSql() {
                 <code>OR()</code>
               </td>
               <td><code>OR</code>를 사용해서 <code>WHERE</code>조건절을 분리한다.
-        여러번 호출할 수 있지만 한개의 로우에 여러번 호출할 경우 에러를 가진 <code>SQL</code>을 만들수도 있다.
+        여러번 호출할 수 있지만 연속해서 여러번 호출할 경우 잘못된 <code>SQL</code>을 만들수도 있다.
               </td>
             </tr>
             <tr>
@@ -274,7 +259,7 @@ public String updatePersonSql() {
                 <code>AND()</code>
               </td>
               <td><code>AND</code>를 가진 <code>WHERE</code>절을 분리한다.
-        여러번 호출할 수 있지만 여러번 호출할 경우 에러를 가진 <code>SQL</code>을 만들수도 있다.
+        여러번 호출할 수 있지만 연속해서 여러번 호출할 경우 잘못된 <code>SQL</code>을 만들수도 있다.
         <code>WHERE</code>와 <code>HAVING</code> 두가지는 <code>AND</code>를 자동으로 붙이기 때문에
         흔하게 사용하지 않고 필요할때만 사용한다.
               </td>
@@ -398,14 +383,14 @@ public String updatePersonSql() {
                 <code>DELETE_FROM(String)</code>
               </td>
               <td>delete구문을 시작하고 삭제할 테이블을 명시한다.
-        대개는 WHERE구문이 뒤에 붙여서 삭제한 대상 조건을 명시한다.
+        대개는 뒤에 WHERE 구문을 붙여서 삭제할 대상 조건을 명시한다.
               </td>
             </tr>
             <tr>
               <td>
                 <code>INSERT_INTO(String)</code>
               </td>
-              <td>insert구문을 시작하고 입력한 테이블을 명시한다.
+              <td>insert구문을 시작하고 입력할 테이블을 명시한다.
         VALUES() or INTO_COLUMNS() and INTO_VALUES() 메소드 호출은 여러번 해서 입력한 칼럼과 값을 명시한다.
               </td>
             </tr>
@@ -426,7 +411,7 @@ public String updatePersonSql() {
               <td>
                 <code>UPDATE(String)</code>
               </td>
-              <td>update구문을 시작하고 update수정할 테이블을 명시한다.
+              <td>update구문을 시작하고 수정할 테이블을 명시한다.
         수정할 칼럼과 값을 명시하기 위해 SET()메소드 호출을 여러번 할수 있고 대개 수정할 대상 데이터를 한정하기 위해 WHERE()메소드도 호출한다.
               </td>
             </tr>
@@ -435,7 +420,7 @@ public String updatePersonSql() {
                 <code>VALUES(String, String)</code>
               </td>
               <td>insert구문에 덧붙인다.
-        첫번째 파라미터는 입력한 칼럼이고 두번째 파라미터는 입력할 값이다.
+        첫번째 파라미터는 입력할 칼럼이고 두번째 파라미터는 입력할 값이다.
               </td>
             </tr>
             <tr>


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><p>Follow-up to #2631 (Korean translation of configuration / dynamic-sql / sqlmap-xml) and #3284 (translating leftover English in <code>ko/xdoc/java-api.xml</code>).</p>
<p>This is the Korean half of #3753 — the code samples that are broken in every locale are fixed there for <code>en</code> / <code>ja</code> / <code>es</code> / <code>zh_CN</code> and here for <code>ko</code>, so the two PRs together leave all five in sync.</p>
<h3>Broken markup</h3>
<ul>
<li><code>configuration.xml</code> — the <code>vfsImpl</code> row of the settings table has only three <code>&lt;td&gt;</code> cells where every other row has four, which shifts the columns of every row below it. After the fix the table has 32 rows, matching the English table row for row by name and order.</li>
<li><code>configuration.xml</code> — the <code>defaultFetchSize</code> row appears twice.</li>
<li><code>index.md</code> — the Chinese link points at <code>../zh/index.html</code>, but the directory is <code>zh_CN</code>, so the link 404s. The English <code>index.md</code> uses <code>zh_CN</code>.</li>
</ul>
<h3>Broken code samples</h3>
<ul>
<li><code>statement-builders.xml</code> — semicolons in the middle of a fluent chain make the sample a Java syntax error. The English original has no semicolons there.</li>
<li><code>dynamic-sql.xml</code> — U+2018/U+2019 curly quotes in the SQL samples, and a stray double quote in the DB2 <code>selectKey</code> SQL.</li>
<li><code>sqlmap-xml.xml</code> — dangling commas before <code>from</code>; the non-existent <code>Cache.hasKey</code> method; <code>colume</code> used twice as an attribute name where the DTD has <code>column</code>.</li>
<li><code>java-api.xml</code> — smart quotes inside a Java code block, and <code>configuration.setEnhancementEnabled(true)</code>, which does not exist in the source.</li>
</ul>
<h3>Translations that reverse or drop the meaning of the original</h3>

Location | The Korean said | Original / source
-- | -- | --
sqlmap-xml flushCache | default is false | true for insert/update/delete — XMLStatementBuilder.java:82, getBooleanAttribute("flushCache", !isSelect)
sqlmap-xml collection | "unlike the association element" | "Just like the association element"
sqlmap-xml auto-mapping | "all columns are handled by manual mapping, not auto-mapping" | "all columns ... that have not a manual mapping will be auto-mapped, then manual mappings will be processed"
sqlmap-xml discriminator | "ignored if nothing matches" | "the rest of the resultMap is ignored"
sqlmap-xml selectKey | "MyBatis can remove this feature" | "MyBatis can usually figure this out"
sqlmap-xml resultOrdered | "fills more memory" | "much more memory friendly"
sqlmap-xml WEAK eviction | "removes gradually" | "More aggressively removes"
sqlmap-xml numericScale | "determines the size" | "how many decimal places are relevant"
java-api selectOne | "throws if null is returned" | "must return exactly one object or null (none)"
java-api Connection | "the Connection acquires the DataSource" | "acquired from the DataSource instance"
java-api SIMPLE executor | "does nothing" | "does nothing special" — contradicted the very next sentence
configuration aggressiveLazyLoading | "true from 3.4.1" | "true in 3.4.1 and below"
configuration poolMaximumLocalBadConnectionTolerance | "must be more than the sum" | "should not more than the sum" — PooledDataSource.java:528
configuration ObjectFactory | "does a bit more than instantiating" | "does little more than instantiate"
configuration RoundingMode | translated as "cyclic mode" | it is a rounding mode
configuration EnumTypeHandler | described as the ordinal one | "ordinary" was read as "ordinal"; the ordinal one is EnumOrdinalTypeHandler
configuration databaseId | "loads every statement that has a databaseId" | "with a databaseId that matches the current one"
dynamic-sql trim | documents override and with attributes | no such attributes; they are prefix and prefixOverrides
statement-builders OR() / AND() | "calling more than once on one row" | "more than once in a row", i.e. consecutively
statement-builders SELECT / FROM | "the driver may not handle it" | "anything acceptable to the driver"


<h3>Korean spelling, spacing and particles</h3>
<p>Roughly 85 fixes: wrong particles after words ending in a vowel vs. a consonant, misspellings, spacing, and a number of sentences whose subject and predicate did not agree.</p>
<p><code>ko/markdown/logging.md</code> also had one paragraph still in English; it is translated now. The <code>transaction-control-methods</code> anchor id is left untouched so existing links keep working.</p>
<p>Nothing here changes behaviour; documentation only.</p>
<h3>A note on how this was found</h3>
<p>I was reading the Korean docs, noticed a few statements that contradicted the sentence right after them, and compared the whole set against the English originals. Part of the sweep was tool-assisted; every technical claim above was verified against <code>src/main/java</code> by hand, and I dropped the candidates that did not hold up. The translation changes are judgement calls on my part — happy to revert any of them if you read them differently.</p></body></html><!--EndFragment-->
</body>
</html>