### PR TITLE
FifoCache must not evict another entry when an existing key is re-put

### DIFF
--- a/src/main/java/org/apache/ibatis/cache/decorators/FifoCache.java
+++ b/src/main/java/org/apache/ibatis/cache/decorators/FifoCache.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,8 +15,9 @@
  */
 package org.apache.ibatis.cache.decorators;
 
-import java.util.Deque;
-import java.util.LinkedList;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 import org.apache.ibatis.cache.Cache;
 
@@ -28,12 +29,12 @@ import org.apache.ibatis.cache.Cache;
 public class FifoCache implements Cache {
 
   private final Cache delegate;
-  private final Deque<Object> keyList;
+  private final Set<Object> keyList;
   private int size;
 
   public FifoCache(Cache delegate) {
     this.delegate = delegate;
-    this.keyList = new LinkedList<>();
+    this.keyList = new LinkedHashSet<>();
     this.size = 1024;
   }
 
@@ -75,9 +76,11 @@ public class FifoCache implements Cache {
   }
 
   private void cycleKeyList(Object key) {
-    keyList.addLast(key);
-    if (keyList.size() > size) {
-      Object oldestKey = keyList.removeFirst();
+    // an existing key is not a new entry, so it must not trigger an eviction
+    if (keyList.add(key) && keyList.size() > size) {
+      Iterator<Object> iterator = keyList.iterator();
+      Object oldestKey = iterator.next();
+      iterator.remove();
       delegate.removeObject(oldestKey);
     }
   }

--- a/src/test/java/org/apache/ibatis/cache/FifoCacheTest.java
+++ b/src/test/java/org/apache/ibatis/cache/FifoCacheTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2023 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -58,6 +58,19 @@ class FifoCacheTest {
     cache.clear();
     assertNull(cache.getObject(0));
     assertNull(cache.getObject(4));
+  }
+
+  @Test
+  void shouldNotEvictOtherEntryWhenExistingKeyIsRePut() {
+    FifoCache cache = new FifoCache(new PerpetualCache("default"));
+    cache.setSize(2);
+    cache.putObject(0, 0);
+    cache.putObject(1, 1);
+    // Updating an existing entry must not evict another entry
+    cache.putObject(1, 11);
+    assertEquals(0, cache.getObject(0));
+    assertEquals(11, cache.getObject(1));
+    assertEquals(2, cache.getSize());
   }
 
   @Test


### PR DESCRIPTION
Fixes #3768

`cycleKeyList` appended the key on every `putObject` without checking whether it was already tracked, so refreshing an existing key added a duplicate to the key list. Once the list exceeded the configured size, an unrelated entry was evicted although the number of distinct cached keys never exceeded the limit, and duplicates of the refreshed key kept occupying list slots, shrinking the effective capacity.

This change tracks keys in a `LinkedHashSet`, which preserves FIFO order by first insertion and ignores duplicate additions.

A regression test re-putting an existing key at capacity fails on `master` and passes with the fix; `FifoCacheTest` passes 5/5.