### PR TITLE
Fix ParamNameResolver.getType() when special parameters shift indices

### DIFF
--- a/src/main/java/org/apache/ibatis/reflection/ParamNameResolver.java
+++ b/src/main/java/org/apache/ibatis/reflection/ParamNameResolver.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2025 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -108,7 +109,7 @@ public class ParamNameResolver {
       useParamMap = true;
     }
     if (names.size() == 1) {
-      Type soleParamType = actualParamTypes[0];
+      Type soleParamType = actualParamTypes[names.firstKey()];
       if (soleParamType instanceof GenericArrayType) {
         typeMap.put("array", soleParamType);
       } else {
@@ -186,9 +187,11 @@ public class ParamNameResolver {
 
     if (type == null && unindexed.startsWith(GENERIC_NAME_PREFIX)) {
       try {
-        Integer paramIndex = Integer.valueOf(unindexed.substring(GENERIC_NAME_PREFIX.length())) - 1;
-        unindexed = names.get(paramIndex);
-        if (unindexed != null) {
+        int paramIndex = Integer.parseInt(unindexed.substring(GENERIC_NAME_PREFIX.length())) - 1;
+        // 'paramN' is positional; it is not necessarily the same as the parameter index
+        // when the method has special parameters (i.e. RowBounds or ResultHandler).
+        if (paramIndex >= 0 && paramIndex < names.size()) {
+          unindexed = new ArrayList<>(names.values()).get(paramIndex);
           type = typeMap.get(unindexed);
         }
       } catch (NumberFormatException e) {

--- a/src/test/java/org/apache/ibatis/reflection/ParamNameResolverTest.java
+++ b/src/test/java/org/apache/ibatis/reflection/ParamNameResolverTest.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2009-2025 the original author or authors.
+ *    Copyright 2009-2026 the original author or authors.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.session.Configuration;
+import org.apache.ibatis.session.RowBounds;
 import org.junit.jupiter.api.Test;
 
 class ParamNameResolverTest {
@@ -32,6 +33,8 @@ class ParamNameResolverTest {
     void m1(@Param("p") Integer p) {}
     void m2(List<String> p) {}
     void m3(Integer[] p) {}
+    void m4(RowBounds rowBounds, List<String> p) {}
+    void m5(@Param("a") Integer a, RowBounds rowBounds, @Param("b") String b) {}
   }
   // @formatter:on
 
@@ -63,5 +66,24 @@ class ParamNameResolverTest {
     assertEquals(Integer.class, resolver.getType("p[0]"));
     assertEquals(Integer[].class, resolver.getType("param1"));
     assertEquals(Integer.class, resolver.getType("param1[0]"));
+  }
+
+  @Test
+  void testGetTypeListAfterSpecialParameter() throws Exception {
+    Class<?> clazz = A.class;
+    Method method = clazz.getDeclaredMethod("m4", RowBounds.class, List.class);
+    ParamNameResolver resolver = new ParamNameResolver(new Configuration(), method, clazz);
+    assertEquals(String.class, resolver.getType("list[0]"));
+    assertEquals(List.class, ((ParameterizedType) resolver.getType("list")).getRawType());
+    assertEquals(List.class, ((ParameterizedType) resolver.getType("collection")).getRawType());
+  }
+
+  @Test
+  void testGetTypeGenericNameWithSpecialParameter() throws Exception {
+    Class<?> clazz = A.class;
+    Method method = clazz.getDeclaredMethod("m5", Integer.class, RowBounds.class, String.class);
+    ParamNameResolver resolver = new ParamNameResolver(new Configuration(), method, clazz);
+    assertEquals(Integer.class, resolver.getType("param1"));
+    assertEquals(String.class, resolver.getType("param2"));
   }
 }

--- a/src/test/java/org/apache/ibatis/submitted/param_name_resolve/ActualParamNameTest.java
+++ b/src/test/java/org/apache/ibatis/submitted/param_name_resolve/ActualParamNameTest.java
@@ -78,6 +78,22 @@ class ActualParamNameTest {
         long count = mapper.getUserCountUsingList_RowBounds(new RowBounds(0, 5), Arrays.asList(1, 2));
         assertEquals(2, count);
       }
+      // use 'collection' as alias with a special parameter #3769
+      {
+        long count = mapper.getUserCountUsingListWithAliasIsCollection_RowBounds(new RowBounds(0, 5),
+            Arrays.asList(1, 2));
+        assertEquals(2, count);
+      }
+      // use 'list' as alias with a special parameter #3769
+      {
+        long count = mapper.getUserCountUsingListWithAliasIsList_RowBounds(new RowBounds(0, 5), Arrays.asList(1, 2));
+        assertEquals(2, count);
+      }
+      // use positional 'paramN' names with a special parameter #3769
+      {
+        long count = mapper.getUserCountBetween_RowBounds(new RowBounds(0, 5), 1, 2);
+        assertEquals(2, count);
+      }
     }
   }
 
@@ -93,6 +109,11 @@ class ActualParamNameTest {
       // use 'array' as alias
       {
         long count = mapper.getUserCountUsingArrayWithAliasArray(1, 2);
+        assertEquals(2, count);
+      }
+      // use 'array' as alias with a special parameter #3769
+      {
+        long count = mapper.getUserCountUsingArrayWithAliasArray_RowBounds(new RowBounds(0, 5), new Integer[] { 1, 2 });
         assertEquals(2, count);
       }
     }
@@ -170,6 +191,45 @@ class ActualParamNameTest {
       })
     // @formatter:on
     Long getUserCountUsingList_RowBounds(RowBounds rowBounds, List<Integer> ids);
+
+    // @formatter:off
+    @Select({
+        "<script>",
+        "  select count(*) from users u where u.id in",
+        "  <foreach item='item' index='index' collection='collection' open='(' separator=',' close=')'>",
+        "    #{item}",
+        "  </foreach>",
+        "</script>"
+      })
+    // @formatter:on
+    Long getUserCountUsingListWithAliasIsCollection_RowBounds(RowBounds rowBounds, List<Integer> ids);
+
+    // @formatter:off
+    @Select({
+        "<script>",
+        "  select count(*) from users u where u.id in",
+        "  <foreach item='item' index='index' collection='list' open='(' separator=',' close=')'>",
+        "    #{item}",
+        "  </foreach>",
+        "</script>"
+      })
+    // @formatter:on
+    Long getUserCountUsingListWithAliasIsList_RowBounds(RowBounds rowBounds, List<Integer> ids);
+
+    @Select("select count(*) from users u where u.id between #{param1} and #{param2}")
+    Long getUserCountBetween_RowBounds(RowBounds rowBounds, int idFrom, int idTo);
+
+    // @formatter:off
+    @Select({
+        "<script>",
+        "  select count(*) from users u where u.id in",
+        "  <foreach item='item' index='index' collection='array' open='(' separator=',' close=')'>",
+        "    #{item}",
+        "  </foreach>",
+        "</script>"
+      })
+    // @formatter:on
+    Long getUserCountUsingArrayWithAliasArray_RowBounds(RowBounds rowBounds, Integer[] ids);
   }
 
 }


### PR DESCRIPTION
Fixes #3769

Two related index bugs when the mapper method has special parameters (`RowBounds`/`ResultHandler`), which are excluded from `names` but still occupy positions in `actualParamTypes`:

- The sole-parameter type lookup read `actualParamTypes[0]` instead of the actual declaration index, returning the special parameter's type when it precedes the sole actual parameter.
- `paramN` resolution treated N as a declaration index into `names` (`names.get(paramIndex)`), failing to resolve the positional generic name when special parameters shift the indices.

This change uses `names.firstKey()` for the sole-parameter lookup and resolves `paramN` positionally over the actual parameters.

Two regression tests fail on `master` and pass with the fix; `ParamNameResolverTest` passes 5/5.