### PR TITLE
Add setter for mapperRegistry to support DataPermission extensions

### DIFF
--- a/src/main/java/org/apache/ibatis/session/Configuration.java
+++ b/src/main/java/org/apache/ibatis/session/Configuration.java
@@ -149,7 +149,7 @@ public class Configuration {
    */
   protected Class<?> configurationFactory;
 
-  protected final MapperRegistry mapperRegistry = new MapperRegistry(this);
+  protected MapperRegistry mapperRegistry = new MapperRegistry(this);
   protected final InterceptorChain interceptorChain = new InterceptorChain();
   protected final TypeHandlerRegistry typeHandlerRegistry = new TypeHandlerRegistry(this);
   protected final TypeAliasRegistry typeAliasRegistry = new TypeAliasRegistry();
@@ -621,6 +621,10 @@ public class Configuration {
    */
   public MapperRegistry getMapperRegistry() {
     return mapperRegistry;
+  }
+
+  public void setMapperRegistry(MapperRegistry mapperRegistry) {
+    this.mapperRegistry = mapperRegistry;
   }
 
   public ReflectorFactory getReflectorFactory() {


### PR DESCRIPTION
Fixes #3609

## Problem
MyBatis lacks a public setter for `mapperRegistry` in `Configuration`, preventing extensions like `@DataPermission` from being implemented. The `MapperRegistry` is a private field in `Configuration` with no setter.

## Solution
- Remove `final` modifier from `mapperRegistry` field
- Add `public void setMapperRegistry(MapperRegistry mapperRegistry)` method

This allows extensions to inject a custom `MapperRegistry` implementation.