### PR TITLE
fix: keep FifoCache from evicting live entries on overwrite

### DIFF
--- a/src/main/java/org/apache/ibatis/cache/decorators/FifoCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/FifoCache.java
@@ -15,8 +15,9 @@
  */
 package org.apache.ibatis.cache.decorators;
 
-import java.util.Deque;
-import java.util.LinkedList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.apache.ibatis.cache.Cache;
 
@@ -28,12 +29,12 @@ import org.apache.ibatis.cache.Cache;
 public class FifoCache implements Cache {
 
   private final Cache delegate;
-  private final Deque<Object> keyList;
+  private final Set<Object> keyList;
   private int size;
 
   public FifoCache(Cache delegate) {
     this.delegate = delegate;
-    this.keyList = new LinkedList<>();
+    this.keyList = new LinkedHashSet<>();
     this.size = 1024;
   }
 
@@ -75,9 +76,11 @@ public class FifoCache implements Cache {
   }
 
   private void cycleKeyList(Object key) {
-    keyList.addLast(key);
-    if (keyList.size() > size) {
-      Object oldestKey = keyList.removeFirst();
+    // Re-inserting a cached key is an overwrite, not a new entry: it keeps its position and evicts nothing.
+    if (keyList.add(key) && keyList.size() > size) {
+      Iterator<Object> keys = keyList.iterator();
+      Object oldestKey = keys.next();
+      keys.remove();
       delegate.removeObject(oldestKey);
     }
   }

--- a/src/test/java/org/apache/ibatis/cache/FifoCacheTest.java
+++ b/src/test/java/org/apache/ibatis/cache/FifoCacheTest.java
@@ -72,4 +72,17 @@ class FifoCacheTest {
     assertNotNull(cache.getObject(0));
   }
 
+  @Test
+  void shouldNotEvictOnOverwriteOfExistingKey() {
+    FifoCache cache = new FifoCache(new PerpetualCache("default"));
+    cache.setSize(5);
+    for (int i = 0; i < 5; i++) {
+      cache.putObject(i, i);
+    }
+    cache.putObject(4, "updated");
+    assertEquals(0, cache.getObject(0));
+    assertEquals("updated", cache.getObject(4));
+    assertEquals(5, cache.getSize());
+  }
+
 }


### PR DESCRIPTION
### Problem

`FifoCache.cycleKeyList` appends the key to `keyList` on every `putObject`, even when that key
is already cached. Overwriting an existing entry therefore pushes `keyList` past the configured
size and evicts a *different* entry that is still live in the delegate cache.

The effective capacity shrinks on every overwrite:

```java
FifoCache cache = new FifoCache(new PerpetualCache("default"));
cache.setSize(5);
for (int i = 0; i < 5; i++) {
  cache.putObject(i, i);
}
cache.getSize();             // 5
cache.putObject(4, "updated");
cache.getSize();             // 4  <- key 0 evicted, although nothing new was added
cache.putObject(5, 5);
cache.getSize();             // 4  <- key 1 evicted too
```

The duplicated key also breaks removeObject, which drops a single occurrence and leaves the
rest behind to evict later, unrelated entries.

This is reachable through the second level cache. TransactionalCache.flushPendingEntries()
writes buffered entries on commit, so when two sessions miss on the same key concurrently, both
write that key into the underlying cache.

### Fix

Track keys in a LinkedHashSet. It preserves insertion order, so FIFO semantics are unchan
and it ignores re-inserts, so an overwrite is no longer counted as a new entry. Eviction takes
the head through the iterator and stays O(1).

### Test

FifoCacheTest.shouldNotEvictOnOverwriteOfExistingKey fails on master (expected: <0> but was: <null>) and passes with the fix. Full suite locally on JDK 21: 2010 tests, 0 failures.